### PR TITLE
[codex] Add Falcon research reviews for PMPCA SAMM50 MORC3

### DIFF
--- a/genes/human/MORC3/MORC3-ai-review.html
+++ b/genes/human/MORC3/MORC3-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>MORC3</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q14149" target="_blank" class="term-link">
                         Q14149
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-initialized">
-                    INITIALIZED
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="Q14149" data-a="DESCRIPTION: TODO: Add description for MORC3..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="Q14149" data-a="DESCRIPTION: MORC3/NXP2 is a nuclear matrix and PML nuclear bod..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for MORC3</p>
+        <p>MORC3/NXP2 is a nuclear matrix and PML nuclear body-associated MORC-family GHKL/HATPase protein with a CW-type zinc finger that reads methylated H3K4. It functions as a SUMO-regulated chromatin/PML-body scaffold and ATPase involved in intrinsic antiviral restriction, chromatin-associated repression, recruitment/maintenance of nuclear restriction factors, and negative regulation of interferon-beta programs.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,2105 +758,2940 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 is a nuclear/nuclear-matrix protein and PML nuclear body component.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Nuclear localization is strongly supported, although more specific PML body and nuclear matrix terms should also be retained.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MORC3 is consistently characterized as a **nuclear matrix protein** that localizes to **PML nuclear bodies**. In immunofluorescence microscopy, MORC3 colocalizes with the PML-NB component Sp100 in punctate nuclear structures (sloan2016morc3acomponent media 84630a9e). During infection with HSV-1 lacking ICP0, MORC3 is recruited to sites associated with incoming viral genomes (identified by ICP4 foci), consistent with a role in intrinsic restriction at early stages of infection (sloan2016morc3acomponent media 5b6c97c8).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Mechanistically, the association with PML-NBs is reported to occur via **SUMO–SIM interaction** with PML.I, and PML-NB localization/recruitment functions require a **functional ATPase domain** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140002" target="_blank" class="term-link">
                                     GO:0140002
                                 </a>
                             </span>
                             <span class="term-label">histone H3K4me3 reader activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0140002" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0140002" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The MORC3 CW-type zinc finger is reported to bind methylated H3K4.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Histone H3K4me3 reader activity is consistent with the CW-domain evidence and chromatin-associated function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules: (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140374" target="_blank" class="term-link">
                                     GO:0140374
                                 </a>
                             </span>
                             <span class="term-label">antiviral innate immune response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0140374" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0140374" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 contributes to intrinsic antiviral restriction, including PML-body-associated restriction of HSV-1 and HCMV.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Antiviral innate immune response is a supported major function of MORC3.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown, viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3 depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol* (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML, γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016605" target="_blank" class="term-link">
                                     GO:0016605
                                 </a>
                             </span>
                             <span class="term-label">PML body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0016605" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0016605" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 localizes to PML nuclear bodies through SUMO/SIM-dependent interactions and helps recruit restriction factors there.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PML body localization is one of the best-supported cellular component annotations for MORC3.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MORC3 is consistently characterized as a **nuclear matrix protein** that localizes to **PML nuclear bodies**. In immunofluorescence microscopy, MORC3 colocalizes with the PML-NB component Sp100 in punctate nuclear structures (sloan2016morc3acomponent media 84630a9e). During infection with HSV-1 lacking ICP0, MORC3 is recruited to sites associated with incoming viral genomes (identified by ICP4 foci), consistent with a role in intrinsic restriction at early stages of infection (sloan2016morc3acomponent media 5b6c97c8).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Mechanistically, the association with PML-NBs is reported to occur via **SUMO–SIM interaction** with PML.I, and PML-NB localization/recruitment functions require a **functional ATPase domain** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006325" target="_blank" class="term-link">
                                     GO:0006325
                                 </a>
                             </span>
                             <span class="term-label">chromatin organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000108
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0006325" data-r="GO_REF:0000108" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0006325" data-r="GO_REF:0000108" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 is a chromatin-associated ATPase/scaffold implicated in epigenetic repression and chromatin organization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Chromatin organization is supported by conserved MORC3 mechanism and by MORC3-mediated repression of viral/foreign DNA and interferon programs.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules: (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Epigenetic silencing / chromatin regulation | MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains; ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Genome-wide sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR | 2,737 reproducible Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Groh et al., *Nat Commun* (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7 |</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002376" target="_blank" class="term-link">
                                     GO:0002376
                                 </a>
                             </span>
                             <span class="term-label">immune system process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0002376" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0002376" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 has immune functions, but the evidence supports the more specific antiviral innate immune response and interferon-beta regulatory terms.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Use antiviral innate immune response rather than the broad parent immune system process.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140374" target="_blank" class="term-link">
+                                    antiviral innate immune response
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown, viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3 depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol* (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML, γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003723" target="_blank" class="term-link">
                                     GO:0003723
                                 </a>
                             </span>
                             <span class="term-label">RNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0003723" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0003723" data-r="GO_REF:0000043" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The curated MORC3 literature supports ATPase, CW histone-reader, chromatin/PML-body scaffold, and antiviral restriction roles, not direct RNA binding.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> This electronically inferred RNA-binding annotation is not supported by the gene-specific functional synthesis.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules: (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005654" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005654" data-r="GO_REF:0000120" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 is nuclear, but the more specific supported locations are PML bodies and nuclear matrix/chromatin-associated nuclear structures.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Use PML body and nuclear matrix instead of broad nucleoplasm when curating MORC3 localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016605" target="_blank" class="term-link">
+                                    PML body
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016363" target="_blank" class="term-link">
+                                    nuclear matrix
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MORC3 is consistently characterized as a **nuclear matrix protein** that localizes to **PML nuclear bodies**. In immunofluorescence microscopy, MORC3 colocalizes with the PML-NB component Sp100 in punctate nuclear structures (sloan2016morc3acomponent media 84630a9e). During infection with HSV-1 lacking ICP0, MORC3 is recruited to sites associated with incoming viral genomes (identified by ICP4 foci), consistent with a role in intrinsic restriction at early stages of infection (sloan2016morc3acomponent media 5b6c97c8).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Mechanistically, the association with PML-NBs is reported to occur via **SUMO–SIM interaction** with PML.I, and PML-NB localization/recruitment functions require a **functional ATPase domain** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005694" target="_blank" class="term-link">
                                     GO:0005694
                                 </a>
                             </span>
                             <span class="term-label">chromosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005694" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005694" data-r="GO_REF:0000044" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 is chromatin-associated, but chromosome is a broad location for this evidence.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Use chromatin to represent the supported chromosome-associated localization/function more precisely.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000785" target="_blank" class="term-link">
+                                    chromatin
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules: (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Epigenetic silencing / chromatin regulation | MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains; ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Genome-wide sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR | 2,737 reproducible Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Groh et al., *Nat Commun* (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7 |</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0008270" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0008270" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 contains a CW-type zinc finger domain.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Zinc ion binding is supported by the CW zinc-finger domain architecture.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules: (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016363" target="_blank" class="term-link">
                                     GO:0016363
                                 </a>
                             </span>
                             <span class="term-label">nuclear matrix</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0016363" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0016363" data-r="GO_REF:0000044" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3/NXP2 is consistently characterized as a nuclear matrix protein.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Nuclear matrix localization is supported by the literature synthesis.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MORC3 is consistently characterized as a **nuclear matrix protein** that localizes to **PML nuclear bodies**. In immunofluorescence microscopy, MORC3 colocalizes with the PML-NB component Sp100 in punctate nuclear structures (sloan2016morc3acomponent media 84630a9e). During infection with HSV-1 lacking ICP0, MORC3 is recruited to sites associated with incoming viral genomes (identified by ICP4 foci), consistent with a role in intrinsic restriction at early stages of infection (sloan2016morc3acomponent media 5b6c97c8).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016605" target="_blank" class="term-link">
                                     GO:0016605
                                 </a>
                             </span>
                             <span class="term-label">PML body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0016605" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0016605" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 localizes to PML nuclear bodies through SUMO/SIM-dependent interactions and helps recruit restriction factors there.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PML body localization is one of the best-supported cellular component annotations for MORC3.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MORC3 is consistently characterized as a **nuclear matrix protein** that localizes to **PML nuclear bodies**. In immunofluorescence microscopy, MORC3 colocalizes with the PML-NB component Sp100 in punctate nuclear structures (sloan2016morc3acomponent media 84630a9e). During infection with HSV-1 lacking ICP0, MORC3 is recruited to sites associated with incoming viral genomes (identified by ICP4 foci), consistent with a role in intrinsic restriction at early stages of infection (sloan2016morc3acomponent media 5b6c97c8).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Mechanistically, the association with PML-NBs is reported to occur via **SUMO–SIM interaction** with PML.I, and PML-NB localization/recruitment functions require a **functional ATPase domain** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0016887" data-r="GO_REF:0000002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0016887" data-r="GO_REF:0000002" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 is a MORC-family GHKL/HATPase ATPase, and ATPase activity is required for PML-body localization/recruitment functions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP hydrolysis activity is a core molecular feature of MORC3.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules: (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Mechanistically, the association with PML-NBs is reported to occur via **SUMO–SIM interaction** with PML.I, and PML-NB localization/recruitment functions require a **functional ATPase domain** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045087" target="_blank" class="term-link">
                                     GO:0045087
                                 </a>
                             </span>
                             <span class="term-label">innate immune response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0045087" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0045087" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 participates in innate immunity, but the evidence is specifically antiviral restriction and interferon regulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Use antiviral innate immune response for the supported immune role.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140374" target="_blank" class="term-link">
+                                    antiviral innate immune response
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown, viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3 depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol* (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML, γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 metal binding is specifically attributable to its CW-type zinc finger.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Use zinc ion binding rather than generic metal ion binding.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                                    zinc ion binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules: (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140002" target="_blank" class="term-link">
                                     GO:0140002
                                 </a>
                             </span>
                             <span class="term-label">histone H3K4me3 reader activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0140002" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0140002" data-r="GO_REF:0000117" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The MORC3 CW-type zinc finger is reported to bind methylated H3K4.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Histone H3K4me3 reader activity is consistent with the CW-domain evidence and chromatin-associated function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules: (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26496610" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26496610
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A human interactome in three quantitative dimensions organiz...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005515" data-r="PMID:26496610" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005515" data-r="PMID:26496610" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding is not informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin organization, and antiviral restriction.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26496610" target="_blank" class="term-link">
-                                        PMID:26496610
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Oct 22. A human interactome in three quantitative dimensions organized by stoichiometries and abundances.</div>
-                                
+
+                                <div class="support-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML, γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27173435" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27173435
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An organelle-specific protein landscape identifies novel dis...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005515" data-r="PMID:27173435" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005515" data-r="PMID:27173435" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding is not informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin organization, and antiviral restriction.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27173435" target="_blank" class="term-link">
-                                        PMID:27173435
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">An organelle-specific protein landscape identifies novel diseases and molecular mechanisms.</div>
-                                
+
+                                <div class="support-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML, γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005515" data-r="PMID:32296183" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding is not informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin organization, and antiviral restriction.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
-                                        PMID:32296183
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Apr 8. A reference map of the human binary protein interactome.</div>
-                                
+
+                                <div class="support-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML, γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005515" data-r="PMID:33961781" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding is not informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin organization, and antiviral restriction.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
-                                        PMID:33961781
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2021 May 6. Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                                
+
+                                <div class="support-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML, γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35271311
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     OpenCell: Endogenous tagging for the cartography of human ce...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005515" data-r="PMID:35271311" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005515" data-r="PMID:35271311" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding is not informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin organization, and antiviral restriction.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
-                                        PMID:35271311
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2022 Mar 11. OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
-                                
+
+                                <div class="support-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML, γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35914814" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35914814
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Chr21 protein-protein interactions: enrichment in proteins i...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005515" data-r="PMID:35914814" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005515" data-r="PMID:35914814" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding is not informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin organization, and antiviral restriction.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35914814" target="_blank" class="term-link">
-                                        PMID:35914814
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Chr21 protein-protein interactions: enrichment in proteins involved in intellectual disability, autism, and late-onset Alzheimer&#39;s disease.</div>
-                                
+
+                                <div class="support-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML, γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005515" data-r="PMID:40205054" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding is not informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin organization, and antiviral restriction.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
-                                        PMID:40205054
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Apr 9. Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                                
+
+                                <div class="support-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML, γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005634" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005634" data-r="GO_REF:0000107" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 is a nuclear/nuclear-matrix protein and PML nuclear body component.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Nuclear localization is strongly supported, although more specific PML body and nuclear matrix terms should also be retained.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MORC3 is consistently characterized as a **nuclear matrix protein** that localizes to **PML nuclear bodies**. In immunofluorescence microscopy, MORC3 colocalizes with the PML-NB component Sp100 in punctate nuclear structures (sloan2016morc3acomponent media 84630a9e). During infection with HSV-1 lacking ICP0, MORC3 is recruited to sites associated with incoming viral genomes (identified by ICP4 foci), consistent with a role in intrinsic restriction at early stages of infection (sloan2016morc3acomponent media 5b6c97c8).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Mechanistically, the association with PML-NBs is reported to occur via **SUMO–SIM interaction** with PML.I, and PML-NB localization/recruitment functions require a **functional ATPase domain** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005654" data-r="GO_REF:0000052" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0005654" data-r="GO_REF:0000052" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 is nuclear, but the more specific supported locations are PML bodies and nuclear matrix/chromatin-associated nuclear structures.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Use PML body and nuclear matrix instead of broad nucleoplasm when curating MORC3 localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016605" target="_blank" class="term-link">
+                                    PML body
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016363" target="_blank" class="term-link">
+                                    nuclear matrix
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MORC3 is consistently characterized as a **nuclear matrix protein** that localizes to **PML nuclear bodies**. In immunofluorescence microscopy, MORC3 colocalizes with the PML-NB component Sp100 in punctate nuclear structures (sloan2016morc3acomponent media 84630a9e). During infection with HSV-1 lacking ICP0, MORC3 is recruited to sites associated with incoming viral genomes (identified by ICP4 foci), consistent with a role in intrinsic restriction at early stages of infection (sloan2016morc3acomponent media 5b6c97c8).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Mechanistically, the association with PML-NBs is reported to occur via **SUMO–SIM interaction** with PML.I, and PML-NB localization/recruitment functions require a **functional ATPase domain** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140002" target="_blank" class="term-link">
                                     GO:0140002
                                 </a>
                             </span>
                             <span class="term-label">histone H3K4me3 reader activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26933034" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26933034
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Family-wide Characterization of Histone Binding Abilities of...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0140002" data-r="PMID:26933034" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0140002" data-r="PMID:26933034" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The MORC3 CW-type zinc finger is reported to bind methylated H3K4.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Histone H3K4me3 reader activity is consistent with the CW-domain evidence and chromatin-associated function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26933034" target="_blank" class="term-link">
-                                        PMID:26933034
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2016 Mar 1. Family-wide Characterization of Histone Binding Abilities of Human CW Domain-containing Proteins.</div>
-                                
+
+                                <div class="support-text">**Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules: (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000122" target="_blank" class="term-link">
                                     GO:0000122
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of transcription by RNA polymerase II</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34759314" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34759314
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Self-guarding of MORC3 enables virulence factor-triggered im...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0000122" data-r="PMID:34759314" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0000122" data-r="PMID:34759314" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 contributes to repression of transcriptional programs, including IFNB1/interferon-linked gene regulation and foreign DNA silencing.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Negative regulation of RNA polymerase II transcription is consistent with the MORC3 chromatin repression evidence.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34759314" target="_blank" class="term-link">
-                                        PMID:34759314
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Nov 10. Self-guarding of MORC3 enables virulence factor-triggered immunity.</div>
-                                
+
+                                <div class="support-text">**Intrinsic immunity and interferon pathway modulation.** In OSCC/HNSCC models, MORC3 knockdown upregulated interferon-associated genes and increased STAT1 and PD-L1, suggesting MORC3 suppresses interferon-driven transcriptional programs in this context (fu2024genomewideanalysisreveals pages 3-7). In myositis/cancer-associated myositis literature, MORC3 is described as an antiviral factor and a repressor of IFNB1 (patasova2023geneticinfluencesin pages 6-8). Together, these suggest MORC3 contributes to a chromatin-based brake on interferon gene expression, with context-dependent consequences (antiviral restriction in fibroblast/hepatocyte models vs immune evasion phenotypes in cancer).</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Epigenetic silencing / chromatin regulation | MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains; ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Genome-wide sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR | 2,737 reproducible Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Groh et al., *Nat Commun* (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7 |</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000785" target="_blank" class="term-link">
                                     GO:0000785
                                 </a>
                             </span>
                             <span class="term-label">chromatin</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34759314" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34759314
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Self-guarding of MORC3 enables virulence factor-triggered im...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0000785" data-r="PMID:34759314" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0000785" data-r="PMID:34759314" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 is a chromatin-associated ATPase/scaffold with roles in repressive chromatin states.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Chromatin localization/function is supported by the mechanistic synthesis.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34759314" target="_blank" class="term-link">
-                                        PMID:34759314
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Nov 10. Self-guarding of MORC3 enables virulence factor-triggered immunity.</div>
-                                
+
+                                <div class="support-text">**Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules: (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Epigenetic silencing / chromatin regulation | MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains; ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Genome-wide sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR | 2,737 reproducible Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Groh et al., *Nat Commun* (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7 |</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003677" target="_blank" class="term-link">
                                     GO:0003677
                                 </a>
                             </span>
                             <span class="term-label">DNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34759314" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34759314
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Self-guarding of MORC3 enables virulence factor-triggered im...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0003677" data-r="PMID:34759314" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0003677" data-r="PMID:34759314" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 regulates chromatin/DNA elements, but available synthesized evidence supports chromatin association and MRE regulation rather than a clearly separable direct DNA-binding MF.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Curate the supported chromatin and transcription-regulatory roles instead of broad DNA binding unless direct DNA-binding evidence is reviewed in detail.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34759314" target="_blank" class="term-link">
-                                        PMID:34759314
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Nov 10. Self-guarding of MORC3 enables virulence factor-triggered immunity.</div>
-                                
+
+                                <div class="support-text">**Intrinsic immunity and interferon pathway modulation.** In OSCC/HNSCC models, MORC3 knockdown upregulated interferon-associated genes and increased STAT1 and PD-L1, suggesting MORC3 suppresses interferon-driven transcriptional programs in this context (fu2024genomewideanalysisreveals pages 3-7). In myositis/cancer-associated myositis literature, MORC3 is described as an antiviral factor and a repressor of IFNB1 (patasova2023geneticinfluencesin pages 6-8). Together, these suggest MORC3 contributes to a chromatin-based brake on interferon gene expression, with context-dependent consequences (antiviral restriction in fibroblast/hepatocyte models vs immune evasion phenotypes in cancer).</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Epigenetic silencing / chromatin regulation | MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains; ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Genome-wide sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR | 2,737 reproducible Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Groh et al., *Nat Commun* (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7 |</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016605" target="_blank" class="term-link">
                                     GO:0016605
                                 </a>
                             </span>
                             <span class="term-label">PML body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27440897" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27440897
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MORC3, a Component of PML Nuclear Bodies, Has a Role in Rest...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0016605" data-r="PMID:27440897" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0016605" data-r="PMID:27440897" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 localizes to PML nuclear bodies through SUMO/SIM-dependent interactions and helps recruit restriction factors there.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PML body localization is one of the best-supported cellular component annotations for MORC3.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27440897" target="_blank" class="term-link">
-                                        PMID:27440897
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">MORC3, a Component of PML Nuclear Bodies, Has a Role in Restricting Herpes Simplex Virus 1 and Human Cytomegalovirus.</div>
-                                
+
+                                <div class="support-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MORC3 is consistently characterized as a **nuclear matrix protein** that localizes to **PML nuclear bodies**. In immunofluorescence microscopy, MORC3 colocalizes with the PML-NB component Sp100 in punctate nuclear structures (sloan2016morc3acomponent media 84630a9e). During infection with HSV-1 lacking ICP0, MORC3 is recruited to sites associated with incoming viral genomes (identified by ICP4 foci), consistent with a role in intrinsic restriction at early stages of infection (sloan2016morc3acomponent media 5b6c97c8).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Mechanistically, the association with PML-NBs is reported to occur via **SUMO–SIM interaction** with PML.I, and PML-NB localization/recruitment functions require a **functional ATPase domain** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
                                     GO:0030674
                                 </a>
                             </span>
                             <span class="term-label">protein-macromolecule adaptor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27440897" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27440897
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MORC3, a Component of PML Nuclear Bodies, Has a Role in Rest...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0030674" data-r="PMID:27440897" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0030674" data-r="PMID:27440897" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 functions as a SUMO-regulated scaffold/adaptor for PML-body and viral-genome-associated restriction factors.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein-macromolecule adaptor activity is supported by MORC3-dependent recruitment of PML, Sp100, hDaxx, gamma-H2AX, p53, and related nuclear factors.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27440897" target="_blank" class="term-link">
-                                        PMID:27440897
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">MORC3, a Component of PML Nuclear Bodies, Has a Role in Restricting Herpes Simplex Virus 1 and Human Cytomegalovirus.</div>
-                                
+
+                                <div class="support-text">A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML, γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown, viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3 depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol* (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032688" target="_blank" class="term-link">
                                     GO:0032688
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of interferon-beta production</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34759314" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34759314
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Self-guarding of MORC3 enables virulence factor-triggered im...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0032688" data-r="PMID:34759314" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0032688" data-r="PMID:34759314" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Loss or degradation of MORC3 derepresses IFNB1/interferon programs, supporting a negative regulatory role.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Negative regulation of interferon-beta production is directly aligned with MORC3-mediated IFNB1 repression.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34759314" target="_blank" class="term-link">
-                                        PMID:34759314
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Nov 10. Self-guarding of MORC3 enables virulence factor-triggered immunity.</div>
-                                
+
+                                <div class="support-text">**Intrinsic immunity and interferon pathway modulation.** In OSCC/HNSCC models, MORC3 knockdown upregulated interferon-associated genes and increased STAT1 and PD-L1, suggesting MORC3 suppresses interferon-driven transcriptional programs in this context (fu2024genomewideanalysisreveals pages 3-7). In myositis/cancer-associated myositis literature, MORC3 is described as an antiviral factor and a repressor of IFNB1 (patasova2023geneticinfluencesin pages 6-8). Together, these suggest MORC3 contributes to a chromatin-based brake on interferon gene expression, with context-dependent consequences (antiviral restriction in fibroblast/hepatocyte models vs immune evasion phenotypes in cancer).</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140374" target="_blank" class="term-link">
                                     GO:0140374
                                 </a>
                             </span>
                             <span class="term-label">antiviral innate immune response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27440897" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27440897
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MORC3, a Component of PML Nuclear Bodies, Has a Role in Rest...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0140374" data-r="PMID:27440897" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0140374" data-r="PMID:27440897" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 contributes to intrinsic antiviral restriction, including PML-body-associated restriction of HSV-1 and HCMV.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Antiviral innate immune response is a supported major function of MORC3.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27440897" target="_blank" class="term-link">
-                                        PMID:27440897
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">MORC3, a Component of PML Nuclear Bodies, Has a Role in Restricting Herpes Simplex Virus 1 and Human Cytomegalovirus.</div>
-                                
+
+                                <div class="support-text">| PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown, viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3 depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol* (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML, γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2000774" target="_blank" class="term-link">
                                     GO:2000774
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of cellular senescence</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17332504
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dynamic regulation of p53 subnuclear localization and senesc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:2000774" data-r="PMID:17332504" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:2000774" data-r="PMID:17332504" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 can activate p53 and induce cellular senescence in fibroblast models.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The p53/senescence phenotype is supported but is a downstream context-specific outcome of MORC3 PML-body localization and scaffold activity rather than the core conserved function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link">
                                         PMID:17332504
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Mar 1. Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
-                                
+
+                                <div class="support-text">Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown, viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3 depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol* (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006468" target="_blank" class="term-link">
                                     GO:0006468
                                 </a>
                             </span>
                             <span class="term-label">protein phosphorylation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17332504
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dynamic regulation of p53 subnuclear localization and senesc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -2868,147 +3703,199 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> MISANNOTATION: MORC3 is a GHL-ATPase (not a kinase) that regulates p53 recruitment to PML-NBs. PMID:17332504 explicitly states &#34;genotoxic stress-induced phosphorylation and stabilization of p53 but barely increased its transcriptional activity in Morc3-/- fibroblasts&#34; - this means p53 IS PHOSPHORYLATED even without MORC3. MORC3 affects p53 activity DOWNSTREAM of phosphorylation through PML-NB recruitment, not by performing phosphorylation itself.
+                            <strong>Summary:</strong> MORC3 is a GHKL ATPase, not a protein kinase; the p53 study states that genotoxic stress-induced p53 phosphorylation still occurs in Morc3-deficient fibroblasts.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> This annotation misattributes phosphorylation catalysis to MORC3. MORC3 regulates p53 localization/activity downstream of phosphorylation through PML nuclear bodies.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link">
                                         PMID:17332504
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Mar 1. Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
-                                
+
+                                <div class="support-text">phosphorylation and stabilization of p53 but barely increased its</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link">
+                                        PMID:17332504
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules: (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016605" target="_blank" class="term-link">
                                     GO:0016605
                                 </a>
                             </span>
                             <span class="term-label">PML body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17332504
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dynamic regulation of p53 subnuclear localization and senesc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0016605" data-r="PMID:17332504" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0016605" data-r="PMID:17332504" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 localizes to PML nuclear bodies through SUMO/SIM-dependent interactions and helps recruit restriction factors there.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PML body localization is one of the best-supported cellular component annotations for MORC3.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link">
-                                        PMID:17332504
-                                    </a>
-                                    
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Mar 1. Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
-                                
+
+                                <div class="support-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MORC3 is consistently characterized as a **nuclear matrix protein** that localizes to **PML nuclear bodies**. In immunofluorescence microscopy, MORC3 colocalizes with the PML-NB component Sp100 in punctate nuclear structures (sloan2016morc3acomponent media 84630a9e). During infection with HSV-1 lacking ICP0, MORC3 is recruited to sites associated with incoming viral genomes (identified by ICP4 foci), consistent with a role in intrinsic restriction at early stages of infection (sloan2016morc3acomponent media 5b6c97c8).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Mechanistically, the association with PML-NBs is reported to occur via **SUMO–SIM interaction** with PML.I, and PML-NB localization/recruitment functions require a **functional ATPase domain** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0018105" target="_blank" class="term-link">
                                     GO:0018105
                                 </a>
                             </span>
                             <span class="term-label">peptidyl-serine phosphorylation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17332504
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dynamic regulation of p53 subnuclear localization and senesc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3020,687 +3907,1526 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> MISANNOTATION: MORC3 is a GHL-ATPase domain protein, NOT a serine/threonine kinase. PMID:17332504 describes MORC3&#39;s role in p53 recruitment to PML-NBs and shows p53 phosphorylation occurs independently of MORC3 (&#34;genotoxic stress-induced phosphorylation... in Morc3-/- fibroblasts&#34;). MORC3 has ATPase activity but no kinase activity. The annotation incorrectly attributes phosphorylation catalysis to MORC3.
+                            <strong>Summary:</strong> MORC3 is not a serine/threonine kinase, and the p53 paper supports a localization/activity role rather than peptidyl-serine phosphorylation by MORC3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The annotation incorrectly converts a p53 phosphorylation phenotype into MORC3 kinase activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link">
                                         PMID:17332504
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Mar 1. Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
-                                
+
+                                <div class="support-text">phosphorylation and stabilization of p53 but barely increased its</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link">
+                                        PMID:17332504
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules: (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048147" target="_blank" class="term-link">
                                     GO:0048147
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of fibroblast proliferation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17332504
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dynamic regulation of p53 subnuclear localization and senesc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0048147" data-r="PMID:17332504" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0048147" data-r="PMID:17332504" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3-dependent p53 activation and cellular senescence in fibroblast models imply reduced fibroblast proliferation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> This is a supported context-specific p53/senescence phenotype rather than a core MORC3 molecular function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link">
                                         PMID:17332504
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Mar 1. Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
-                                
+
+                                <div class="support-text">Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown, viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3 depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol* (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
                                     GO:0050821
                                 </a>
                             </span>
                             <span class="term-label">protein stabilization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17332504
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dynamic regulation of p53 subnuclear localization and senesc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0050821" data-r="PMID:17332504" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0050821" data-r="PMID:17332504" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The p53 study indicates that genotoxic stress-induced p53 stabilization still occurs in Morc3-deficient fibroblasts; MORC3 instead affects p53 localization and transcriptional activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein stabilization is not the supported MORC3 activity from this evidence.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link">
                                         PMID:17332504
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Mar 1. Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
-                                
+
+                                <div class="support-text">phosphorylation and stabilization of p53 but barely increased its</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link">
+                                        PMID:17332504
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051457" target="_blank" class="term-link">
                                     GO:0051457
                                 </a>
                             </span>
                             <span class="term-label">maintenance of protein location in nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17332504
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dynamic regulation of p53 subnuclear localization and senesc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0051457" data-r="PMID:17332504" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0051457" data-r="PMID:17332504" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 helps recruit/maintain p53, Sp100, and viral-genome-associated restriction factors in nuclear PML-body contexts.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Maintenance of nuclear protein location is supported as a scaffold/localization role, but is secondary to the core PML-body chromatin-adaptor function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link">
                                         PMID:17332504
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Mar 1. Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
-                                
+
+                                <div class="support-text">Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown, viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3 depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol* (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051457" target="_blank" class="term-link">
                                     GO:0051457
                                 </a>
                             </span>
                             <span class="term-label">maintenance of protein location in nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17332504
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dynamic regulation of p53 subnuclear localization and senesc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0051457" data-r="PMID:17332504" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q14149" data-a="GO:0051457" data-r="PMID:17332504" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MORC3 helps recruit/maintain p53, Sp100, and viral-genome-associated restriction factors in nuclear PML-body contexts.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Maintenance of nuclear protein location is supported as a scaffold/localization role, but is secondary to the core PML-body chromatin-adaptor function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link">
                                         PMID:17332504
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Mar 1. Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
-                                
+
+                                <div class="support-text">Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MORC3/MORC3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown, viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3 depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol* (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MORC3 is a MORC-family GHKL/HATPase chromatin-associated ATPase. Its ATPase cycle works with its CW zinc-finger chromatin-reader module and SUMOylation to support repressive chromatin organization at foreign or deleterious DNA templates.</h3>
+                <span class="vote-buttons" data-g="Q14149" data-a="FUNCTION: MORC3 is a MORC-family GHKL/HATPase chromatin-asso..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                            ATP hydrolysis activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006325" target="_blank" class="term-link">
+                                chromatin organization
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000122" target="_blank" class="term-link">
+                                negative regulation of transcription by RNA polymerase II
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000785" target="_blank" class="term-link">
+                                chromatin
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016363" target="_blank" class="term-link">
+                                nuclear matrix
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MORC3/MORC3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules: (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MORC3/MORC3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">| Epigenetic silencing / chromatin regulation | MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains; ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Genome-wide sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR | 2,737 reproducible Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Groh et al., *Nat Commun* (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7 |</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>The MORC3 CW-type zinc finger recognizes methylated H3K4, connecting MORC3 to chromatin-reader activity in nuclear chromatin contexts.</h3>
+                <span class="vote-buttons" data-g="Q14149" data-a="FUNCTION: The MORC3 CW-type zinc finger recognizes methylate..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140002" target="_blank" class="term-link">
+                            histone H3K4me3 reader activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006325" target="_blank" class="term-link">
+                                chromatin organization
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000785" target="_blank" class="term-link">
+                                chromatin
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MORC3/MORC3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules: (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MORC3 acts as a SUMO-regulated PML-body scaffold/adaptor that recruits and maintains nuclear restriction factors at PML bodies and incoming viral genomes, contributing to antiviral restriction and interferon-beta regulatory programs.</h3>
+                <span class="vote-buttons" data-g="Q14149" data-a="FUNCTION: MORC3 acts as a SUMO-regulated PML-body scaffold/a..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                            protein-macromolecule adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140374" target="_blank" class="term-link">
+                                antiviral innate immune response
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032688" target="_blank" class="term-link">
+                                negative regulation of interferon-beta production
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016605" target="_blank" class="term-link">
+                                PML body
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016363" target="_blank" class="term-link">
+                                nuclear matrix
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MORC3/MORC3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MORC3/MORC3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">| PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown, viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3 depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol* (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MORC3/MORC3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**Intrinsic immunity and interferon pathway modulation.** In OSCC/HNSCC models, MORC3 knockdown upregulated interferon-associated genes and increased STAT1 and PD-L1, suggesting MORC3 suppresses interferon-driven transcriptional programs in this context (fu2024genomewideanalysisreveals pages 3-7). In myositis/cancer-associated myositis literature, MORC3 is described as an antiviral factor and a repressor of IFNB1 (patasova2023geneticinfluencesin pages 6-8). Together, these suggest MORC3 contributes to a chromatin-based brake on interferon gene expression, with context-dependent consequences (antiviral restriction in fibroblast/hepatocyte models vs immune evasion phenotypes in cancer).</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
                             GO_REF:0000108
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17332504" target="_blank" class="term-link">
                             PMID:17332504
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dynamic regulation of p53 subnuclear localization and senescence by MORC3.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26496610" target="_blank" class="term-link">
                             PMID:26496610
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A human interactome in three quantitative dimensions organized by stoichiometries and abundances.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26933034" target="_blank" class="term-link">
                             PMID:26933034
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Family-wide Characterization of Histone Binding Abilities of Human CW Domain-containing Proteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27173435" target="_blank" class="term-link">
                             PMID:27173435
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An organelle-specific protein landscape identifies novel diseases and molecular mechanisms.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27440897" target="_blank" class="term-link">
                             PMID:27440897
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MORC3, a Component of PML Nuclear Bodies, Has a Role in Restricting Herpes Simplex Virus 1 and Human Cytomegalovirus.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34759314" target="_blank" class="term-link">
                             PMID:34759314
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Self-guarding of MORC3 enables virulence factor-triggered immunity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
                             PMID:35271311
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35914814" target="_blank" class="term-link">
                             PMID:35914814
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Chr21 protein-protein interactions: enrichment in proteins involved in intellectual disability, autism, and late-onset Alzheimer&#39;s disease.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/MORC3/MORC3-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research on MORC3 function</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MORC3 is a nuclear matrix and PML nuclear body protein with GHKL ATPase and CW zinc-finger domains.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MORC3 contributes to PML nuclear body-associated intrinsic antiviral restriction of HSV-1 and HCMV.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MORC3 acts as a chromatin-associated ATPase/scaffold involved in epigenetic repression and interferon program regulation.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which MORC3 activities in human cells require the ATPase domain, the CW H3K4me3-reader domain, SUMOylation/SIM interactions, or combinations of these modules?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q14149" data-a="Q: Which MORC3 activities in human cells require the ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Does MORC3 directly bind specific DNA elements such as the IFNB1-adjacent MRE, or is repression mediated through chromatin-associated partner proteins?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q14149" data-a="Q: Does MORC3 directly bind specific DNA elements suc..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Rescue MORC3 knockout human cells with ATPase-dead, CW-domain, SUMOylation-defective, and SIM-interaction mutants, then measure PML-body localization, restriction-factor recruitment, IFNB1/MRE repression, and HSV-1/HCMV restriction.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MORC3 antiviral and interferon-repressive functions require separable ATPase, chromatin-reader, and SUMO/PML-body interaction modules.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q14149" data-a="EXPERIMENT: Rescue MORC3 knockout human cells with ATPase-dead..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform CUT&amp;RUN/CUT&amp;Tag or ChIP-seq for endogenous MORC3 together with DNA-binding-deficient and partner-recruitment mutants at IFNB1/MRE, viral episomes, and retroelement loci.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: MORC3 occupies repressed chromatin templates through a partner-dependent chromatin scaffold mechanism rather than generic sequence-independent DNA binding.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q14149" data-a="EXPERIMENT: Perform CUT&amp;RUN/CUT&amp;Tag or ChIP-seq for endogenous..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MORC3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q14149" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T19:39:23.450007'<br />
+end_time: '2026-05-11T19:52:20.206960'<br />
+duration_seconds: 776.76<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: MORC3<br />
+  gene_symbol: MORC3<br />
+  uniprot_accession: Q14149<br />
+  protein_description: 'RecName: Full=MORC family CW-type zinc finger protein 3; AltName:<br />
+    Full=Nuclear matrix protein 2 {ECO:0000303|PubMed:11927593}; AltName: Full=Zinc<br />
+    finger CW-type coiled-coil domain protein 3;'<br />
+  gene_info: Name=MORC3 {ECO:0000312|HGNC:HGNC:23572}; Synonyms=KIAA0136 {ECO:0000312|HGNC:HGNC:23572},<br />
+    NXP2 {ECO:0000312|HGNC:HGNC:23572}, ZCWCC3 {ECO:0000312|HGNC:HGNC:23572};<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Not specified in UniProt<br />
+  protein_domains: HATPase_C_sf. (IPR036890); MORC_ATPase. (IPR045261); Morc_S5. (IPR041006);<br />
+    Znf_CW. (IPR011124); HATPase_c_3 (PF13589)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 17</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q14149</li>
+<li><strong>Protein Description:</strong> RecName: Full=MORC family CW-type zinc finger protein 3; AltName: Full=Nuclear matrix protein 2 {ECO:0000303|PubMed:11927593}; AltName: Full=Zinc finger CW-type coiled-coil domain protein 3;</li>
+<li><strong>Gene Information:</strong> Name=MORC3 {ECO:0000312|HGNC:HGNC:23572}; Synonyms=KIAA0136 {ECO:0000312|HGNC:HGNC:23572}, NXP2 {ECO:0000312|HGNC:HGNC:23572}, ZCWCC3 {ECO:0000312|HGNC:HGNC:23572};</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> HATPase_C_sf. (IPR036890); MORC_ATPase. (IPR045261); Morc_S5. (IPR041006); Znf_CW. (IPR011124); HATPase_c_3 (PF13589)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "MORC3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'MORC3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>MORC3</strong> (gene ID: MORC3, UniProt: Q14149) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q14149</li>
+<li><strong>Protein Description:</strong> RecName: Full=MORC family CW-type zinc finger protein 3; AltName: Full=Nuclear matrix protein 2 {ECO:0000303|PubMed:11927593}; AltName: Full=Zinc finger CW-type coiled-coil domain protein 3;</li>
+<li><strong>Gene Information:</strong> Name=MORC3 {ECO:0000312|HGNC:HGNC:23572}; Synonyms=KIAA0136 {ECO:0000312|HGNC:HGNC:23572}, NXP2 {ECO:0000312|HGNC:HGNC:23572}, ZCWCC3 {ECO:0000312|HGNC:HGNC:23572};</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> HATPase_C_sf. (IPR036890); MORC_ATPase. (IPR045261); Morc_S5. (IPR041006); Znf_CW. (IPR011124); HATPase_c_3 (PF13589)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "MORC3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'MORC3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>MORC3</strong> (gene ID: MORC3, UniProt: Q14149) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-human-morc3-uniprot-q14149-gene-morc3-aliases-nxp2-nuclear-matrix-protein-2-zcwcc3">Research report: Human MORC3 (UniProt Q14149; gene <strong>MORC3</strong>, aliases <strong>NXP2</strong>, <strong>nuclear matrix protein 2</strong>, <strong>ZCWCC3</strong>)</h2>
+<h3 id="1-key-concepts-definitions-and-current-understanding">1) Key concepts, definitions, and current understanding</h3>
+<p><strong>Target verification and naming.</strong> The UniProt accession Q14149 corresponds to human <strong>MORC family CW-type zinc finger protein 3 (MORC3)</strong>, historically described as <strong>NXP2/nuclear matrix protein 2</strong> and recognized as an autoantigen in dermatomyositis. Multiple primary and review sources explicitly use the combined name <strong>NXP2/MORC3</strong>, confirming that the literature discussed here matches the intended human protein (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).</p>
+<p><strong>Domain architecture and biochemical capabilities.</strong> MORC3 is described as containing three conserved modules: (i) a <strong>GHKL/HATPase-like ATPase domain</strong> (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a <strong>CW-type zinc finger</strong> reported to bind <strong>methylated H3K4</strong>, and (iii) a <strong>coiled-coil</strong> region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as <strong>chromatin-associated ATPases</strong> that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).</p>
+<p><strong>SUMO biology and PML nuclear bodies (PML-NBs/ND10).</strong> MORC3 is a <strong>SUMOylated</strong> nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through <strong>SUMO–SIM interactions</strong> (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with <strong>PML isoform I</strong> (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).</p>
+<p><strong>Primary functional framing (current consensus from available evidence).</strong> Across experimental systems, MORC3 is best viewed as a <strong>nuclear, chromatin-associated ATPase and SUMO-regulated scaffold</strong> that:<br />
+1) contributes to <strong>PML nuclear body organization and intrinsic antiviral restriction</strong>, and<br />
+2) participates in <strong>epigenetic repression programs</strong> (including retroelement silencing and interferon program repression) likely through chromatin remodeling/assembly mechanisms.<br />
+These themes converge on the idea that MORC3 helps enforce repressive chromatin states on foreign or potentially deleterious nucleic acids (viral genomes, transgenes, retroelements) and modulates innate immune gene expression (sloan2016morc3acomponent pages 3-5, groh2021morc3silencesendogenous pages 10-11, fu2024genomewideanalysisreveals pages 3-7, OpenTargets Search: -MORC3).</p>
+<h3 id="2-recent-developments-and-latest-research-prioritizing-20232024">2) Recent developments and latest research (prioritizing 2023–2024)</h3>
+<h4 id="21-morc3-as-a-restriction-factor-for-gene-therapy-vectors-2023">2.1 MORC3 as a restriction factor for gene therapy vectors (2023)</h4>
+<p>A 2023 genome-scale CRISPR screening study identified MORC3 as a cellular factor that <strong>restricts transgene expression</strong> from recombinant adeno-associated virus (rAAV) vectors. MORC3 knockout improved transgene expression across <strong>multiple AAV serotypes</strong>, and also increased expression from other viral vectors (lentivirus and adenovirus). Importantly, the enhancement was also demonstrated in <strong>human primary cells</strong>, underscoring translational relevance for gene therapy optimization (OpenTargets Search: -MORC3).</p>
+<p><strong>Interpretation.</strong> This work connects MORC3 to a clinically relevant, real-world implementation problem: host-cell <strong>epigenetic silencing of therapeutic vectors</strong>. The association with SETDB1/HUSH-linked restriction pathways (also implicated in antiviral and retroelement silencing) supports a coherent model in which MORC3 contributes to chromatin-based repression of newly introduced DNA templates (OpenTargets Search: -MORC3).</p>
+<h4 id="22-morc3-represses-interferon-programs-and-pd-l1-in-head-and-neck-cancer-2024">2.2 MORC3 represses interferon programs and PD-L1 in head and neck cancer (2024)</h4>
+<p>A 2024 “genome-wide” study in head and neck/oral squamous cell carcinoma (HNSCC/OSCC) reported MORC3 as a <strong>repressor of PD-L1 expression</strong> and of interferon-associated gene programs. The study combined TCGA/GEPIA2 analyses, OSCC tissue microarray immunohistochemistry (<strong>48 OSCC vs 10 normal oral mucosa</strong>), siRNA knockdown in CAL27 cells, RNA-seq, qRT-PCR, western blot, and flow cytometry of PD-L1 surface expression (fu2024genomewideanalysisreveals pages 2-3, fu2024genomewideanalysisreveals pages 3-7).</p>
+<p>Key reported results include:<br />
+- <strong>MORC3 downregulation</strong> in multiple cancers and lower MORC3 protein expression in OSCC relative to normal tissue (fu2024genomewideanalysisreveals pages 2-3, fu2024genomewideanalysisreveals pages 3-7).<br />
+- In male TCGA HNSCC patients, higher MORC3 expression was associated with longer survival (stratification sizes reported as <strong>high n=105 vs low n=262</strong>) (fu2024genomewideanalysisreveals pages 3-7).<br />
+- MORC3 knockdown induced interferon/ISG programs and increased STAT1 and PD-L1; RNA-seq after knockdown identified <strong>270 differentially expressed genes (DEGs)</strong> (171 up, 99 down), with enrichment for interferon signaling and PD-1/PD-L1 checkpoint pathways; the study proposed an axis involving <strong>LINC00880</strong> contributing to PD-L1 regulation (fu2024genomewideanalysisreveals pages 3-7).</p>
+<p><strong>Interpretation.</strong> This positions MORC3 as an upstream modulator of tumor-immune interactions through interferon-linked regulation of PD-L1. However, the work is in a specific tumor context, and further mechanistic dissection (e.g., direct chromatin binding at PD-L1 regulators) would be needed to generalize.</p>
+<h4 id="23-anti-nxp2morc3-autoantibodies-and-cancer-associated-myositis-genetics-2023">2.3 Anti-NXP2/MORC3 autoantibodies and cancer-associated myositis genetics (2023)</h4>
+<p>A 2023 review focusing on cancer-associated myositis summarizes anti-NXP2 antibodies (targeting MORC3/NXP2) as clinically meaningful biomarkers with prevalence and cancer association estimates. It reports:<br />
+- Anti-NXP2 occurs in ~<strong>22–25% of juvenile dermatomyositis</strong> and <strong>1–17%</strong> of adult-onset dermatomyositis (patasova2023geneticinfluencesin pages 6-8).<br />
+- Anti-NXP2 is described as increasing cancer-associated myositis risk by ~<strong>30%</strong> in adult-onset dermatomyositis, and retrospective series are summarized in which malignant neoplasms were observed in <strong>24–37.5%</strong> of anti-NXP2-positive adult patients (patasova2023geneticinfluencesin pages 6-8).<br />
+This review also frames MORC3 mechanistically as a MORC-family ATPase with nuclear matrix binding features, with roles in chromatin/epigenetic regulation, antiviral activity, and repression of <strong>IFNB1</strong> (patasova2023geneticinfluencesin pages 6-8).</p>
+<p><strong>Interpretation.</strong> The clinical association literature is heterogeneous, and newer multicenter cohorts (not limited to 2023–2024 in the retrieved set) indicate that assay methodology can strongly influence apparent anti-NXP2 positivity rates and downstream phenotype associations; therefore, conclusions about cancer risk should be made with attention to the detection method and cohort structure (OpenTargets Search: -MORC3).</p>
+<h3 id="3-molecular-and-cellular-functions-functional-annotation">3) Molecular and cellular functions (functional annotation)</h3>
+<h4 id="31-subcellular-localization-nuclear-matrix-and-pml-nuclear-bodies-recruitment-to-viral-genomes">3.1 Subcellular localization: nuclear matrix and PML nuclear bodies; recruitment to viral genomes</h4>
+<p>MORC3 is consistently characterized as a <strong>nuclear matrix protein</strong> that localizes to <strong>PML nuclear bodies</strong>. In immunofluorescence microscopy, MORC3 colocalizes with the PML-NB component Sp100 in punctate nuclear structures (sloan2016morc3acomponent media 84630a9e). During infection with HSV-1 lacking ICP0, MORC3 is recruited to sites associated with incoming viral genomes (identified by ICP4 foci), consistent with a role in intrinsic restriction at early stages of infection (sloan2016morc3acomponent media 5b6c97c8).</p>
+<p>Mechanistically, the association with PML-NBs is reported to occur via <strong>SUMO–SIM interaction</strong> with PML.I, and PML-NB localization/recruitment functions require a <strong>functional ATPase domain</strong> (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).</p>
+<h4 id="32-post-translational-regulation-sumoylation-and-viral-antagonism">3.2 Post-translational regulation: SUMOylation and viral antagonism</h4>
+<p>In a SILAC proteomics study of HSV-1 infection, MORC3/NXP2 was identified as a <strong>SUMO2-modified</strong> nuclear matrix protein whose abundance decreased by approximately <strong>5.6-fold</strong> during HSV-1 infection. Both SUMOylated and unmodified MORC3 were degraded during infection in an <strong>ICP0-dependent</strong> manner, consistent with ICP0 functioning as an E3 ubiquitin ligase targeting SUMOylated substrates to counter intrinsic immunity (sloan2016morc3acomponent pages 3-5).</p>
+<h4 id="33-antiviral-restriction-roles-hsv-1-and-hcmv">3.3 Antiviral restriction roles: HSV-1 and HCMV</h4>
+<p>Functional depletion experiments support MORC3 as a contributor to PML-NB–associated intrinsic restriction.<br />
+- MORC3 depletion increased plaque formation efficiency of <strong>ICP0-null HSV-1</strong>, and increased levels of viral proteins (e.g., ICP4, UL42) early after infection, consistent with loss of a restriction activity. In contrast, wild-type HSV-1 did not show similar dependence because ICP0 rapidly degrades MORC3 and other SUMO-linked restriction factors, thereby counteracting MORC3-mediated restriction (sloan2016morc3acomponent pages 13-15).<br />
+- MORC3 depletion also increased plaque formation efficiency of wild-type <strong>HCMV</strong>, consistent with MORC3 contributing to repression of DNA viruses (sloan2016morc3acomponent pages 13-15).</p>
+<p>A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML, γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).</p>
+<h4 id="34-epigenetic-silencing-and-chromatin-regulation-inference-grounded-in-conserved-morc3-biology">3.4 Epigenetic silencing and chromatin regulation (inference grounded in conserved MORC3 biology)</h4>
+<p>Direct mechanistic evidence for MORC3 in epigenetic silencing is strong in mouse embryonic stem cells and is likely informative for human MORC3 given conserved architecture.<br />
+- Morc3 was identified in a genome-wide sgRNA screen for endogenous retrovirus (ERV) silencing factors, and Morc3 knockout caused ERV derepression, reduced H3K9me3, and increased chromatin accessibility (groh2021morc3silencesendogenous pages 1-2).<br />
+- The mechanistic link to chromatin assembly is that Morc3 enables <strong>Daxx-mediated histone H3.3 incorporation</strong>, and Morc3 mutant proteins (defective in the ATPase cycle and/or SUMOylation) fail to interact effectively with Daxx. The interaction depends on Morc3 SUMOylation and Daxx SUMO binding (groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13).</p>
+<p>Although these experiments are not in human cells, they provide a plausible mechanistic basis for human MORC3’s effects on viral genomes and foreign DNA templates, consistent with the 2023 AAV restriction-factor finding and with interferon-program repression in cancer models (OpenTargets Search: -MORC3, fu2024genomewideanalysisreveals pages 3-7).</p>
+<h3 id="4-pathways-and-interaction-context">4) Pathways and interaction context</h3>
+<p><strong>SUMO–PML nuclear body pathway.</strong> MORC3 is SUMOylated and operates as a SUMO-regulated PML-NB client, with localization mediated by SUMO–SIM interaction with PML.I. This situates MORC3 within the broader PML-NB/SUMO pathway central to intrinsic immunity and nuclear quality control (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).</p>
+<p><strong>Intrinsic immunity and interferon pathway modulation.</strong> In OSCC/HNSCC models, MORC3 knockdown upregulated interferon-associated genes and increased STAT1 and PD-L1, suggesting MORC3 suppresses interferon-driven transcriptional programs in this context (fu2024genomewideanalysisreveals pages 3-7). In myositis/cancer-associated myositis literature, MORC3 is described as an antiviral factor and a repressor of IFNB1 (patasova2023geneticinfluencesin pages 6-8). Together, these suggest MORC3 contributes to a chromatin-based brake on interferon gene expression, with context-dependent consequences (antiviral restriction in fibroblast/hepatocyte models vs immune evasion phenotypes in cancer).</p>
+<h3 id="5-current-applications-and-real-world-implementations">5) Current applications and real-world implementations</h3>
+<h4 id="51-clinical-biomarker-anti-nxp2-anti-morc3-in-idiopathic-inflammatory-myopathies">5.1 Clinical biomarker: anti-NXP2 (anti-MORC3) in idiopathic inflammatory myopathies</h4>
+<p>Anti-NXP2 autoantibodies (targeting MORC3/NXP2) are used in clinical phenotyping and risk stratification of dermatomyositis. Recent synthesis reports prevalence of ~22–25% in juvenile DM and 1–17% in adult DM, and highlights associations with muscle disease severity and calcinosis (patasova2023geneticinfluencesin pages 6-8). These antibodies are also discussed in the context of cancer-associated myositis with summaries of retrospective malignancy proportions (24–37.5% in anti-NXP2-positive adults across certain series) and an estimated ~30% increase in cancer-associated myositis risk in adult DM (patasova2023geneticinfluencesin pages 6-8). These data support clinical utility but also underscore heterogeneity and the need for careful interpretation across cohorts.</p>
+<h4 id="52-gene-therapy-optimization-overcoming-morc3-mediated-transgene-silencing">5.2 Gene therapy optimization: overcoming MORC3-mediated transgene silencing</h4>
+<p>Because MORC3 knockout increases rAAV and other vector transgene expression in human primary cells, MORC3 (and related epigenetic restriction factors) represent actionable targets for improving gene therapy efficacy through vector engineering or transient modulation of host restriction pathways (OpenTargets Search: -MORC3).</p>
+<h4 id="53-cancer-immuno-oncology-morc3-as-a-potential-modulator-of-pd-l1ifn-programs">5.3 Cancer immuno-oncology: MORC3 as a potential modulator of PD-L1/IFN programs</h4>
+<p>The 2024 head and neck cancer study suggests MORC3 acts as a negative regulator of PD-L1 and interferon programs, linking its expression level to survival and tumor immune signaling (fu2024genomewideanalysisreveals pages 3-7). This provides a hypothesis-generating direction for biomarker development and for combination strategies involving immune checkpoint modulation, though further validation in independent cohorts and mechanistic work is needed.</p>
+<h3 id="6-expert-opinions-and-analysis-from-authoritative-sources-within-the-retrieved-set">6) Expert opinions and analysis (from authoritative sources within the retrieved set)</h3>
+<ul>
+<li>The 2016 virology study interprets MORC3 as a <strong>PML-NB component</strong> whose SUMO-dependent recruitment to incoming viral genomes contributes to intrinsic restriction, and shows that HSV-1 ICP0 antagonizes MORC3 by degradation—an archetypal virus–host arms race feature of intrinsic immunity (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).</li>
+<li>The 2023 gene therapy restriction-factor study frames MORC3/SETDB1-linked factors as practical modulators of foreign DNA silencing that could be leveraged to enhance therapeutic transgene expression (OpenTargets Search: -MORC3).</li>
+<li>The 2024 cancer study interprets MORC3 as a repressor of IFN-associated pathways and PD-L1 and connects its downregulation to poor outcomes, suggesting a role in shaping tumor immune landscapes (fu2024genomewideanalysisreveals pages 3-7).</li>
+<li>The 2023 cancer-associated myositis review treats MORC3/NXP2 as both an autoantigen biomarker and a protein with plausible mechanistic ties to malignancy-related immune phenomena (via chromatin/p53/innate immunity links), while acknowledging that evidence is built from diverse retrospective cohorts (patasova2023geneticinfluencesin pages 6-8).</li>
+</ul>
+<h3 id="7-relevant-statistics-and-quantitative-data-points-recent-studies-prioritized-where-possible">7) Relevant statistics and quantitative data points (recent studies prioritized where possible)</h3>
+<ul>
+<li><strong>~5.6-fold decrease</strong> in MORC3 abundance during HSV-1 infection (SILAC proteomics), with ICP0-dependent degradation of both SUMOylated and unmodified MORC3 (sloan2016morc3acomponent pages 3-5).</li>
+<li>OSCC/HNSCC cancer study sample sizes: <strong>48 OSCC vs 10 normal</strong> oral mucosa on tissue microarray; male TCGA HNSCC survival stratification <strong>high MORC3 n=105 vs low n=262</strong>; <strong>270 DEGs</strong> upon MORC3 knockdown (fu2024genomewideanalysisreveals pages 3-7).</li>
+<li>Anti-NXP2 prevalence and cancer association (reviewed data): <strong>~22–25% juvenile DM</strong>, <strong>1–17% adult DM</strong>, estimated ~<strong>30%</strong> increased risk of cancer-associated myositis in adult-onset DM, and <strong>24–37.5%</strong> malignancy in anti-NXP2-positive adults in certain retrospective series (patasova2023geneticinfluencesin pages 6-8).</li>
+<li>OpenTargets disease associations (database synthesis): MORC3 has reported associations with cardiovascular disease and hypertension (scores ~0.52–0.54) based on limited evidence entries (OpenTargets Search: -MORC3).</li>
+</ul>
+<h3 id="summary-table-of-major-functional-themes">Summary table of major functional themes</h3>
+<table>
+<thead>
+<tr>
+<th>Functional theme</th>
+<th>Key mechanism</th>
+<th>Experimental evidence type</th>
+<th>Key quantitative/statistical points (if available)</th>
+<th>Representative recent source with DOI/URL and publication month/year</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>PML nuclear bodies / viral restriction</td>
+<td>Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e)</td>
+<td>SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown, viral protein immunoblotting</td>
+<td>MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3 depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e)</td>
+<td>Sloan et al., <em>J Virol</em> (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16</td>
+</tr>
+<tr>
+<td>Epigenetic silencing / chromatin regulation</td>
+<td>MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains; ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13)</td>
+<td>Genome-wide sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR</td>
+<td>2,737 reproducible Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13)</td>
+<td>Groh et al., <em>Nat Commun</em> (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7</td>
+</tr>
+<tr>
+<td>Innate immunity / IFNB1 repression</td>
+<td>Recent work positions MORC3 as a negative regulator of type I interferon programs: it represses IFNB1 and broader IFN-stimulated gene expression, consistent with SUMO- and ATPase-dependent chromatin repression. In cancer cells, MORC3 knockdown derepresses IFN-associated genes; reviews of cancer-associated myositis also summarize MORC3 as an antiviral factor and IFNB1 repressor. (patasova2023geneticinfluencesin pages 6-8, fu2024genomewideanalysisreveals pages 1-2, fu2024genomewideanalysisreveals pages 3-7)</td>
+<td>RNAi knockdown, RNA-seq, qRT-PCR, pathway enrichment, single-cell correlation analyses; clinical-review synthesis</td>
+<td>In CAL27 cells, MORC3 knockdown yielded 270 DEGs (171 up, 99 down) and increased expression of multiple IFN-related genes (including MX2, IFIT1/2, IRF7, IRF9, IFI44L, IFIH1); reviews report anti-NXP2 adult DM cancer risk elevation of ~30% and connect MORC3 to antiviral/IFNB1-repressive biology. (fu2024genomewideanalysisreveals pages 3-7, patasova2023geneticinfluencesin pages 6-8)</td>
+<td>Fu et al., <em>Front Cell Dev Biol</em> (Sep 2024), DOI: 10.3389/fcell.2024.1410130, https://doi.org/10.3389/fcell.2024.1410130; Patasova et al., <em>Arthritis Rheumatol</em> (Dec 2023), DOI: 10.1002/art.42345, https://doi.org/10.1002/art.42345</td>
+</tr>
+<tr>
+<td>Cancer / PD-L1 regulation</td>
+<td>In head and neck/oral squamous cancer, MORC3 acts as a transcriptional repressor of immune-evasion pathways: knockdown increases STAT1 and PD-L1 and induces IFN-associated programs; LINC00880 contributes to this PD-L1 upregulation. MORC3 expression is broadly reduced in multiple cancers and higher expression is associated with better survival in HNSCC analyses. (fu2024genomewideanalysisreveals pages 2-3, fu2024genomewideanalysisreveals pages 1-2, fu2024genomewideanalysisreveals pages 3-7)</td>
+<td>TCGA/GEPIA2 bioinformatics, RNA-seq after siRNA knockdown, qRT-PCR, western blot, flow cytometry, tissue microarray IHC, single-cell transcriptomics</td>
+<td>Tissue microarray included 48 OSCC and 10 normal oral mucosa samples; survival comparison reported high MORC3 expression (n=105) vs low (n=262) in male TCGA HNSCC; MORC3 knockdown increased STAT1 and PD-L1 and promoted proliferation. (fu2024genomewideanalysisreveals pages 2-3, fu2024genomewideanalysisreveals pages 3-7)</td>
+<td>Fu et al., <em>Front Cell Dev Biol</em> (Sep 2024), DOI: 10.3389/fcell.2024.1410130, https://doi.org/10.3389/fcell.2024.1410130</td>
+</tr>
+<tr>
+<td>Biomarker / anti-NXP2 autoantibodies in myositis</td>
+<td>MORC3/NXP2 is a clinically important autoantigen in idiopathic inflammatory myopathies, especially dermatomyositis. Anti-NXP2 antibodies are used as serologic biomarkers associated with dermatomyositis, severe muscle disease/calcinosis, dysphagia in some cohorts, and possible cancer association in adults; assay methodology matters because line blot may overcall positivity relative to immunoprecipitation. (patasova2023geneticinfluencesin pages 6-8, OpenTargets Search: -MORC3)</td>
+<td>Multicenter serology studies, immunoprecipitation, line blot, IP-Western, clinical correlation studies, review synthesis</td>
+<td>Anti-NXP2 reported in ~22–25% of juvenile DM and 1–17% of adult-onset DM; retrospective adult series found malignancy in 24–37.5% of anti-NXP2-positive adults; in an Italian multicenter study, 60 line-blot-positive patients were analyzed, but IP confirmed 31/52 available sera (62%); anti-NXP2 positivity was associated with younger onset and more dermatomyositis, while cancer risk was similar to NXP2-negative myositis in that cohort. (patasova2023geneticinfluencesin pages 6-8, OpenTargets Search: -MORC3)</td>
+<td>Patasova et al., <em>Arthritis Rheumatol</em> (Dec 2023), DOI: 10.1002/art.42345, https://doi.org/10.1002/art.42345; Fredi et al., <em>Clin Rev Allergy Immunol</em> (Jan 2022), DOI: 10.1007/s12016-021-08920-y, https://doi.org/10.1007/s12016-021-08920-y</td>
+</tr>
+<tr>
+<td>Gene therapy relevance / restriction of transgene expression</td>
+<td>MORC3 functions as a cellular restriction factor that suppresses expression from recombinant AAV and other viral vectors, likely via chromatin-based silencing pathways overlapping with SETDB1-linked repression. This gives MORC3 translational relevance in vector engineering and gene therapy optimization. (OpenTargets Search: -MORC3)</td>
+<td>Genome-scale CRISPR screens, knockout validation in human cells and primary cells, transgene expression assays across vector serotypes</td>
+<td>MORC3 knockout increased transgene expression from several AAV serotypes and also improved expression from lentiviral and adenoviral vectors; enhancement was observed in human primary cells, supporting physiological relevance. (OpenTargets Search: -MORC3)</td>
+<td>Ngo &amp; Puschnik, <em>J Virol</em> (Apr 2023), DOI: 10.1128/jvi.01948-22, https://doi.org/10.1128/jvi.01948-22</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the main experimentally supported functional annotations for human MORC3/NXP2, including nuclear-body biology, chromatin silencing, innate immune regulation, cancer relevance, biomarker use, and translational implications. It prioritizes recent 2023-2024 evidence where available and includes quantitative points and source details.</em></p>
+<h3 id="key-primary-sources-urls-and-publication-dates">Key primary sources (URLs and publication dates)</h3>
+<ul>
+<li>Sloan E, Orr A, Everett RD. <strong>“MORC3, a Component of PML Nuclear Bodies, Has a Role in Restricting Herpes Simplex Virus 1 and Human Cytomegalovirus.”</strong> <em>Journal of Virology</em> (Oct 2016). https://doi.org/10.1128/JVI.00621-16 (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15)</li>
+<li>Ngo AM, Puschnik AS. <strong>“Genome-Scale Analysis of Cellular Restriction Factors That Inhibit Transgene Expression from Adeno-Associated Virus Vectors.”</strong> <em>Journal of Virology</em> (Apr 2023). https://doi.org/10.1128/jvi.01948-22 (OpenTargets Search: -MORC3)</li>
+<li>Fu W, Chang X, Ye K, et al. <strong>“Genome-wide analysis reveals the MORC3-mediated repression of PD-L1 expression in head and neck cancer.”</strong> <em>Frontiers in Cell and Developmental Biology</em> (Sep 2024). https://doi.org/10.3389/fcell.2024.1410130 (fu2024genomewideanalysisreveals pages 3-7)</li>
+<li>Patasova K, Lundberg IE, Holmqvist M. <strong>“Genetic Influences in Cancer-Associated Myositis.”</strong> <em>Arthritis &amp; Rheumatology</em> (Dec 2023). https://doi.org/10.1002/art.42345 (patasova2023geneticinfluencesin pages 6-8)</li>
+<li>Groh S, Milton AV, Marinelli LK, et al. <strong>“Morc3 silences endogenous retroviruses by enabling Daxx-mediated histone H3.3 incorporation.”</strong> <em>Nature Communications</em> (Oct 2021). https://doi.org/10.1038/s41467-021-26288-7 (groh2021morc3silencesendogenous pages 1-2)</li>
+</ul>
+<h3 id="notes-on-evidence-scope-and-limitations">Notes on evidence scope and limitations</h3>
+<ul>
+<li>Some mechanistic chromatin-silencing evidence is derived from <strong>mouse Morc3</strong> ES cell systems. These experiments provide strong mechanistic clarity (ATPase cycle/SUMOylation→Daxx→H3.3 deposition→ERV silencing) and are likely relevant to human MORC3 due to conserved architecture, but the specific loci and regulatory partners may be context dependent (groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13).</li>
+<li>The 2024 PD-L1 finding is currently supported by one primary study in head and neck cancer models and requires broader validation (fu2024genomewideanalysisreveals pages 3-7).</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(sloan2016morc3acomponent pages 3-5): Elizabeth Sloan, Anne Orr, and Roger D. Everett. Morc3, a component of pml nuclear bodies, has a role in restricting herpes simplex virus 1 and human cytomegalovirus. Journal of Virology, 90:8621-8633, Oct 2016. URL: https://doi.org/10.1128/jvi.00621-16, doi:10.1128/jvi.00621-16. This article has 68 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sloan2016morc3acomponent pages 13-15): Elizabeth Sloan, Anne Orr, and Roger D. Everett. Morc3, a component of pml nuclear bodies, has a role in restricting herpes simplex virus 1 and human cytomegalovirus. Journal of Virology, 90:8621-8633, Oct 2016. URL: https://doi.org/10.1128/jvi.00621-16, doi:10.1128/jvi.00621-16. This article has 68 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(groh2021morc3silencesendogenous pages 10-11): Sophia Groh, Anna Viktoria Milton, Lisa Katherina Marinelli, Cara V. Sickinger, Angela Russo, Heike Bollig, Gustavo Pereira de Almeida, Andreas Schmidt, Ignasi Forné, Axel Imhof, and Gunnar Schotta. Morc3 silences endogenous retroviruses by enabling daxx-mediated histone h3.3 incorporation. Nature Communications, Oct 2021. URL: https://doi.org/10.1038/s41467-021-26288-7, doi:10.1038/s41467-021-26288-7. This article has 60 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fu2024genomewideanalysisreveals pages 3-7): Wenxuan Fu, Xiaomeng Chang, Kun Ye, Zige Zheng, Qianyi Lai, Minyang Ge, and Yan Shi. Genome-wide analysis reveals the morc3-mediated repression of pd-l1 expression in head and neck cancer. Frontiers in Cell and Developmental Biology, Sep 2024. URL: https://doi.org/10.3389/fcell.2024.1410130, doi:10.3389/fcell.2024.1410130. This article has 1 citations.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -MORC3): Open Targets Query (-MORC3, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(fu2024genomewideanalysisreveals pages 2-3): Wenxuan Fu, Xiaomeng Chang, Kun Ye, Zige Zheng, Qianyi Lai, Minyang Ge, and Yan Shi. Genome-wide analysis reveals the morc3-mediated repression of pd-l1 expression in head and neck cancer. Frontiers in Cell and Developmental Biology, Sep 2024. URL: https://doi.org/10.3389/fcell.2024.1410130, doi:10.3389/fcell.2024.1410130. This article has 1 citations.</p>
+</li>
+<li>
+<p>(patasova2023geneticinfluencesin pages 6-8): Karina Patasova, Ingrid E. Lundberg, and Marie Holmqvist. Genetic influences in <scp>cancer‐associated</scp> myositis. Arthritis &amp; Rheumatology, 75:153-163, Dec 2023. URL: https://doi.org/10.1002/art.42345, doi:10.1002/art.42345. This article has 17 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sloan2016morc3acomponent media 84630a9e): Elizabeth Sloan, Anne Orr, and Roger D. Everett. Morc3, a component of pml nuclear bodies, has a role in restricting herpes simplex virus 1 and human cytomegalovirus. Journal of Virology, 90:8621-8633, Oct 2016. URL: https://doi.org/10.1128/jvi.00621-16, doi:10.1128/jvi.00621-16. This article has 68 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sloan2016morc3acomponent media 5b6c97c8): Elizabeth Sloan, Anne Orr, and Roger D. Everett. Morc3, a component of pml nuclear bodies, has a role in restricting herpes simplex virus 1 and human cytomegalovirus. Journal of Virology, 90:8621-8633, Oct 2016. URL: https://doi.org/10.1128/jvi.00621-16, doi:10.1128/jvi.00621-16. This article has 68 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(groh2021morc3silencesendogenous pages 1-2): Sophia Groh, Anna Viktoria Milton, Lisa Katherina Marinelli, Cara V. Sickinger, Angela Russo, Heike Bollig, Gustavo Pereira de Almeida, Andreas Schmidt, Ignasi Forné, Axel Imhof, and Gunnar Schotta. Morc3 silences endogenous retroviruses by enabling daxx-mediated histone h3.3 incorporation. Nature Communications, Oct 2021. URL: https://doi.org/10.1038/s41467-021-26288-7, doi:10.1038/s41467-021-26288-7. This article has 60 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(groh2020morc3silencesendogenous pages 10-13): Sophia Groh, Anna Viktoria Milton, Lisa Marinelli, Cara V. Sickinger, Heike Bollig, Gustavo Pereira de Almeida, Ignasi Forné, Andreas Schmidt, Axel Imhof, and Gunnar Schotta. Morc3 silences endogenous retroviruses by enabling daxx-mediated h3.3 incorporation. bioRxiv, Nov 2020. URL: https://doi.org/10.1101/2020.11.12.380204, doi:10.1101/2020.11.12.380204. This article has 2 citations.</p>
+</li>
+<li>
+<p>(groh2020morc3silencesendogenous pages 7-10): Sophia Groh, Anna Viktoria Milton, Lisa Marinelli, Cara V. Sickinger, Heike Bollig, Gustavo Pereira de Almeida, Ignasi Forné, Andreas Schmidt, Axel Imhof, and Gunnar Schotta. Morc3 silences endogenous retroviruses by enabling daxx-mediated h3.3 incorporation. bioRxiv, Nov 2020. URL: https://doi.org/10.1101/2020.11.12.380204, doi:10.1101/2020.11.12.380204. This article has 2 citations.</p>
+</li>
+<li>
+<p>(fu2024genomewideanalysisreveals pages 1-2): Wenxuan Fu, Xiaomeng Chang, Kun Ye, Zige Zheng, Qianyi Lai, Minyang Ge, and Yan Shi. Genome-wide analysis reveals the morc3-mediated repression of pd-l1 expression in head and neck cancer. Frontiers in Cell and Developmental Biology, Sep 2024. URL: https://doi.org/10.3389/fcell.2024.1410130, doi:10.3389/fcell.2024.1410130. This article has 1 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>fu2024genomewideanalysisreveals pages 3-7</li>
+<li>patasova2023geneticinfluencesin pages 6-8</li>
+<li>fu2024genomewideanalysisreveals pages 2-3</li>
+<li>fu2024genomewideanalysisreveals pages 1-2</li>
+<li>https://doi.org/10.1128/JVI.00621-16</li>
+<li>https://doi.org/10.1038/s41467-021-26288-7</li>
+<li>https://doi.org/10.3389/fcell.2024.1410130;</li>
+<li>https://doi.org/10.1002/art.42345</li>
+<li>https://doi.org/10.3389/fcell.2024.1410130</li>
+<li>https://doi.org/10.1002/art.42345;</li>
+<li>https://doi.org/10.1007/s12016-021-08920-y</li>
+<li>https://doi.org/10.1128/jvi.01948-22</li>
+<li>https://doi.org/10.1128/jvi.00621-16,</li>
+<li>https://doi.org/10.1038/s41467-021-26288-7,</li>
+<li>https://doi.org/10.3389/fcell.2024.1410130,</li>
+<li>https://doi.org/10.1002/art.42345,</li>
+<li>https://doi.org/10.1101/2020.11.12.380204,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -3712,11 +5438,15 @@
                 <pre><code>id: Q14149
 gene_symbol: MORC3
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: &#39;TODO: Add description for MORC3&#39;
+description: &gt;-
+  MORC3/NXP2 is a nuclear matrix and PML nuclear body-associated MORC-family GHKL/HATPase protein with a CW-type zinc finger
+  that reads methylated H3K4. It functions as a SUMO-regulated chromatin/PML-body scaffold and ATPase involved in intrinsic
+  antiviral restriction, chromatin-associated repression, recruitment/maintenance of nuclear restriction factors, and negative
+  regulation of interferon-beta programs.
 existing_annotations:
   - term:
       id: GO:0005634
@@ -3724,337 +5454,733 @@ existing_annotations:
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 is a nuclear/nuclear-matrix protein and PML nuclear body component.
+      action: ACCEPT
+      reason: &gt;-
+        Nuclear localization is strongly supported, although more specific PML body and nuclear matrix terms should also be
+        retained.
+      supported_by: &amp;id001
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            MORC3 is consistently characterized as a **nuclear matrix protein** that localizes to **PML nuclear bodies**.
+            In immunofluorescence microscopy, MORC3 colocalizes with the PML-NB component Sp100 in punctate nuclear structures
+            (sloan2016morc3acomponent media 84630a9e). During infection with HSV-1 lacking ICP0, MORC3 is recruited to sites
+            associated with incoming viral genomes (identified by ICP4 foci), consistent with a role in intrinsic restriction
+            at early stages of infection (sloan2016morc3acomponent media 5b6c97c8).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            Mechanistically, the association with PML-NBs is reported to occur via **SUMO–SIM interaction** with PML.I, and
+            PML-NB localization/recruitment functions require a **functional ATPase domain** (sloan2016morc3acomponent pages
+            3-5, sloan2016morc3acomponent pages 13-15).
   - term:
       id: GO:0140002
       label: histone H3K4me3 reader activity
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        The MORC3 CW-type zinc finger is reported to bind methylated H3K4.
+      action: ACCEPT
+      reason: &gt;-
+        Histone H3K4me3 reader activity is consistent with the CW-domain evidence and chromatin-associated function.
+      supported_by: &amp;id003
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            **Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules:
+            (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type
+            zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization
+            (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated
+            ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent
+            interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent
+            pages 3-5).
   - term:
       id: GO:0140374
       label: antiviral innate immune response
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 contributes to intrinsic antiviral restriction, including PML-body-associated restriction of HSV-1 and HCMV.
+      action: ACCEPT
+      reason: &gt;-
+        Antiviral innate immune response is a supported major function of MORC3.
+      supported_by: &amp;id002
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            | PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes
+            to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization
+            and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes
+            recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading
+            MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other
+            contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent
+            media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown,
+            viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3
+            depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque
+            formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages
+            3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol*
+            (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0016605
       label: PML body
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 localizes to PML nuclear bodies through SUMO/SIM-dependent interactions and helps recruit restriction factors
+        there.
+      action: ACCEPT
+      reason: &gt;-
+        PML body localization is one of the best-supported cellular component annotations for MORC3.
+      supported_by: *id001
   - term:
       id: GO:0006325
       label: chromatin organization
     evidence_type: IEA
     original_reference_id: GO_REF:0000108
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 is a chromatin-associated ATPase/scaffold implicated in epigenetic repression and chromatin organization.
+      action: ACCEPT
+      reason: &gt;-
+        Chromatin organization is supported by conserved MORC3 mechanism and by MORC3-mediated repression of viral/foreign
+        DNA and interferon programs.
+      supported_by: &amp;id004
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            **Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules:
+            (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type
+            zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization
+            (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated
+            ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent
+            interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            | Epigenetic silencing / chromatin regulation | MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains;
+            ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement
+            loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism
+            is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous
+            pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Genome-wide
+            sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR | 2,737 reproducible
+            Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS
+            identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous
+            pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Groh et
+            al., *Nat Commun* (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7 |
   - term:
       id: GO:0002376
       label: immune system process
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 has immune functions, but the evidence supports the more specific antiviral innate immune response and interferon-beta
+        regulatory terms.
+      action: MODIFY
+      reason: &gt;-
+        Use antiviral innate immune response rather than the broad parent immune system process.
+      proposed_replacement_terms:
+        - id: GO:0140374
+          label: antiviral innate immune response
+      supported_by: *id002
   - term:
       id: GO:0003723
       label: RNA binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        The curated MORC3 literature supports ATPase, CW histone-reader, chromatin/PML-body scaffold, and antiviral restriction
+        roles, not direct RNA binding.
+      action: REMOVE
+      reason: &gt;-
+        This electronically inferred RNA-binding annotation is not supported by the gene-specific functional synthesis.
+      supported_by: *id003
   - term:
       id: GO:0005654
       label: nucleoplasm
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 is nuclear, but the more specific supported locations are PML bodies and nuclear matrix/chromatin-associated
+        nuclear structures.
+      action: MODIFY
+      reason: &gt;-
+        Use PML body and nuclear matrix instead of broad nucleoplasm when curating MORC3 localization.
+      proposed_replacement_terms:
+        - id: GO:0016605
+          label: PML body
+        - id: GO:0016363
+          label: nuclear matrix
+      supported_by: *id001
   - term:
       id: GO:0005694
       label: chromosome
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 is chromatin-associated, but chromosome is a broad location for this evidence.
+      action: MODIFY
+      reason: &gt;-
+        Use chromatin to represent the supported chromosome-associated localization/function more precisely.
+      proposed_replacement_terms:
+        - id: GO:0000785
+          label: chromatin
+      supported_by: *id004
   - term:
       id: GO:0008270
       label: zinc ion binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 contains a CW-type zinc finger domain.
+      action: ACCEPT
+      reason: &gt;-
+        Zinc ion binding is supported by the CW zinc-finger domain architecture.
+      supported_by: *id003
   - term:
       id: GO:0016363
       label: nuclear matrix
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3/NXP2 is consistently characterized as a nuclear matrix protein.
+      action: ACCEPT
+      reason: &gt;-
+        Nuclear matrix localization is supported by the literature synthesis.
+      supported_by:
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            MORC3 is consistently characterized as a **nuclear matrix protein** that localizes to **PML nuclear bodies**.
+            In immunofluorescence microscopy, MORC3 colocalizes with the PML-NB component Sp100 in punctate nuclear structures
+            (sloan2016morc3acomponent media 84630a9e). During infection with HSV-1 lacking ICP0, MORC3 is recruited to sites
+            associated with incoming viral genomes (identified by ICP4 foci), consistent with a role in intrinsic restriction
+            at early stages of infection (sloan2016morc3acomponent media 5b6c97c8).
   - term:
       id: GO:0016605
       label: PML body
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 localizes to PML nuclear bodies through SUMO/SIM-dependent interactions and helps recruit restriction factors
+        there.
+      action: ACCEPT
+      reason: &gt;-
+        PML body localization is one of the best-supported cellular component annotations for MORC3.
+      supported_by: *id001
   - term:
       id: GO:0016887
       label: ATP hydrolysis activity
     evidence_type: IEA
     original_reference_id: GO_REF:0000002
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 is a MORC-family GHKL/HATPase ATPase, and ATPase activity is required for PML-body localization/recruitment
+        functions.
+      action: ACCEPT
+      reason: &gt;-
+        ATP hydrolysis activity is a core molecular feature of MORC3.
+      supported_by:
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            **Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules:
+            (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type
+            zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization
+            (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated
+            ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent
+            interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            Mechanistically, the association with PML-NBs is reported to occur via **SUMO–SIM interaction** with PML.I, and
+            PML-NB localization/recruitment functions require a **functional ATPase domain** (sloan2016morc3acomponent pages
+            3-5, sloan2016morc3acomponent pages 13-15).
   - term:
       id: GO:0045087
       label: innate immune response
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 participates in innate immunity, but the evidence is specifically antiviral restriction and interferon regulation.
+      action: MODIFY
+      reason: &gt;-
+        Use antiviral innate immune response for the supported immune role.
+      proposed_replacement_terms:
+        - id: GO:0140374
+          label: antiviral innate immune response
+      supported_by: *id002
   - term:
       id: GO:0046872
       label: metal ion binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 metal binding is specifically attributable to its CW-type zinc finger.
+      action: MODIFY
+      reason: &gt;-
+        Use zinc ion binding rather than generic metal ion binding.
+      proposed_replacement_terms:
+        - id: GO:0008270
+          label: zinc ion binding
+      supported_by: *id003
   - term:
       id: GO:0140002
       label: histone H3K4me3 reader activity
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        The MORC3 CW-type zinc finger is reported to bind methylated H3K4.
+      action: ACCEPT
+      reason: &gt;-
+        Histone H3K4me3 reader activity is consistent with the CW-domain evidence and chromatin-associated function.
+      supported_by: *id003
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:26496610
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding
+        is not informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin
+        organization, and antiviral restriction.
       supported_by:
-        - reference_id: PMID:26496610
-          supporting_text: Oct 22. A human interactome in three quantitative 
-            dimensions organized by stoichiometries and abundances.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:27173435
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding
+        is not informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin
+        organization, and antiviral restriction.
       supported_by:
-        - reference_id: PMID:27173435
-          supporting_text: An organelle-specific protein landscape identifies 
-            novel diseases and molecular mechanisms.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:32296183
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding
+        is not informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin
+        organization, and antiviral restriction.
       supported_by:
-        - reference_id: PMID:32296183
-          supporting_text: Apr 8. A reference map of the human binary protein 
-            interactome.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:33961781
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding
+        is not informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin
+        organization, and antiviral restriction.
       supported_by:
-        - reference_id: PMID:33961781
-          supporting_text: 2021 May 6. Dual proteome-scale networks reveal 
-            cell-specific remodeling of the human interactome.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:35271311
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding
+        is not informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin
+        organization, and antiviral restriction.
       supported_by:
-        - reference_id: PMID:35271311
-          supporting_text: &#39;2022 Mar 11. OpenCell: Endogenous tagging for the cartography
-            of human cellular organization.&#39;
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:35914814
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding
+        is not informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin
+        organization, and antiviral restriction.
       supported_by:
-        - reference_id: PMID:35914814
-          supporting_text: &#34;Chr21 protein-protein interactions: enrichment in proteins
-            involved in intellectual disability, autism, and late-onset Alzheimer&#39;s
-            disease.&#34;
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:40205054
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding
+        is not informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin
+        organization, and antiviral restriction.
       supported_by:
-        - reference_id: PMID:40205054
-          supporting_text: Apr 9. Multimodal cell maps as a foundation for 
-            structural and functional genomics.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 is a nuclear/nuclear-matrix protein and PML nuclear body component.
+      action: ACCEPT
+      reason: &gt;-
+        Nuclear localization is strongly supported, although more specific PML body and nuclear matrix terms should also be
+        retained.
+      supported_by: *id001
   - term:
       id: GO:0005654
       label: nucleoplasm
     evidence_type: IDA
     original_reference_id: GO_REF:0000052
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 is nuclear, but the more specific supported locations are PML bodies and nuclear matrix/chromatin-associated
+        nuclear structures.
+      action: MODIFY
+      reason: &gt;-
+        Use PML body and nuclear matrix instead of broad nucleoplasm when curating MORC3 localization.
+      proposed_replacement_terms:
+        - id: GO:0016605
+          label: PML body
+        - id: GO:0016363
+          label: nuclear matrix
+      supported_by: *id001
   - term:
       id: GO:0140002
       label: histone H3K4me3 reader activity
     evidence_type: IDA
     original_reference_id: PMID:26933034
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:26933034
-          supporting_text: 2016 Mar 1. Family-wide Characterization of Histone 
-            Binding Abilities of Human CW Domain-containing Proteins.
+      summary: &gt;-
+        The MORC3 CW-type zinc finger is reported to bind methylated H3K4.
+      action: ACCEPT
+      reason: &gt;-
+        Histone H3K4me3 reader activity is consistent with the CW-domain evidence and chromatin-associated function.
+      supported_by: *id003
   - term:
       id: GO:0000122
       label: negative regulation of transcription by RNA polymerase II
     evidence_type: IDA
     original_reference_id: PMID:34759314
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 contributes to repression of transcriptional programs, including IFNB1/interferon-linked gene regulation and
+        foreign DNA silencing.
+      action: ACCEPT
+      reason: &gt;-
+        Negative regulation of RNA polymerase II transcription is consistent with the MORC3 chromatin repression evidence.
       supported_by:
-        - reference_id: PMID:34759314
-          supporting_text: Nov 10. Self-guarding of MORC3 enables virulence 
-            factor-triggered immunity.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            **Intrinsic immunity and interferon pathway modulation.** In OSCC/HNSCC models, MORC3 knockdown upregulated interferon-associated
+            genes and increased STAT1 and PD-L1, suggesting MORC3 suppresses interferon-driven transcriptional programs in
+            this context (fu2024genomewideanalysisreveals pages 3-7). In myositis/cancer-associated myositis literature, MORC3
+            is described as an antiviral factor and a repressor of IFNB1 (patasova2023geneticinfluencesin pages 6-8). Together,
+            these suggest MORC3 contributes to a chromatin-based brake on interferon gene expression, with context-dependent
+            consequences (antiviral restriction in fibroblast/hepatocyte models vs immune evasion phenotypes in cancer).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            | Epigenetic silencing / chromatin regulation | MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains;
+            ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement
+            loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism
+            is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous
+            pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Genome-wide
+            sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR | 2,737 reproducible
+            Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS
+            identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous
+            pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Groh et
+            al., *Nat Commun* (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7 |
   - term:
       id: GO:0000785
       label: chromatin
     evidence_type: IDA
     original_reference_id: PMID:34759314
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:34759314
-          supporting_text: Nov 10. Self-guarding of MORC3 enables virulence 
-            factor-triggered immunity.
+      summary: &gt;-
+        MORC3 is a chromatin-associated ATPase/scaffold with roles in repressive chromatin states.
+      action: ACCEPT
+      reason: &gt;-
+        Chromatin localization/function is supported by the mechanistic synthesis.
+      supported_by: *id004
   - term:
       id: GO:0003677
       label: DNA binding
     evidence_type: IDA
     original_reference_id: PMID:34759314
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 regulates chromatin/DNA elements, but available synthesized evidence supports chromatin association and MRE
+        regulation rather than a clearly separable direct DNA-binding MF.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Curate the supported chromatin and transcription-regulatory roles instead of broad DNA binding unless direct DNA-binding
+        evidence is reviewed in detail.
       supported_by:
-        - reference_id: PMID:34759314
-          supporting_text: Nov 10. Self-guarding of MORC3 enables virulence 
-            factor-triggered immunity.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            **Intrinsic immunity and interferon pathway modulation.** In OSCC/HNSCC models, MORC3 knockdown upregulated interferon-associated
+            genes and increased STAT1 and PD-L1, suggesting MORC3 suppresses interferon-driven transcriptional programs in
+            this context (fu2024genomewideanalysisreveals pages 3-7). In myositis/cancer-associated myositis literature, MORC3
+            is described as an antiviral factor and a repressor of IFNB1 (patasova2023geneticinfluencesin pages 6-8). Together,
+            these suggest MORC3 contributes to a chromatin-based brake on interferon gene expression, with context-dependent
+            consequences (antiviral restriction in fibroblast/hepatocyte models vs immune evasion phenotypes in cancer).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            | Epigenetic silencing / chromatin regulation | MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains;
+            ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement
+            loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism
+            is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous
+            pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Genome-wide
+            sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR | 2,737 reproducible
+            Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS
+            identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous
+            pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Groh et
+            al., *Nat Commun* (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7 |
   - term:
       id: GO:0016605
       label: PML body
     evidence_type: IDA
     original_reference_id: PMID:27440897
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:27440897
-          supporting_text: MORC3, a Component of PML Nuclear Bodies, Has a Role 
-            in Restricting Herpes Simplex Virus 1 and Human Cytomegalovirus.
+      summary: &gt;-
+        MORC3 localizes to PML nuclear bodies through SUMO/SIM-dependent interactions and helps recruit restriction factors
+        there.
+      action: ACCEPT
+      reason: &gt;-
+        PML body localization is one of the best-supported cellular component annotations for MORC3.
+      supported_by: *id001
   - term:
       id: GO:0030674
       label: protein-macromolecule adaptor activity
     evidence_type: IDA
     original_reference_id: PMID:27440897
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 functions as a SUMO-regulated scaffold/adaptor for PML-body and viral-genome-associated restriction factors.
+      action: ACCEPT
+      reason: &gt;-
+        Protein-macromolecule adaptor activity is supported by MORC3-dependent recruitment of PML, Sp100, hDaxx, gamma-H2AX,
+        p53, and related nuclear factors.
       supported_by:
-        - reference_id: PMID:27440897
-          supporting_text: MORC3, a Component of PML Nuclear Bodies, Has a Role 
-            in Restricting Herpes Simplex Virus 1 and Human Cytomegalovirus.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            | PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes
+            to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization
+            and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes
+            recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading
+            MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other
+            contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent
+            media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown,
+            viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3
+            depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque
+            formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages
+            3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol*
+            (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |
   - term:
       id: GO:0032688
       label: negative regulation of interferon-beta production
     evidence_type: IDA
     original_reference_id: PMID:34759314
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        Loss or degradation of MORC3 derepresses IFNB1/interferon programs, supporting a negative regulatory role.
+      action: ACCEPT
+      reason: &gt;-
+        Negative regulation of interferon-beta production is directly aligned with MORC3-mediated IFNB1 repression.
       supported_by:
-        - reference_id: PMID:34759314
-          supporting_text: Nov 10. Self-guarding of MORC3 enables virulence 
-            factor-triggered immunity.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            **Intrinsic immunity and interferon pathway modulation.** In OSCC/HNSCC models, MORC3 knockdown upregulated interferon-associated
+            genes and increased STAT1 and PD-L1, suggesting MORC3 suppresses interferon-driven transcriptional programs in
+            this context (fu2024genomewideanalysisreveals pages 3-7). In myositis/cancer-associated myositis literature, MORC3
+            is described as an antiviral factor and a repressor of IFNB1 (patasova2023geneticinfluencesin pages 6-8). Together,
+            these suggest MORC3 contributes to a chromatin-based brake on interferon gene expression, with context-dependent
+            consequences (antiviral restriction in fibroblast/hepatocyte models vs immune evasion phenotypes in cancer).
   - term:
       id: GO:0140374
       label: antiviral innate immune response
     evidence_type: IDA
     original_reference_id: PMID:27440897
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:27440897
-          supporting_text: MORC3, a Component of PML Nuclear Bodies, Has a Role 
-            in Restricting Herpes Simplex Virus 1 and Human Cytomegalovirus.
+      summary: &gt;-
+        MORC3 contributes to intrinsic antiviral restriction, including PML-body-associated restriction of HSV-1 and HCMV.
+      action: ACCEPT
+      reason: &gt;-
+        Antiviral innate immune response is a supported major function of MORC3.
+      supported_by: *id002
   - term:
       id: GO:2000774
       label: positive regulation of cellular senescence
     evidence_type: IDA
     original_reference_id: PMID:17332504
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
+      summary: &gt;-
+        MORC3 can activate p53 and induce cellular senescence in fibroblast models.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        The p53/senescence phenotype is supported but is a downstream context-specific outcome of MORC3 PML-body localization
+        and scaffold activity rather than the core conserved function.
+      supported_by: &amp;id006
         - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+          supporting_text: &gt;-
+            Dynamic regulation of p53 subnuclear localization and senescence by MORC3.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            | PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes
+            to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization
+            and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes
+            recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading
+            MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other
+            contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent
+            media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown,
+            viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3
+            depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque
+            formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages
+            3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol*
+            (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |
   - term:
       id: GO:0006468
       label: protein phosphorylation
@@ -4062,31 +6188,41 @@ existing_annotations:
     original_reference_id: PMID:17332504
     review:
       summary: &gt;-
-        MISANNOTATION: MORC3 is a GHL-ATPase (not a kinase) that regulates p53 recruitment
-        to PML-NBs. PMID:17332504 explicitly states &#34;genotoxic stress-induced phosphorylation
-        and stabilization of p53 but barely increased its transcriptional activity
-        in
-        Morc3-/- fibroblasts&#34; - this means p53 IS PHOSPHORYLATED even without MORC3.
-        MORC3
-        affects p53 activity DOWNSTREAM of phosphorylation through PML-NB recruitment,
-        not by performing phosphorylation itself.
+        MORC3 is a GHKL ATPase, not a protein kinase; the p53 study states that genotoxic stress-induced p53 phosphorylation
+        still occurs in Morc3-deficient fibroblasts.
       action: REMOVE
-      supported_by:
+      reason: &gt;-
+        This annotation misattributes phosphorylation catalysis to MORC3. MORC3 regulates p53 localization/activity downstream
+        of phosphorylation through PML nuclear bodies.
+      supported_by: &amp;id005
         - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+          supporting_text: &gt;-
+            phosphorylation and stabilization of p53 but barely increased its
+        - reference_id: PMID:17332504
+          supporting_text: &gt;-
+            Dynamic regulation of p53 subnuclear localization and senescence by MORC3.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            **Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules:
+            (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type
+            zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization
+            (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated
+            ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent
+            interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent
+            pages 3-5).
   - term:
       id: GO:0016605
       label: PML body
     evidence_type: IDA
     original_reference_id: PMID:17332504
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+      summary: &gt;-
+        MORC3 localizes to PML nuclear bodies through SUMO/SIM-dependent interactions and helps recruit restriction factors
+        there.
+      action: ACCEPT
+      reason: &gt;-
+        PML body localization is one of the best-supported cellular component annotations for MORC3.
+      supported_by: *id001
   - term:
       id: GO:0018105
       label: peptidyl-serine phosphorylation
@@ -4094,128 +6230,153 @@ existing_annotations:
     original_reference_id: PMID:17332504
     review:
       summary: &gt;-
-        MISANNOTATION: MORC3 is a GHL-ATPase domain protein, NOT a serine/threonine
-        kinase. PMID:17332504 describes MORC3&#39;s role in p53 recruitment to PML-NBs
-        and
-        shows p53 phosphorylation occurs independently of MORC3 (&#34;genotoxic stress-induced
-        phosphorylation... in Morc3-/- fibroblasts&#34;). MORC3 has ATPase activity but
-        no
-        kinase activity. The annotation incorrectly attributes phosphorylation catalysis
-        to MORC3.
+        MORC3 is not a serine/threonine kinase, and the p53 paper supports a localization/activity role rather than peptidyl-serine
+        phosphorylation by MORC3.
       action: REMOVE
-      supported_by:
-        - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+      reason: &gt;-
+        The annotation incorrectly converts a p53 phosphorylation phenotype into MORC3 kinase activity.
+      supported_by: *id005
   - term:
       id: GO:0048147
       label: negative regulation of fibroblast proliferation
     evidence_type: IDA
     original_reference_id: PMID:17332504
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+      summary: &gt;-
+        MORC3-dependent p53 activation and cellular senescence in fibroblast models imply reduced fibroblast proliferation.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        This is a supported context-specific p53/senescence phenotype rather than a core MORC3 molecular function.
+      supported_by: *id006
   - term:
       id: GO:0050821
       label: protein stabilization
     evidence_type: IDA
     original_reference_id: PMID:17332504
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        The p53 study indicates that genotoxic stress-induced p53 stabilization still occurs in Morc3-deficient fibroblasts;
+        MORC3 instead affects p53 localization and transcriptional activity.
+      action: REMOVE
+      reason: &gt;-
+        Protein stabilization is not the supported MORC3 activity from this evidence.
       supported_by:
         - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+          supporting_text: &gt;-
+            phosphorylation and stabilization of p53 but barely increased its
+        - reference_id: PMID:17332504
+          supporting_text: &gt;-
+            Dynamic regulation of p53 subnuclear localization and senescence by MORC3.
   - term:
       id: GO:0051457
       label: maintenance of protein location in nucleus
     evidence_type: IDA
     original_reference_id: PMID:17332504
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 helps recruit/maintain p53, Sp100, and viral-genome-associated restriction factors in nuclear PML-body contexts.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Maintenance of nuclear protein location is supported as a scaffold/localization role, but is secondary to the core
+        PML-body chromatin-adaptor function.
       supported_by:
         - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+          supporting_text: &gt;-
+            Dynamic regulation of p53 subnuclear localization and senescence by MORC3.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            | PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes
+            to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization
+            and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes
+            recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading
+            MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other
+            contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent
+            media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown,
+            viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3
+            depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque
+            formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages
+            3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol*
+            (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |
   - term:
       id: GO:0051457
       label: maintenance of protein location in nucleus
     evidence_type: IMP
     original_reference_id: PMID:17332504
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MORC3 helps recruit/maintain p53, Sp100, and viral-genome-associated restriction factors in nuclear PML-body contexts.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Maintenance of nuclear protein location is supported as a scaffold/localization role, but is secondary to the core
+        PML-body chromatin-adaptor function.
       supported_by:
         - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+          supporting_text: &gt;-
+            Dynamic regulation of p53 subnuclear localization and senescence by MORC3.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: &gt;-
+            | PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes
+            to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization
+            and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes
+            recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading
+            MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other
+            contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent
+            media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown,
+            viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3
+            depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque
+            formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages
+            3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol*
+            (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |
 references:
   - id: GO_REF:0000002
-    title: Gene Ontology annotation through association of InterPro records with
-      GO terms
+    title: Gene Ontology annotation through association of InterPro records with GO terms
     findings: []
   - id: GO_REF:0000033
     title: Annotation inferences using phylogenetic trees
     findings: []
   - id: GO_REF:0000043
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword 
-      mapping
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
     findings: []
   - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+      by conservative changes to GO terms applied by UniProt
     findings: []
   - id: GO_REF:0000052
     title: Gene Ontology annotation based on curation of immunofluorescence data
     findings: []
   - id: GO_REF:0000107
-    title: Automatic transfer of experimentally verified manual GO annotation 
-      data to orthologs using Ensembl Compara
+    title: Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara
     findings: []
   - id: GO_REF:0000108
-    title: Automatic assignment of GO terms using logical inference, based on on
-      inter-ontology links
+    title: Automatic assignment of GO terms using logical inference, based on on inter-ontology links
     findings: []
   - id: GO_REF:0000117
-    title: Electronic Gene Ontology annotations created by ARBA machine learning
-      models
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
     findings: []
   - id: GO_REF:0000120
     title: Combined Automated Annotation using Multiple IEA Methods
     findings: []
   - id: PMID:17332504
-    title: Dynamic regulation of p53 subnuclear localization and senescence by 
-      MORC3.
+    title: Dynamic regulation of p53 subnuclear localization and senescence by MORC3.
     findings: []
   - id: PMID:26496610
-    title: A human interactome in three quantitative dimensions organized by 
-      stoichiometries and abundances.
+    title: A human interactome in three quantitative dimensions organized by stoichiometries and abundances.
     findings: []
   - id: PMID:26933034
-    title: Family-wide Characterization of Histone Binding Abilities of Human CW
-      Domain-containing Proteins.
+    title: Family-wide Characterization of Histone Binding Abilities of Human CW Domain-containing Proteins.
     findings: []
   - id: PMID:27173435
-    title: An organelle-specific protein landscape identifies novel diseases and
-      molecular mechanisms.
+    title: An organelle-specific protein landscape identifies novel diseases and molecular mechanisms.
     findings: []
   - id: PMID:27440897
-    title: MORC3, a Component of PML Nuclear Bodies, Has a Role in Restricting 
-      Herpes Simplex Virus 1 and Human Cytomegalovirus.
+    title: MORC3, a Component of PML Nuclear Bodies, Has a Role in Restricting Herpes Simplex Virus 1 and Human
+      Cytomegalovirus.
     findings: []
   - id: PMID:32296183
     title: A reference map of the human binary protein interactome.
     findings: []
   - id: PMID:33961781
-    title: Dual proteome-scale networks reveal cell-specific remodeling of the 
-      human interactome.
+    title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
     findings: []
   - id: PMID:34759314
     title: Self-guarding of MORC3 enables virulence factor-triggered immunity.
@@ -4224,20 +6385,161 @@ references:
     title: &#39;OpenCell: Endogenous tagging for the cartography of human cellular organization.&#39;
     findings: []
   - id: PMID:35914814
-    title: &#39;Chr21 protein-protein interactions: enrichment in proteins involved in
-      intellectual disability, autism, and late-onset Alzheimer&#39;&#39;s disease.&#39;
+    title: &#39;Chr21 protein-protein interactions: enrichment in proteins involved in intellectual disability, autism, and late-onset
+      Alzheimer&#39;&#39;s disease.&#39;
     findings: []
   - id: PMID:40205054
-    title: Multimodal cell maps as a foundation for structural and functional 
-      genomics.
+    title: Multimodal cell maps as a foundation for structural and functional genomics.
     findings: []
+  - id: file:human/MORC3/MORC3-deep-research-falcon.md
+    title: Falcon deep research on MORC3 function
+    findings:
+      - statement: MORC3 is a nuclear matrix and PML nuclear body protein with GHKL ATPase and CW zinc-finger domains.
+      - statement: MORC3 contributes to PML nuclear body-associated intrinsic antiviral restriction of HSV-1 and HCMV.
+      - statement: MORC3 acts as a chromatin-associated ATPase/scaffold involved in epigenetic repression and interferon
+          program regulation.
+core_functions:
+  - molecular_function:
+      id: GO:0016887
+      label: ATP hydrolysis activity
+    description: &gt;-
+      MORC3 is a MORC-family GHKL/HATPase chromatin-associated ATPase. Its ATPase cycle works with its CW zinc-finger chromatin-reader
+      module and SUMOylation to support repressive chromatin organization at foreign or deleterious DNA templates.
+    directly_involved_in:
+      - id: GO:0006325
+        label: chromatin organization
+      - id: GO:0000122
+        label: negative regulation of transcription by RNA polymerase II
+    locations:
+      - id: GO:0000785
+        label: chromatin
+      - id: GO:0016363
+        label: nuclear matrix
+      - id: GO:0005634
+        label: nucleus
+    supported_by:
+      - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+        supporting_text: &gt;-
+          **Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules:
+          (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type
+          zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization
+          (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated
+          ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent
+          interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent
+          pages 3-5).
+      - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+        supporting_text: &gt;-
+          | Epigenetic silencing / chromatin regulation | MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains;
+          ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement
+          loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism
+          is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous
+          pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Genome-wide
+          sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR | 2,737 reproducible
+          Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS
+          identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous
+          pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Groh et al.,
+          *Nat Commun* (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7 |
+  - molecular_function:
+      id: GO:0140002
+      label: histone H3K4me3 reader activity
+    description: &gt;-
+      The MORC3 CW-type zinc finger recognizes methylated H3K4, connecting MORC3 to chromatin-reader activity in nuclear chromatin
+      contexts.
+    directly_involved_in:
+      - id: GO:0006325
+        label: chromatin organization
+    locations:
+      - id: GO:0000785
+        label: chromatin
+      - id: GO:0005634
+        label: nucleus
+    supported_by:
+      - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+        supporting_text: &gt;-
+          **Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules:
+          (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type
+          zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization
+          (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated
+          ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent
+          interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent
+          pages 3-5).
+  - molecular_function:
+      id: GO:0030674
+      label: protein-macromolecule adaptor activity
+    description: &gt;-
+      MORC3 acts as a SUMO-regulated PML-body scaffold/adaptor that recruits and maintains nuclear restriction factors at
+      PML bodies and incoming viral genomes, contributing to antiviral restriction and interferon-beta regulatory programs.
+    directly_involved_in:
+      - id: GO:0140374
+        label: antiviral innate immune response
+      - id: GO:0032688
+        label: negative regulation of interferon-beta production
+    locations:
+      - id: GO:0016605
+        label: PML body
+      - id: GO:0016363
+        label: nuclear matrix
+      - id: GO:0005634
+        label: nucleus
+    supported_by:
+      - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+        supporting_text: &gt;-
+          **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+          client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+          a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent
+          pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and
+          hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is
+          one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).
+      - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+        supporting_text: &gt;-
+          | PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes
+          to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization
+          and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes
+          recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading
+          MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other contexts.
+          (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e)
+          | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown, viral protein immunoblotting
+          | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3 depletion caused a marked increase
+          in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque formation; MORC3 colocalizes with PML-NB
+          markers in punctate nuclear structures. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15,
+          sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol* (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16
+          |
+      - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+        supporting_text: &gt;-
+          **Intrinsic immunity and interferon pathway modulation.** In OSCC/HNSCC models, MORC3 knockdown upregulated interferon-associated
+          genes and increased STAT1 and PD-L1, suggesting MORC3 suppresses interferon-driven transcriptional programs in this
+          context (fu2024genomewideanalysisreveals pages 3-7). In myositis/cancer-associated myositis literature, MORC3 is
+          described as an antiviral factor and a repressor of IFNB1 (patasova2023geneticinfluencesin pages 6-8). Together,
+          these suggest MORC3 contributes to a chromatin-based brake on interferon gene expression, with context-dependent
+          consequences (antiviral restriction in fibroblast/hepatocyte models vs immune evasion phenotypes in cancer).
+proposed_new_terms: []
+suggested_questions:
+  - question: &gt;-
+      Which MORC3 activities in human cells require the ATPase domain, the CW H3K4me3-reader domain, SUMOylation/SIM interactions,
+      or combinations of these modules?
+  - question: &gt;-
+      Does MORC3 directly bind specific DNA elements such as the IFNB1-adjacent MRE, or is repression mediated through chromatin-associated
+      partner proteins?
+suggested_experiments:
+  - description: &gt;-
+      Rescue MORC3 knockout human cells with ATPase-dead, CW-domain, SUMOylation-defective, and SIM-interaction mutants, then
+      measure PML-body localization, restriction-factor recruitment, IFNB1/MRE repression, and HSV-1/HCMV restriction.
+    hypothesis: &gt;-
+      MORC3 antiviral and interferon-repressive functions require separable ATPase, chromatin-reader, and SUMO/PML-body interaction
+      modules.
+  - description: &gt;-
+      Perform CUT&amp;RUN/CUT&amp;Tag or ChIP-seq for endogenous MORC3 together with DNA-binding-deficient and partner-recruitment
+      mutants at IFNB1/MRE, viral episomes, and retroelement loci.
+    hypothesis: &gt;-
+      MORC3 occupies repressed chromatin templates through a partner-dependent chromatin scaffold mechanism rather than generic
+      sequence-independent DNA binding.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/MORC3/MORC3-ai-review.yaml
+++ b/genes/human/MORC3/MORC3-ai-review.yaml
@@ -1,11 +1,15 @@
 id: Q14149
 gene_symbol: MORC3
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for MORC3'
+description: >-
+  MORC3/NXP2 is a nuclear matrix and PML nuclear body-associated MORC-family GHKL/HATPase protein with a CW-type zinc finger
+  that reads methylated H3K4. It functions as a SUMO-regulated chromatin/PML-body scaffold and ATPase involved in intrinsic
+  antiviral restriction, chromatin-associated repression, recruitment/maintenance of nuclear restriction factors, and negative
+  regulation of interferon-beta programs.
 existing_annotations:
   - term:
       id: GO:0005634
@@ -13,337 +17,733 @@ existing_annotations:
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 is a nuclear/nuclear-matrix protein and PML nuclear body component.
+      action: ACCEPT
+      reason: >-
+        Nuclear localization is strongly supported, although more specific PML body and nuclear matrix terms should also be
+        retained.
+      supported_by: &id001
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            MORC3 is consistently characterized as a **nuclear matrix protein** that localizes to **PML nuclear bodies**.
+            In immunofluorescence microscopy, MORC3 colocalizes with the PML-NB component Sp100 in punctate nuclear structures
+            (sloan2016morc3acomponent media 84630a9e). During infection with HSV-1 lacking ICP0, MORC3 is recruited to sites
+            associated with incoming viral genomes (identified by ICP4 foci), consistent with a role in intrinsic restriction
+            at early stages of infection (sloan2016morc3acomponent media 5b6c97c8).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            Mechanistically, the association with PML-NBs is reported to occur via **SUMO–SIM interaction** with PML.I, and
+            PML-NB localization/recruitment functions require a **functional ATPase domain** (sloan2016morc3acomponent pages
+            3-5, sloan2016morc3acomponent pages 13-15).
   - term:
       id: GO:0140002
       label: histone H3K4me3 reader activity
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        The MORC3 CW-type zinc finger is reported to bind methylated H3K4.
+      action: ACCEPT
+      reason: >-
+        Histone H3K4me3 reader activity is consistent with the CW-domain evidence and chromatin-associated function.
+      supported_by: &id003
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            **Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules:
+            (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type
+            zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization
+            (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated
+            ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent
+            interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent
+            pages 3-5).
   - term:
       id: GO:0140374
       label: antiviral innate immune response
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 contributes to intrinsic antiviral restriction, including PML-body-associated restriction of HSV-1 and HCMV.
+      action: ACCEPT
+      reason: >-
+        Antiviral innate immune response is a supported major function of MORC3.
+      supported_by: &id002
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            | PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes
+            to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization
+            and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes
+            recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading
+            MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other
+            contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent
+            media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown,
+            viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3
+            depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque
+            formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages
+            3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol*
+            (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0016605
       label: PML body
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 localizes to PML nuclear bodies through SUMO/SIM-dependent interactions and helps recruit restriction factors
+        there.
+      action: ACCEPT
+      reason: >-
+        PML body localization is one of the best-supported cellular component annotations for MORC3.
+      supported_by: *id001
   - term:
       id: GO:0006325
       label: chromatin organization
     evidence_type: IEA
     original_reference_id: GO_REF:0000108
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 is a chromatin-associated ATPase/scaffold implicated in epigenetic repression and chromatin organization.
+      action: ACCEPT
+      reason: >-
+        Chromatin organization is supported by conserved MORC3 mechanism and by MORC3-mediated repression of viral/foreign
+        DNA and interferon programs.
+      supported_by: &id004
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            **Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules:
+            (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type
+            zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization
+            (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated
+            ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent
+            interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            | Epigenetic silencing / chromatin regulation | MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains;
+            ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement
+            loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism
+            is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous
+            pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Genome-wide
+            sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR | 2,737 reproducible
+            Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS
+            identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous
+            pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Groh et
+            al., *Nat Commun* (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7 |
   - term:
       id: GO:0002376
       label: immune system process
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 has immune functions, but the evidence supports the more specific antiviral innate immune response and interferon-beta
+        regulatory terms.
+      action: MODIFY
+      reason: >-
+        Use antiviral innate immune response rather than the broad parent immune system process.
+      proposed_replacement_terms:
+        - id: GO:0140374
+          label: antiviral innate immune response
+      supported_by: *id002
   - term:
       id: GO:0003723
       label: RNA binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        The curated MORC3 literature supports ATPase, CW histone-reader, chromatin/PML-body scaffold, and antiviral restriction
+        roles, not direct RNA binding.
+      action: REMOVE
+      reason: >-
+        This electronically inferred RNA-binding annotation is not supported by the gene-specific functional synthesis.
+      supported_by: *id003
   - term:
       id: GO:0005654
       label: nucleoplasm
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 is nuclear, but the more specific supported locations are PML bodies and nuclear matrix/chromatin-associated
+        nuclear structures.
+      action: MODIFY
+      reason: >-
+        Use PML body and nuclear matrix instead of broad nucleoplasm when curating MORC3 localization.
+      proposed_replacement_terms:
+        - id: GO:0016605
+          label: PML body
+        - id: GO:0016363
+          label: nuclear matrix
+      supported_by: *id001
   - term:
       id: GO:0005694
       label: chromosome
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 is chromatin-associated, but chromosome is a broad location for this evidence.
+      action: MODIFY
+      reason: >-
+        Use chromatin to represent the supported chromosome-associated localization/function more precisely.
+      proposed_replacement_terms:
+        - id: GO:0000785
+          label: chromatin
+      supported_by: *id004
   - term:
       id: GO:0008270
       label: zinc ion binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 contains a CW-type zinc finger domain.
+      action: ACCEPT
+      reason: >-
+        Zinc ion binding is supported by the CW zinc-finger domain architecture.
+      supported_by: *id003
   - term:
       id: GO:0016363
       label: nuclear matrix
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3/NXP2 is consistently characterized as a nuclear matrix protein.
+      action: ACCEPT
+      reason: >-
+        Nuclear matrix localization is supported by the literature synthesis.
+      supported_by:
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            MORC3 is consistently characterized as a **nuclear matrix protein** that localizes to **PML nuclear bodies**.
+            In immunofluorescence microscopy, MORC3 colocalizes with the PML-NB component Sp100 in punctate nuclear structures
+            (sloan2016morc3acomponent media 84630a9e). During infection with HSV-1 lacking ICP0, MORC3 is recruited to sites
+            associated with incoming viral genomes (identified by ICP4 foci), consistent with a role in intrinsic restriction
+            at early stages of infection (sloan2016morc3acomponent media 5b6c97c8).
   - term:
       id: GO:0016605
       label: PML body
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 localizes to PML nuclear bodies through SUMO/SIM-dependent interactions and helps recruit restriction factors
+        there.
+      action: ACCEPT
+      reason: >-
+        PML body localization is one of the best-supported cellular component annotations for MORC3.
+      supported_by: *id001
   - term:
       id: GO:0016887
       label: ATP hydrolysis activity
     evidence_type: IEA
     original_reference_id: GO_REF:0000002
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 is a MORC-family GHKL/HATPase ATPase, and ATPase activity is required for PML-body localization/recruitment
+        functions.
+      action: ACCEPT
+      reason: >-
+        ATP hydrolysis activity is a core molecular feature of MORC3.
+      supported_by:
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            **Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules:
+            (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type
+            zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization
+            (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated
+            ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent
+            interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            Mechanistically, the association with PML-NBs is reported to occur via **SUMO–SIM interaction** with PML.I, and
+            PML-NB localization/recruitment functions require a **functional ATPase domain** (sloan2016morc3acomponent pages
+            3-5, sloan2016morc3acomponent pages 13-15).
   - term:
       id: GO:0045087
       label: innate immune response
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 participates in innate immunity, but the evidence is specifically antiviral restriction and interferon regulation.
+      action: MODIFY
+      reason: >-
+        Use antiviral innate immune response for the supported immune role.
+      proposed_replacement_terms:
+        - id: GO:0140374
+          label: antiviral innate immune response
+      supported_by: *id002
   - term:
       id: GO:0046872
       label: metal ion binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 metal binding is specifically attributable to its CW-type zinc finger.
+      action: MODIFY
+      reason: >-
+        Use zinc ion binding rather than generic metal ion binding.
+      proposed_replacement_terms:
+        - id: GO:0008270
+          label: zinc ion binding
+      supported_by: *id003
   - term:
       id: GO:0140002
       label: histone H3K4me3 reader activity
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        The MORC3 CW-type zinc finger is reported to bind methylated H3K4.
+      action: ACCEPT
+      reason: >-
+        Histone H3K4me3 reader activity is consistent with the CW-domain evidence and chromatin-associated function.
+      supported_by: *id003
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:26496610
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding
+        is not informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin
+        organization, and antiviral restriction.
       supported_by:
-        - reference_id: PMID:26496610
-          supporting_text: Oct 22. A human interactome in three quantitative 
-            dimensions organized by stoichiometries and abundances.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:27173435
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding
+        is not informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin
+        organization, and antiviral restriction.
       supported_by:
-        - reference_id: PMID:27173435
-          supporting_text: An organelle-specific protein landscape identifies 
-            novel diseases and molecular mechanisms.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:32296183
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding
+        is not informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin
+        organization, and antiviral restriction.
       supported_by:
-        - reference_id: PMID:32296183
-          supporting_text: Apr 8. A reference map of the human binary protein 
-            interactome.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:33961781
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding
+        is not informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin
+        organization, and antiviral restriction.
       supported_by:
-        - reference_id: PMID:33961781
-          supporting_text: 2021 May 6. Dual proteome-scale networks reveal 
-            cell-specific remodeling of the human interactome.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:35271311
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding
+        is not informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin
+        organization, and antiviral restriction.
       supported_by:
-        - reference_id: PMID:35271311
-          supporting_text: '2022 Mar 11. OpenCell: Endogenous tagging for the cartography
-            of human cellular organization.'
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:35914814
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding
+        is not informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin
+        organization, and antiviral restriction.
       supported_by:
-        - reference_id: PMID:35914814
-          supporting_text: "Chr21 protein-protein interactions: enrichment in proteins
-            involved in intellectual disability, autism, and late-onset Alzheimer's
-            disease."
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:40205054
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 has many protein partners in PML body, SUMO, chromatin, and interactome datasets, but generic protein binding
+        is not informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        The actionable biology is better represented by protein-macromolecule adaptor activity, PML body localization, chromatin
+        organization, and antiviral restriction.
       supported_by:
-        - reference_id: PMID:40205054
-          supporting_text: Apr 9. Multimodal cell maps as a foundation for 
-            structural and functional genomics.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+            client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+            a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I**
+            (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched
+            subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other
+            nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent
+            pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 is a nuclear/nuclear-matrix protein and PML nuclear body component.
+      action: ACCEPT
+      reason: >-
+        Nuclear localization is strongly supported, although more specific PML body and nuclear matrix terms should also be
+        retained.
+      supported_by: *id001
   - term:
       id: GO:0005654
       label: nucleoplasm
     evidence_type: IDA
     original_reference_id: GO_REF:0000052
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 is nuclear, but the more specific supported locations are PML bodies and nuclear matrix/chromatin-associated
+        nuclear structures.
+      action: MODIFY
+      reason: >-
+        Use PML body and nuclear matrix instead of broad nucleoplasm when curating MORC3 localization.
+      proposed_replacement_terms:
+        - id: GO:0016605
+          label: PML body
+        - id: GO:0016363
+          label: nuclear matrix
+      supported_by: *id001
   - term:
       id: GO:0140002
       label: histone H3K4me3 reader activity
     evidence_type: IDA
     original_reference_id: PMID:26933034
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:26933034
-          supporting_text: 2016 Mar 1. Family-wide Characterization of Histone 
-            Binding Abilities of Human CW Domain-containing Proteins.
+      summary: >-
+        The MORC3 CW-type zinc finger is reported to bind methylated H3K4.
+      action: ACCEPT
+      reason: >-
+        Histone H3K4me3 reader activity is consistent with the CW-domain evidence and chromatin-associated function.
+      supported_by: *id003
   - term:
       id: GO:0000122
       label: negative regulation of transcription by RNA polymerase II
     evidence_type: IDA
     original_reference_id: PMID:34759314
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 contributes to repression of transcriptional programs, including IFNB1/interferon-linked gene regulation and
+        foreign DNA silencing.
+      action: ACCEPT
+      reason: >-
+        Negative regulation of RNA polymerase II transcription is consistent with the MORC3 chromatin repression evidence.
       supported_by:
-        - reference_id: PMID:34759314
-          supporting_text: Nov 10. Self-guarding of MORC3 enables virulence 
-            factor-triggered immunity.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            **Intrinsic immunity and interferon pathway modulation.** In OSCC/HNSCC models, MORC3 knockdown upregulated interferon-associated
+            genes and increased STAT1 and PD-L1, suggesting MORC3 suppresses interferon-driven transcriptional programs in
+            this context (fu2024genomewideanalysisreveals pages 3-7). In myositis/cancer-associated myositis literature, MORC3
+            is described as an antiviral factor and a repressor of IFNB1 (patasova2023geneticinfluencesin pages 6-8). Together,
+            these suggest MORC3 contributes to a chromatin-based brake on interferon gene expression, with context-dependent
+            consequences (antiviral restriction in fibroblast/hepatocyte models vs immune evasion phenotypes in cancer).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            | Epigenetic silencing / chromatin regulation | MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains;
+            ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement
+            loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism
+            is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous
+            pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Genome-wide
+            sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR | 2,737 reproducible
+            Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS
+            identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous
+            pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Groh et
+            al., *Nat Commun* (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7 |
   - term:
       id: GO:0000785
       label: chromatin
     evidence_type: IDA
     original_reference_id: PMID:34759314
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:34759314
-          supporting_text: Nov 10. Self-guarding of MORC3 enables virulence 
-            factor-triggered immunity.
+      summary: >-
+        MORC3 is a chromatin-associated ATPase/scaffold with roles in repressive chromatin states.
+      action: ACCEPT
+      reason: >-
+        Chromatin localization/function is supported by the mechanistic synthesis.
+      supported_by: *id004
   - term:
       id: GO:0003677
       label: DNA binding
     evidence_type: IDA
     original_reference_id: PMID:34759314
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 regulates chromatin/DNA elements, but available synthesized evidence supports chromatin association and MRE
+        regulation rather than a clearly separable direct DNA-binding MF.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        Curate the supported chromatin and transcription-regulatory roles instead of broad DNA binding unless direct DNA-binding
+        evidence is reviewed in detail.
       supported_by:
-        - reference_id: PMID:34759314
-          supporting_text: Nov 10. Self-guarding of MORC3 enables virulence 
-            factor-triggered immunity.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            **Intrinsic immunity and interferon pathway modulation.** In OSCC/HNSCC models, MORC3 knockdown upregulated interferon-associated
+            genes and increased STAT1 and PD-L1, suggesting MORC3 suppresses interferon-driven transcriptional programs in
+            this context (fu2024genomewideanalysisreveals pages 3-7). In myositis/cancer-associated myositis literature, MORC3
+            is described as an antiviral factor and a repressor of IFNB1 (patasova2023geneticinfluencesin pages 6-8). Together,
+            these suggest MORC3 contributes to a chromatin-based brake on interferon gene expression, with context-dependent
+            consequences (antiviral restriction in fibroblast/hepatocyte models vs immune evasion phenotypes in cancer).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            | Epigenetic silencing / chromatin regulation | MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains;
+            ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement
+            loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism
+            is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous
+            pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Genome-wide
+            sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR | 2,737 reproducible
+            Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS
+            identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous
+            pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Groh et
+            al., *Nat Commun* (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7 |
   - term:
       id: GO:0016605
       label: PML body
     evidence_type: IDA
     original_reference_id: PMID:27440897
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:27440897
-          supporting_text: MORC3, a Component of PML Nuclear Bodies, Has a Role 
-            in Restricting Herpes Simplex Virus 1 and Human Cytomegalovirus.
+      summary: >-
+        MORC3 localizes to PML nuclear bodies through SUMO/SIM-dependent interactions and helps recruit restriction factors
+        there.
+      action: ACCEPT
+      reason: >-
+        PML body localization is one of the best-supported cellular component annotations for MORC3.
+      supported_by: *id001
   - term:
       id: GO:0030674
       label: protein-macromolecule adaptor activity
     evidence_type: IDA
     original_reference_id: PMID:27440897
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 functions as a SUMO-regulated scaffold/adaptor for PML-body and viral-genome-associated restriction factors.
+      action: ACCEPT
+      reason: >-
+        Protein-macromolecule adaptor activity is supported by MORC3-dependent recruitment of PML, Sp100, hDaxx, gamma-H2AX,
+        p53, and related nuclear factors.
       supported_by:
-        - reference_id: PMID:27440897
-          supporting_text: MORC3, a Component of PML Nuclear Bodies, Has a Role 
-            in Restricting Herpes Simplex Virus 1 and Human Cytomegalovirus.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML,
+            γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment
+            at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            | PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes
+            to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization
+            and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes
+            recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading
+            MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other
+            contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent
+            media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown,
+            viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3
+            depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque
+            formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages
+            3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol*
+            (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |
   - term:
       id: GO:0032688
       label: negative regulation of interferon-beta production
     evidence_type: IDA
     original_reference_id: PMID:34759314
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        Loss or degradation of MORC3 derepresses IFNB1/interferon programs, supporting a negative regulatory role.
+      action: ACCEPT
+      reason: >-
+        Negative regulation of interferon-beta production is directly aligned with MORC3-mediated IFNB1 repression.
       supported_by:
-        - reference_id: PMID:34759314
-          supporting_text: Nov 10. Self-guarding of MORC3 enables virulence 
-            factor-triggered immunity.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            **Intrinsic immunity and interferon pathway modulation.** In OSCC/HNSCC models, MORC3 knockdown upregulated interferon-associated
+            genes and increased STAT1 and PD-L1, suggesting MORC3 suppresses interferon-driven transcriptional programs in
+            this context (fu2024genomewideanalysisreveals pages 3-7). In myositis/cancer-associated myositis literature, MORC3
+            is described as an antiviral factor and a repressor of IFNB1 (patasova2023geneticinfluencesin pages 6-8). Together,
+            these suggest MORC3 contributes to a chromatin-based brake on interferon gene expression, with context-dependent
+            consequences (antiviral restriction in fibroblast/hepatocyte models vs immune evasion phenotypes in cancer).
   - term:
       id: GO:0140374
       label: antiviral innate immune response
     evidence_type: IDA
     original_reference_id: PMID:27440897
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:27440897
-          supporting_text: MORC3, a Component of PML Nuclear Bodies, Has a Role 
-            in Restricting Herpes Simplex Virus 1 and Human Cytomegalovirus.
+      summary: >-
+        MORC3 contributes to intrinsic antiviral restriction, including PML-body-associated restriction of HSV-1 and HCMV.
+      action: ACCEPT
+      reason: >-
+        Antiviral innate immune response is a supported major function of MORC3.
+      supported_by: *id002
   - term:
       id: GO:2000774
       label: positive regulation of cellular senescence
     evidence_type: IDA
     original_reference_id: PMID:17332504
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
+      summary: >-
+        MORC3 can activate p53 and induce cellular senescence in fibroblast models.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        The p53/senescence phenotype is supported but is a downstream context-specific outcome of MORC3 PML-body localization
+        and scaffold activity rather than the core conserved function.
+      supported_by: &id006
         - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+          supporting_text: >-
+            Dynamic regulation of p53 subnuclear localization and senescence by MORC3.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            | PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes
+            to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization
+            and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes
+            recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading
+            MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other
+            contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent
+            media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown,
+            viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3
+            depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque
+            formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages
+            3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol*
+            (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |
   - term:
       id: GO:0006468
       label: protein phosphorylation
@@ -351,31 +751,41 @@ existing_annotations:
     original_reference_id: PMID:17332504
     review:
       summary: >-
-        MISANNOTATION: MORC3 is a GHL-ATPase (not a kinase) that regulates p53 recruitment
-        to PML-NBs. PMID:17332504 explicitly states "genotoxic stress-induced phosphorylation
-        and stabilization of p53 but barely increased its transcriptional activity
-        in
-        Morc3-/- fibroblasts" - this means p53 IS PHOSPHORYLATED even without MORC3.
-        MORC3
-        affects p53 activity DOWNSTREAM of phosphorylation through PML-NB recruitment,
-        not by performing phosphorylation itself.
+        MORC3 is a GHKL ATPase, not a protein kinase; the p53 study states that genotoxic stress-induced p53 phosphorylation
+        still occurs in Morc3-deficient fibroblasts.
       action: REMOVE
-      supported_by:
+      reason: >-
+        This annotation misattributes phosphorylation catalysis to MORC3. MORC3 regulates p53 localization/activity downstream
+        of phosphorylation through PML nuclear bodies.
+      supported_by: &id005
         - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+          supporting_text: >-
+            phosphorylation and stabilization of p53 but barely increased its
+        - reference_id: PMID:17332504
+          supporting_text: >-
+            Dynamic regulation of p53 subnuclear localization and senescence by MORC3.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            **Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules:
+            (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type
+            zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization
+            (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated
+            ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent
+            interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent
+            pages 3-5).
   - term:
       id: GO:0016605
       label: PML body
     evidence_type: IDA
     original_reference_id: PMID:17332504
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+      summary: >-
+        MORC3 localizes to PML nuclear bodies through SUMO/SIM-dependent interactions and helps recruit restriction factors
+        there.
+      action: ACCEPT
+      reason: >-
+        PML body localization is one of the best-supported cellular component annotations for MORC3.
+      supported_by: *id001
   - term:
       id: GO:0018105
       label: peptidyl-serine phosphorylation
@@ -383,128 +793,153 @@ existing_annotations:
     original_reference_id: PMID:17332504
     review:
       summary: >-
-        MISANNOTATION: MORC3 is a GHL-ATPase domain protein, NOT a serine/threonine
-        kinase. PMID:17332504 describes MORC3's role in p53 recruitment to PML-NBs
-        and
-        shows p53 phosphorylation occurs independently of MORC3 ("genotoxic stress-induced
-        phosphorylation... in Morc3-/- fibroblasts"). MORC3 has ATPase activity but
-        no
-        kinase activity. The annotation incorrectly attributes phosphorylation catalysis
-        to MORC3.
+        MORC3 is not a serine/threonine kinase, and the p53 paper supports a localization/activity role rather than peptidyl-serine
+        phosphorylation by MORC3.
       action: REMOVE
-      supported_by:
-        - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+      reason: >-
+        The annotation incorrectly converts a p53 phosphorylation phenotype into MORC3 kinase activity.
+      supported_by: *id005
   - term:
       id: GO:0048147
       label: negative regulation of fibroblast proliferation
     evidence_type: IDA
     original_reference_id: PMID:17332504
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+      summary: >-
+        MORC3-dependent p53 activation and cellular senescence in fibroblast models imply reduced fibroblast proliferation.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        This is a supported context-specific p53/senescence phenotype rather than a core MORC3 molecular function.
+      supported_by: *id006
   - term:
       id: GO:0050821
       label: protein stabilization
     evidence_type: IDA
     original_reference_id: PMID:17332504
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        The p53 study indicates that genotoxic stress-induced p53 stabilization still occurs in Morc3-deficient fibroblasts;
+        MORC3 instead affects p53 localization and transcriptional activity.
+      action: REMOVE
+      reason: >-
+        Protein stabilization is not the supported MORC3 activity from this evidence.
       supported_by:
         - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+          supporting_text: >-
+            phosphorylation and stabilization of p53 but barely increased its
+        - reference_id: PMID:17332504
+          supporting_text: >-
+            Dynamic regulation of p53 subnuclear localization and senescence by MORC3.
   - term:
       id: GO:0051457
       label: maintenance of protein location in nucleus
     evidence_type: IDA
     original_reference_id: PMID:17332504
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 helps recruit/maintain p53, Sp100, and viral-genome-associated restriction factors in nuclear PML-body contexts.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        Maintenance of nuclear protein location is supported as a scaffold/localization role, but is secondary to the core
+        PML-body chromatin-adaptor function.
       supported_by:
         - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+          supporting_text: >-
+            Dynamic regulation of p53 subnuclear localization and senescence by MORC3.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            | PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes
+            to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization
+            and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes
+            recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading
+            MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other
+            contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent
+            media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown,
+            viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3
+            depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque
+            formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages
+            3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol*
+            (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |
   - term:
       id: GO:0051457
       label: maintenance of protein location in nucleus
     evidence_type: IMP
     original_reference_id: PMID:17332504
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MORC3 helps recruit/maintain p53, Sp100, and viral-genome-associated restriction factors in nuclear PML-body contexts.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        Maintenance of nuclear protein location is supported as a scaffold/localization role, but is secondary to the core
+        PML-body chromatin-adaptor function.
       supported_by:
         - reference_id: PMID:17332504
-          supporting_text: Mar 1. Dynamic regulation of p53 subnuclear 
-            localization and senescence by MORC3.
+          supporting_text: >-
+            Dynamic regulation of p53 subnuclear localization and senescence by MORC3.
+        - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+          supporting_text: >-
+            | PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes
+            to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization
+            and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes
+            recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading
+            MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other
+            contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent
+            media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown,
+            viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3
+            depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque
+            formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages
+            3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol*
+            (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |
 references:
   - id: GO_REF:0000002
-    title: Gene Ontology annotation through association of InterPro records with
-      GO terms
+    title: Gene Ontology annotation through association of InterPro records with GO terms
     findings: []
   - id: GO_REF:0000033
     title: Annotation inferences using phylogenetic trees
     findings: []
   - id: GO_REF:0000043
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword 
-      mapping
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
     findings: []
   - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+      by conservative changes to GO terms applied by UniProt
     findings: []
   - id: GO_REF:0000052
     title: Gene Ontology annotation based on curation of immunofluorescence data
     findings: []
   - id: GO_REF:0000107
-    title: Automatic transfer of experimentally verified manual GO annotation 
-      data to orthologs using Ensembl Compara
+    title: Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara
     findings: []
   - id: GO_REF:0000108
-    title: Automatic assignment of GO terms using logical inference, based on on
-      inter-ontology links
+    title: Automatic assignment of GO terms using logical inference, based on on inter-ontology links
     findings: []
   - id: GO_REF:0000117
-    title: Electronic Gene Ontology annotations created by ARBA machine learning
-      models
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
     findings: []
   - id: GO_REF:0000120
     title: Combined Automated Annotation using Multiple IEA Methods
     findings: []
   - id: PMID:17332504
-    title: Dynamic regulation of p53 subnuclear localization and senescence by 
-      MORC3.
+    title: Dynamic regulation of p53 subnuclear localization and senescence by MORC3.
     findings: []
   - id: PMID:26496610
-    title: A human interactome in three quantitative dimensions organized by 
-      stoichiometries and abundances.
+    title: A human interactome in three quantitative dimensions organized by stoichiometries and abundances.
     findings: []
   - id: PMID:26933034
-    title: Family-wide Characterization of Histone Binding Abilities of Human CW
-      Domain-containing Proteins.
+    title: Family-wide Characterization of Histone Binding Abilities of Human CW Domain-containing Proteins.
     findings: []
   - id: PMID:27173435
-    title: An organelle-specific protein landscape identifies novel diseases and
-      molecular mechanisms.
+    title: An organelle-specific protein landscape identifies novel diseases and molecular mechanisms.
     findings: []
   - id: PMID:27440897
-    title: MORC3, a Component of PML Nuclear Bodies, Has a Role in Restricting 
-      Herpes Simplex Virus 1 and Human Cytomegalovirus.
+    title: MORC3, a Component of PML Nuclear Bodies, Has a Role in Restricting Herpes Simplex Virus 1 and Human
+      Cytomegalovirus.
     findings: []
   - id: PMID:32296183
     title: A reference map of the human binary protein interactome.
     findings: []
   - id: PMID:33961781
-    title: Dual proteome-scale networks reveal cell-specific remodeling of the 
-      human interactome.
+    title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
     findings: []
   - id: PMID:34759314
     title: Self-guarding of MORC3 enables virulence factor-triggered immunity.
@@ -513,10 +948,151 @@ references:
     title: 'OpenCell: Endogenous tagging for the cartography of human cellular organization.'
     findings: []
   - id: PMID:35914814
-    title: 'Chr21 protein-protein interactions: enrichment in proteins involved in
-      intellectual disability, autism, and late-onset Alzheimer''s disease.'
+    title: 'Chr21 protein-protein interactions: enrichment in proteins involved in intellectual disability, autism, and late-onset
+      Alzheimer''s disease.'
     findings: []
   - id: PMID:40205054
-    title: Multimodal cell maps as a foundation for structural and functional 
-      genomics.
+    title: Multimodal cell maps as a foundation for structural and functional genomics.
     findings: []
+  - id: file:human/MORC3/MORC3-deep-research-falcon.md
+    title: Falcon deep research on MORC3 function
+    findings:
+      - statement: MORC3 is a nuclear matrix and PML nuclear body protein with GHKL ATPase and CW zinc-finger domains.
+      - statement: MORC3 contributes to PML nuclear body-associated intrinsic antiviral restriction of HSV-1 and HCMV.
+      - statement: MORC3 acts as a chromatin-associated ATPase/scaffold involved in epigenetic repression and interferon
+          program regulation.
+core_functions:
+  - molecular_function:
+      id: GO:0016887
+      label: ATP hydrolysis activity
+    description: >-
+      MORC3 is a MORC-family GHKL/HATPase chromatin-associated ATPase. Its ATPase cycle works with its CW zinc-finger chromatin-reader
+      module and SUMOylation to support repressive chromatin organization at foreign or deleterious DNA templates.
+    directly_involved_in:
+      - id: GO:0006325
+        label: chromatin organization
+      - id: GO:0000122
+        label: negative regulation of transcription by RNA polymerase II
+    locations:
+      - id: GO:0000785
+        label: chromatin
+      - id: GO:0016363
+        label: nuclear matrix
+      - id: GO:0005634
+        label: nucleus
+    supported_by:
+      - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+        supporting_text: >-
+          **Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules:
+          (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type
+          zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization
+          (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated
+          ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent
+          interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent
+          pages 3-5).
+      - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+        supporting_text: >-
+          | Epigenetic silencing / chromatin regulation | MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains;
+          ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement
+          loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism
+          is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous
+          pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Genome-wide
+          sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR | 2,737 reproducible
+          Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS
+          identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous
+          pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Groh et al.,
+          *Nat Commun* (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7 |
+  - molecular_function:
+      id: GO:0140002
+      label: histone H3K4me3 reader activity
+    description: >-
+      The MORC3 CW-type zinc finger recognizes methylated H3K4, connecting MORC3 to chromatin-reader activity in nuclear chromatin
+      contexts.
+    directly_involved_in:
+      - id: GO:0006325
+        label: chromatin organization
+    locations:
+      - id: GO:0000785
+        label: chromatin
+      - id: GO:0005634
+        label: nucleus
+    supported_by:
+      - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+        supporting_text: >-
+          **Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules:
+          (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type
+          zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization
+          (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated
+          ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent
+          interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent
+          pages 3-5).
+  - molecular_function:
+      id: GO:0030674
+      label: protein-macromolecule adaptor activity
+    description: >-
+      MORC3 acts as a SUMO-regulated PML-body scaffold/adaptor that recruits and maintains nuclear restriction factors at
+      PML bodies and incoming viral genomes, contributing to antiviral restriction and interferon-beta regulatory programs.
+    directly_involved_in:
+      - id: GO:0140374
+        label: antiviral innate immune response
+      - id: GO:0032688
+        label: negative regulation of interferon-beta production
+    locations:
+      - id: GO:0016605
+        label: PML body
+      - id: GO:0016363
+        label: nuclear matrix
+      - id: GO:0005634
+        label: nucleus
+    supported_by:
+      - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+        supporting_text: >-
+          **SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body
+          client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and
+          a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent
+          pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and
+          hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is
+          one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).
+      - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+        supporting_text: >-
+          | PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes
+          to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization
+          and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes
+          recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading
+          MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other contexts.
+          (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e)
+          | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown, viral protein immunoblotting
+          | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3 depletion caused a marked increase
+          in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque formation; MORC3 colocalizes with PML-NB
+          markers in punctate nuclear structures. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15,
+          sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol* (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16
+          |
+      - reference_id: file:human/MORC3/MORC3-deep-research-falcon.md
+        supporting_text: >-
+          **Intrinsic immunity and interferon pathway modulation.** In OSCC/HNSCC models, MORC3 knockdown upregulated interferon-associated
+          genes and increased STAT1 and PD-L1, suggesting MORC3 suppresses interferon-driven transcriptional programs in this
+          context (fu2024genomewideanalysisreveals pages 3-7). In myositis/cancer-associated myositis literature, MORC3 is
+          described as an antiviral factor and a repressor of IFNB1 (patasova2023geneticinfluencesin pages 6-8). Together,
+          these suggest MORC3 contributes to a chromatin-based brake on interferon gene expression, with context-dependent
+          consequences (antiviral restriction in fibroblast/hepatocyte models vs immune evasion phenotypes in cancer).
+proposed_new_terms: []
+suggested_questions:
+  - question: >-
+      Which MORC3 activities in human cells require the ATPase domain, the CW H3K4me3-reader domain, SUMOylation/SIM interactions,
+      or combinations of these modules?
+  - question: >-
+      Does MORC3 directly bind specific DNA elements such as the IFNB1-adjacent MRE, or is repression mediated through chromatin-associated
+      partner proteins?
+suggested_experiments:
+  - description: >-
+      Rescue MORC3 knockout human cells with ATPase-dead, CW-domain, SUMOylation-defective, and SIM-interaction mutants, then
+      measure PML-body localization, restriction-factor recruitment, IFNB1/MRE repression, and HSV-1/HCMV restriction.
+    hypothesis: >-
+      MORC3 antiviral and interferon-repressive functions require separable ATPase, chromatin-reader, and SUMO/PML-body interaction
+      modules.
+  - description: >-
+      Perform CUT&RUN/CUT&Tag or ChIP-seq for endogenous MORC3 together with DNA-binding-deficient and partner-recruitment
+      mutants at IFNB1/MRE, viral episomes, and retroelement loci.
+    hypothesis: >-
+      MORC3 occupies repressed chromatin templates through a partner-dependent chromatin scaffold mechanism rather than generic
+      sequence-independent DNA binding.

--- a/genes/human/MORC3/MORC3-deep-research-falcon.md
+++ b/genes/human/MORC3/MORC3-deep-research-falcon.md
@@ -1,0 +1,310 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T19:39:23.450007'
+end_time: '2026-05-11T19:52:20.206960'
+duration_seconds: 776.76
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: MORC3
+  gene_symbol: MORC3
+  uniprot_accession: Q14149
+  protein_description: 'RecName: Full=MORC family CW-type zinc finger protein 3; AltName:
+    Full=Nuclear matrix protein 2 {ECO:0000303|PubMed:11927593}; AltName: Full=Zinc
+    finger CW-type coiled-coil domain protein 3;'
+  gene_info: Name=MORC3 {ECO:0000312|HGNC:HGNC:23572}; Synonyms=KIAA0136 {ECO:0000312|HGNC:HGNC:23572},
+    NXP2 {ECO:0000312|HGNC:HGNC:23572}, ZCWCC3 {ECO:0000312|HGNC:HGNC:23572};
+  organism_full: Homo sapiens (Human).
+  protein_family: Not specified in UniProt
+  protein_domains: HATPase_C_sf. (IPR036890); MORC_ATPase. (IPR045261); Morc_S5. (IPR041006);
+    Znf_CW. (IPR011124); HATPase_c_3 (PF13589)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 17
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q14149
+- **Protein Description:** RecName: Full=MORC family CW-type zinc finger protein 3; AltName: Full=Nuclear matrix protein 2 {ECO:0000303|PubMed:11927593}; AltName: Full=Zinc finger CW-type coiled-coil domain protein 3;
+- **Gene Information:** Name=MORC3 {ECO:0000312|HGNC:HGNC:23572}; Synonyms=KIAA0136 {ECO:0000312|HGNC:HGNC:23572}, NXP2 {ECO:0000312|HGNC:HGNC:23572}, ZCWCC3 {ECO:0000312|HGNC:HGNC:23572};
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** HATPase_C_sf. (IPR036890); MORC_ATPase. (IPR045261); Morc_S5. (IPR041006); Znf_CW. (IPR011124); HATPase_c_3 (PF13589)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "MORC3" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'MORC3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **MORC3** (gene ID: MORC3, UniProt: Q14149) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q14149
+- **Protein Description:** RecName: Full=MORC family CW-type zinc finger protein 3; AltName: Full=Nuclear matrix protein 2 {ECO:0000303|PubMed:11927593}; AltName: Full=Zinc finger CW-type coiled-coil domain protein 3;
+- **Gene Information:** Name=MORC3 {ECO:0000312|HGNC:HGNC:23572}; Synonyms=KIAA0136 {ECO:0000312|HGNC:HGNC:23572}, NXP2 {ECO:0000312|HGNC:HGNC:23572}, ZCWCC3 {ECO:0000312|HGNC:HGNC:23572};
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** HATPase_C_sf. (IPR036890); MORC_ATPase. (IPR045261); Morc_S5. (IPR041006); Znf_CW. (IPR011124); HATPase_c_3 (PF13589)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "MORC3" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'MORC3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **MORC3** (gene ID: MORC3, UniProt: Q14149) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: Human MORC3 (UniProt Q14149; gene **MORC3**, aliases **NXP2**, **nuclear matrix protein 2**, **ZCWCC3**)
+
+### 1) Key concepts, definitions, and current understanding
+
+**Target verification and naming.** The UniProt accession Q14149 corresponds to human **MORC family CW-type zinc finger protein 3 (MORC3)**, historically described as **NXP2/nuclear matrix protein 2** and recognized as an autoantigen in dermatomyositis. Multiple primary and review sources explicitly use the combined name **NXP2/MORC3**, confirming that the literature discussed here matches the intended human protein (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).
+
+**Domain architecture and biochemical capabilities.** MORC3 is described as containing three conserved modules: (i) a **GHKL/HATPase-like ATPase domain** (a “GHL ATPase”/GHKL-type ATPase in the MORC family), (ii) a **CW-type zinc finger** reported to bind **methylated H3K4**, and (iii) a **coiled-coil** region implicated in dimerization/oligomerization (sloan2016morc3acomponent pages 3-5). These features fit the concept of MORC proteins as **chromatin-associated ATPases** that integrate ATPase-driven conformational changes with chromatin recognition (via CW) and multivalent interactions (via coiled-coil) to regulate nuclear substructures and transcriptional states (sloan2016morc3acomponent pages 3-5).
+
+**SUMO biology and PML nuclear bodies (PML-NBs/ND10).** MORC3 is a **SUMOylated** nuclear matrix/PML nuclear body client protein. It associates with PML nuclear bodies through **SUMO–SIM interactions** (SUMO on one partner and a SUMO-interacting motif on the other), specifically reported as a SUMO–SIM interaction with **PML isoform I** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15). PML nuclear bodies are SUMO-enriched subnuclear condensates and hubs for intrinsic immunity, DNA damage response, transcription regulation, and other nuclear processes; MORC3 is one of the SUMO-linked client proteins integrated into these assemblies (sloan2016morc3acomponent pages 3-5).
+
+**Primary functional framing (current consensus from available evidence).** Across experimental systems, MORC3 is best viewed as a **nuclear, chromatin-associated ATPase and SUMO-regulated scaffold** that:
+1) contributes to **PML nuclear body organization and intrinsic antiviral restriction**, and
+2) participates in **epigenetic repression programs** (including retroelement silencing and interferon program repression) likely through chromatin remodeling/assembly mechanisms.
+These themes converge on the idea that MORC3 helps enforce repressive chromatin states on foreign or potentially deleterious nucleic acids (viral genomes, transgenes, retroelements) and modulates innate immune gene expression (sloan2016morc3acomponent pages 3-5, groh2021morc3silencesendogenous pages 10-11, fu2024genomewideanalysisreveals pages 3-7, OpenTargets Search: -MORC3).
+
+### 2) Recent developments and latest research (prioritizing 2023–2024)
+
+#### 2.1 MORC3 as a restriction factor for gene therapy vectors (2023)
+A 2023 genome-scale CRISPR screening study identified MORC3 as a cellular factor that **restricts transgene expression** from recombinant adeno-associated virus (rAAV) vectors. MORC3 knockout improved transgene expression across **multiple AAV serotypes**, and also increased expression from other viral vectors (lentivirus and adenovirus). Importantly, the enhancement was also demonstrated in **human primary cells**, underscoring translational relevance for gene therapy optimization (OpenTargets Search: -MORC3).
+
+**Interpretation.** This work connects MORC3 to a clinically relevant, real-world implementation problem: host-cell **epigenetic silencing of therapeutic vectors**. The association with SETDB1/HUSH-linked restriction pathways (also implicated in antiviral and retroelement silencing) supports a coherent model in which MORC3 contributes to chromatin-based repression of newly introduced DNA templates (OpenTargets Search: -MORC3).
+
+#### 2.2 MORC3 represses interferon programs and PD-L1 in head and neck cancer (2024)
+A 2024 “genome-wide” study in head and neck/oral squamous cell carcinoma (HNSCC/OSCC) reported MORC3 as a **repressor of PD-L1 expression** and of interferon-associated gene programs. The study combined TCGA/GEPIA2 analyses, OSCC tissue microarray immunohistochemistry (**48 OSCC vs 10 normal oral mucosa**), siRNA knockdown in CAL27 cells, RNA-seq, qRT-PCR, western blot, and flow cytometry of PD-L1 surface expression (fu2024genomewideanalysisreveals pages 2-3, fu2024genomewideanalysisreveals pages 3-7).
+
+Key reported results include:
+- **MORC3 downregulation** in multiple cancers and lower MORC3 protein expression in OSCC relative to normal tissue (fu2024genomewideanalysisreveals pages 2-3, fu2024genomewideanalysisreveals pages 3-7).
+- In male TCGA HNSCC patients, higher MORC3 expression was associated with longer survival (stratification sizes reported as **high n=105 vs low n=262**) (fu2024genomewideanalysisreveals pages 3-7).
+- MORC3 knockdown induced interferon/ISG programs and increased STAT1 and PD-L1; RNA-seq after knockdown identified **270 differentially expressed genes (DEGs)** (171 up, 99 down), with enrichment for interferon signaling and PD-1/PD-L1 checkpoint pathways; the study proposed an axis involving **LINC00880** contributing to PD-L1 regulation (fu2024genomewideanalysisreveals pages 3-7).
+
+**Interpretation.** This positions MORC3 as an upstream modulator of tumor-immune interactions through interferon-linked regulation of PD-L1. However, the work is in a specific tumor context, and further mechanistic dissection (e.g., direct chromatin binding at PD-L1 regulators) would be needed to generalize.
+
+#### 2.3 Anti-NXP2/MORC3 autoantibodies and cancer-associated myositis genetics (2023)
+A 2023 review focusing on cancer-associated myositis summarizes anti-NXP2 antibodies (targeting MORC3/NXP2) as clinically meaningful biomarkers with prevalence and cancer association estimates. It reports:
+- Anti-NXP2 occurs in ~**22–25% of juvenile dermatomyositis** and **1–17%** of adult-onset dermatomyositis (patasova2023geneticinfluencesin pages 6-8).
+- Anti-NXP2 is described as increasing cancer-associated myositis risk by ~**30%** in adult-onset dermatomyositis, and retrospective series are summarized in which malignant neoplasms were observed in **24–37.5%** of anti-NXP2-positive adult patients (patasova2023geneticinfluencesin pages 6-8).
+This review also frames MORC3 mechanistically as a MORC-family ATPase with nuclear matrix binding features, with roles in chromatin/epigenetic regulation, antiviral activity, and repression of **IFNB1** (patasova2023geneticinfluencesin pages 6-8).
+
+**Interpretation.** The clinical association literature is heterogeneous, and newer multicenter cohorts (not limited to 2023–2024 in the retrieved set) indicate that assay methodology can strongly influence apparent anti-NXP2 positivity rates and downstream phenotype associations; therefore, conclusions about cancer risk should be made with attention to the detection method and cohort structure (OpenTargets Search: -MORC3).
+
+### 3) Molecular and cellular functions (functional annotation)
+
+#### 3.1 Subcellular localization: nuclear matrix and PML nuclear bodies; recruitment to viral genomes
+MORC3 is consistently characterized as a **nuclear matrix protein** that localizes to **PML nuclear bodies**. In immunofluorescence microscopy, MORC3 colocalizes with the PML-NB component Sp100 in punctate nuclear structures (sloan2016morc3acomponent media 84630a9e). During infection with HSV-1 lacking ICP0, MORC3 is recruited to sites associated with incoming viral genomes (identified by ICP4 foci), consistent with a role in intrinsic restriction at early stages of infection (sloan2016morc3acomponent media 5b6c97c8).
+
+Mechanistically, the association with PML-NBs is reported to occur via **SUMO–SIM interaction** with PML.I, and PML-NB localization/recruitment functions require a **functional ATPase domain** (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).
+
+#### 3.2 Post-translational regulation: SUMOylation and viral antagonism
+In a SILAC proteomics study of HSV-1 infection, MORC3/NXP2 was identified as a **SUMO2-modified** nuclear matrix protein whose abundance decreased by approximately **5.6-fold** during HSV-1 infection. Both SUMOylated and unmodified MORC3 were degraded during infection in an **ICP0-dependent** manner, consistent with ICP0 functioning as an E3 ubiquitin ligase targeting SUMOylated substrates to counter intrinsic immunity (sloan2016morc3acomponent pages 3-5).
+
+#### 3.3 Antiviral restriction roles: HSV-1 and HCMV
+Functional depletion experiments support MORC3 as a contributor to PML-NB–associated intrinsic restriction.
+- MORC3 depletion increased plaque formation efficiency of **ICP0-null HSV-1**, and increased levels of viral proteins (e.g., ICP4, UL42) early after infection, consistent with loss of a restriction activity. In contrast, wild-type HSV-1 did not show similar dependence because ICP0 rapidly degrades MORC3 and other SUMO-linked restriction factors, thereby counteracting MORC3-mediated restriction (sloan2016morc3acomponent pages 13-15).
+- MORC3 depletion also increased plaque formation efficiency of wild-type **HCMV**, consistent with MORC3 contributing to repression of DNA viruses (sloan2016morc3acomponent pages 13-15).
+
+A notable mechanistic finding is that MORC3 depletion reduced recruitment of multiple factors (Sp100, hDaxx, PML, γH2AX) to viral genomes, implying MORC3 participates in building/maintaining a restrictive chromatin environment at incoming HSV-1 genomes (sloan2016morc3acomponent pages 3-5).
+
+#### 3.4 Epigenetic silencing and chromatin regulation (inference grounded in conserved MORC3 biology)
+Direct mechanistic evidence for MORC3 in epigenetic silencing is strong in mouse embryonic stem cells and is likely informative for human MORC3 given conserved architecture.
+- Morc3 was identified in a genome-wide sgRNA screen for endogenous retrovirus (ERV) silencing factors, and Morc3 knockout caused ERV derepression, reduced H3K9me3, and increased chromatin accessibility (groh2021morc3silencesendogenous pages 1-2).
+- The mechanistic link to chromatin assembly is that Morc3 enables **Daxx-mediated histone H3.3 incorporation**, and Morc3 mutant proteins (defective in the ATPase cycle and/or SUMOylation) fail to interact effectively with Daxx. The interaction depends on Morc3 SUMOylation and Daxx SUMO binding (groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13).
+
+Although these experiments are not in human cells, they provide a plausible mechanistic basis for human MORC3’s effects on viral genomes and foreign DNA templates, consistent with the 2023 AAV restriction-factor finding and with interferon-program repression in cancer models (OpenTargets Search: -MORC3, fu2024genomewideanalysisreveals pages 3-7).
+
+### 4) Pathways and interaction context
+
+**SUMO–PML nuclear body pathway.** MORC3 is SUMOylated and operates as a SUMO-regulated PML-NB client, with localization mediated by SUMO–SIM interaction with PML.I. This situates MORC3 within the broader PML-NB/SUMO pathway central to intrinsic immunity and nuclear quality control (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).
+
+**Intrinsic immunity and interferon pathway modulation.** In OSCC/HNSCC models, MORC3 knockdown upregulated interferon-associated genes and increased STAT1 and PD-L1, suggesting MORC3 suppresses interferon-driven transcriptional programs in this context (fu2024genomewideanalysisreveals pages 3-7). In myositis/cancer-associated myositis literature, MORC3 is described as an antiviral factor and a repressor of IFNB1 (patasova2023geneticinfluencesin pages 6-8). Together, these suggest MORC3 contributes to a chromatin-based brake on interferon gene expression, with context-dependent consequences (antiviral restriction in fibroblast/hepatocyte models vs immune evasion phenotypes in cancer).
+
+### 5) Current applications and real-world implementations
+
+#### 5.1 Clinical biomarker: anti-NXP2 (anti-MORC3) in idiopathic inflammatory myopathies
+Anti-NXP2 autoantibodies (targeting MORC3/NXP2) are used in clinical phenotyping and risk stratification of dermatomyositis. Recent synthesis reports prevalence of ~22–25% in juvenile DM and 1–17% in adult DM, and highlights associations with muscle disease severity and calcinosis (patasova2023geneticinfluencesin pages 6-8). These antibodies are also discussed in the context of cancer-associated myositis with summaries of retrospective malignancy proportions (24–37.5% in anti-NXP2-positive adults across certain series) and an estimated ~30% increase in cancer-associated myositis risk in adult DM (patasova2023geneticinfluencesin pages 6-8). These data support clinical utility but also underscore heterogeneity and the need for careful interpretation across cohorts.
+
+#### 5.2 Gene therapy optimization: overcoming MORC3-mediated transgene silencing
+Because MORC3 knockout increases rAAV and other vector transgene expression in human primary cells, MORC3 (and related epigenetic restriction factors) represent actionable targets for improving gene therapy efficacy through vector engineering or transient modulation of host restriction pathways (OpenTargets Search: -MORC3).
+
+#### 5.3 Cancer immuno-oncology: MORC3 as a potential modulator of PD-L1/IFN programs
+The 2024 head and neck cancer study suggests MORC3 acts as a negative regulator of PD-L1 and interferon programs, linking its expression level to survival and tumor immune signaling (fu2024genomewideanalysisreveals pages 3-7). This provides a hypothesis-generating direction for biomarker development and for combination strategies involving immune checkpoint modulation, though further validation in independent cohorts and mechanistic work is needed.
+
+### 6) Expert opinions and analysis (from authoritative sources within the retrieved set)
+
+- The 2016 virology study interprets MORC3 as a **PML-NB component** whose SUMO-dependent recruitment to incoming viral genomes contributes to intrinsic restriction, and shows that HSV-1 ICP0 antagonizes MORC3 by degradation—an archetypal virus–host arms race feature of intrinsic immunity (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15).
+- The 2023 gene therapy restriction-factor study frames MORC3/SETDB1-linked factors as practical modulators of foreign DNA silencing that could be leveraged to enhance therapeutic transgene expression (OpenTargets Search: -MORC3).
+- The 2024 cancer study interprets MORC3 as a repressor of IFN-associated pathways and PD-L1 and connects its downregulation to poor outcomes, suggesting a role in shaping tumor immune landscapes (fu2024genomewideanalysisreveals pages 3-7).
+- The 2023 cancer-associated myositis review treats MORC3/NXP2 as both an autoantigen biomarker and a protein with plausible mechanistic ties to malignancy-related immune phenomena (via chromatin/p53/innate immunity links), while acknowledging that evidence is built from diverse retrospective cohorts (patasova2023geneticinfluencesin pages 6-8).
+
+### 7) Relevant statistics and quantitative data points (recent studies prioritized where possible)
+
+- **~5.6-fold decrease** in MORC3 abundance during HSV-1 infection (SILAC proteomics), with ICP0-dependent degradation of both SUMOylated and unmodified MORC3 (sloan2016morc3acomponent pages 3-5).
+- OSCC/HNSCC cancer study sample sizes: **48 OSCC vs 10 normal** oral mucosa on tissue microarray; male TCGA HNSCC survival stratification **high MORC3 n=105 vs low n=262**; **270 DEGs** upon MORC3 knockdown (fu2024genomewideanalysisreveals pages 3-7).
+- Anti-NXP2 prevalence and cancer association (reviewed data): **~22–25% juvenile DM**, **1–17% adult DM**, estimated ~**30%** increased risk of cancer-associated myositis in adult-onset DM, and **24–37.5%** malignancy in anti-NXP2-positive adults in certain retrospective series (patasova2023geneticinfluencesin pages 6-8).
+- OpenTargets disease associations (database synthesis): MORC3 has reported associations with cardiovascular disease and hypertension (scores ~0.52–0.54) based on limited evidence entries (OpenTargets Search: -MORC3).
+
+### Summary table of major functional themes
+
+| Functional theme | Key mechanism | Experimental evidence type | Key quantitative/statistical points (if available) | Representative recent source with DOI/URL and publication month/year |
+|---|---|---|---|---|
+| PML nuclear bodies / viral restriction | Human MORC3 (NXP2) is a SUMOylated nuclear-matrix protein that localizes to PML nuclear bodies via SUMO-SIM interactions with PML.I; its ATPase domain is required for PML-NB localization and for recruiting Sp100/p53. During HSV-1 infection, MORC3 is recruited to incoming viral genomes and promotes recruitment of intrinsic restriction factors (Sp100, hDaxx, PML, γH2AX). HSV-1 ICP0 counteracts this by degrading MORC3. MORC3 also restricts HCMV, although influenza studies indicate virus-specific proviral effects in other contexts. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | SILAC/MS proteomics, colocalization microscopy, HSV-1 and HCMV plaque assays, shRNA knockdown, viral protein immunoblotting | MORC3 abundance decreased ~5.6-fold during HSV-1 infection in proteomics; MORC3 depletion caused a marked increase in plaque formation efficiency of ICP0-null HSV-1 and increased HCMV plaque formation; MORC3 colocalizes with PML-NB markers in punctate nuclear structures. (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15, sloan2016morc3acomponent media 84630a9e) | Sloan et al., *J Virol* (Oct 2016), DOI: 10.1128/JVI.00621-16, https://doi.org/10.1128/JVI.00621-16 |
+| Epigenetic silencing / chromatin regulation | MORC3 is a GHKL ATPase with CW zinc finger and coiled-coil domains; ATP binding/hydrolysis and SUMOylation enable interaction with DAXX and promote histone H3.3 deposition at retroelement loci, supporting H3K9me3 heterochromatin and silencing. Although shown directly in mouse ES cells, the mechanism is highly relevant to human MORC3 because the same domain architecture/function is conserved. (groh2021morc3silencesendogenous pages 10-11, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Genome-wide sgRNA screen, knockout/rescue mutants, ChIP-seq, ChIP-MS/IP-MS, ATAC-seq, H3.3 ChIP-qPCR, RT-qPCR | 2,737 reproducible Morc3 ChIP peaks; Morc3 loss increased chromatin accessibility at 444 peaks and decreased it at 10 peaks; ChIP-MS identified 489 Morc3-associated proteins; ATPase-cycle mutants failed to rescue ERV silencing. (groh2020morc3silencesendogenous pages 7-10, groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13) | Groh et al., *Nat Commun* (Oct 2021), DOI: 10.1038/s41467-021-26288-7, https://doi.org/10.1038/s41467-021-26288-7 |
+| Innate immunity / IFNB1 repression | Recent work positions MORC3 as a negative regulator of type I interferon programs: it represses IFNB1 and broader IFN-stimulated gene expression, consistent with SUMO- and ATPase-dependent chromatin repression. In cancer cells, MORC3 knockdown derepresses IFN-associated genes; reviews of cancer-associated myositis also summarize MORC3 as an antiviral factor and IFNB1 repressor. (patasova2023geneticinfluencesin pages 6-8, fu2024genomewideanalysisreveals pages 1-2, fu2024genomewideanalysisreveals pages 3-7) | RNAi knockdown, RNA-seq, qRT-PCR, pathway enrichment, single-cell correlation analyses; clinical-review synthesis | In CAL27 cells, MORC3 knockdown yielded 270 DEGs (171 up, 99 down) and increased expression of multiple IFN-related genes (including MX2, IFIT1/2, IRF7, IRF9, IFI44L, IFIH1); reviews report anti-NXP2 adult DM cancer risk elevation of ~30% and connect MORC3 to antiviral/IFNB1-repressive biology. (fu2024genomewideanalysisreveals pages 3-7, patasova2023geneticinfluencesin pages 6-8) | Fu et al., *Front Cell Dev Biol* (Sep 2024), DOI: 10.3389/fcell.2024.1410130, https://doi.org/10.3389/fcell.2024.1410130; Patasova et al., *Arthritis Rheumatol* (Dec 2023), DOI: 10.1002/art.42345, https://doi.org/10.1002/art.42345 |
+| Cancer / PD-L1 regulation | In head and neck/oral squamous cancer, MORC3 acts as a transcriptional repressor of immune-evasion pathways: knockdown increases STAT1 and PD-L1 and induces IFN-associated programs; LINC00880 contributes to this PD-L1 upregulation. MORC3 expression is broadly reduced in multiple cancers and higher expression is associated with better survival in HNSCC analyses. (fu2024genomewideanalysisreveals pages 2-3, fu2024genomewideanalysisreveals pages 1-2, fu2024genomewideanalysisreveals pages 3-7) | TCGA/GEPIA2 bioinformatics, RNA-seq after siRNA knockdown, qRT-PCR, western blot, flow cytometry, tissue microarray IHC, single-cell transcriptomics | Tissue microarray included 48 OSCC and 10 normal oral mucosa samples; survival comparison reported high MORC3 expression (n=105) vs low (n=262) in male TCGA HNSCC; MORC3 knockdown increased STAT1 and PD-L1 and promoted proliferation. (fu2024genomewideanalysisreveals pages 2-3, fu2024genomewideanalysisreveals pages 3-7) | Fu et al., *Front Cell Dev Biol* (Sep 2024), DOI: 10.3389/fcell.2024.1410130, https://doi.org/10.3389/fcell.2024.1410130 |
+| Biomarker / anti-NXP2 autoantibodies in myositis | MORC3/NXP2 is a clinically important autoantigen in idiopathic inflammatory myopathies, especially dermatomyositis. Anti-NXP2 antibodies are used as serologic biomarkers associated with dermatomyositis, severe muscle disease/calcinosis, dysphagia in some cohorts, and possible cancer association in adults; assay methodology matters because line blot may overcall positivity relative to immunoprecipitation. (patasova2023geneticinfluencesin pages 6-8, OpenTargets Search: -MORC3) | Multicenter serology studies, immunoprecipitation, line blot, IP-Western, clinical correlation studies, review synthesis | Anti-NXP2 reported in ~22–25% of juvenile DM and 1–17% of adult-onset DM; retrospective adult series found malignancy in 24–37.5% of anti-NXP2-positive adults; in an Italian multicenter study, 60 line-blot-positive patients were analyzed, but IP confirmed 31/52 available sera (62%); anti-NXP2 positivity was associated with younger onset and more dermatomyositis, while cancer risk was similar to NXP2-negative myositis in that cohort. (patasova2023geneticinfluencesin pages 6-8, OpenTargets Search: -MORC3) | Patasova et al., *Arthritis Rheumatol* (Dec 2023), DOI: 10.1002/art.42345, https://doi.org/10.1002/art.42345; Fredi et al., *Clin Rev Allergy Immunol* (Jan 2022), DOI: 10.1007/s12016-021-08920-y, https://doi.org/10.1007/s12016-021-08920-y |
+| Gene therapy relevance / restriction of transgene expression | MORC3 functions as a cellular restriction factor that suppresses expression from recombinant AAV and other viral vectors, likely via chromatin-based silencing pathways overlapping with SETDB1-linked repression. This gives MORC3 translational relevance in vector engineering and gene therapy optimization. (OpenTargets Search: -MORC3) | Genome-scale CRISPR screens, knockout validation in human cells and primary cells, transgene expression assays across vector serotypes | MORC3 knockout increased transgene expression from several AAV serotypes and also improved expression from lentiviral and adenoviral vectors; enhancement was observed in human primary cells, supporting physiological relevance. (OpenTargets Search: -MORC3) | Ngo & Puschnik, *J Virol* (Apr 2023), DOI: 10.1128/jvi.01948-22, https://doi.org/10.1128/jvi.01948-22 |
+
+
+*Table: This table summarizes the main experimentally supported functional annotations for human MORC3/NXP2, including nuclear-body biology, chromatin silencing, innate immune regulation, cancer relevance, biomarker use, and translational implications. It prioritizes recent 2023-2024 evidence where available and includes quantitative points and source details.*
+
+### Key primary sources (URLs and publication dates)
+
+- Sloan E, Orr A, Everett RD. **“MORC3, a Component of PML Nuclear Bodies, Has a Role in Restricting Herpes Simplex Virus 1 and Human Cytomegalovirus.”** *Journal of Virology* (Oct 2016). https://doi.org/10.1128/JVI.00621-16 (sloan2016morc3acomponent pages 3-5, sloan2016morc3acomponent pages 13-15)
+- Ngo AM, Puschnik AS. **“Genome-Scale Analysis of Cellular Restriction Factors That Inhibit Transgene Expression from Adeno-Associated Virus Vectors.”** *Journal of Virology* (Apr 2023). https://doi.org/10.1128/jvi.01948-22 (OpenTargets Search: -MORC3)
+- Fu W, Chang X, Ye K, et al. **“Genome-wide analysis reveals the MORC3-mediated repression of PD-L1 expression in head and neck cancer.”** *Frontiers in Cell and Developmental Biology* (Sep 2024). https://doi.org/10.3389/fcell.2024.1410130 (fu2024genomewideanalysisreveals pages 3-7)
+- Patasova K, Lundberg IE, Holmqvist M. **“Genetic Influences in Cancer-Associated Myositis.”** *Arthritis & Rheumatology* (Dec 2023). https://doi.org/10.1002/art.42345 (patasova2023geneticinfluencesin pages 6-8)
+- Groh S, Milton AV, Marinelli LK, et al. **“Morc3 silences endogenous retroviruses by enabling Daxx-mediated histone H3.3 incorporation.”** *Nature Communications* (Oct 2021). https://doi.org/10.1038/s41467-021-26288-7 (groh2021morc3silencesendogenous pages 1-2)
+
+### Notes on evidence scope and limitations
+
+- Some mechanistic chromatin-silencing evidence is derived from **mouse Morc3** ES cell systems. These experiments provide strong mechanistic clarity (ATPase cycle/SUMOylation→Daxx→H3.3 deposition→ERV silencing) and are likely relevant to human MORC3 due to conserved architecture, but the specific loci and regulatory partners may be context dependent (groh2021morc3silencesendogenous pages 1-2, groh2020morc3silencesendogenous pages 10-13).
+- The 2024 PD-L1 finding is currently supported by one primary study in head and neck cancer models and requires broader validation (fu2024genomewideanalysisreveals pages 3-7).
+
+
+
+References
+
+1. (sloan2016morc3acomponent pages 3-5): Elizabeth Sloan, Anne Orr, and Roger D. Everett. Morc3, a component of pml nuclear bodies, has a role in restricting herpes simplex virus 1 and human cytomegalovirus. Journal of Virology, 90:8621-8633, Oct 2016. URL: https://doi.org/10.1128/jvi.00621-16, doi:10.1128/jvi.00621-16. This article has 68 citations and is from a domain leading peer-reviewed journal.
+
+2. (sloan2016morc3acomponent pages 13-15): Elizabeth Sloan, Anne Orr, and Roger D. Everett. Morc3, a component of pml nuclear bodies, has a role in restricting herpes simplex virus 1 and human cytomegalovirus. Journal of Virology, 90:8621-8633, Oct 2016. URL: https://doi.org/10.1128/jvi.00621-16, doi:10.1128/jvi.00621-16. This article has 68 citations and is from a domain leading peer-reviewed journal.
+
+3. (groh2021morc3silencesendogenous pages 10-11): Sophia Groh, Anna Viktoria Milton, Lisa Katherina Marinelli, Cara V. Sickinger, Angela Russo, Heike Bollig, Gustavo Pereira de Almeida, Andreas Schmidt, Ignasi Forné, Axel Imhof, and Gunnar Schotta. Morc3 silences endogenous retroviruses by enabling daxx-mediated histone h3.3 incorporation. Nature Communications, Oct 2021. URL: https://doi.org/10.1038/s41467-021-26288-7, doi:10.1038/s41467-021-26288-7. This article has 60 citations and is from a highest quality peer-reviewed journal.
+
+4. (fu2024genomewideanalysisreveals pages 3-7): Wenxuan Fu, Xiaomeng Chang, Kun Ye, Zige Zheng, Qianyi Lai, Minyang Ge, and Yan Shi. Genome-wide analysis reveals the morc3-mediated repression of pd-l1 expression in head and neck cancer. Frontiers in Cell and Developmental Biology, Sep 2024. URL: https://doi.org/10.3389/fcell.2024.1410130, doi:10.3389/fcell.2024.1410130. This article has 1 citations.
+
+5. (OpenTargets Search: -MORC3): Open Targets Query (-MORC3, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+6. (fu2024genomewideanalysisreveals pages 2-3): Wenxuan Fu, Xiaomeng Chang, Kun Ye, Zige Zheng, Qianyi Lai, Minyang Ge, and Yan Shi. Genome-wide analysis reveals the morc3-mediated repression of pd-l1 expression in head and neck cancer. Frontiers in Cell and Developmental Biology, Sep 2024. URL: https://doi.org/10.3389/fcell.2024.1410130, doi:10.3389/fcell.2024.1410130. This article has 1 citations.
+
+7. (patasova2023geneticinfluencesin pages 6-8): Karina Patasova, Ingrid E. Lundberg, and Marie Holmqvist. Genetic influences in <scp>cancer‐associated</scp> myositis. Arthritis &amp; Rheumatology, 75:153-163, Dec 2023. URL: https://doi.org/10.1002/art.42345, doi:10.1002/art.42345. This article has 17 citations and is from a highest quality peer-reviewed journal.
+
+8. (sloan2016morc3acomponent media 84630a9e): Elizabeth Sloan, Anne Orr, and Roger D. Everett. Morc3, a component of pml nuclear bodies, has a role in restricting herpes simplex virus 1 and human cytomegalovirus. Journal of Virology, 90:8621-8633, Oct 2016. URL: https://doi.org/10.1128/jvi.00621-16, doi:10.1128/jvi.00621-16. This article has 68 citations and is from a domain leading peer-reviewed journal.
+
+9. (sloan2016morc3acomponent media 5b6c97c8): Elizabeth Sloan, Anne Orr, and Roger D. Everett. Morc3, a component of pml nuclear bodies, has a role in restricting herpes simplex virus 1 and human cytomegalovirus. Journal of Virology, 90:8621-8633, Oct 2016. URL: https://doi.org/10.1128/jvi.00621-16, doi:10.1128/jvi.00621-16. This article has 68 citations and is from a domain leading peer-reviewed journal.
+
+10. (groh2021morc3silencesendogenous pages 1-2): Sophia Groh, Anna Viktoria Milton, Lisa Katherina Marinelli, Cara V. Sickinger, Angela Russo, Heike Bollig, Gustavo Pereira de Almeida, Andreas Schmidt, Ignasi Forné, Axel Imhof, and Gunnar Schotta. Morc3 silences endogenous retroviruses by enabling daxx-mediated histone h3.3 incorporation. Nature Communications, Oct 2021. URL: https://doi.org/10.1038/s41467-021-26288-7, doi:10.1038/s41467-021-26288-7. This article has 60 citations and is from a highest quality peer-reviewed journal.
+
+11. (groh2020morc3silencesendogenous pages 10-13): Sophia Groh, Anna Viktoria Milton, Lisa Marinelli, Cara V. Sickinger, Heike Bollig, Gustavo Pereira de Almeida, Ignasi Forné, Andreas Schmidt, Axel Imhof, and Gunnar Schotta. Morc3 silences endogenous retroviruses by enabling daxx-mediated h3.3 incorporation. bioRxiv, Nov 2020. URL: https://doi.org/10.1101/2020.11.12.380204, doi:10.1101/2020.11.12.380204. This article has 2 citations.
+
+12. (groh2020morc3silencesendogenous pages 7-10): Sophia Groh, Anna Viktoria Milton, Lisa Marinelli, Cara V. Sickinger, Heike Bollig, Gustavo Pereira de Almeida, Ignasi Forné, Andreas Schmidt, Axel Imhof, and Gunnar Schotta. Morc3 silences endogenous retroviruses by enabling daxx-mediated h3.3 incorporation. bioRxiv, Nov 2020. URL: https://doi.org/10.1101/2020.11.12.380204, doi:10.1101/2020.11.12.380204. This article has 2 citations.
+
+13. (fu2024genomewideanalysisreveals pages 1-2): Wenxuan Fu, Xiaomeng Chang, Kun Ye, Zige Zheng, Qianyi Lai, Minyang Ge, and Yan Shi. Genome-wide analysis reveals the morc3-mediated repression of pd-l1 expression in head and neck cancer. Frontiers in Cell and Developmental Biology, Sep 2024. URL: https://doi.org/10.3389/fcell.2024.1410130, doi:10.3389/fcell.2024.1410130. This article has 1 citations.
+
+## Citations
+
+1. fu2024genomewideanalysisreveals pages 3-7
+2. patasova2023geneticinfluencesin pages 6-8
+3. fu2024genomewideanalysisreveals pages 2-3
+4. fu2024genomewideanalysisreveals pages 1-2
+5. https://doi.org/10.1128/JVI.00621-16
+6. https://doi.org/10.1038/s41467-021-26288-7
+7. https://doi.org/10.3389/fcell.2024.1410130;
+8. https://doi.org/10.1002/art.42345
+9. https://doi.org/10.3389/fcell.2024.1410130
+10. https://doi.org/10.1002/art.42345;
+11. https://doi.org/10.1007/s12016-021-08920-y
+12. https://doi.org/10.1128/jvi.01948-22
+13. https://doi.org/10.1128/jvi.00621-16,
+14. https://doi.org/10.1038/s41467-021-26288-7,
+15. https://doi.org/10.3389/fcell.2024.1410130,
+16. https://doi.org/10.1002/art.42345,
+17. https://doi.org/10.1101/2020.11.12.380204,

--- a/genes/human/PMPCA/PMPCA-ai-review.html
+++ b/genes/human/PMPCA/PMPCA-ai-review.html
@@ -1,0 +1,4645 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PMPCA - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PMPCA</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q10713" target="_blank" class="term-link">
+                        Q10713
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "PMPCA";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q10713" data-a="DESCRIPTION: PMPCA encodes the alpha subunit of the mitochondri..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>PMPCA encodes the alpha subunit of the mitochondrial processing peptidase (MPP), a matrix heterodimer with PMPCB that removes N-terminal mitochondrial targeting presequences from imported precursor proteins. PMPCA is the substrate-recognition/binding subunit, including a glycine-rich loop that helps position precursor proteins for cleavage by the catalytic PMPCB beta subunit; it is essential for productive MPP activity but is not itself the catalytic metalloprotease.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017087" target="_blank" class="term-link">
+                                    GO:0017087
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial processing peptidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0017087" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PMPCA is a defining alpha subunit of the heterodimeric mitochondrial processing peptidase complex with PMPCB.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The annotation captures the core complex membership of PMPCA in MPP.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004222" target="_blank" class="term-link">
+                                    GO:0004222
+                                </a>
+                            </span>
+                            <span class="term-label">metalloendopeptidase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0004222" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The MPP complex has Zn2+-dependent metalloendopeptidase activity, but the catalytic site is in PMPCB; PMPCA contributes substrate recognition and positioning.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> As an enabled molecular function on PMPCA alone, metalloendopeptidase activity overstates the alpha subunit. Replace the direct enabled MF with protein-macromolecule adaptor activity and represent complex protease activity as contributes_to in core_functions.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                                    protein-macromolecule adaptor activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **Zn2+-dependent metallopeptidase**. The catalytic model described for MPP cleavage is thermolysin-like, in which a **Zn2+-bound water** (polarized by a catalytic glutamate) performs nucleophilic attack on the scissile peptide bond; the **Zn2+-binding motif** resides in PMPCB/MPPβ (HxxEH…E) (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). PMPCA is therefore **catalytically inactive** in the metalloprotease sense but essential for productive substrate engagement (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, joshi2016mutationsinthe pages 1-2).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0005743" data-r="GO_REF:0000044" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PMPCA/MPP acts in the mitochondrial matrix after precursor import rather than being an inner-membrane component.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The more precise supported cellular component for PMPCA is mitochondrial matrix.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    mitochondrial matrix
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof pages 1-2) |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000120
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0005759" data-r="GO_REF:0000120" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MPP acts in the mitochondrial matrix where imported precursor proteins are processed.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix localization is directly consistent with the synthesized literature and Reactome annotations for MPP processing events.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof pages 1-2) |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006508" target="_blank" class="term-link">
+                                    GO:0006508
+                                </a>
+                            </span>
+                            <span class="term-label">proteolysis</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0006508" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PMPCA contributes to proteolytic removal of mitochondrial targeting presequences as part of MPP, but generic proteolysis is less informative than protein processing.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use protein processing to capture the maturation of imported mitochondrial precursor proteins rather than broad proteolysis.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016485" target="_blank" class="term-link">
+                                    protein processing
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016485" target="_blank" class="term-link">
+                                    GO:0016485
+                                </a>
+                            </span>
+                            <span class="term-label">protein processing</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000117
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0016485" data-r="GO_REF:0000117" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PMPCA contributes to MPP-dependent maturation of imported mitochondrial precursor proteins by presequence cleavage.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein processing is the appropriate biological process for MPP-dependent precursor maturation.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
+                                    GO:0046872
+                                </a>
+                            </span>
+                            <span class="term-label">metal ion binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0046872" data-r="GO_REF:0000002" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The catalytic zinc-binding motif of MPP resides in PMPCB/MPP beta, not PMPCA.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The available evidence does not support metal ion binding as a direct PMPCA activity; this appears to be propagated from the complex/beta subunit metalloprotease mechanism.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **Zn2+-dependent metallopeptidase**. The catalytic model described for MPP cleavage is thermolysin-like, in which a **Zn2+-bound water** (polarized by a catalytic glutamate) performs nucleophilic attack on the scissile peptide bond; the **Zn2+-binding motif** resides in PMPCB/MPPβ (HxxEH…E) (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). PMPCA is therefore **catalytically inactive** in the metalloprotease sense but essential for productive substrate engagement (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, joshi2016mutationsinthe pages 1-2).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30021884" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30021884
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Histone Interaction Landscapes Visualized by Crosslinking Ma...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0005515" data-r="PMID:30021884" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic protein binding is uninformative for PMPCA. The biologically meaningful interaction is substrate recognition/positioning within the MPP complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The annotation should be replaced in curation practice by specific MPP complex membership and the substrate-recognition/adaptor role, rather than retained as broad protein binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP recognizes presequences that are typically **positively charged amphipathic α-helices**; reviews emphasize a frequent preference for **arginine at −2 or −3** relative to the cleavage site (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). PMPCA’s **glycine-rich loop** is described as critical for substrate binding and/or guiding the precursor toward the catalytic center (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic protein binding is uninformative for PMPCA. The biologically meaningful interaction is substrate recognition/positioning within the MPP complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The annotation should be replaced in curation practice by specific MPP complex membership and the substrate-recognition/adaptor role, rather than retained as broad protein binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP recognizes presequences that are typically **positively charged amphipathic α-helices**; reviews emphasize a frequent preference for **arginine at −2 or −3** relative to the cleavage site (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). PMPCA’s **glycine-rich loop** is described as critical for substrate binding and/or guiding the precursor toward the catalytic center (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Generic protein binding is uninformative for PMPCA. The biologically meaningful interaction is substrate recognition/positioning within the MPP complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The annotation should be replaced in curation practice by specific MPP complex membership and the substrate-recognition/adaptor role, rather than retained as broad protein binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP recognizes presequences that are typically **positively charged amphipathic α-helices**; reviews emphasize a frequent preference for **arginine at −2 or −3** relative to the cleavage site (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). PMPCA’s **glycine-rich loop** is described as critical for substrate binding and/or guiding the precursor toward the catalytic center (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32443488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32443488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial Protein Quality Control Mechanisms.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0005739" data-r="PMID:32443488" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PMPCA is mitochondrial, but the evidence supports the more specific mitochondrial matrix localization of the MPP machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial matrix rather than the broad parent term mitochondrion.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    mitochondrial matrix
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof pages 1-2) |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017087" target="_blank" class="term-link">
+                                    GO:0017087
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial processing peptidase complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32443488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32443488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial Protein Quality Control Mechanisms.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0017087" data-r="PMID:32443488" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PMPCA is a defining alpha subunit of the heterodimeric mitochondrial processing peptidase complex with PMPCB.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The annotation captures the core complex membership of PMPCA in MPP.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070585" target="_blank" class="term-link">
+                                    GO:0070585
+                                </a>
+                            </span>
+                            <span class="term-label">protein localization to mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32443488" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32443488
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial Protein Quality Control Mechanisms.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0070585" data-r="PMID:32443488" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MPP processing is coupled to import for some substrates, but PMPCA acts after import by cleaving targeting presequences rather than serving as the localization/import machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The core process is mitochondrial precursor protein processing, not general protein localization to mitochondrion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PMPCA is mitochondrial, but the evidence supports the more specific mitochondrial matrix localization of the MPP machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial matrix rather than the broad parent term mitochondrion.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    mitochondrial matrix
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof pages 1-2) |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016485" target="_blank" class="term-link">
+                                    GO:0016485
+                                </a>
+                            </span>
+                            <span class="term-label">protein processing</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22354088" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22354088
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondrial processing peptidase regulates PINK1 processin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0016485" data-r="PMID:22354088" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PMPCA contributes to MPP-dependent maturation of imported mitochondrial precursor proteins by presequence cleavage.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein processing is the appropriate biological process for MPP-dependent precursor maturation.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016485" target="_blank" class="term-link">
+                                    GO:0016485
+                                </a>
+                            </span>
+                            <span class="term-label">protein processing</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25808372" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25808372
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PMPCA mutations cause abnormal mitochondrial protein process...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0016485" data-r="PMID:25808372" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PMPCA contributes to MPP-dependent maturation of imported mitochondrial precursor proteins by presequence cleavage.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein processing is the appropriate biological process for MPP-dependent precursor maturation.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0005739" data-r="PMID:34800366" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PMPCA is mitochondrial, but the evidence supports the more specific mitochondrial matrix localization of the MPP machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial matrix rather than the broad parent term mitochondrion.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    mitochondrial matrix
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof pages 1-2) |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0005759" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MPP acts in the mitochondrial matrix where imported precursor proteins are processed.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix localization is directly consistent with the synthesized literature and Reactome annotations for MPP processing events.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof pages 1-2) |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-8949649
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0005759" data-r="Reactome:R-HSA-8949649" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MPP acts in the mitochondrial matrix where imported precursor proteins are processed.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix localization is directly consistent with the synthesized literature and Reactome annotations for MPP processing events.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof pages 1-2) |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9838081
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0005759" data-r="Reactome:R-HSA-9838081" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MPP acts in the mitochondrial matrix where imported precursor proteins are processed.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix localization is directly consistent with the synthesized literature and Reactome annotations for MPP processing events.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof pages 1-2) |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    GO:0005759
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">TAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            Reactome:R-HSA-9838093
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0005759" data-r="Reactome:R-HSA-9838093" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> MPP acts in the mitochondrial matrix where imported precursor proteins are processed.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Matrix localization is directly consistent with the synthesized literature and Reactome annotations for MPP processing events.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof pages 1-2) |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005743" target="_blank" class="term-link">
+                                    GO:0005743
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial inner membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25808372" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25808372
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    PMPCA mutations cause abnormal mitochondrial protein process...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0005743" data-r="PMID:25808372" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PMPCA/MPP acts in the mitochondrial matrix after precursor import rather than being an inner-membrane component.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The more precise supported cellular component for PMPCA is mitochondrial matrix.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    mitochondrial matrix
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof pages 1-2) |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                    GO:0005576
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular region</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22664934" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22664934
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Comparison of tear protein levels in breast cancer patients ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0005576" data-r="PMID:22664934" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PMPCA is a mitochondrial matrix MPP subunit; the extracellular-region annotation is inconsistent with the curated functional literature.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This high-throughput extracellular annotation is not supported by the gene-specific evidence and conflicts with the mitochondrial matrix role.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof pages 1-2) |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000054
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0005739" data-r="GO_REF:0000054" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PMPCA is mitochondrial, but the evidence supports the more specific mitochondrial matrix localization of the MPP machinery.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial matrix rather than the broad parent term mitochondrion.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                    mitochondrial matrix
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">| Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof pages 1-2) |</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                                    GO:0030674
+                                </a>
+                            </span>
+                            <span class="term-label">protein-macromolecule adaptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q10713" data-a="GO:0030674" data-r="file:human/PMPCA/PMPCA-deep-research-falcon.md" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> PMPCA has a substrate-recognition/positioning role within the MPP heterodimer, guiding precursor proteins toward the PMPCB catalytic site.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the best available MF-level representation of the alpha subunit role distinct from PMPCB catalytic metalloendopeptidase activity.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">MPP recognizes presequences that are typically **positively charged amphipathic α-helices**; reviews emphasize a frequent preference for **arginine at −2 or −3** relative to the cleavage site (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). PMPCA’s **glycine-rich loop** is described as critical for substrate binding and/or guiding the precursor toward the catalytic center (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>PMPCA is the substrate-recognition alpha subunit of the mitochondrial processing peptidase. It binds/positions imported mitochondrial precursor proteins through a glycine-rich substrate-handling loop and thereby contributes to the PMPCA:PMPCB complex metalloendopeptidase activity that removes N-terminal mitochondrial targeting presequences in the matrix.</h3>
+                <span class="vote-buttons" data-g="Q10713" data-a="FUNCTION: PMPCA is the substrate-recognition alpha subunit o..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030674" target="_blank" class="term-link">
+                            protein-macromolecule adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016485" target="_blank" class="term-link">
+                                protein processing
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005759" target="_blank" class="term-link">
+                                mitochondrial matrix
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0017087" target="_blank" class="term-link">
+                            mitochondrial processing peptidase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">MPP is a **Zn2+-dependent metallopeptidase**. The catalytic model described for MPP cleavage is thermolysin-like, in which a **Zn2+-bound water** (polarized by a catalytic glutamate) performs nucleophilic attack on the scissile peptide bond; the **Zn2+-binding motif** resides in PMPCB/MPPβ (HxxEH…E) (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). PMPCA is therefore **catalytically inactive** in the metalloprotease sense but essential for productive substrate engagement (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, joshi2016mutationsinthe pages 1-2).</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">| Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof pages 1-2) |</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000054.md" target="_blank" class="term-link">
+                            GO_REF:0000054
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of intracellular localizations of expressed fusion proteins in living cells</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
+                            GO_REF:0000117
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
+                            GO_REF:0000120
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22354088" target="_blank" class="term-link">
+                            PMID:22354088
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondrial processing peptidase regulates PINK1 processing, import and Parkin recruitment.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22664934" target="_blank" class="term-link">
+                            PMID:22664934
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Comparison of tear protein levels in breast cancer patients and healthy controls using a de novo proteomic approach.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25808372" target="_blank" class="term-link">
+                            PMID:25808372
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PMPCA mutations cause abnormal mitochondrial protein processing in patients with non-progressive cerebellar ataxia.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30021884" target="_blank" class="term-link">
+                            PMID:30021884
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Histone Interaction Landscapes Visualized by Crosslinking Mass Spectrometry in Intact Cell Nuclei.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32443488" target="_blank" class="term-link">
+                            PMID:32443488
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondrial Protein Quality Control Mechanisms.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-8949649
+
+                    </span>
+                </div>
+
+                <div class="reference-title">PMPCA:PMPCB cleaves the transit peptide of proSMDT1 (proEMRE)</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9838081
+
+                    </span>
+                </div>
+
+                <div class="reference-title">LONP1 degrades mitochondrial matrix proteins</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        Reactome:R-HSA-9838093
+
+                    </span>
+                </div>
+
+                <div class="reference-title">LONP1 binds mitochondrial matrix proteins</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PMPCA/PMPCA-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research on PMPCA function</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">PMPCA is the alpha, substrate-recognition subunit of the PMPCA:PMPCB mitochondrial processing peptidase complex.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The MPP complex cleaves N-terminal mitochondrial targeting presequences after import into the mitochondrial matrix.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">The catalytic zinc metallopeptidase active site resides in PMPCB rather than PMPCA.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Would GO benefit from a term for mitochondrial presequence-recognition activity or MPP alpha-subunit substrate-guiding activity, distinct from generic adaptor activity and from PMPCB catalytic metalloendopeptidase activity?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q10713" data-a="Q: Would GO benefit from a term for mitochondrial pre..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute human PMPCA/PMPCB MPP variants with precursor substrates and measure substrate binding, positioning, and cleavage kinetics for PMPCA glycine-loop and patient alleles.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: PMPCA variants primarily impair precursor recognition/positioning while PMPCB provides the catalytic metallopeptidase chemistry.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q10713" data-a="EXPERIMENT: Reconstitute human PMPCA/PMPCB MPP variants with p..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PMPCA-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q10713" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T19:42:38.854924'<br />
+end_time: '2026-05-11T19:58:06.753509'<br />
+duration_seconds: 927.9<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: PMPCA<br />
+  gene_symbol: PMPCA<br />
+  uniprot_accession: Q10713<br />
+  protein_description: 'RecName: Full=Mitochondrial-processing peptidase subunit alpha;<br />
+    AltName: Full=Alpha-MPP; AltName: Full=Inactive zinc metalloprotease alpha {ECO:0000305};<br />
+    AltName: Full=P-55; Flags: Precursor;'<br />
+  gene_info: Name=PMPCA; Synonyms=INPP5E, KIAA0123, MPPA;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the peptidase M16 family. .<br />
+  protein_domains: Metalloenz_LuxS/M16. (IPR011249); MPP/UQCRC_Complex. (IPR050361);<br />
+    Pept_M16_N. (IPR011765); Pept_M16_Zn_BS. (IPR001431); Peptidase_M16_C. (IPR007863)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 28</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q10713</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial-processing peptidase subunit alpha; AltName: Full=Alpha-MPP; AltName: Full=Inactive zinc metalloprotease alpha {ECO:0000305}; AltName: Full=P-55; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=PMPCA; Synonyms=INPP5E, KIAA0123, MPPA;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the peptidase M16 family. .</li>
+<li><strong>Key Domains:</strong> Metalloenz_LuxS/M16. (IPR011249); MPP/UQCRC_Complex. (IPR050361); Pept_M16_N. (IPR011765); Pept_M16_Zn_BS. (IPR001431); Peptidase_M16_C. (IPR007863)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "PMPCA" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'PMPCA' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>PMPCA</strong> (gene ID: PMPCA, UniProt: Q10713) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q10713</li>
+<li><strong>Protein Description:</strong> RecName: Full=Mitochondrial-processing peptidase subunit alpha; AltName: Full=Alpha-MPP; AltName: Full=Inactive zinc metalloprotease alpha {ECO:0000305}; AltName: Full=P-55; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=PMPCA; Synonyms=INPP5E, KIAA0123, MPPA;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the peptidase M16 family. .</li>
+<li><strong>Key Domains:</strong> Metalloenz_LuxS/M16. (IPR011249); MPP/UQCRC_Complex. (IPR050361); Pept_M16_N. (IPR011765); Pept_M16_Zn_BS. (IPR001431); Peptidase_M16_C. (IPR007863)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "PMPCA" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'PMPCA' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>PMPCA</strong> (gene ID: PMPCA, UniProt: Q10713) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-human-pmpca-uniprot-q10713-mitochondrial-processing-peptidase-subunit-alpha">Research report: Human <strong>PMPCA</strong> (UniProt <strong>Q10713</strong>) — mitochondrial-processing peptidase subunit alpha</h2>
+<h3 id="0-mandatory-target-verification-identity-check">0) Mandatory target verification (identity check)</h3>
+<p>The literature retrieved and synthesized here pertains to <strong>human PMPCA</strong> encoding <strong>mitochondrial-processing peptidase subunit alpha (α-MPP)</strong>, consistent with UniProt accession <strong>Q10713</strong> and the protein description “mitochondrial-processing peptidase subunit alpha/Alpha-MPP/P-55 precursor.” Multiple independent sources explicitly define <strong>MPP</strong> as a <strong>heterodimeric</strong> enzyme composed of <strong>PMPCA (α)</strong> and <strong>PMPCB (β)</strong> that removes <strong>N-terminal mitochondrial targeting presequences</strong> after import, with PMPCA acting in substrate recognition/binding and PMPCB containing the catalytic metalloprotease site (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, kucukkose2021functionalcouplingof pages 1-2). Cross-species naming can be confusing (e.g., yeast MPPA/MPPB corresponding to MPPα/MPPβ); however, the human gene symbol and function described in the cited human disease and mechanistic papers consistently refer to PMPCA as α-MPP (kunova2022mitochondrialprocessingpeptidases—structure pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-mitochondrial-targeting-presequences-and-processing">1.1 Mitochondrial targeting presequences and processing</h4>
+<p>A large fraction of mitochondrial proteins are <strong>nuclear encoded</strong>, synthesized in the cytosol, and imported into mitochondria using <strong>N-terminal presequences</strong> (matrix-targeting signals) that must be removed for maturation and function. In human mitochondria, the <strong>mitochondrial processing peptidase (MPP)</strong> is the essential protease that cleaves these N-terminal presequences after import into the organelle (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).</p>
+<h4 id="12-what-pmpca-does-in-the-mpp-complex">1.2 What PMPCA does in the MPP complex</h4>
+<p>MPP is a <strong>heterodimer</strong> of <strong>PMPCA (α subunit)</strong> and <strong>PMPCB (β subunit)</strong>. PMPCB provides the <strong>Zn2+-dependent catalytic site</strong>, while PMPCA provides <strong>substrate recognition/binding</strong>, including a conserved <strong>glycine-rich loop</strong> required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).</p>
+<h4 id="13-structural-concepts-substrate-cavity-catalytic-zn2-glycine-rich-loop">1.3 Structural concepts: substrate cavity, catalytic Zn2+, glycine-rich loop</h4>
+<p>A structural synthesis from a dedicated review shows (i) the α/β dimer arrangement, (ii) the <strong>Zn2+-binding catalytic site</strong> in MPPβ/PMPCB, and (iii) the <strong>glycine-rich loop</strong> in MPPα/PMPCA, alongside signal peptide binding and electrostatic properties of the active-site cavity (kunova2022mitochondrialprocessingpeptidases—structure media ea670898). The substrate-binding cavity is described as strongly <strong>negatively charged</strong>, which complements the typically <strong>positively charged</strong> amphipathic presequences (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).</p>
+<h3 id="2-molecular-function-mechanism-substrate-specificity-and-pathways">2) Molecular function, mechanism, substrate specificity, and pathways</h3>
+<h4 id="21-primary-molecular-function-reaction-and-substrates">2.1 Primary molecular function (reaction and substrates)</h4>
+<p><strong>Primary function:</strong> PMPCA, as part of MPP, enables <strong>proteolytic cleavage of N-terminal mitochondrial targeting presequences</strong> from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the <strong>primary</strong> presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).</p>
+<h4 id="22-catalytic-mechanism">2.2 Catalytic mechanism</h4>
+<p>MPP is a <strong>Zn2+-dependent metallopeptidase</strong>. The catalytic model described for MPP cleavage is thermolysin-like, in which a <strong>Zn2+-bound water</strong> (polarized by a catalytic glutamate) performs nucleophilic attack on the scissile peptide bond; the <strong>Zn2+-binding motif</strong> resides in PMPCB/MPPβ (HxxEH…E) (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). PMPCA is therefore <strong>catalytically inactive</strong> in the metalloprotease sense but essential for productive substrate engagement (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, joshi2016mutationsinthe pages 1-2).</p>
+<h4 id="23-substrate-determinants-and-cleavage-preferences">2.3 Substrate determinants and cleavage preferences</h4>
+<p>MPP recognizes presequences that are typically <strong>positively charged amphipathic α-helices</strong>; reviews emphasize a frequent preference for <strong>arginine at −2 or −3</strong> relative to the cleavage site (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). PMPCA’s <strong>glycine-rich loop</strong> is described as critical for substrate binding and/or guiding the precursor toward the catalytic center (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).</p>
+<h4 id="24-example-substrates-and-experimentally-supported-client-effects">2.4 Example substrates and experimentally supported client effects</h4>
+<p><strong>Frataxin (FXN)</strong> is a highly disease-relevant MPP substrate. Patient-derived studies show that PMPCA mutations can cause <strong>impaired frataxin maturation</strong>, with accumulation of an intermediate frataxin form and reduction of mature frataxin, linking defective presequence processing to downstream mitochondrial dysfunction (jobling2015pmpcamutationscause pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6). A review summarizing the disease mechanism notes accumulation of an intermediate FXN species with decreased mature FXN and altered redox balance (kunova2022mitochondrialprocessingpeptidases—structure pages 4-6). <strong>TRX2</strong> is also discussed as an MPP substrate whose processing can be influenced by PMPCA regulation (including post-translational modification) (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).</p>
+<h4 id="25-pathway-coupling-presequence-processing-and-peptide-degradation-prep-feedback">2.5 Pathway coupling: presequence processing and peptide degradation (PreP feedback)</h4>
+<p>After MPP cleavage, the released presequence peptides are normally degraded in the matrix. In human cells, genetic deletion of <strong>PreP</strong> (presequence peptidase) causes accumulation of presequence peptides that <strong>feed back to inhibit MPP</strong>, leading to accumulation of nonprocessed precursor proteins and severe oxidative phosphorylation defects—demonstrating functional coupling between PMPCA/MPP activity and matrix peptide turnover (kucukkose2021functionalcouplingof pages 1-2).</p>
+<h3 id="3-recent-developments-and-latest-research-prioritize-20232024">3) Recent developments and latest research (prioritize 2023–2024)</h3>
+<h4 id="31-2024-mechanistic-use-of-pmpcapmpcb-knockouts">3.1 2024 mechanistic use of PMPCA/PMPCB knockouts</h4>
+<p>A 2024 Nature Communications study on noncanonical peptides/microproteins explicitly reports setting up <strong>PMPCA and PMPCB knockouts</strong> to test whether a peptide is processed by MPP in mitochondria, illustrating continued adoption of PMPCA loss-of-function models as tools to validate mitochondrial processing dependencies (kucukkose2021functionalcouplingof pages 1-2).</p>
+<h4 id="32-2024-clinical-genetics-new-pmpca-variants-and-diagnostic-workflows">3.2 2024 clinical genetics: new PMPCA variants and diagnostic workflows</h4>
+<p>A 2024 clinical report from Saudi Arabia describes <strong>whole-exome sequencing (WES)</strong> discovery of a novel homozygous <strong>PMPCA c.802C&gt;T (p.Arg268Trp)</strong> variant in a 12-year-old patient with a SCAR2-like phenotype; the variant call was <strong>validated by Sanger sequencing</strong>, representing real-world implementation of exome diagnostics for PMPCA-related disease (bagabir2024clinicalwholeexome pages 1-2).</p>
+<h4 id="33-2024-cohort-genetics-optic-neuropathy-susceptibility-in-alcohol-use-disorder">3.3 2024 cohort genetics: optic neuropathy susceptibility in alcohol use disorder</h4>
+<p>A 2024 retrospective cohort study (n=102) used <strong>optical coherence tomography (OCT)</strong> to detect subclinical optic neuropathy and then evaluated <strong>genetic susceptibility</strong> using a multi-gene panel (87 nuclear genes + mtDNA). In affected sequenced cases, PMPCA was among genes harboring variants of uncertain significance close to probable pathogenicity (delibes2024geneticsusceptibilityto pages 1-2). This positions PMPCA not only as a Mendelian gene for ataxia/mitochondrial disease but also as a candidate contributor to susceptibility in specific clinical contexts (while requiring further validation).</p>
+<h3 id="4-current-applications-and-real-world-implementations">4) Current applications and real-world implementations</h3>
+<h4 id="41-clinical-genetic-testing-and-case-resolution">4.1 Clinical genetic testing and case resolution</h4>
+<p>PMPCA is used in modern rare-disease pipelines, including WES for unresolved neurogenetic phenotypes, with orthogonal validation (Sanger) as shown in 2024 (bagabir2024clinicalwholeexome pages 1-2). Earlier clinical studies also highlight that PMPCA-associated disease can be missed by narrower mitochondrial panels, with exome sequencing enabling identification of causative variants (joshi2016mutationsinthe pages 2-4).</p>
+<h4 id="42-gene-panel-design-expert-recommendation">4.2 Gene panel design (expert recommendation)</h4>
+<p>A 2024 multi-omics paper on ataxia diagnosis explicitly argues that <strong>ataxia gene panels should include PMPCB</strong> “in a similar fashion to its partner, PMPCA,” reflecting PMPCA’s established relevance and the practical, panel-based approach to diagnosing disorders involving the MPP complex (audet2024integrationofmultiomics pages 10-11).</p>
+<h4 id="43-research-and-functional-validation-workflows">4.3 Research and functional validation workflows</h4>
+<p>Functional assays used across PMPCA studies include measurement of PMPCA protein levels, assessment of processing/maturation of client proteins (notably frataxin), and genetic complementation (WT PMPCA cDNA rescue) in patient fibroblasts (joshi2016mutationsinthe pages 6-8, joshi2016mutationsinthe pages 1-2). These constitute a practical experimental toolkit for variant interpretation in clinical genomics.</p>
+<h3 id="5-expert-opinions-and-analysis-authoritative-sources">5) Expert opinions and analysis (authoritative sources)</h3>
+<p>A comprehensive review of mitochondrial processing peptidases emphasizes that MPP is the principal presequence-cleaving enzyme, that PMPCA harbors a glycine-rich loop critical for substrate binding, and that mutations in PMPCA/PMPCB cause severe human mitochondrial disease phenotypes (Kunová et al., 2022; https://doi.org/10.3390/ijms23031297; published Jan 2022) (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). Human-focused mechanistic work underscores that correct processing is not an isolated step but is coupled to downstream peptide degradation; disruption of peptide turnover (PreP knockout) can inhibit MPP and broadly impair mitochondrial proteostasis (Kücükköse et al., 2021; https://doi.org/10.1111/febs.15358; published Jun 2021) (kucukkose2021functionalcouplingof pages 1-2). These perspectives converge on a systems view: PMPCA is essential not only for individual cleavage events but for maintaining organellar proteome integrity.</p>
+<h3 id="6-relevant-statistics-and-quantitative-data-recent-studies">6) Relevant statistics and quantitative data (recent studies)</h3>
+<h4 id="61-pmpca-disease-cohorts-and-case-series">6.1 PMPCA disease cohorts and case series</h4>
+<ul>
+<li>Foundational NPCA/SCAR2 cohort: <strong>17 patients across 4 families</strong> with PMPCA-associated non-progressive cerebellar ataxia, providing early genotype–phenotype definition and cellular evidence of impaired MPP function and frataxin maturation (Jobling et al., 2015; https://doi.org/10.1093/brain/awv057; published Jun 2015) (jobling2015pmpcamutationscause pages 1-2).</li>
+<li>Severe multisystem mitochondrial disease: a 2016 family study described <strong>two affected cousins</strong> with severe early-onset multisystem disease and demonstrated rescue of frataxin processing by WT PMPCA complementation (Joshi et al., 2016; https://doi.org/10.1101/mcs.a000786; published May 2016) (joshi2016mutationsinthe pages 1-2).</li>
+</ul>
+<h4 id="62-2024-optic-neuropathy-cohort-with-genetic-susceptibility-testing">6.2 2024 optic neuropathy cohort with genetic susceptibility testing</h4>
+<p>In a retrospective cohort of <strong>102</strong> alcohol-use disorder patients, optic neuropathy was detected in <strong>36% (37/102)</strong> by OCT; among affected patients who underwent genetic testing (<strong>30</strong>), <strong>5/30 (16.7%)</strong> carried variants of uncertain significance close to probable pathogenicity including PMPCA, and no pathogenic mtDNA variants were found (Delibes et al., 2024; https://doi.org/10.1186/s12967-024-05334-0; published May 2024) (delibes2024geneticsusceptibilityto pages 1-2).</p>
+<h4 id="63-dominant-optic-atrophy-context-statistics-background-for-pmpcas-newer-phenotype">6.3 Dominant optic atrophy context statistics (background for PMPCA’s newer phenotype)</h4>
+<p>A 2022 study connecting heterozygous PMPCA variants to late-onset dominant optic atrophy (n=5) provides contextual epidemiology: DOA prevalence ≈ <strong>1/25,000</strong>, OPA1 explains ~<strong>60–70%</strong> of DOA cases, and DOAplus occurs in ~<strong>20%</strong> of patients (Charif et al., 2022; https://doi.org/10.3390/genes13071202; published Jul 2022) (charif2022nextgenerationsequencingidentifies pages 1-2).</p>
+<h3 id="7-consolidated-functional-annotation-summary-table">7) Consolidated functional annotation (summary table)</h3>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Key points</th>
+<th>Key citations (with short paper identifiers and years)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity/Complex</td>
+<td>Human <strong>PMPCA</strong> (UniProt <strong>Q10713</strong>) encodes the <strong>alpha subunit of mitochondrial processing peptidase (α-MPP)</strong>, a <strong>heterodimeric</strong> presequence-processing enzyme with <strong>PMPCB</strong> as the beta subunit; PMPCA primarily mediates <strong>substrate recognition/binding</strong>, whereas PMPCB contains the catalytic site. PMPCA is consistently discussed in the literature as α-MPP, distinct from PMPCB/β-MPP.</td>
+<td>Jobling 2015; Joshi 2016; Kunová 2022 (jobling2015pmpcamutationscause pages 1-2, joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4)</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>MPP acts in the <strong>mitochondrial matrix</strong> after precursor import; human studies describe PMPCA/PMPCB as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of <strong>matrix precursors</strong>.</td>
+<td>Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof pages 1-2)</td>
+</tr>
+<tr>
+<td>Molecular function</td>
+<td>PMPCA participates in the <strong>proteolytic removal of N-terminal mitochondrial targeting presequences</strong> from nuclear-encoded precursor proteins after import, a maturation step required for folding and mitochondrial proteome biogenesis. MPP is described as the primary peptidase for the majority of presequence-containing mitochondrial proteins.</td>
+<td>Jobling 2015; Kunová 2022; Kücükköse 2021 (jobling2015pmpcamutationscause pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, kucukkose2021functionalcouplingof pages 1-2)</td>
+</tr>
+<tr>
+<td>Catalytic mechanism</td>
+<td>MPP is a <strong>Zn2+-dependent metallopeptidase</strong>; the <strong>catalytic site is in PMPCB</strong>, not PMPCA. Reviews describe a <strong>thermolysin-like mechanism</strong> in which a Zn2+-bound water, polarized by a catalytic glutamate, attacks the scissile bond. Structural summaries show a dimeric α/β complex with PMPCA’s glycine-rich loop and PMPCB’s Zn2+-binding catalytic center.</td>
+<td>Kunová 2022; structural figure summary (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, kunova2022mitochondrialprocessingpeptidases—structure media ea670898)</td>
+</tr>
+<tr>
+<td>Substrate determinants</td>
+<td>Typical substrates carry <strong>positively charged amphipathic α-helical presequences</strong>. MPP often prefers an <strong>Arg at -2 or -3</strong> relative to the cleavage site. PMPCA contains a conserved <strong>glycine-rich loop (GRL)</strong> essential for substrate binding/guidance into the active site; disease variants near this loop disrupt processing.</td>
+<td>Kunová 2022; Joshi 2016 (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6, joshi2016mutationsinthe pages 1-2)</td>
+</tr>
+<tr>
+<td>Example substrates</td>
+<td><strong>Frataxin (FXN)</strong> is the best-supported disease-relevant example: PMPCA dysfunction causes impaired FXN maturation with accumulation of intermediate forms and reduced mature frataxin. <strong>TRX2</strong> is also cited as an MPP substrate whose processing can be influenced by PMPCA regulation.</td>
+<td>Jobling 2015; Joshi 2016; Kunová 2022 (jobling2015pmpcamutationscause pages 1-2, joshi2016mutationsinthe pages 6-8, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6)</td>
+</tr>
+<tr>
+<td>Pathway coupling/quality control</td>
+<td>PMPCA functions within the <strong>mitochondrial protein import/maturation pathway</strong>. After MPP cleavage, released presequences are normally degraded by <strong>PreP</strong>; in <strong>human PreP knockout cells</strong>, presequence peptides accumulate, <strong>feed back to inhibit MPP</strong>, and cause buildup of nonprocessed precursors plus OXPHOS defects. This places PMPCA in a broader matrix <strong>proteostasis/quality-control</strong> network.</td>
+<td>Kücükköse 2021; Deshwal 2020 (kucukkose2021functionalcouplingof pages 1-2, baker2025qualitycontrolat pages 4-5)</td>
+</tr>
+<tr>
+<td>Disease associations</td>
+<td>Biallelic <strong>PMPCA</strong> variants cause a spectrum from <strong>non-progressive cerebellar ataxia / SCAR2</strong> to <strong>severe progressive multisystem mitochondrial encephalopathy</strong>, with intermediate progressive encephalopathy also reported. A foundational cohort identified <strong>17 patients from 4 families</strong> with NPCA; a severe 2016 family study reported <strong>2 affected cousins</strong> with developmental delay, hypotonia, blindness, respiratory insufficiency, and lactic acidemia. Heterozygous PMPCA variants were also reported in <strong>late-onset dominant optic atrophy</strong> in <strong>5 patients</strong>.</td>
+<td>Jobling 2015; Joshi 2016; Serpieri 2021; Charif 2022 (jobling2015pmpcamutationscause pages 1-2, joshi2016mutationsinthe pages 1-2, serpieri2021phenotypicdefinitionand pages 1-2, charif2022nextgenerationsequencingidentifies pages 1-2)</td>
+</tr>
+<tr>
+<td>Clinical applications/diagnostics</td>
+<td>PMPCA is a <strong>real-world clinical genetics gene</strong> identified by <strong>WES/exome sequencing</strong> and validated by <strong>Sanger</strong> in rare ataxia cases; a 2024 Saudi case report described a novel homozygous <strong>p.Arg268Trp</strong> variant. In ataxia diagnostics, experts recommended that <strong>PMPCB</strong> be added to panels “similarly to its partner, PMPCA,” underscoring PMPCA’s established panel relevance. In a 2024 alcohol-use cohort, optic neuropathy was detected in <strong>36% (37/102)</strong> by OCT, and among affected sequenced patients <strong>5/30 (16.7%)</strong> carried near-probably-pathogenic VUS including <strong>PMPCA</strong>.</td>
+<td>Bagabir 2024; Audet 2024; Delibes 2024 (bagabir2024clinicalwholeexome pages 1-2, audet2024integrationofmultiomics pages 10-11, delibes2024geneticsusceptibilityto pages 1-2)</td>
+</tr>
+<tr>
+<td>Recent developments 2024</td>
+<td>2024 studies extended PMPCA’s practical and mechanistic relevance: (1) <strong>clinical WES</strong> identified a new PMPCA SCAR2 allele in Saudi Arabia; (2) cohort genetics placed PMPCA among candidate susceptibility genes for optic neuropathy in alcohol-use disorder; (3) a 2024 experimental study used <strong>PMPCA/PMPCB knockout</strong> cells to test whether a peptide/microprotein undergoes <strong>MPP-dependent mitochondrial processing</strong>, demonstrating continuing use of PMPCA loss-of-function models as mechanistic tools.</td>
+<td>Bagabir 2024; Delibes 2024; Yang 2024 (bagabir2024clinicalwholeexome pages 1-2, delibes2024geneticsusceptibilityto pages 1-2, kucukkose2021functionalcouplingof pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, mitochondrial role, mechanism, substrate features, disease spectrum, and clinical relevance of human PMPCA (UniProt Q10713). It condenses the main functional annotation points and links each to supporting evidence gathered in the conversation.</em></p>
+<h3 id="8-key-figure-structural-mechanism-overview">8) Key figure (structural mechanism overview)</h3>
+<p>A structural summary figure depicts MPP’s α/β architecture, PMPCA’s glycine-rich loop, and the PMPCB Zn2+ catalytic site, supporting mechanistic statements in this report (kunova2022mitochondrialprocessingpeptidases—structure media ea670898).</p>
+<h3 id="9-limitations-and-evidence-gaps">9) Limitations and evidence gaps</h3>
+<ul>
+<li>The retrieved evidence strongly supports <strong>function, localization, mechanism, and disease relevance</strong> for human PMPCA. However, explicit “peptidase M16 family” labeling for <em>human PMPCA</em> was not consistently stated in the human-focused excerpts retrieved; this classification is strongly supported by conserved mechanism and homology discussions and is consistent with UniProt/domain annotations but would ideally be corroborated by a dedicated human-focused structural/enzymology primary paper or database citation not retrieved here (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, torres2019matrixprocessingpeptidase pages 24-28).</li>
+<li>Some 2023–2024 PMPCA phenotype-expansion reports were flagged as unobtainable in this run, limiting coverage of the newest case series in Movement Disorders Clinical Practice.</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(joshi2016mutationsinthe pages 1-2): Mugdha Joshi, Irina Anselm, Jiahai Shi, Tejus A. Bale, Meghan Towne, Klaus Schmitz-Abe, Laura Crowley, Felix C. Giani, Shideh Kazerounian, Kyriacos Markianos, Hart G. Lidov, Rebecca Folkerth, Vijay G. Sankaran, and Pankaj B. Agrawal. Mutations in the substrate binding glycine-rich loop of the mitochondrial processing peptidase-α protein (pmpca) cause a severe mitochondrial disease. Cold Spring Harbor Molecular Case Studies, 2:a000786, May 2016. URL: https://doi.org/10.1101/mcs.a000786, doi:10.1101/mcs.a000786. This article has 51 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kunova2022mitochondrialprocessingpeptidases—structure pages 2-4): Nina Kunová, Henrieta Havalová, Gabriela Ondrovičová, Barbora Stojkovičová, Jacob A. Bauer, Vladena Bauerová-Hlinková, Vladimir Pevala, and Eva Kutejová. Mitochondrial processing peptidases—structure, function and the role in human diseases. International Journal of Molecular Sciences, 23:1297, Jan 2022. URL: https://doi.org/10.3390/ijms23031297, doi:10.3390/ijms23031297. This article has 39 citations.</p>
+</li>
+<li>
+<p>(kucukkose2021functionalcouplingof pages 1-2): Cansu Kücükköse, Asli Aras Taskin, Adinarayana Marada, Tilman Brummer, Sven Dennerlein, and Friederike‐Nora Vögtle. Functional coupling of presequence processing and degradation in human mitochondria. The FEBS Journal, 288:600-613, Jun 2021. URL: https://doi.org/10.1111/febs.15358, doi:10.1111/febs.15358. This article has 31 citations.</p>
+</li>
+<li>
+<p>(kunova2022mitochondrialprocessingpeptidases—structure pages 4-6): Nina Kunová, Henrieta Havalová, Gabriela Ondrovičová, Barbora Stojkovičová, Jacob A. Bauer, Vladena Bauerová-Hlinková, Vladimir Pevala, and Eva Kutejová. Mitochondrial processing peptidases—structure, function and the role in human diseases. International Journal of Molecular Sciences, 23:1297, Jan 2022. URL: https://doi.org/10.3390/ijms23031297, doi:10.3390/ijms23031297. This article has 39 citations.</p>
+</li>
+<li>
+<p>(jobling2015pmpcamutationscause pages 1-2): Rebekah K. Jobling, Mirna Assoum, Oleksandr Gakh, Susan Blaser, Julian A. Raiman, Cyril Mignot, Emmanuel Roze, Alexandra Dürr, Alexis Brice, Nicolas Lévy, Chitra Prasad, Tara Paton, Andrew D. Paterson, Nicole M. Roslin, Christian R. Marshall, Jean-Pierre Desvignes, Nathalie Roëckel-Trevisiol, Stephen W. Scherer, Guy A. Rouleau, André Mégarbané, Grazia Isaya, Valérie Delague, and Grace Yoon. Pmpca mutations cause abnormal mitochondrial protein processing in patients with non-progressive cerebellar ataxia. Brain : a journal of neurology, 138 Pt 6:1505-17, Jun 2015. URL: https://doi.org/10.1093/brain/awv057, doi:10.1093/brain/awv057. This article has 101 citations.</p>
+</li>
+<li>
+<p>(kunova2022mitochondrialprocessingpeptidases—structure media ea670898): Nina Kunová, Henrieta Havalová, Gabriela Ondrovičová, Barbora Stojkovičová, Jacob A. Bauer, Vladena Bauerová-Hlinková, Vladimir Pevala, and Eva Kutejová. Mitochondrial processing peptidases—structure, function and the role in human diseases. International Journal of Molecular Sciences, 23:1297, Jan 2022. URL: https://doi.org/10.3390/ijms23031297, doi:10.3390/ijms23031297. This article has 39 citations.</p>
+</li>
+<li>
+<p>(bagabir2024clinicalwholeexome pages 1-2): Hala Abubaker Bagabir, Angham Abdulrhman Abdulkareem, Osama Yousef Muthaffar, Bader H. Shirah, and Muhammad Imran Naseer. Clinical whole exome sequencing reveals novel homozygous missense variant in the pmpca gene causing autosomal recessive spinocerebellar ataxia. Pakistan Journal of Medical Sciences, 40:2243-2250, Oct 2024. URL: https://doi.org/10.12669/pjms.40.10.10474, doi:10.12669/pjms.40.10.10474. This article has 0 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(delibes2024geneticsusceptibilityto pages 1-2): Camille Delibes, Marc Ferré, Marine Rozet, Valérie Desquiret-Dumas, Alexis Descatha, Bénédicte Gohier, Philippe Gohier, Patrizia Amati-Bonneau, Dan Milea, and Pascal Reynier. Genetic susceptibility to optic neuropathy in patients with alcohol use disorder. Journal of Translational Medicine, May 2024. URL: https://doi.org/10.1186/s12967-024-05334-0, doi:10.1186/s12967-024-05334-0. This article has 6 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(joshi2016mutationsinthe pages 2-4): Mugdha Joshi, Irina Anselm, Jiahai Shi, Tejus A. Bale, Meghan Towne, Klaus Schmitz-Abe, Laura Crowley, Felix C. Giani, Shideh Kazerounian, Kyriacos Markianos, Hart G. Lidov, Rebecca Folkerth, Vijay G. Sankaran, and Pankaj B. Agrawal. Mutations in the substrate binding glycine-rich loop of the mitochondrial processing peptidase-α protein (pmpca) cause a severe mitochondrial disease. Cold Spring Harbor Molecular Case Studies, 2:a000786, May 2016. URL: https://doi.org/10.1101/mcs.a000786, doi:10.1101/mcs.a000786. This article has 51 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(audet2024integrationofmultiomics pages 10-11): Sebastien Audet, Valerie Triassi, Myriam Gelinas, Nab Legault-Cadieux, Vincent Ferraro, Antoine Duquette, and Martine Tetreault. Integration of multi-omics technologies for molecular diagnosis in ataxia patients. Frontiers in Genetics, Jan 2024. URL: https://doi.org/10.3389/fgene.2023.1304711, doi:10.3389/fgene.2023.1304711. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(joshi2016mutationsinthe pages 6-8): Mugdha Joshi, Irina Anselm, Jiahai Shi, Tejus A. Bale, Meghan Towne, Klaus Schmitz-Abe, Laura Crowley, Felix C. Giani, Shideh Kazerounian, Kyriacos Markianos, Hart G. Lidov, Rebecca Folkerth, Vijay G. Sankaran, and Pankaj B. Agrawal. Mutations in the substrate binding glycine-rich loop of the mitochondrial processing peptidase-α protein (pmpca) cause a severe mitochondrial disease. Cold Spring Harbor Molecular Case Studies, 2:a000786, May 2016. URL: https://doi.org/10.1101/mcs.a000786, doi:10.1101/mcs.a000786. This article has 51 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(charif2022nextgenerationsequencingidentifies pages 1-2): Majida Charif, Arnaud Chevrollier, Naïg Gueguen, Selma Kane, Céline Bris, David Goudenège, Valerie Desquiret-Dumas, Isabelle Meunier, Fanny Mochel, Luc Jeanjean, Fanny Varenne, Vincent Procaccio, Pascal Reynier, Dominique Bonneau, Patrizia Amati-Bonneau, and Guy Lenaers. Next-generation sequencing identifies novel pmpca variants in patients with late-onset dominant optic atrophy. Genes, 13:1202, Jul 2022. URL: https://doi.org/10.3390/genes13071202, doi:10.3390/genes13071202. This article has 3 citations.</p>
+</li>
+<li>
+<p>(baker2025qualitycontrolat pages 4-5): Megan J. Baker, Kai Qi Yek, and Diana Stojanovski. Quality control at the powerhouse: mitochondrial proteostasis dysfunction and disease. Biochemical Society Transactions, 53:1105-1117, Aug 2025. URL: https://doi.org/10.1042/bst20253044, doi:10.1042/bst20253044. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(serpieri2021phenotypicdefinitionand pages 1-2): Valentina Serpieri, Tommaso Biagini, Concetta Mazzotta, Rosa Pasquariello, Anna Rubegni, Filippo Santorelli, Gerardo Ongari, Silvia Cerri, Tommaso Mazza, Roberta Battini, and Enza Maria Valente. Phenotypic definition and genotype-phenotype correlates in pmpca-related disease. Applied Sciences, 11:748, Jan 2021. URL: https://doi.org/10.3390/app11020748, doi:10.3390/app11020748. This article has 5 citations.</p>
+</li>
+<li>
+<p>(torres2019matrixprocessingpeptidase pages 24-28): E Torres. Matrix processing peptidase and putative roles in mitochondrial biogenesis. nuc1 and porin influence la killer virus loads co-dependently in saccharomyces …. Unknown journal, 2019.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>kucukkose2021functionalcouplingof pages 1-2</li>
+<li>bagabir2024clinicalwholeexome pages 1-2</li>
+<li>delibes2024geneticsusceptibilityto pages 1-2</li>
+<li>joshi2016mutationsinthe pages 2-4</li>
+<li>audet2024integrationofmultiomics pages 10-11</li>
+<li>jobling2015pmpcamutationscause pages 1-2</li>
+<li>joshi2016mutationsinthe pages 1-2</li>
+<li>charif2022nextgenerationsequencingidentifies pages 1-2</li>
+<li>joshi2016mutationsinthe pages 6-8</li>
+<li>baker2025qualitycontrolat pages 4-5</li>
+<li>serpieri2021phenotypicdefinitionand pages 1-2</li>
+<li>torres2019matrixprocessingpeptidase pages 24-28</li>
+<li>https://doi.org/10.3390/ijms23031297;</li>
+<li>https://doi.org/10.1111/febs.15358;</li>
+<li>https://doi.org/10.1093/brain/awv057;</li>
+<li>https://doi.org/10.1101/mcs.a000786;</li>
+<li>https://doi.org/10.1186/s12967-024-05334-0;</li>
+<li>https://doi.org/10.3390/genes13071202;</li>
+<li>https://doi.org/10.1101/mcs.a000786,</li>
+<li>https://doi.org/10.3390/ijms23031297,</li>
+<li>https://doi.org/10.1111/febs.15358,</li>
+<li>https://doi.org/10.1093/brain/awv057,</li>
+<li>https://doi.org/10.12669/pjms.40.10.10474,</li>
+<li>https://doi.org/10.1186/s12967-024-05334-0,</li>
+<li>https://doi.org/10.3389/fgene.2023.1304711,</li>
+<li>https://doi.org/10.3390/genes13071202,</li>
+<li>https://doi.org/10.1042/bst20253044,</li>
+<li>https://doi.org/10.3390/app11020748,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q10713
+gene_symbol: PMPCA
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  PMPCA encodes the alpha subunit of the mitochondrial processing peptidase (MPP), a matrix heterodimer with PMPCB that removes
+  N-terminal mitochondrial targeting presequences from imported precursor proteins. PMPCA is the substrate-recognition/binding
+  subunit, including a glycine-rich loop that helps position precursor proteins for cleavage by the catalytic PMPCB beta subunit;
+  it is essential for productive MPP activity but is not itself the catalytic metalloprotease.
+alternative_products:
+  - name: &#39;1&#39;
+    id: Q10713-1
+  - name: &#39;2&#39;
+    id: Q10713-2
+    sequence_note: VSP_054916, VSP_054917
+existing_annotations:
+  - term:
+      id: GO:0017087
+      label: mitochondrial processing peptidase complex
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: &gt;-
+        PMPCA is a defining alpha subunit of the heterodimeric mitochondrial processing peptidase complex with PMPCB.
+      action: ACCEPT
+      reason: &gt;-
+        The annotation captures the core complex membership of PMPCA in MPP.
+      supported_by:
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: &gt;-
+            MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent
+            catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich
+            loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure
+            pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate
+            recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe
+            pages 1-2, jobling2015pmpcamutationscause pages 1-2).
+  - term:
+      id: GO:0004222
+      label: metalloendopeptidase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    review:
+      summary: &gt;-
+        The MPP complex has Zn2+-dependent metalloendopeptidase activity, but the catalytic site is in PMPCB; PMPCA contributes
+        substrate recognition and positioning.
+      action: MODIFY
+      reason: &gt;-
+        As an enabled molecular function on PMPCA alone, metalloendopeptidase activity overstates the alpha subunit. Replace
+        the direct enabled MF with protein-macromolecule adaptor activity and represent complex protease activity as contributes_to
+        in core_functions.
+      proposed_replacement_terms:
+        - id: GO:0030674
+          label: protein-macromolecule adaptor activity
+      supported_by: &amp;id003
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: &gt;-
+            MPP is a **Zn2+-dependent metallopeptidase**. The catalytic model described for MPP cleavage is thermolysin-like,
+            in which a **Zn2+-bound water** (polarized by a catalytic glutamate) performs nucleophilic attack on the scissile
+            peptide bond; the **Zn2+-binding motif** resides in PMPCB/MPPβ (HxxEH…E) (kunova2022mitochondrialprocessingpeptidases—structure
+            pages 2-4). PMPCA is therefore **catalytically inactive** in the metalloprotease sense but essential for productive
+            substrate engagement (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, joshi2016mutationsinthe
+            pages 1-2).
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: &gt;-
+            MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent
+            catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich
+            loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure
+            pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate
+            recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe
+            pages 1-2, jobling2015pmpcamutationscause pages 1-2).
+  - term:
+      id: GO:0005743
+      label: mitochondrial inner membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    review:
+      summary: &gt;-
+        PMPCA/MPP acts in the mitochondrial matrix after precursor import rather than being an inner-membrane component.
+      action: MODIFY
+      reason: &gt;-
+        The more precise supported cellular component for PMPCA is mitochondrial matrix.
+      proposed_replacement_terms:
+        - id: GO:0005759
+          label: mitochondrial matrix
+      supported_by: &amp;id001
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: &gt;-
+            | Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB
+            as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation
+            of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof
+            pages 1-2) |
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: &gt;-
+            **Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting
+            presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly
+            (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).
+            MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial
+            proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages
+            1-2).
+  - term:
+      id: GO:0005759
+      label: mitochondrial matrix
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    review:
+      summary: &gt;-
+        MPP acts in the mitochondrial matrix where imported precursor proteins are processed.
+      action: ACCEPT
+      reason: &gt;-
+        Matrix localization is directly consistent with the synthesized literature and Reactome annotations for MPP processing
+        events.
+      supported_by: *id001
+  - term:
+      id: GO:0006508
+      label: proteolysis
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    review:
+      summary: &gt;-
+        PMPCA contributes to proteolytic removal of mitochondrial targeting presequences as part of MPP, but generic proteolysis
+        is less informative than protein processing.
+      action: MODIFY
+      reason: &gt;-
+        Use protein processing to capture the maturation of imported mitochondrial precursor proteins rather than broad proteolysis.
+      proposed_replacement_terms:
+        - id: GO:0016485
+          label: protein processing
+      supported_by: &amp;id002
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: &gt;-
+            **Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting
+            presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly
+            (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).
+            MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial
+            proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages
+            1-2).
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: &gt;-
+            MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent
+            catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich
+            loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure
+            pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate
+            recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe
+            pages 1-2, jobling2015pmpcamutationscause pages 1-2).
+  - term:
+      id: GO:0016485
+      label: protein processing
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000117
+    review:
+      summary: &gt;-
+        PMPCA contributes to MPP-dependent maturation of imported mitochondrial precursor proteins by presequence cleavage.
+      action: ACCEPT
+      reason: &gt;-
+        Protein processing is the appropriate biological process for MPP-dependent precursor maturation.
+      supported_by: *id002
+  - term:
+      id: GO:0046872
+      label: metal ion binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    review:
+      summary: &gt;-
+        The catalytic zinc-binding motif of MPP resides in PMPCB/MPP beta, not PMPCA.
+      action: REMOVE
+      reason: &gt;-
+        The available evidence does not support metal ion binding as a direct PMPCA activity; this appears to be propagated
+        from the complex/beta subunit metalloprotease mechanism.
+      supported_by: *id003
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:30021884
+    review:
+      summary: &gt;-
+        Generic protein binding is uninformative for PMPCA. The biologically meaningful interaction is substrate recognition/positioning
+        within the MPP complex.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        The annotation should be replaced in curation practice by specific MPP complex membership and the substrate-recognition/adaptor
+        role, rather than retained as broad protein binding.
+      supported_by: &amp;id004
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: &gt;-
+            MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent
+            catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich
+            loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure
+            pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate
+            recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe
+            pages 1-2, jobling2015pmpcamutationscause pages 1-2).
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: &gt;-
+            MPP recognizes presequences that are typically **positively charged amphipathic α-helices**; reviews emphasize
+            a frequent preference for **arginine at −2 or −3** relative to the cleavage site (kunova2022mitochondrialprocessingpeptidases—structure
+            pages 2-4). PMPCA’s **glycine-rich loop** is described as critical for substrate binding and/or guiding the precursor
+            toward the catalytic center (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:32296183
+    review:
+      summary: &gt;-
+        Generic protein binding is uninformative for PMPCA. The biologically meaningful interaction is substrate recognition/positioning
+        within the MPP complex.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        The annotation should be replaced in curation practice by specific MPP complex membership and the substrate-recognition/adaptor
+        role, rather than retained as broad protein binding.
+      supported_by: *id004
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:33961781
+    review:
+      summary: &gt;-
+        Generic protein binding is uninformative for PMPCA. The biologically meaningful interaction is substrate recognition/positioning
+        within the MPP complex.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        The annotation should be replaced in curation practice by specific MPP complex membership and the substrate-recognition/adaptor
+        role, rather than retained as broad protein binding.
+      supported_by: *id004
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: NAS
+    original_reference_id: PMID:32443488
+    review:
+      summary: &gt;-
+        PMPCA is mitochondrial, but the evidence supports the more specific mitochondrial matrix localization of the MPP machinery.
+      action: MODIFY
+      reason: &gt;-
+        Use mitochondrial matrix rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005759
+          label: mitochondrial matrix
+      supported_by: *id001
+  - term:
+      id: GO:0017087
+      label: mitochondrial processing peptidase complex
+    evidence_type: NAS
+    original_reference_id: PMID:32443488
+    review:
+      summary: &gt;-
+        PMPCA is a defining alpha subunit of the heterodimeric mitochondrial processing peptidase complex with PMPCB.
+      action: ACCEPT
+      reason: &gt;-
+        The annotation captures the core complex membership of PMPCA in MPP.
+      supported_by:
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: &gt;-
+            MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent
+            catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich
+            loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure
+            pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate
+            recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe
+            pages 1-2, jobling2015pmpcamutationscause pages 1-2).
+  - term:
+      id: GO:0070585
+      label: protein localization to mitochondrion
+    evidence_type: NAS
+    original_reference_id: PMID:32443488
+    review:
+      summary: &gt;-
+        MPP processing is coupled to import for some substrates, but PMPCA acts after import by cleaving targeting presequences
+        rather than serving as the localization/import machinery.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        The core process is mitochondrial precursor protein processing, not general protein localization to mitochondrion.
+      supported_by: *id002
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: IDA
+    original_reference_id: GO_REF:0000052
+    review:
+      summary: &gt;-
+        PMPCA is mitochondrial, but the evidence supports the more specific mitochondrial matrix localization of the MPP machinery.
+      action: MODIFY
+      reason: &gt;-
+        Use mitochondrial matrix rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005759
+          label: mitochondrial matrix
+      supported_by: *id001
+  - term:
+      id: GO:0016485
+      label: protein processing
+    evidence_type: IDA
+    original_reference_id: PMID:22354088
+    review:
+      summary: &gt;-
+        PMPCA contributes to MPP-dependent maturation of imported mitochondrial precursor proteins by presequence cleavage.
+      action: ACCEPT
+      reason: &gt;-
+        Protein processing is the appropriate biological process for MPP-dependent precursor maturation.
+      supported_by: *id002
+  - term:
+      id: GO:0016485
+      label: protein processing
+    evidence_type: IMP
+    original_reference_id: PMID:25808372
+    review:
+      summary: &gt;-
+        PMPCA contributes to MPP-dependent maturation of imported mitochondrial precursor proteins by presequence cleavage.
+      action: ACCEPT
+      reason: &gt;-
+        Protein processing is the appropriate biological process for MPP-dependent precursor maturation.
+      supported_by: *id002
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: HTP
+    original_reference_id: PMID:34800366
+    review:
+      summary: &gt;-
+        PMPCA is mitochondrial, but the evidence supports the more specific mitochondrial matrix localization of the MPP machinery.
+      action: MODIFY
+      reason: &gt;-
+        Use mitochondrial matrix rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005759
+          label: mitochondrial matrix
+      supported_by: *id001
+  - term:
+      id: GO:0005759
+      label: mitochondrial matrix
+    evidence_type: ISS
+    original_reference_id: GO_REF:0000024
+    review:
+      summary: &gt;-
+        MPP acts in the mitochondrial matrix where imported precursor proteins are processed.
+      action: ACCEPT
+      reason: &gt;-
+        Matrix localization is directly consistent with the synthesized literature and Reactome annotations for MPP processing
+        events.
+      supported_by: *id001
+  - term:
+      id: GO:0005759
+      label: mitochondrial matrix
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-8949649
+    review:
+      summary: &gt;-
+        MPP acts in the mitochondrial matrix where imported precursor proteins are processed.
+      action: ACCEPT
+      reason: &gt;-
+        Matrix localization is directly consistent with the synthesized literature and Reactome annotations for MPP processing
+        events.
+      supported_by: *id001
+  - term:
+      id: GO:0005759
+      label: mitochondrial matrix
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-9838081
+    review:
+      summary: &gt;-
+        MPP acts in the mitochondrial matrix where imported precursor proteins are processed.
+      action: ACCEPT
+      reason: &gt;-
+        Matrix localization is directly consistent with the synthesized literature and Reactome annotations for MPP processing
+        events.
+      supported_by: *id001
+  - term:
+      id: GO:0005759
+      label: mitochondrial matrix
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-9838093
+    review:
+      summary: &gt;-
+        MPP acts in the mitochondrial matrix where imported precursor proteins are processed.
+      action: ACCEPT
+      reason: &gt;-
+        Matrix localization is directly consistent with the synthesized literature and Reactome annotations for MPP processing
+        events.
+      supported_by: *id001
+  - term:
+      id: GO:0005743
+      label: mitochondrial inner membrane
+    evidence_type: IDA
+    original_reference_id: PMID:25808372
+    review:
+      summary: &gt;-
+        PMPCA/MPP acts in the mitochondrial matrix after precursor import rather than being an inner-membrane component.
+      action: MODIFY
+      reason: &gt;-
+        The more precise supported cellular component for PMPCA is mitochondrial matrix.
+      proposed_replacement_terms:
+        - id: GO:0005759
+          label: mitochondrial matrix
+      supported_by: *id001
+  - term:
+      id: GO:0005576
+      label: extracellular region
+    evidence_type: HDA
+    original_reference_id: PMID:22664934
+    review:
+      summary: &gt;-
+        PMPCA is a mitochondrial matrix MPP subunit; the extracellular-region annotation is inconsistent with the curated
+        functional literature.
+      action: REMOVE
+      reason: &gt;-
+        This high-throughput extracellular annotation is not supported by the gene-specific evidence and conflicts with the
+        mitochondrial matrix role.
+      supported_by: *id001
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: IDA
+    original_reference_id: GO_REF:0000054
+    review:
+      summary: &gt;-
+        PMPCA is mitochondrial, but the evidence supports the more specific mitochondrial matrix localization of the MPP machinery.
+      action: MODIFY
+      reason: &gt;-
+        Use mitochondrial matrix rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005759
+          label: mitochondrial matrix
+      supported_by: *id001
+  - term:
+      id: GO:0030674
+      label: protein-macromolecule adaptor activity
+    evidence_type: NAS
+    original_reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+    review:
+      summary: &gt;-
+        PMPCA has a substrate-recognition/positioning role within the MPP heterodimer, guiding precursor proteins toward the
+        PMPCB catalytic site.
+      action: NEW
+      reason: &gt;-
+        This is the best available MF-level representation of the alpha subunit role distinct from PMPCB catalytic metalloendopeptidase
+        activity.
+      supported_by: *id004
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000024
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of
+      sequence similarity
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+      by conservative changes to GO terms applied by UniProt
+    findings: []
+  - id: GO_REF:0000052
+    title: Gene Ontology annotation based on curation of immunofluorescence data
+    findings: []
+  - id: GO_REF:0000054
+    title: Gene Ontology annotation based on curation of intracellular localizations of expressed fusion proteins in
+      living cells
+    findings: []
+  - id: GO_REF:0000117
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: PMID:22354088
+    title: Mitochondrial processing peptidase regulates PINK1 processing, import and Parkin recruitment.
+    findings: []
+  - id: PMID:22664934
+    title: Comparison of tear protein levels in breast cancer patients and healthy controls using a de novo proteomic
+      approach.
+    findings: []
+  - id: PMID:25808372
+    title: PMPCA mutations cause abnormal mitochondrial protein processing in patients with non-progressive cerebellar
+      ataxia.
+    findings: []
+  - id: PMID:30021884
+    title: Histone Interaction Landscapes Visualized by Crosslinking Mass Spectrometry in Intact Cell Nuclei.
+    findings: []
+  - id: PMID:32296183
+    title: A reference map of the human binary protein interactome.
+    findings: []
+  - id: PMID:32443488
+    title: Mitochondrial Protein Quality Control Mechanisms.
+    findings: []
+  - id: PMID:33961781
+    title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
+    findings: []
+  - id: PMID:34800366
+    title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
+    findings: []
+  - id: Reactome:R-HSA-8949649
+    title: PMPCA:PMPCB cleaves the transit peptide of proSMDT1 (proEMRE)
+    findings: []
+  - id: Reactome:R-HSA-9838081
+    title: LONP1 degrades mitochondrial matrix proteins
+    findings: []
+  - id: Reactome:R-HSA-9838093
+    title: LONP1 binds mitochondrial matrix proteins
+    findings: []
+  - id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+    title: Falcon deep research on PMPCA function
+    findings:
+      - statement: PMPCA is the alpha, substrate-recognition subunit of the PMPCA:PMPCB mitochondrial processing
+          peptidase complex.
+      - statement: The MPP complex cleaves N-terminal mitochondrial targeting presequences after import into the
+          mitochondrial matrix.
+      - statement: The catalytic zinc metallopeptidase active site resides in PMPCB rather than PMPCA.
+core_functions:
+  - molecular_function:
+      id: GO:0030674
+      label: protein-macromolecule adaptor activity
+    contributes_to_molecular_function:
+      id: GO:0004222
+      label: metalloendopeptidase activity
+    description: &gt;-
+      PMPCA is the substrate-recognition alpha subunit of the mitochondrial processing peptidase. It binds/positions imported
+      mitochondrial precursor proteins through a glycine-rich substrate-handling loop and thereby contributes to the PMPCA:PMPCB
+      complex metalloendopeptidase activity that removes N-terminal mitochondrial targeting presequences in the matrix.
+    directly_involved_in:
+      - id: GO:0016485
+        label: protein processing
+    locations:
+      - id: GO:0005759
+        label: mitochondrial matrix
+    in_complex:
+      id: GO:0017087
+      label: mitochondrial processing peptidase complex
+    supported_by:
+      - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+        supporting_text: &gt;-
+          MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent
+          catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop**
+          required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure
+          pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition
+          and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe
+          pages 1-2, jobling2015pmpcamutationscause pages 1-2).
+      - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+        supporting_text: &gt;-
+          **Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting
+          presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof
+          pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary**
+          presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure
+          pages 2-4, jobling2015pmpcamutationscause pages 1-2).
+      - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+        supporting_text: &gt;-
+          MPP is a **Zn2+-dependent metallopeptidase**. The catalytic model described for MPP cleavage is thermolysin-like,
+          in which a **Zn2+-bound water** (polarized by a catalytic glutamate) performs nucleophilic attack on the scissile
+          peptide bond; the **Zn2+-binding motif** resides in PMPCB/MPPβ (HxxEH…E) (kunova2022mitochondrialprocessingpeptidases—structure
+          pages 2-4). PMPCA is therefore **catalytically inactive** in the metalloprotease sense but essential for productive
+          substrate engagement (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, joshi2016mutationsinthe pages
+          1-2).
+      - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+        supporting_text: &gt;-
+          | Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB
+          as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of
+          **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof
+          pages 1-2) |
+proposed_new_terms: []
+suggested_questions:
+  - question: &gt;-
+      Would GO benefit from a term for mitochondrial presequence-recognition activity or MPP alpha-subunit substrate-guiding
+      activity, distinct from generic adaptor activity and from PMPCB catalytic metalloendopeptidase activity?
+suggested_experiments:
+  - description: &gt;-
+      Reconstitute human PMPCA/PMPCB MPP variants with precursor substrates and measure substrate binding, positioning, and
+      cleavage kinetics for PMPCA glycine-loop and patient alleles.
+    hypothesis: &gt;-
+      PMPCA variants primarily impair precursor recognition/positioning while PMPCB provides the catalytic metallopeptidase
+      chemistry.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/PMPCA/PMPCA-ai-review.yaml
+++ b/genes/human/PMPCA/PMPCA-ai-review.yaml
@@ -1,276 +1,573 @@
 id: Q10713
 gene_symbol: PMPCA
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for PMPCA'
+description: >-
+  PMPCA encodes the alpha subunit of the mitochondrial processing peptidase (MPP), a matrix heterodimer with PMPCB that removes
+  N-terminal mitochondrial targeting presequences from imported precursor proteins. PMPCA is the substrate-recognition/binding
+  subunit, including a glycine-rich loop that helps position precursor proteins for cleavage by the catalytic PMPCB beta subunit;
+  it is essential for productive MPP activity but is not itself the catalytic metalloprotease.
 alternative_products:
-- name: '1'
-  id: Q10713-1
-- name: '2'
-  id: Q10713-2
-  sequence_note: VSP_054916, VSP_054917
+  - name: '1'
+    id: Q10713-1
+  - name: '2'
+    id: Q10713-2
+    sequence_note: VSP_054916, VSP_054917
 existing_annotations:
-- term:
-    id: GO:0017087
-    label: mitochondrial processing peptidase complex
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0004222
-    label: metalloendopeptidase activity
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005743
-    label: mitochondrial inner membrane
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005759
-    label: mitochondrial matrix
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0006508
-    label: proteolysis
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0016485
-    label: protein processing
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000117
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0046872
-    label: metal ion binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:30021884
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:32296183
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:33961781
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005739
-    label: mitochondrion
-  evidence_type: NAS
-  original_reference_id: PMID:32443488
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0017087
-    label: mitochondrial processing peptidase complex
-  evidence_type: NAS
-  original_reference_id: PMID:32443488
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0070585
-    label: protein localization to mitochondrion
-  evidence_type: NAS
-  original_reference_id: PMID:32443488
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005739
-    label: mitochondrion
-  evidence_type: IDA
-  original_reference_id: GO_REF:0000052
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0016485
-    label: protein processing
-  evidence_type: IDA
-  original_reference_id: PMID:22354088
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0016485
-    label: protein processing
-  evidence_type: IMP
-  original_reference_id: PMID:25808372
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005739
-    label: mitochondrion
-  evidence_type: HTP
-  original_reference_id: PMID:34800366
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005759
-    label: mitochondrial matrix
-  evidence_type: ISS
-  original_reference_id: GO_REF:0000024
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005759
-    label: mitochondrial matrix
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-8949649
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005759
-    label: mitochondrial matrix
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-9838081
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005759
-    label: mitochondrial matrix
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-9838093
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005743
-    label: mitochondrial inner membrane
-  evidence_type: IDA
-  original_reference_id: PMID:25808372
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005576
-    label: extracellular region
-  evidence_type: HDA
-  original_reference_id: PMID:22664934
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005739
-    label: mitochondrion
-  evidence_type: IDA
-  original_reference_id: GO_REF:0000054
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+  - term:
+      id: GO:0017087
+      label: mitochondrial processing peptidase complex
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: >-
+        PMPCA is a defining alpha subunit of the heterodimeric mitochondrial processing peptidase complex with PMPCB.
+      action: ACCEPT
+      reason: >-
+        The annotation captures the core complex membership of PMPCA in MPP.
+      supported_by:
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: >-
+            MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent
+            catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich
+            loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure
+            pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate
+            recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe
+            pages 1-2, jobling2015pmpcamutationscause pages 1-2).
+  - term:
+      id: GO:0004222
+      label: metalloendopeptidase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    review:
+      summary: >-
+        The MPP complex has Zn2+-dependent metalloendopeptidase activity, but the catalytic site is in PMPCB; PMPCA contributes
+        substrate recognition and positioning.
+      action: MODIFY
+      reason: >-
+        As an enabled molecular function on PMPCA alone, metalloendopeptidase activity overstates the alpha subunit. Replace
+        the direct enabled MF with protein-macromolecule adaptor activity and represent complex protease activity as contributes_to
+        in core_functions.
+      proposed_replacement_terms:
+        - id: GO:0030674
+          label: protein-macromolecule adaptor activity
+      supported_by: &id003
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: >-
+            MPP is a **Zn2+-dependent metallopeptidase**. The catalytic model described for MPP cleavage is thermolysin-like,
+            in which a **Zn2+-bound water** (polarized by a catalytic glutamate) performs nucleophilic attack on the scissile
+            peptide bond; the **Zn2+-binding motif** resides in PMPCB/MPPβ (HxxEH…E) (kunova2022mitochondrialprocessingpeptidases—structure
+            pages 2-4). PMPCA is therefore **catalytically inactive** in the metalloprotease sense but essential for productive
+            substrate engagement (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, joshi2016mutationsinthe
+            pages 1-2).
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: >-
+            MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent
+            catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich
+            loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure
+            pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate
+            recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe
+            pages 1-2, jobling2015pmpcamutationscause pages 1-2).
+  - term:
+      id: GO:0005743
+      label: mitochondrial inner membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    review:
+      summary: >-
+        PMPCA/MPP acts in the mitochondrial matrix after precursor import rather than being an inner-membrane component.
+      action: MODIFY
+      reason: >-
+        The more precise supported cellular component for PMPCA is mitochondrial matrix.
+      proposed_replacement_terms:
+        - id: GO:0005759
+          label: mitochondrial matrix
+      supported_by: &id001
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: >-
+            | Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB
+            as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation
+            of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof
+            pages 1-2) |
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: >-
+            **Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting
+            presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly
+            (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).
+            MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial
+            proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages
+            1-2).
+  - term:
+      id: GO:0005759
+      label: mitochondrial matrix
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    review:
+      summary: >-
+        MPP acts in the mitochondrial matrix where imported precursor proteins are processed.
+      action: ACCEPT
+      reason: >-
+        Matrix localization is directly consistent with the synthesized literature and Reactome annotations for MPP processing
+        events.
+      supported_by: *id001
+  - term:
+      id: GO:0006508
+      label: proteolysis
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    review:
+      summary: >-
+        PMPCA contributes to proteolytic removal of mitochondrial targeting presequences as part of MPP, but generic proteolysis
+        is less informative than protein processing.
+      action: MODIFY
+      reason: >-
+        Use protein processing to capture the maturation of imported mitochondrial precursor proteins rather than broad proteolysis.
+      proposed_replacement_terms:
+        - id: GO:0016485
+          label: protein processing
+      supported_by: &id002
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: >-
+            **Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting
+            presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly
+            (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).
+            MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial
+            proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages
+            1-2).
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: >-
+            MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent
+            catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich
+            loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure
+            pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate
+            recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe
+            pages 1-2, jobling2015pmpcamutationscause pages 1-2).
+  - term:
+      id: GO:0016485
+      label: protein processing
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000117
+    review:
+      summary: >-
+        PMPCA contributes to MPP-dependent maturation of imported mitochondrial precursor proteins by presequence cleavage.
+      action: ACCEPT
+      reason: >-
+        Protein processing is the appropriate biological process for MPP-dependent precursor maturation.
+      supported_by: *id002
+  - term:
+      id: GO:0046872
+      label: metal ion binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    review:
+      summary: >-
+        The catalytic zinc-binding motif of MPP resides in PMPCB/MPP beta, not PMPCA.
+      action: REMOVE
+      reason: >-
+        The available evidence does not support metal ion binding as a direct PMPCA activity; this appears to be propagated
+        from the complex/beta subunit metalloprotease mechanism.
+      supported_by: *id003
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:30021884
+    review:
+      summary: >-
+        Generic protein binding is uninformative for PMPCA. The biologically meaningful interaction is substrate recognition/positioning
+        within the MPP complex.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        The annotation should be replaced in curation practice by specific MPP complex membership and the substrate-recognition/adaptor
+        role, rather than retained as broad protein binding.
+      supported_by: &id004
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: >-
+            MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent
+            catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich
+            loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure
+            pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate
+            recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe
+            pages 1-2, jobling2015pmpcamutationscause pages 1-2).
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: >-
+            MPP recognizes presequences that are typically **positively charged amphipathic α-helices**; reviews emphasize
+            a frequent preference for **arginine at −2 or −3** relative to the cleavage site (kunova2022mitochondrialprocessingpeptidases—structure
+            pages 2-4). PMPCA’s **glycine-rich loop** is described as critical for substrate binding and/or guiding the precursor
+            toward the catalytic center (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:32296183
+    review:
+      summary: >-
+        Generic protein binding is uninformative for PMPCA. The biologically meaningful interaction is substrate recognition/positioning
+        within the MPP complex.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        The annotation should be replaced in curation practice by specific MPP complex membership and the substrate-recognition/adaptor
+        role, rather than retained as broad protein binding.
+      supported_by: *id004
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:33961781
+    review:
+      summary: >-
+        Generic protein binding is uninformative for PMPCA. The biologically meaningful interaction is substrate recognition/positioning
+        within the MPP complex.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        The annotation should be replaced in curation practice by specific MPP complex membership and the substrate-recognition/adaptor
+        role, rather than retained as broad protein binding.
+      supported_by: *id004
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: NAS
+    original_reference_id: PMID:32443488
+    review:
+      summary: >-
+        PMPCA is mitochondrial, but the evidence supports the more specific mitochondrial matrix localization of the MPP machinery.
+      action: MODIFY
+      reason: >-
+        Use mitochondrial matrix rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005759
+          label: mitochondrial matrix
+      supported_by: *id001
+  - term:
+      id: GO:0017087
+      label: mitochondrial processing peptidase complex
+    evidence_type: NAS
+    original_reference_id: PMID:32443488
+    review:
+      summary: >-
+        PMPCA is a defining alpha subunit of the heterodimeric mitochondrial processing peptidase complex with PMPCB.
+      action: ACCEPT
+      reason: >-
+        The annotation captures the core complex membership of PMPCA in MPP.
+      supported_by:
+        - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+          supporting_text: >-
+            MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent
+            catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich
+            loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure
+            pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate
+            recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe
+            pages 1-2, jobling2015pmpcamutationscause pages 1-2).
+  - term:
+      id: GO:0070585
+      label: protein localization to mitochondrion
+    evidence_type: NAS
+    original_reference_id: PMID:32443488
+    review:
+      summary: >-
+        MPP processing is coupled to import for some substrates, but PMPCA acts after import by cleaving targeting presequences
+        rather than serving as the localization/import machinery.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        The core process is mitochondrial precursor protein processing, not general protein localization to mitochondrion.
+      supported_by: *id002
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: IDA
+    original_reference_id: GO_REF:0000052
+    review:
+      summary: >-
+        PMPCA is mitochondrial, but the evidence supports the more specific mitochondrial matrix localization of the MPP machinery.
+      action: MODIFY
+      reason: >-
+        Use mitochondrial matrix rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005759
+          label: mitochondrial matrix
+      supported_by: *id001
+  - term:
+      id: GO:0016485
+      label: protein processing
+    evidence_type: IDA
+    original_reference_id: PMID:22354088
+    review:
+      summary: >-
+        PMPCA contributes to MPP-dependent maturation of imported mitochondrial precursor proteins by presequence cleavage.
+      action: ACCEPT
+      reason: >-
+        Protein processing is the appropriate biological process for MPP-dependent precursor maturation.
+      supported_by: *id002
+  - term:
+      id: GO:0016485
+      label: protein processing
+    evidence_type: IMP
+    original_reference_id: PMID:25808372
+    review:
+      summary: >-
+        PMPCA contributes to MPP-dependent maturation of imported mitochondrial precursor proteins by presequence cleavage.
+      action: ACCEPT
+      reason: >-
+        Protein processing is the appropriate biological process for MPP-dependent precursor maturation.
+      supported_by: *id002
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: HTP
+    original_reference_id: PMID:34800366
+    review:
+      summary: >-
+        PMPCA is mitochondrial, but the evidence supports the more specific mitochondrial matrix localization of the MPP machinery.
+      action: MODIFY
+      reason: >-
+        Use mitochondrial matrix rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005759
+          label: mitochondrial matrix
+      supported_by: *id001
+  - term:
+      id: GO:0005759
+      label: mitochondrial matrix
+    evidence_type: ISS
+    original_reference_id: GO_REF:0000024
+    review:
+      summary: >-
+        MPP acts in the mitochondrial matrix where imported precursor proteins are processed.
+      action: ACCEPT
+      reason: >-
+        Matrix localization is directly consistent with the synthesized literature and Reactome annotations for MPP processing
+        events.
+      supported_by: *id001
+  - term:
+      id: GO:0005759
+      label: mitochondrial matrix
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-8949649
+    review:
+      summary: >-
+        MPP acts in the mitochondrial matrix where imported precursor proteins are processed.
+      action: ACCEPT
+      reason: >-
+        Matrix localization is directly consistent with the synthesized literature and Reactome annotations for MPP processing
+        events.
+      supported_by: *id001
+  - term:
+      id: GO:0005759
+      label: mitochondrial matrix
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-9838081
+    review:
+      summary: >-
+        MPP acts in the mitochondrial matrix where imported precursor proteins are processed.
+      action: ACCEPT
+      reason: >-
+        Matrix localization is directly consistent with the synthesized literature and Reactome annotations for MPP processing
+        events.
+      supported_by: *id001
+  - term:
+      id: GO:0005759
+      label: mitochondrial matrix
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-9838093
+    review:
+      summary: >-
+        MPP acts in the mitochondrial matrix where imported precursor proteins are processed.
+      action: ACCEPT
+      reason: >-
+        Matrix localization is directly consistent with the synthesized literature and Reactome annotations for MPP processing
+        events.
+      supported_by: *id001
+  - term:
+      id: GO:0005743
+      label: mitochondrial inner membrane
+    evidence_type: IDA
+    original_reference_id: PMID:25808372
+    review:
+      summary: >-
+        PMPCA/MPP acts in the mitochondrial matrix after precursor import rather than being an inner-membrane component.
+      action: MODIFY
+      reason: >-
+        The more precise supported cellular component for PMPCA is mitochondrial matrix.
+      proposed_replacement_terms:
+        - id: GO:0005759
+          label: mitochondrial matrix
+      supported_by: *id001
+  - term:
+      id: GO:0005576
+      label: extracellular region
+    evidence_type: HDA
+    original_reference_id: PMID:22664934
+    review:
+      summary: >-
+        PMPCA is a mitochondrial matrix MPP subunit; the extracellular-region annotation is inconsistent with the curated
+        functional literature.
+      action: REMOVE
+      reason: >-
+        This high-throughput extracellular annotation is not supported by the gene-specific evidence and conflicts with the
+        mitochondrial matrix role.
+      supported_by: *id001
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: IDA
+    original_reference_id: GO_REF:0000054
+    review:
+      summary: >-
+        PMPCA is mitochondrial, but the evidence supports the more specific mitochondrial matrix localization of the MPP machinery.
+      action: MODIFY
+      reason: >-
+        Use mitochondrial matrix rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005759
+          label: mitochondrial matrix
+      supported_by: *id001
+  - term:
+      id: GO:0030674
+      label: protein-macromolecule adaptor activity
+    evidence_type: NAS
+    original_reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+    review:
+      summary: >-
+        PMPCA has a substrate-recognition/positioning role within the MPP heterodimer, guiding precursor proteins toward the
+        PMPCB catalytic site.
+      action: NEW
+      reason: >-
+        This is the best available MF-level representation of the alpha subunit role distinct from PMPCB catalytic metalloendopeptidase
+        activity.
+      supported_by: *id004
 references:
-- id: GO_REF:0000002
-  title: Gene Ontology annotation through association of InterPro records with GO
-    terms
-  findings: []
-- id: GO_REF:0000024
-  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
-    by curator judgment of sequence similarity
-  findings: []
-- id: GO_REF:0000033
-  title: Annotation inferences using phylogenetic trees
-  findings: []
-- id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
-    vocabulary mapping, accompanied by conservative changes to GO terms applied by
-    UniProt
-  findings: []
-- id: GO_REF:0000052
-  title: Gene Ontology annotation based on curation of immunofluorescence data
-  findings: []
-- id: GO_REF:0000054
-  title: Gene Ontology annotation based on curation of intracellular localizations
-    of expressed fusion proteins in living cells
-  findings: []
-- id: GO_REF:0000117
-  title: Electronic Gene Ontology annotations created by ARBA machine learning models
-  findings: []
-- id: GO_REF:0000120
-  title: Combined Automated Annotation using Multiple IEA Methods
-  findings: []
-- id: PMID:22354088
-  title: Mitochondrial processing peptidase regulates PINK1 processing, import and
-    Parkin recruitment.
-  findings: []
-- id: PMID:22664934
-  title: Comparison of tear protein levels in breast cancer patients and healthy controls
-    using a de novo proteomic approach.
-  findings: []
-- id: PMID:25808372
-  title: PMPCA mutations cause abnormal mitochondrial protein processing in patients
-    with non-progressive cerebellar ataxia.
-  findings: []
-- id: PMID:30021884
-  title: Histone Interaction Landscapes Visualized by Crosslinking Mass Spectrometry
-    in Intact Cell Nuclei.
-  findings: []
-- id: PMID:32296183
-  title: A reference map of the human binary protein interactome.
-  findings: []
-- id: PMID:32443488
-  title: Mitochondrial Protein Quality Control Mechanisms.
-  findings: []
-- id: PMID:33961781
-  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
-    interactome.
-  findings: []
-- id: PMID:34800366
-  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
-    in cellular context.
-  findings: []
-- id: Reactome:R-HSA-8949649
-  title: PMPCA:PMPCB cleaves the transit peptide of proSMDT1 (proEMRE)
-  findings: []
-- id: Reactome:R-HSA-9838081
-  title: LONP1 degrades mitochondrial matrix proteins
-  findings: []
-- id: Reactome:R-HSA-9838093
-  title: LONP1 binds mitochondrial matrix proteins
-  findings: []
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000024
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of
+      sequence similarity
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+      by conservative changes to GO terms applied by UniProt
+    findings: []
+  - id: GO_REF:0000052
+    title: Gene Ontology annotation based on curation of immunofluorescence data
+    findings: []
+  - id: GO_REF:0000054
+    title: Gene Ontology annotation based on curation of intracellular localizations of expressed fusion proteins in
+      living cells
+    findings: []
+  - id: GO_REF:0000117
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: PMID:22354088
+    title: Mitochondrial processing peptidase regulates PINK1 processing, import and Parkin recruitment.
+    findings: []
+  - id: PMID:22664934
+    title: Comparison of tear protein levels in breast cancer patients and healthy controls using a de novo proteomic
+      approach.
+    findings: []
+  - id: PMID:25808372
+    title: PMPCA mutations cause abnormal mitochondrial protein processing in patients with non-progressive cerebellar
+      ataxia.
+    findings: []
+  - id: PMID:30021884
+    title: Histone Interaction Landscapes Visualized by Crosslinking Mass Spectrometry in Intact Cell Nuclei.
+    findings: []
+  - id: PMID:32296183
+    title: A reference map of the human binary protein interactome.
+    findings: []
+  - id: PMID:32443488
+    title: Mitochondrial Protein Quality Control Mechanisms.
+    findings: []
+  - id: PMID:33961781
+    title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
+    findings: []
+  - id: PMID:34800366
+    title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
+    findings: []
+  - id: Reactome:R-HSA-8949649
+    title: PMPCA:PMPCB cleaves the transit peptide of proSMDT1 (proEMRE)
+    findings: []
+  - id: Reactome:R-HSA-9838081
+    title: LONP1 degrades mitochondrial matrix proteins
+    findings: []
+  - id: Reactome:R-HSA-9838093
+    title: LONP1 binds mitochondrial matrix proteins
+    findings: []
+  - id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+    title: Falcon deep research on PMPCA function
+    findings:
+      - statement: PMPCA is the alpha, substrate-recognition subunit of the PMPCA:PMPCB mitochondrial processing
+          peptidase complex.
+      - statement: The MPP complex cleaves N-terminal mitochondrial targeting presequences after import into the
+          mitochondrial matrix.
+      - statement: The catalytic zinc metallopeptidase active site resides in PMPCB rather than PMPCA.
+core_functions:
+  - molecular_function:
+      id: GO:0030674
+      label: protein-macromolecule adaptor activity
+    contributes_to_molecular_function:
+      id: GO:0004222
+      label: metalloendopeptidase activity
+    description: >-
+      PMPCA is the substrate-recognition alpha subunit of the mitochondrial processing peptidase. It binds/positions imported
+      mitochondrial precursor proteins through a glycine-rich substrate-handling loop and thereby contributes to the PMPCA:PMPCB
+      complex metalloendopeptidase activity that removes N-terminal mitochondrial targeting presequences in the matrix.
+    directly_involved_in:
+      - id: GO:0016485
+        label: protein processing
+    locations:
+      - id: GO:0005759
+        label: mitochondrial matrix
+    in_complex:
+      id: GO:0017087
+      label: mitochondrial processing peptidase complex
+    supported_by:
+      - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+        supporting_text: >-
+          MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent
+          catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop**
+          required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure
+          pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition
+          and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe
+          pages 1-2, jobling2015pmpcamutationscause pages 1-2).
+      - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+        supporting_text: >-
+          **Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting
+          presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof
+          pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary**
+          presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure
+          pages 2-4, jobling2015pmpcamutationscause pages 1-2).
+      - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+        supporting_text: >-
+          MPP is a **Zn2+-dependent metallopeptidase**. The catalytic model described for MPP cleavage is thermolysin-like,
+          in which a **Zn2+-bound water** (polarized by a catalytic glutamate) performs nucleophilic attack on the scissile
+          peptide bond; the **Zn2+-binding motif** resides in PMPCB/MPPβ (HxxEH…E) (kunova2022mitochondrialprocessingpeptidases—structure
+          pages 2-4). PMPCA is therefore **catalytically inactive** in the metalloprotease sense but essential for productive
+          substrate engagement (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, joshi2016mutationsinthe pages
+          1-2).
+      - reference_id: file:human/PMPCA/PMPCA-deep-research-falcon.md
+        supporting_text: >-
+          | Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB
+          as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of
+          **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof
+          pages 1-2) |
+proposed_new_terms: []
+suggested_questions:
+  - question: >-
+      Would GO benefit from a term for mitochondrial presequence-recognition activity or MPP alpha-subunit substrate-guiding
+      activity, distinct from generic adaptor activity and from PMPCB catalytic metalloendopeptidase activity?
+suggested_experiments:
+  - description: >-
+      Reconstitute human PMPCA/PMPCB MPP variants with precursor substrates and measure substrate binding, positioning, and
+      cleavage kinetics for PMPCA glycine-loop and patient alleles.
+    hypothesis: >-
+      PMPCA variants primarily impair precursor recognition/positioning while PMPCB provides the catalytic metallopeptidase
+      chemistry.

--- a/genes/human/PMPCA/PMPCA-deep-research-falcon.md
+++ b/genes/human/PMPCA/PMPCA-deep-research-falcon.md
@@ -1,0 +1,296 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T19:42:38.854924'
+end_time: '2026-05-11T19:58:06.753509'
+duration_seconds: 927.9
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: PMPCA
+  gene_symbol: PMPCA
+  uniprot_accession: Q10713
+  protein_description: 'RecName: Full=Mitochondrial-processing peptidase subunit alpha;
+    AltName: Full=Alpha-MPP; AltName: Full=Inactive zinc metalloprotease alpha {ECO:0000305};
+    AltName: Full=P-55; Flags: Precursor;'
+  gene_info: Name=PMPCA; Synonyms=INPP5E, KIAA0123, MPPA;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the peptidase M16 family. .
+  protein_domains: Metalloenz_LuxS/M16. (IPR011249); MPP/UQCRC_Complex. (IPR050361);
+    Pept_M16_N. (IPR011765); Pept_M16_Zn_BS. (IPR001431); Peptidase_M16_C. (IPR007863)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 28
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q10713
+- **Protein Description:** RecName: Full=Mitochondrial-processing peptidase subunit alpha; AltName: Full=Alpha-MPP; AltName: Full=Inactive zinc metalloprotease alpha {ECO:0000305}; AltName: Full=P-55; Flags: Precursor;
+- **Gene Information:** Name=PMPCA; Synonyms=INPP5E, KIAA0123, MPPA;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the peptidase M16 family. .
+- **Key Domains:** Metalloenz_LuxS/M16. (IPR011249); MPP/UQCRC_Complex. (IPR050361); Pept_M16_N. (IPR011765); Pept_M16_Zn_BS. (IPR001431); Peptidase_M16_C. (IPR007863)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "PMPCA" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'PMPCA' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **PMPCA** (gene ID: PMPCA, UniProt: Q10713) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q10713
+- **Protein Description:** RecName: Full=Mitochondrial-processing peptidase subunit alpha; AltName: Full=Alpha-MPP; AltName: Full=Inactive zinc metalloprotease alpha {ECO:0000305}; AltName: Full=P-55; Flags: Precursor;
+- **Gene Information:** Name=PMPCA; Synonyms=INPP5E, KIAA0123, MPPA;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the peptidase M16 family. .
+- **Key Domains:** Metalloenz_LuxS/M16. (IPR011249); MPP/UQCRC_Complex. (IPR050361); Pept_M16_N. (IPR011765); Pept_M16_Zn_BS. (IPR001431); Peptidase_M16_C. (IPR007863)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "PMPCA" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'PMPCA' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **PMPCA** (gene ID: PMPCA, UniProt: Q10713) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: Human **PMPCA** (UniProt **Q10713**) — mitochondrial-processing peptidase subunit alpha
+
+### 0) Mandatory target verification (identity check)
+The literature retrieved and synthesized here pertains to **human PMPCA** encoding **mitochondrial-processing peptidase subunit alpha (α-MPP)**, consistent with UniProt accession **Q10713** and the protein description “mitochondrial-processing peptidase subunit alpha/Alpha-MPP/P-55 precursor.” Multiple independent sources explicitly define **MPP** as a **heterodimeric** enzyme composed of **PMPCA (α)** and **PMPCB (β)** that removes **N-terminal mitochondrial targeting presequences** after import, with PMPCA acting in substrate recognition/binding and PMPCB containing the catalytic metalloprotease site (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, kucukkose2021functionalcouplingof pages 1-2). Cross-species naming can be confusing (e.g., yeast MPPA/MPPB corresponding to MPPα/MPPβ); however, the human gene symbol and function described in the cited human disease and mechanistic papers consistently refer to PMPCA as α-MPP (kunova2022mitochondrialprocessingpeptidases—structure pages 4-6, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 Mitochondrial targeting presequences and processing
+A large fraction of mitochondrial proteins are **nuclear encoded**, synthesized in the cytosol, and imported into mitochondria using **N-terminal presequences** (matrix-targeting signals) that must be removed for maturation and function. In human mitochondria, the **mitochondrial processing peptidase (MPP)** is the essential protease that cleaves these N-terminal presequences after import into the organelle (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).
+
+#### 1.2 What PMPCA does in the MPP complex
+MPP is a **heterodimer** of **PMPCA (α subunit)** and **PMPCB (β subunit)**. PMPCB provides the **Zn2+-dependent catalytic site**, while PMPCA provides **substrate recognition/binding**, including a conserved **glycine-rich loop** required for substrate handling (joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). This division of labor is clinically important: pathogenic variants in PMPCA can disrupt substrate recognition and thereby impair processing of specific client proteins and broader mitochondrial biogenesis (joshi2016mutationsinthe pages 1-2, jobling2015pmpcamutationscause pages 1-2).
+
+#### 1.3 Structural concepts: substrate cavity, catalytic Zn2+, glycine-rich loop
+A structural synthesis from a dedicated review shows (i) the α/β dimer arrangement, (ii) the **Zn2+-binding catalytic site** in MPPβ/PMPCB, and (iii) the **glycine-rich loop** in MPPα/PMPCA, alongside signal peptide binding and electrostatic properties of the active-site cavity (kunova2022mitochondrialprocessingpeptidases—structure media ea670898). The substrate-binding cavity is described as strongly **negatively charged**, which complements the typically **positively charged** amphipathic presequences (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).
+
+### 2) Molecular function, mechanism, substrate specificity, and pathways
+
+#### 2.1 Primary molecular function (reaction and substrates)
+**Primary function:** PMPCA, as part of MPP, enables **proteolytic cleavage of N-terminal mitochondrial targeting presequences** from imported precursor proteins, generating mature proteins competent for folding and assembly (kucukkose2021functionalcouplingof pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). MPP is described as the **primary** presequence-processing enzyme for the majority of presequence-containing mitochondrial proteins (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, jobling2015pmpcamutationscause pages 1-2).
+
+#### 2.2 Catalytic mechanism
+MPP is a **Zn2+-dependent metallopeptidase**. The catalytic model described for MPP cleavage is thermolysin-like, in which a **Zn2+-bound water** (polarized by a catalytic glutamate) performs nucleophilic attack on the scissile peptide bond; the **Zn2+-binding motif** resides in PMPCB/MPPβ (HxxEH…E) (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). PMPCA is therefore **catalytically inactive** in the metalloprotease sense but essential for productive substrate engagement (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, joshi2016mutationsinthe pages 1-2).
+
+#### 2.3 Substrate determinants and cleavage preferences
+MPP recognizes presequences that are typically **positively charged amphipathic α-helices**; reviews emphasize a frequent preference for **arginine at −2 or −3** relative to the cleavage site (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). PMPCA’s **glycine-rich loop** is described as critical for substrate binding and/or guiding the precursor toward the catalytic center (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).
+
+#### 2.4 Example substrates and experimentally supported client effects
+**Frataxin (FXN)** is a highly disease-relevant MPP substrate. Patient-derived studies show that PMPCA mutations can cause **impaired frataxin maturation**, with accumulation of an intermediate frataxin form and reduction of mature frataxin, linking defective presequence processing to downstream mitochondrial dysfunction (jobling2015pmpcamutationscause pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6). A review summarizing the disease mechanism notes accumulation of an intermediate FXN species with decreased mature FXN and altered redox balance (kunova2022mitochondrialprocessingpeptidases—structure pages 4-6). **TRX2** is also discussed as an MPP substrate whose processing can be influenced by PMPCA regulation (including post-translational modification) (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4).
+
+#### 2.5 Pathway coupling: presequence processing and peptide degradation (PreP feedback)
+After MPP cleavage, the released presequence peptides are normally degraded in the matrix. In human cells, genetic deletion of **PreP** (presequence peptidase) causes accumulation of presequence peptides that **feed back to inhibit MPP**, leading to accumulation of nonprocessed precursor proteins and severe oxidative phosphorylation defects—demonstrating functional coupling between PMPCA/MPP activity and matrix peptide turnover (kucukkose2021functionalcouplingof pages 1-2).
+
+### 3) Recent developments and latest research (prioritize 2023–2024)
+
+#### 3.1 2024 mechanistic use of PMPCA/PMPCB knockouts
+A 2024 Nature Communications study on noncanonical peptides/microproteins explicitly reports setting up **PMPCA and PMPCB knockouts** to test whether a peptide is processed by MPP in mitochondria, illustrating continued adoption of PMPCA loss-of-function models as tools to validate mitochondrial processing dependencies (kucukkose2021functionalcouplingof pages 1-2).
+
+#### 3.2 2024 clinical genetics: new PMPCA variants and diagnostic workflows
+A 2024 clinical report from Saudi Arabia describes **whole-exome sequencing (WES)** discovery of a novel homozygous **PMPCA c.802C>T (p.Arg268Trp)** variant in a 12-year-old patient with a SCAR2-like phenotype; the variant call was **validated by Sanger sequencing**, representing real-world implementation of exome diagnostics for PMPCA-related disease (bagabir2024clinicalwholeexome pages 1-2).
+
+#### 3.3 2024 cohort genetics: optic neuropathy susceptibility in alcohol use disorder
+A 2024 retrospective cohort study (n=102) used **optical coherence tomography (OCT)** to detect subclinical optic neuropathy and then evaluated **genetic susceptibility** using a multi-gene panel (87 nuclear genes + mtDNA). In affected sequenced cases, PMPCA was among genes harboring variants of uncertain significance close to probable pathogenicity (delibes2024geneticsusceptibilityto pages 1-2). This positions PMPCA not only as a Mendelian gene for ataxia/mitochondrial disease but also as a candidate contributor to susceptibility in specific clinical contexts (while requiring further validation).
+
+### 4) Current applications and real-world implementations
+
+#### 4.1 Clinical genetic testing and case resolution
+PMPCA is used in modern rare-disease pipelines, including WES for unresolved neurogenetic phenotypes, with orthogonal validation (Sanger) as shown in 2024 (bagabir2024clinicalwholeexome pages 1-2). Earlier clinical studies also highlight that PMPCA-associated disease can be missed by narrower mitochondrial panels, with exome sequencing enabling identification of causative variants (joshi2016mutationsinthe pages 2-4).
+
+#### 4.2 Gene panel design (expert recommendation)
+A 2024 multi-omics paper on ataxia diagnosis explicitly argues that **ataxia gene panels should include PMPCB** “in a similar fashion to its partner, PMPCA,” reflecting PMPCA’s established relevance and the practical, panel-based approach to diagnosing disorders involving the MPP complex (audet2024integrationofmultiomics pages 10-11).
+
+#### 4.3 Research and functional validation workflows
+Functional assays used across PMPCA studies include measurement of PMPCA protein levels, assessment of processing/maturation of client proteins (notably frataxin), and genetic complementation (WT PMPCA cDNA rescue) in patient fibroblasts (joshi2016mutationsinthe pages 6-8, joshi2016mutationsinthe pages 1-2). These constitute a practical experimental toolkit for variant interpretation in clinical genomics.
+
+### 5) Expert opinions and analysis (authoritative sources)
+
+A comprehensive review of mitochondrial processing peptidases emphasizes that MPP is the principal presequence-cleaving enzyme, that PMPCA harbors a glycine-rich loop critical for substrate binding, and that mutations in PMPCA/PMPCB cause severe human mitochondrial disease phenotypes (Kunová et al., 2022; https://doi.org/10.3390/ijms23031297; published Jan 2022) (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4). Human-focused mechanistic work underscores that correct processing is not an isolated step but is coupled to downstream peptide degradation; disruption of peptide turnover (PreP knockout) can inhibit MPP and broadly impair mitochondrial proteostasis (Kücükköse et al., 2021; https://doi.org/10.1111/febs.15358; published Jun 2021) (kucukkose2021functionalcouplingof pages 1-2). These perspectives converge on a systems view: PMPCA is essential not only for individual cleavage events but for maintaining organellar proteome integrity.
+
+### 6) Relevant statistics and quantitative data (recent studies)
+
+#### 6.1 PMPCA disease cohorts and case series
+* Foundational NPCA/SCAR2 cohort: **17 patients across 4 families** with PMPCA-associated non-progressive cerebellar ataxia, providing early genotype–phenotype definition and cellular evidence of impaired MPP function and frataxin maturation (Jobling et al., 2015; https://doi.org/10.1093/brain/awv057; published Jun 2015) (jobling2015pmpcamutationscause pages 1-2).
+* Severe multisystem mitochondrial disease: a 2016 family study described **two affected cousins** with severe early-onset multisystem disease and demonstrated rescue of frataxin processing by WT PMPCA complementation (Joshi et al., 2016; https://doi.org/10.1101/mcs.a000786; published May 2016) (joshi2016mutationsinthe pages 1-2).
+
+#### 6.2 2024 optic neuropathy cohort with genetic susceptibility testing
+In a retrospective cohort of **102** alcohol-use disorder patients, optic neuropathy was detected in **36% (37/102)** by OCT; among affected patients who underwent genetic testing (**30**), **5/30 (16.7%)** carried variants of uncertain significance close to probable pathogenicity including PMPCA, and no pathogenic mtDNA variants were found (Delibes et al., 2024; https://doi.org/10.1186/s12967-024-05334-0; published May 2024) (delibes2024geneticsusceptibilityto pages 1-2).
+
+#### 6.3 Dominant optic atrophy context statistics (background for PMPCA’s newer phenotype)
+A 2022 study connecting heterozygous PMPCA variants to late-onset dominant optic atrophy (n=5) provides contextual epidemiology: DOA prevalence ≈ **1/25,000**, OPA1 explains ~**60–70%** of DOA cases, and DOAplus occurs in ~**20%** of patients (Charif et al., 2022; https://doi.org/10.3390/genes13071202; published Jul 2022) (charif2022nextgenerationsequencingidentifies pages 1-2).
+
+### 7) Consolidated functional annotation (summary table)
+| Category | Key points | Key citations (with short paper identifiers and years) |
+|---|---|---|
+| Identity/Complex | Human **PMPCA** (UniProt **Q10713**) encodes the **alpha subunit of mitochondrial processing peptidase (α-MPP)**, a **heterodimeric** presequence-processing enzyme with **PMPCB** as the beta subunit; PMPCA primarily mediates **substrate recognition/binding**, whereas PMPCB contains the catalytic site. PMPCA is consistently discussed in the literature as α-MPP, distinct from PMPCB/β-MPP. | Jobling 2015; Joshi 2016; Kunová 2022 (jobling2015pmpcamutationscause pages 1-2, joshi2016mutationsinthe pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4) |
+| Localization | MPP acts in the **mitochondrial matrix** after precursor import; human studies describe PMPCA/PMPCB as matrix-localized machinery that cleaves imported presequences, and impaired function leads to accumulation of **matrix precursors**. | Joshi 2016; Kücükköse 2021 (joshi2016mutationsinthe pages 1-2, kucukkose2021functionalcouplingof pages 1-2) |
+| Molecular function | PMPCA participates in the **proteolytic removal of N-terminal mitochondrial targeting presequences** from nuclear-encoded precursor proteins after import, a maturation step required for folding and mitochondrial proteome biogenesis. MPP is described as the primary peptidase for the majority of presequence-containing mitochondrial proteins. | Jobling 2015; Kunová 2022; Kücükköse 2021 (jobling2015pmpcamutationscause pages 1-2, kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, kucukkose2021functionalcouplingof pages 1-2) |
+| Catalytic mechanism | MPP is a **Zn2+-dependent metallopeptidase**; the **catalytic site is in PMPCB**, not PMPCA. Reviews describe a **thermolysin-like mechanism** in which a Zn2+-bound water, polarized by a catalytic glutamate, attacks the scissile bond. Structural summaries show a dimeric α/β complex with PMPCA’s glycine-rich loop and PMPCB’s Zn2+-binding catalytic center. | Kunová 2022; structural figure summary (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, kunova2022mitochondrialprocessingpeptidases—structure media ea670898) |
+| Substrate determinants | Typical substrates carry **positively charged amphipathic α-helical presequences**. MPP often prefers an **Arg at -2 or -3** relative to the cleavage site. PMPCA contains a conserved **glycine-rich loop (GRL)** essential for substrate binding/guidance into the active site; disease variants near this loop disrupt processing. | Kunová 2022; Joshi 2016 (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6, joshi2016mutationsinthe pages 1-2) |
+| Example substrates | **Frataxin (FXN)** is the best-supported disease-relevant example: PMPCA dysfunction causes impaired FXN maturation with accumulation of intermediate forms and reduced mature frataxin. **TRX2** is also cited as an MPP substrate whose processing can be influenced by PMPCA regulation. | Jobling 2015; Joshi 2016; Kunová 2022 (jobling2015pmpcamutationscause pages 1-2, joshi2016mutationsinthe pages 6-8, kunova2022mitochondrialprocessingpeptidases—structure pages 4-6) |
+| Pathway coupling/quality control | PMPCA functions within the **mitochondrial protein import/maturation pathway**. After MPP cleavage, released presequences are normally degraded by **PreP**; in **human PreP knockout cells**, presequence peptides accumulate, **feed back to inhibit MPP**, and cause buildup of nonprocessed precursors plus OXPHOS defects. This places PMPCA in a broader matrix **proteostasis/quality-control** network. | Kücükköse 2021; Deshwal 2020 (kucukkose2021functionalcouplingof pages 1-2, baker2025qualitycontrolat pages 4-5) |
+| Disease associations | Biallelic **PMPCA** variants cause a spectrum from **non-progressive cerebellar ataxia / SCAR2** to **severe progressive multisystem mitochondrial encephalopathy**, with intermediate progressive encephalopathy also reported. A foundational cohort identified **17 patients from 4 families** with NPCA; a severe 2016 family study reported **2 affected cousins** with developmental delay, hypotonia, blindness, respiratory insufficiency, and lactic acidemia. Heterozygous PMPCA variants were also reported in **late-onset dominant optic atrophy** in **5 patients**. | Jobling 2015; Joshi 2016; Serpieri 2021; Charif 2022 (jobling2015pmpcamutationscause pages 1-2, joshi2016mutationsinthe pages 1-2, serpieri2021phenotypicdefinitionand pages 1-2, charif2022nextgenerationsequencingidentifies pages 1-2) |
+| Clinical applications/diagnostics | PMPCA is a **real-world clinical genetics gene** identified by **WES/exome sequencing** and validated by **Sanger** in rare ataxia cases; a 2024 Saudi case report described a novel homozygous **p.Arg268Trp** variant. In ataxia diagnostics, experts recommended that **PMPCB** be added to panels “similarly to its partner, PMPCA,” underscoring PMPCA’s established panel relevance. In a 2024 alcohol-use cohort, optic neuropathy was detected in **36% (37/102)** by OCT, and among affected sequenced patients **5/30 (16.7%)** carried near-probably-pathogenic VUS including **PMPCA**. | Bagabir 2024; Audet 2024; Delibes 2024 (bagabir2024clinicalwholeexome pages 1-2, audet2024integrationofmultiomics pages 10-11, delibes2024geneticsusceptibilityto pages 1-2) |
+| Recent developments 2024 | 2024 studies extended PMPCA’s practical and mechanistic relevance: (1) **clinical WES** identified a new PMPCA SCAR2 allele in Saudi Arabia; (2) cohort genetics placed PMPCA among candidate susceptibility genes for optic neuropathy in alcohol-use disorder; (3) a 2024 experimental study used **PMPCA/PMPCB knockout** cells to test whether a peptide/microprotein undergoes **MPP-dependent mitochondrial processing**, demonstrating continuing use of PMPCA loss-of-function models as mechanistic tools. | Bagabir 2024; Delibes 2024; Yang 2024 (bagabir2024clinicalwholeexome pages 1-2, delibes2024geneticsusceptibilityto pages 1-2, kucukkose2021functionalcouplingof pages 1-2) |
+
+
+*Table: This table summarizes the verified identity, mitochondrial role, mechanism, substrate features, disease spectrum, and clinical relevance of human PMPCA (UniProt Q10713). It condenses the main functional annotation points and links each to supporting evidence gathered in the conversation.*
+
+### 8) Key figure (structural mechanism overview)
+A structural summary figure depicts MPP’s α/β architecture, PMPCA’s glycine-rich loop, and the PMPCB Zn2+ catalytic site, supporting mechanistic statements in this report (kunova2022mitochondrialprocessingpeptidases—structure media ea670898).
+
+### 9) Limitations and evidence gaps
+* The retrieved evidence strongly supports **function, localization, mechanism, and disease relevance** for human PMPCA. However, explicit “peptidase M16 family” labeling for *human PMPCA* was not consistently stated in the human-focused excerpts retrieved; this classification is strongly supported by conserved mechanism and homology discussions and is consistent with UniProt/domain annotations but would ideally be corroborated by a dedicated human-focused structural/enzymology primary paper or database citation not retrieved here (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4, torres2019matrixprocessingpeptidase pages 24-28).
+* Some 2023–2024 PMPCA phenotype-expansion reports were flagged as unobtainable in this run, limiting coverage of the newest case series in Movement Disorders Clinical Practice.
+
+
+References
+
+1. (joshi2016mutationsinthe pages 1-2): Mugdha Joshi, Irina Anselm, Jiahai Shi, Tejus A. Bale, Meghan Towne, Klaus Schmitz-Abe, Laura Crowley, Felix C. Giani, Shideh Kazerounian, Kyriacos Markianos, Hart G. Lidov, Rebecca Folkerth, Vijay G. Sankaran, and Pankaj B. Agrawal. Mutations in the substrate binding glycine-rich loop of the mitochondrial processing peptidase-α protein (pmpca) cause a severe mitochondrial disease. Cold Spring Harbor Molecular Case Studies, 2:a000786, May 2016. URL: https://doi.org/10.1101/mcs.a000786, doi:10.1101/mcs.a000786. This article has 51 citations and is from a peer-reviewed journal.
+
+2. (kunova2022mitochondrialprocessingpeptidases—structure pages 2-4): Nina Kunová, Henrieta Havalová, Gabriela Ondrovičová, Barbora Stojkovičová, Jacob A. Bauer, Vladena Bauerová-Hlinková, Vladimir Pevala, and Eva Kutejová. Mitochondrial processing peptidases—structure, function and the role in human diseases. International Journal of Molecular Sciences, 23:1297, Jan 2022. URL: https://doi.org/10.3390/ijms23031297, doi:10.3390/ijms23031297. This article has 39 citations.
+
+3. (kucukkose2021functionalcouplingof pages 1-2): Cansu Kücükköse, Asli Aras Taskin, Adinarayana Marada, Tilman Brummer, Sven Dennerlein, and Friederike‐Nora Vögtle. Functional coupling of presequence processing and degradation in human mitochondria. The FEBS Journal, 288:600-613, Jun 2021. URL: https://doi.org/10.1111/febs.15358, doi:10.1111/febs.15358. This article has 31 citations.
+
+4. (kunova2022mitochondrialprocessingpeptidases—structure pages 4-6): Nina Kunová, Henrieta Havalová, Gabriela Ondrovičová, Barbora Stojkovičová, Jacob A. Bauer, Vladena Bauerová-Hlinková, Vladimir Pevala, and Eva Kutejová. Mitochondrial processing peptidases—structure, function and the role in human diseases. International Journal of Molecular Sciences, 23:1297, Jan 2022. URL: https://doi.org/10.3390/ijms23031297, doi:10.3390/ijms23031297. This article has 39 citations.
+
+5. (jobling2015pmpcamutationscause pages 1-2): Rebekah K. Jobling, Mirna Assoum, Oleksandr Gakh, Susan Blaser, Julian A. Raiman, Cyril Mignot, Emmanuel Roze, Alexandra Dürr, Alexis Brice, Nicolas Lévy, Chitra Prasad, Tara Paton, Andrew D. Paterson, Nicole M. Roslin, Christian R. Marshall, Jean-Pierre Desvignes, Nathalie Roëckel-Trevisiol, Stephen W. Scherer, Guy A. Rouleau, André Mégarbané, Grazia Isaya, Valérie Delague, and Grace Yoon. Pmpca mutations cause abnormal mitochondrial protein processing in patients with non-progressive cerebellar ataxia. Brain : a journal of neurology, 138 Pt 6:1505-17, Jun 2015. URL: https://doi.org/10.1093/brain/awv057, doi:10.1093/brain/awv057. This article has 101 citations.
+
+6. (kunova2022mitochondrialprocessingpeptidases—structure media ea670898): Nina Kunová, Henrieta Havalová, Gabriela Ondrovičová, Barbora Stojkovičová, Jacob A. Bauer, Vladena Bauerová-Hlinková, Vladimir Pevala, and Eva Kutejová. Mitochondrial processing peptidases—structure, function and the role in human diseases. International Journal of Molecular Sciences, 23:1297, Jan 2022. URL: https://doi.org/10.3390/ijms23031297, doi:10.3390/ijms23031297. This article has 39 citations.
+
+7. (bagabir2024clinicalwholeexome pages 1-2): Hala Abubaker Bagabir, Angham Abdulrhman Abdulkareem, Osama Yousef Muthaffar, Bader H. Shirah, and Muhammad Imran Naseer. Clinical whole exome sequencing reveals novel homozygous missense variant in the pmpca gene causing autosomal recessive spinocerebellar ataxia. Pakistan Journal of Medical Sciences, 40:2243-2250, Oct 2024. URL: https://doi.org/10.12669/pjms.40.10.10474, doi:10.12669/pjms.40.10.10474. This article has 0 citations and is from a peer-reviewed journal.
+
+8. (delibes2024geneticsusceptibilityto pages 1-2): Camille Delibes, Marc Ferré, Marine Rozet, Valérie Desquiret-Dumas, Alexis Descatha, Bénédicte Gohier, Philippe Gohier, Patrizia Amati-Bonneau, Dan Milea, and Pascal Reynier. Genetic susceptibility to optic neuropathy in patients with alcohol use disorder. Journal of Translational Medicine, May 2024. URL: https://doi.org/10.1186/s12967-024-05334-0, doi:10.1186/s12967-024-05334-0. This article has 6 citations and is from a peer-reviewed journal.
+
+9. (joshi2016mutationsinthe pages 2-4): Mugdha Joshi, Irina Anselm, Jiahai Shi, Tejus A. Bale, Meghan Towne, Klaus Schmitz-Abe, Laura Crowley, Felix C. Giani, Shideh Kazerounian, Kyriacos Markianos, Hart G. Lidov, Rebecca Folkerth, Vijay G. Sankaran, and Pankaj B. Agrawal. Mutations in the substrate binding glycine-rich loop of the mitochondrial processing peptidase-α protein (pmpca) cause a severe mitochondrial disease. Cold Spring Harbor Molecular Case Studies, 2:a000786, May 2016. URL: https://doi.org/10.1101/mcs.a000786, doi:10.1101/mcs.a000786. This article has 51 citations and is from a peer-reviewed journal.
+
+10. (audet2024integrationofmultiomics pages 10-11): Sebastien Audet, Valerie Triassi, Myriam Gelinas, Nab Legault-Cadieux, Vincent Ferraro, Antoine Duquette, and Martine Tetreault. Integration of multi-omics technologies for molecular diagnosis in ataxia patients. Frontiers in Genetics, Jan 2024. URL: https://doi.org/10.3389/fgene.2023.1304711, doi:10.3389/fgene.2023.1304711. This article has 4 citations and is from a peer-reviewed journal.
+
+11. (joshi2016mutationsinthe pages 6-8): Mugdha Joshi, Irina Anselm, Jiahai Shi, Tejus A. Bale, Meghan Towne, Klaus Schmitz-Abe, Laura Crowley, Felix C. Giani, Shideh Kazerounian, Kyriacos Markianos, Hart G. Lidov, Rebecca Folkerth, Vijay G. Sankaran, and Pankaj B. Agrawal. Mutations in the substrate binding glycine-rich loop of the mitochondrial processing peptidase-α protein (pmpca) cause a severe mitochondrial disease. Cold Spring Harbor Molecular Case Studies, 2:a000786, May 2016. URL: https://doi.org/10.1101/mcs.a000786, doi:10.1101/mcs.a000786. This article has 51 citations and is from a peer-reviewed journal.
+
+12. (charif2022nextgenerationsequencingidentifies pages 1-2): Majida Charif, Arnaud Chevrollier, Naïg Gueguen, Selma Kane, Céline Bris, David Goudenège, Valerie Desquiret-Dumas, Isabelle Meunier, Fanny Mochel, Luc Jeanjean, Fanny Varenne, Vincent Procaccio, Pascal Reynier, Dominique Bonneau, Patrizia Amati-Bonneau, and Guy Lenaers. Next-generation sequencing identifies novel pmpca variants in patients with late-onset dominant optic atrophy. Genes, 13:1202, Jul 2022. URL: https://doi.org/10.3390/genes13071202, doi:10.3390/genes13071202. This article has 3 citations.
+
+13. (baker2025qualitycontrolat pages 4-5): Megan J. Baker, Kai Qi Yek, and Diana Stojanovski. Quality control at the powerhouse: mitochondrial proteostasis dysfunction and disease. Biochemical Society Transactions, 53:1105-1117, Aug 2025. URL: https://doi.org/10.1042/bst20253044, doi:10.1042/bst20253044. This article has 3 citations and is from a peer-reviewed journal.
+
+14. (serpieri2021phenotypicdefinitionand pages 1-2): Valentina Serpieri, Tommaso Biagini, Concetta Mazzotta, Rosa Pasquariello, Anna Rubegni, Filippo Santorelli, Gerardo Ongari, Silvia Cerri, Tommaso Mazza, Roberta Battini, and Enza Maria Valente. Phenotypic definition and genotype-phenotype correlates in pmpca-related disease. Applied Sciences, 11:748, Jan 2021. URL: https://doi.org/10.3390/app11020748, doi:10.3390/app11020748. This article has 5 citations.
+
+15. (torres2019matrixprocessingpeptidase pages 24-28): E Torres. Matrix processing peptidase and putative roles in mitochondrial biogenesis. nuc1 and porin influence la killer virus loads co-dependently in saccharomyces …. Unknown journal, 2019.
+
+## Citations
+
+1. kucukkose2021functionalcouplingof pages 1-2
+2. bagabir2024clinicalwholeexome pages 1-2
+3. delibes2024geneticsusceptibilityto pages 1-2
+4. joshi2016mutationsinthe pages 2-4
+5. audet2024integrationofmultiomics pages 10-11
+6. jobling2015pmpcamutationscause pages 1-2
+7. joshi2016mutationsinthe pages 1-2
+8. charif2022nextgenerationsequencingidentifies pages 1-2
+9. joshi2016mutationsinthe pages 6-8
+10. baker2025qualitycontrolat pages 4-5
+11. serpieri2021phenotypicdefinitionand pages 1-2
+12. torres2019matrixprocessingpeptidase pages 24-28
+13. https://doi.org/10.3390/ijms23031297;
+14. https://doi.org/10.1111/febs.15358;
+15. https://doi.org/10.1093/brain/awv057;
+16. https://doi.org/10.1101/mcs.a000786;
+17. https://doi.org/10.1186/s12967-024-05334-0;
+18. https://doi.org/10.3390/genes13071202;
+19. https://doi.org/10.1101/mcs.a000786,
+20. https://doi.org/10.3390/ijms23031297,
+21. https://doi.org/10.1111/febs.15358,
+22. https://doi.org/10.1093/brain/awv057,
+23. https://doi.org/10.12669/pjms.40.10.10474,
+24. https://doi.org/10.1186/s12967-024-05334-0,
+25. https://doi.org/10.3389/fgene.2023.1304711,
+26. https://doi.org/10.3390/genes13071202,
+27. https://doi.org/10.1042/bst20253044,
+28. https://doi.org/10.3390/app11020748,

--- a/genes/human/SAMM50/SAMM50-ai-review.html
+++ b/genes/human/SAMM50/SAMM50-ai-review.html
@@ -1,0 +1,5612 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SAMM50 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>SAMM50</h1>
+        <div class="gene-info">
+
+            <div class="info-item">
+
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/Q9Y512" target="_blank" class="term-link">
+                        Q9Y512
+                    </a>
+                </span>
+
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Homo sapiens</span>
+            </div>
+
+
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-complete">
+                    COMPLETE
+                </span>
+            </div>
+
+
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "SAMM50";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="Q9Y512" data-a="DESCRIPTION: SAMM50 encodes the human Sam50/SAM50 Omp85-family ..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>SAMM50 encodes the human Sam50/SAM50 Omp85-family beta-barrel subunit of the mitochondrial sorting and assembly machinery (SAM) complex. It is an outer mitochondrial membrane insertase for beta-barrel proteins such as TOM40 and VDACs and also participates in SAM-MICOS/MIB contact sites that link outer-membrane beta-barrel biogenesis to cristae organization.</p>
+    </div>
+
+
+
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001401" target="_blank" class="term-link">
+                                    GO:0001401
+                                </a>
+                            </span>
+                            <span class="term-label">SAM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0001401" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is the conserved core beta-barrel subunit of the mitochondrial SAM complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> SAM complex membership is a core cellular component annotation for SAMM50.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2, ravi2025mitochondrialsortingand pages 1-3)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                    GO:0045040
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IBA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000033
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0045040" data-r="GO_REF:0000033" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50/SAM inserts and assembles mitochondrial outer-membrane beta-barrel proteins such as TOM40 and VDAC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein insertion into the mitochondrial outer membrane captures the central biological process of SAMM50.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2, ravi2025mitochondrialsortingand pages 1-3)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** SAMM50 is the core insertase/chaperone of the SAM complex that assembles **mitochondrial outer membrane β-barrel proteins** (including **Tom40** and **VDACs**) in an **energy-independent** manner. (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is an outer mitochondrial membrane beta-barrel protein, not a cytoplasmic protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cytoplasm annotation conflicts with the curated outer mitochondrial membrane localization and likely reflects a broad or transferred location call.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005739" data-r="GO_REF:0000044" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    mitochondrial outer membrane
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000044
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005741" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is an outer mitochondrial membrane Omp85-family beta-barrel protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Outer mitochondrial membrane localization is central to SAMM50 topology and function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019867" target="_blank" class="term-link">
+                                    GO:0019867
+                                </a>
+                            </span>
+                            <span class="term-label">outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000002
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0019867" data-r="GO_REF:0000002" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is in an outer membrane, specifically the mitochondrial outer membrane.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The taxon/gene-specific evidence supports mitochondrial outer membrane as the precise location.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    mitochondrial outer membrane
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25416956
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A proteome-scale map of the human interactome network.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005515" data-r="PMID:25416956" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding is less informative than its insertase and complex annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/27059175" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:27059175
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    SAMM50 Affects Mitochondrial Morphology through the Associat...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005515" data-r="PMID:27059175" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding is less informative than its insertase and complex annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:32296183
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    A reference map of the human binary protein interactome.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding is less informative than its insertase and complex annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:33961781
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dual proteome-scale networks reveal cell-specific remodeling...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding is less informative than its insertase and complex annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000052
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005739" data-r="GO_REF:0000052" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    mitochondrial outer membrane
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                    GO:0005737
+                                </a>
+                            </span>
+                            <span class="term-label">cytoplasm</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            GO_REF:0000024
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005737" data-r="GO_REF:0000024" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is an outer mitochondrial membrane beta-barrel protein, not a cytoplasmic protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The cytoplasm annotation conflicts with the curated outer mitochondrial membrane localization and likely reflects a broad or transferred location call.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001401" target="_blank" class="term-link">
+                                    GO:0001401
+                                </a>
+                            </span>
+                            <span class="term-label">SAM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17510655" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:17510655
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Conserved roles of Sam50 and metaxins in VDAC biogenesis.
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0001401" data-r="PMID:17510655" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is the conserved core beta-barrel subunit of the mitochondrial SAM complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> SAM complex membership is a core cellular component annotation for SAMM50.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2, ravi2025mitochondrialsortingand pages 1-3)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31387448" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31387448
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondria-hubs for regulating cellular biochemistry: emer...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005741" data-r="PMID:31387448" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is an outer mitochondrial membrane Omp85-family beta-barrel protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Outer mitochondrial membrane localization is central to SAMM50 topology and function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                    GO:0045040
+                                </a>
+                            </span>
+                            <span class="term-label">protein insertion into mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31387448" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31387448
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mitochondria-hubs for regulating cellular biochemistry: emer...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0045040" data-r="PMID:31387448" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50/SAM inserts and assembles mitochondrial outer-membrane beta-barrel proteins such as TOM40 and VDAC.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein insertion into the mitochondrial outer membrane captures the central biological process of SAMM50.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2, ravi2025mitochondrialsortingand pages 1-3)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** SAMM50 is the core insertase/chaperone of the SAM complex that assembles **mitochondrial outer membrane β-barrel proteins** (including **Tom40** and **VDACs**) in an **energy-independent** manner. (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030150" target="_blank" class="term-link">
+                                    GO:0030150
+                                </a>
+                            </span>
+                            <span class="term-label">protein import into mitochondrial matrix</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15644312
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dissection of the mitochondrial import and assembly pathway ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0030150" data-r="PMID:15644312" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 handles outer-membrane beta-barrel substrates after TOM translocation, not matrix-targeted presequence import through TIM23.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The original Tom40 pathway evidence is better captured by protein insertion into mitochondrial outer membrane.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                    protein insertion into mitochondrial outer membrane
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2, ravi2025mitochondrialsortingand pages 1-3)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** SAMM50 is the core insertase/chaperone of the SAM complex that assembles **mitochondrial outer membrane β-barrel proteins** (including **Tom40** and **VDACs**) in an **energy-independent** manner. (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HTP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:34800366
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Quantitative high-confidence human mitochondrial proteome an...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005739" data-r="PMID:34800366" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    mitochondrial outer membrane
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/31644573" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:31644573
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Armadillo repeat-containing protein 1 is a dual localization...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005515" data-r="PMID:31644573" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding is less informative than its insertase and complex annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001401" target="_blank" class="term-link">
+                                    GO:0001401
+                                </a>
+                            </span>
+                            <span class="term-label">SAM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26477565" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26477565
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Evolution and structural organization of the mitochondrial c...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0001401" data-r="PMID:26477565" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is the conserved core beta-barrel subunit of the mitochondrial SAM complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> SAM complex membership is a core cellular component annotation for SAMM50.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2, ravi2025mitochondrialsortingand pages 1-3)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007007" target="_blank" class="term-link">
+                                    GO:0007007
+                                </a>
+                            </span>
+                            <span class="term-label">inner mitochondrial membrane organization</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26477565" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26477565
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Evolution and structural organization of the mitochondrial c...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0007007" data-r="PMID:26477565" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 contributes to inner-membrane/cristae architecture through SAM-MICOS/MIB contact sites, but this is secondary to its core SAM insertase role.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The annotation is supported as a downstream organizational role of the MIB/SAM-MICOS axis rather than the primary evolved molecular function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140275" target="_blank" class="term-link">
+                                    GO:0140275
+                                </a>
+                            </span>
+                            <span class="term-label">MIB complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/26477565" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:26477565
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Evolution and structural organization of the mitochondrial c...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0140275" data-r="PMID:26477565" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 participates in the mitochondrial intermembrane-space bridging (MIB) complex/contact-site axis with MICOS components.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> MIB complex association is supported but is treated as a contact-site/architecture role secondary to SAM beta-barrel insertion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25781180" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25781180
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Detailed analysis of the human mitochondrial contact site co...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005739" data-r="PMID:25781180" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    mitochondrial outer membrane
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042407" target="_blank" class="term-link">
+                                    GO:0042407
+                                </a>
+                            </span>
+                            <span class="term-label">cristae formation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/22252321" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:22252321
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Sam50 functions in mitochondrial intermembrane space bridgin...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0042407" data-r="PMID:22252321" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 perturbation affects cristae organization through SAM-MICOS/MIB contact sites.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cristae formation is a supported cellular architecture consequence, but the core SAMM50 function remains outer-membrane beta-barrel insertion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042407" target="_blank" class="term-link">
+                                    GO:0042407
+                                </a>
+                            </span>
+                            <span class="term-label">cristae formation</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/25781180" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:25781180
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Detailed analysis of the human mitochondrial contact site co...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0042407" data-r="PMID:25781180" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 perturbation affects cristae organization through SAM-MICOS/MIB contact sites.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Cristae formation is a supported cellular architecture consequence, but the core SAMM50 function remains outer-membrane beta-barrel insertion.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20833797" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20833797
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Phosphoproteome analysis of functional mitochondria isolated...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005739" data-r="PMID:20833797" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    mitochondrial outer membrane
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
+                                    GO:0070062
+                                </a>
+                            </span>
+                            <span class="term-label">extracellular exosome</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">HDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:19056867
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Large-scale proteomics and phosphoproteomics of urinary exos...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-remove">
+                            REMOVE
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0070062" data-r="PMID:19056867" data-act="REMOVE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> The curated literature supports mitochondrial outer membrane localization and SAM complex function, not extracellular exosome localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This high-throughput exosome annotation is not supported by gene-specific functional evidence for SAMM50.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
+                                    GO:0016020
+                                </a>
+                            </span>
+                            <span class="term-label">membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15644312
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dissection of the mitochondrial import and assembly pathway ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0016020" data-r="PMID:15644312" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is a membrane protein, specifically a mitochondrial outer membrane beta-barrel protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial outer membrane rather than generic membrane.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    mitochondrial outer membrane
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/21081504" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:21081504
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    ChChd3, an inner mitochondrial membrane protein, is essentia...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005515" data-r="PMID:21081504" data-act="MARK_AS_OVER_ANNOTATED">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding is less informative than its insertase and complex annotations.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001401" target="_blank" class="term-link">
+                                    GO:0001401
+                                </a>
+                            </span>
+                            <span class="term-label">SAM complex</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15644312
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dissection of the mitochondrial import and assembly pathway ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0001401" data-r="PMID:15644312" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is the conserved core beta-barrel subunit of the mitochondrial SAM complex.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> SAM complex membership is a core cellular component annotation for SAMM50.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2, ravi2025mitochondrialsortingand pages 1-3)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
+                                    GO:0005739
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrion</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15644312
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dissection of the mitochondrial import and assembly pathway ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005739" data-r="PMID:15644312" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    mitochondrial outer membrane
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                    GO:0005741
+                                </a>
+                            </span>
+                            <span class="term-label">mitochondrial outer membrane</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:15644312
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Dissection of the mitochondrial import and assembly pathway ...
+                                </span>
+
+
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0005741" data-r="PMID:15644312" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is an outer mitochondrial membrane Omp85-family beta-barrel protein.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Outer mitochondrial membrane localization is central to SAMM50 topology and function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032977" target="_blank" class="term-link">
+                                    GO:0032977
+                                </a>
+                            </span>
+                            <span class="term-label">membrane insertase activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">NAS</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q9Y512" data-a="GO:0032977" data-r="file:human/SAMM50/SAMM50-deep-research-falcon.md" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> SAMM50 is the core Sam50/SAM50 membrane insertase subunit that inserts and assembles mitochondrial outer-membrane beta-barrel proteins.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> The current GOA captures the biological process and complex but lacks the precise molecular function membrane insertase activity for SAMM50.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2, ravi2025mitochondrialsortingand pages 1-3)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** SAMM50 is the core insertase/chaperone of the SAM complex that assembles **mitochondrial outer membrane β-barrel proteins** (including **Tom40** and **VDACs**) in an **energy-independent** manner. (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
+            </tbody>
+        </table>
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>SAMM50 is the core Omp85-family membrane insertase of the mitochondrial SAM complex. It recognizes and assembles beta-barrel precursor proteins delivered by the TOM/IMS chaperone pathway and releases mature beta-barrels such as TOM40 and VDAC into the outer mitochondrial membrane.</h3>
+                <span class="vote-buttons" data-g="Q9Y512" data-a="FUNCTION: SAMM50 is the core Omp85-family membrane insertase..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032977" target="_blank" class="term-link">
+                            membrane insertase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045040" target="_blank" class="term-link">
+                                protein insertion into mitochondrial outer membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005741" target="_blank" class="term-link">
+                                mitochondrial outer membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001401" target="_blank" class="term-link">
+                            SAM complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2, ravi2025mitochondrialsortingand pages 1-3)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**Primary function:** SAMM50 is the core insertase/chaperone of the SAM complex that assembles **mitochondrial outer membrane β-barrel proteins** (including **Tom40** and **VDACs**) in an **energy-independent** manner. (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
+                            GO_REF:0000002
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
+                            GO_REF:0000033
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Annotation inferences using phylogenetic trees</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
+                            GO_REF:0000052
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/15644312" target="_blank" class="term-link">
+                            PMID:15644312
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dissection of the mitochondrial import and assembly pathway for human Tom40.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/17510655" target="_blank" class="term-link">
+                            PMID:17510655
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Conserved roles of Sam50 and metaxins in VDAC biogenesis.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
+                            PMID:19056867
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/20833797" target="_blank" class="term-link">
+                            PMID:20833797
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Phosphoproteome analysis of functional mitochondria isolated from resting human muscle reveals extensive phosphorylation of inner membrane protein complexes and enzymes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/21081504" target="_blank" class="term-link">
+                            PMID:21081504
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">ChChd3, an inner mitochondrial membrane protein, is essential for maintaining crista integrity and mitochondrial function.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/22252321" target="_blank" class="term-link">
+                            PMID:22252321
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Sam50 functions in mitochondrial intermembrane space bridging and biogenesis of respiratory complexes.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
+                            PMID:25416956
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A proteome-scale map of the human interactome network.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/25781180" target="_blank" class="term-link">
+                            PMID:25781180
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Detailed analysis of the human mitochondrial contact site complex indicate a hierarchy of subunits.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/26477565" target="_blank" class="term-link">
+                            PMID:26477565
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Evolution and structural organization of the mitochondrial contact site (MICOS) complex and the mitochondrial intermembrane space bridging (MIB) complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/27059175" target="_blank" class="term-link">
+                            PMID:27059175
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">SAMM50 Affects Mitochondrial Morphology through the Association of Drp1 in Mammalian Cells.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31387448" target="_blank" class="term-link">
+                            PMID:31387448
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Mitochondria-hubs for regulating cellular biochemistry: emerging concepts and networks.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31644573" target="_blank" class="term-link">
+                            PMID:31644573
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Armadillo repeat-containing protein 1 is a dual localization protein associated with mitochondrial intermembrane space bridging complex.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
+                            PMID:32296183
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">A reference map of the human binary protein interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
+                            PMID:33961781
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/34800366" target="_blank" class="term-link">
+                            PMID:34800366
+                        </a>
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/SAMM50/SAMM50-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research on SAMM50 function</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">SAMM50 is the core Omp85-family beta-barrel subunit of the mitochondrial SAM complex.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">SAMM50/SAM mediates insertion and assembly of mitochondrial outer-membrane beta-barrel proteins.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">SAMM50 participates in SAM-MICOS/MIB contacts that affect cristae organization, but this is secondary to its core insertase role.</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+        </div>
+    </div>
+
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should human SAMM50 be annotated directly to membrane insertase activity in GOA, and should that annotation be made with a contributes_to qualifier for the SAM complex or as enabled by the Sam50 subunit itself?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q9Y512" data-a="Q: Should human SAMM50 be annotated directly to membr..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Reconstitute the human SAMM50-MTX SAM complex with purified human TOM40 or VDAC beta-barrel precursors and assay insertion intermediates, lateral-gate mutants, and beta-signal dependence.</p>
+
+
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: Human SAMM50 provides the core membrane insertase activity for outer-membrane beta-barrel substrate assembly.</em></p>
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q9Y512" data-a="EXPERIMENT: Reconstitute the human SAMM50-MTX SAM complex with..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+    <!-- Computational Predictions Section -->
+
+
+    <!-- Additional Documentation Sections -->
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(SAMM50-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9Y512" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T19:29:00.008552'<br />
+end_time: '2026-05-11T19:39:19.210275'<br />
+duration_seconds: 619.2<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: SAMM50<br />
+  gene_symbol: SAMM50<br />
+  uniprot_accession: Q9Y512<br />
+  protein_description: 'RecName: Full=Sorting and assembly machinery component 50<br />
+    homolog; AltName: Full=Transformation-related gene 3 protein; Short=TRG-3;'<br />
+  gene_info: Name=SAMM50; Synonyms=SAM50; ORFNames=CGI-51, TRG3;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the SAM50/omp85 family. .<br />
+  protein_domains: Bac_surfAg_D15. (IPR000184); D15-like. (IPR039910); POTRA. (IPR034746);<br />
+    Omp85 (PF01103)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 17</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9Y512</li>
+<li><strong>Protein Description:</strong> RecName: Full=Sorting and assembly machinery component 50 homolog; AltName: Full=Transformation-related gene 3 protein; Short=TRG-3;</li>
+<li><strong>Gene Information:</strong> Name=SAMM50; Synonyms=SAM50; ORFNames=CGI-51, TRG3;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the SAM50/omp85 family. .</li>
+<li><strong>Key Domains:</strong> Bac_surfAg_D15. (IPR000184); D15-like. (IPR039910); POTRA. (IPR034746); Omp85 (PF01103)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "SAMM50" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'SAMM50' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>SAMM50</strong> (gene ID: SAMM50, UniProt: Q9Y512) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9Y512</li>
+<li><strong>Protein Description:</strong> RecName: Full=Sorting and assembly machinery component 50 homolog; AltName: Full=Transformation-related gene 3 protein; Short=TRG-3;</li>
+<li><strong>Gene Information:</strong> Name=SAMM50; Synonyms=SAM50; ORFNames=CGI-51, TRG3;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the SAM50/omp85 family. .</li>
+<li><strong>Key Domains:</strong> Bac_surfAg_D15. (IPR000184); D15-like. (IPR039910); POTRA. (IPR034746); Omp85 (PF01103)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "SAMM50" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'SAMM50' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>SAMM50</strong> (gene ID: SAMM50, UniProt: Q9Y512) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="comprehensive-research-report-human-samm50-sam50-uniprot-q9y512-functional-annotation">Comprehensive research report: Human <strong>SAMM50 / SAM50</strong> (UniProt <strong>Q9Y512</strong>) — functional annotation</h1>
+<h2 id="0-mandatory-identity-verification-disambiguation">0) Mandatory identity verification (disambiguation)</h2>
+<p>The target in this report is <strong>human SAMM50</strong> (UniProt <strong>Q9Y512</strong>), annotated as <strong>Sorting and assembly machinery component 50 homolog</strong> (also called <strong>SAM50</strong>; synonym <strong>TRG-3 / transformation-related gene 3</strong>) and belonging to the <strong>SAM50/Omp85</strong> family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes <strong>Sam50/SAMM50</strong> as the <strong>core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex</strong>, localized to the <strong>mitochondrial outer membrane (OMM)</strong> and functionally homologous to bacterial <strong>BamA</strong> (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</p>
+<h2 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h2>
+<h3 id="11-what-is-the-sam-complex">1.1 What is the SAM complex?</h3>
+<p>The <strong>Sorting and Assembly Machinery (SAM)</strong> is the <strong>mitochondrial outer-membrane insertase</strong> required for insertion/assembly of <strong>β-barrel proteins</strong> into the OMM. Its core subunit <strong>Sam50 (SAMM50 in humans)</strong> is itself an Omp85-family β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the accessory subunits are functionally replaced by <strong>metaxins</strong>. (ganesan2024biogenesisofmitochondrial pages 1-2, ravi2025mitochondrialsortingand pages 1-3)</p>
+<h3 id="12-what-are-mitochondrial-barrel-proteins-and-why-are-they-important">1.2 What are mitochondrial β-barrel proteins and why are they important?</h3>
+<p>Mitochondrial β-barrel proteins (e.g., <strong>Tom40</strong> and <strong>VDAC</strong>) reside in the OMM, where they mediate metabolite exchange and/or serve as key import pores (Tom40) for nuclear-encoded mitochondrial proteins. Their correct insertion requires the TOM→SAM pathway. (ganesan2024biogenesisofmitochondrial pages 1-2, ravi2025mitochondrialsortingand pages 1-3)</p>
+<h3 id="13-signal-lateral-gate-and-barrel-switching-mechanistic-vocabulary">1.3 “β-signal”, lateral gate, and “β-barrel switching” (mechanistic vocabulary)</h3>
+<p>Recent review syntheses describe the following mechanistic framework:<br />
+- <strong>β-signal</strong>: a C-terminal signal in β-barrel precursors recognized by Sam50; Sam50 loop features (including a conserved <strong>IRGF</strong>-like motif in loop 6) participate in recognition and folding initiation. (ganesan2024biogenesisofmitochondrial pages 2-4, ravi2025mitochondrialsortingand pages 20-24)<br />
+- <strong>Lateral gate</strong>: the site at the Sam50 barrel “seam” (β1–β16) that can open laterally to allow β-strand insertion; Sam50 is described as <strong>not fully closed</strong> (no β1–β16 H-bonds in available structures), consistent with lateral gating. (ravi2025mitochondrialsortingand pages 20-24)<br />
+- <strong>β-barrel switching</strong>: a model in which β-strands of the precursor assemble at Sam50 to form a <strong>Sam50–preprotein hybrid barrel</strong>, then the nascent barrel is released into the OMM via displacement/switching. (ganesan2024biogenesisofmitochondrial pages 1-2)</p>
+<h2 id="2-molecular-function-and-mechanism-experimental-inference">2) Molecular function and mechanism (experimental + inference)</h2>
+<h3 id="21-subcellular-localization-and-topology">2.1 Subcellular localization and topology</h3>
+<p>SAMM50/Sam50 is an <strong>outer mitochondrial membrane (OMM)</strong> protein. It is described as a <strong>16-stranded transmembrane β-barrel</strong> with a single N-terminal <strong>POTRA</strong> domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)</p>
+<h3 id="22-core-function-insertionassembly-of-omm-barrel-proteins">2.2 Core function: insertion/assembly of OMM β-barrel proteins</h3>
+<p><strong>Primary function:</strong> SAMM50 is the core insertase/chaperone of the SAM complex that assembles <strong>mitochondrial outer membrane β-barrel proteins</strong> (including <strong>Tom40</strong> and <strong>VDACs</strong>) in an <strong>energy-independent</strong> manner. (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)</p>
+<p><strong>Import/assembly pathway (current consensus):</strong><br />
+1. Precursor β-barrel proteins are synthesized in the cytosol and targeted to mitochondria.<br />
+2. They are translocated across the OMM by the <strong>TOM complex</strong> into the <strong>intermembrane space (IMS)</strong>.<br />
+3. IMS chaperones (small Tims, e.g., <strong>Tim9/10</strong> or <strong>Tim8/13</strong>) prevent aggregation and deliver precursors to SAM.<br />
+4. SAM (via Sam50/SAMM50) inserts/assembles the β-barrel in the OMM, with models emphasizing <strong>β-signal recognition</strong>, <strong>lateral gating</strong>, and <strong>β-barrel switching</strong> as key mechanistic steps. (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4)</p>
+<h3 id="23-key-binding-partners-and-multi-complex-organization">2.3 Key binding partners and multi-complex organization</h3>
+<p><strong>Accessory SAM partners in mammals:</strong> Mammalian SAM is described as using <strong>metaxins (MTX1/MTX2)</strong> as functional analogs of yeast Sam35/Sam37 on the cytosolic face of Sam50, consistent with the conserved cytosolic loop interaction surfaces on Sam50. (ravi2025mitochondrialsortingand pages 16-17, ravi2025mitochondrialsortingand pages 20-24)</p>
+<p><strong>TOM–SAM coupling:</strong> SAM forms <strong>TOM–SAM supercomplexes</strong> that couple translocation through TOM to assembly by SAM, supporting efficient β-barrel biogenesis. (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial media a6c2469b)</p>
+<p><strong>SAM–MICOS contact site / MIB axis (cristae junction biology):</strong> SAM is also described as an interaction hub forming a defined <strong>outer–inner membrane contact</strong> with <strong>MICOS</strong>, notably via interaction between Sam50 and MICOS subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to <strong>cristae organization</strong> and mitochondrial architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)</p>
+<p><strong>ER–mitochondria contacts and lipid transfer:</strong> Review synthesis also connects Sam50/SAMM50 with ER proteins <strong>ORP5/ORP8</strong> at ER–mitochondria contact sites (MERCS), proposing a structural/functional contribution to phospholipid transfer (e.g., PS→PE conversion pathways) that can indirectly impact inner-membrane structure and cristae. (ravi2025mitochondrialsortingand pages 30-35, ravi2025mitochondrialsortingand pages 1-3)</p>
+<h2 id="3-recent-developments-prioritizing-20232024">3) Recent developments (prioritizing 2023–2024)</h2>
+<h3 id="31-2024-review-synthesis-barrel-biogenesis-and-sam-as-a-multi-pathway-hub">3.1 2024 review synthesis: β-barrel biogenesis and SAM as a multi-pathway hub</h3>
+<p>A 2024 FEBS Open Bio review emphasizes that SAM is required for β-barrel insertion, describes the <strong>Sam50 lateral gate</strong> and <strong>β-barrel switching</strong> mechanism, and highlights that SAM forms <strong>TOM–SAM supercomplexes</strong> and contacts <strong>MICOS</strong>, placing SAMM50 at the intersection of protein import, membrane contact-site biology, and mitochondrial architecture. (Publication date: Sep 2024; https://doi.org/10.1002/2211-5463.13905) (ganesan2024biogenesisofmitochondrial pages 1-2)</p>
+<p><strong>Visual evidence (mechanism and connectivity):</strong> The same review includes schematics of (i) <strong>β-barrel switching</strong> and (ii) <strong>TOM–SAM</strong> and <strong>SAM–MICOS</strong> contact-site architecture. (ganesan2024biogenesisofmitochondrial media 50bb168a, ganesan2024biogenesisofmitochondrial media a6c2469b)</p>
+<h3 id="32-2024-human-genetics-samm50-variants-associated-with-nafld-risk-and-fibrosis-proxy">3.2 2024 human genetics: SAMM50 variants associated with NAFLD risk and fibrosis proxy</h3>
+<p>A 2023 community-based case–control study in an elderly Chinese cohort (<strong>n=1,053; 590 NAFLD cases</strong>) reported associations between SAMM50 variants and NAFLD risk:<br />
+- <strong>rs2073082 G</strong>: NAFLD risk <strong>OR 1.962</strong> (95% CI 1.448–2.659; p&lt;0.001)<br />
+- <strong>rs738491 T</strong>: NAFLD risk <strong>OR 1.532</strong> (95% CI 1.246–1.884; p=0.021)<br />
+The study also reported increased <strong>liver stiffness measurement (LSM)</strong> in carriers of <strong>rs738491 T</strong> and <strong>rs3761472 G</strong>, and found that a three-SNP interaction model (rs2073082/rs738491/rs3761472) had the best NAFLD predictive performance in their GMDR analysis. (Publication date: Aug 2023; https://doi.org/10.3390/biomedicines11092416) (zhao2023samm50rs2073082rs738491and pages 2-4, zhao2023samm50rs2073082rs738491and pages 1-2)</p>
+<h3 id="33-20232024-diseasephenotype-landscape-knowledge-graph-summary">3.3 2023–2024 disease/phenotype landscape (knowledge graph summary)</h3>
+<p>Open Targets aggregates genetic/functional evidence linking <strong>SAMM50</strong> to <strong>liver disease/NAFLD</strong>, <strong>type 2 diabetes mellitus</strong>, <strong>hypercholesterolemia</strong>, and <strong>neurodegenerative disease</strong> (association-level summaries rather than mechanistic proof). (OpenTargets Search: -SAMM50)</p>
+<h2 id="4-current-applications-and-real-world-implementations">4) Current applications and real-world implementations</h2>
+<h3 id="41-variant-interpretation-and-genetic-risk-modeling-in-steatotic-liver-disease">4.1 Variant interpretation and genetic risk modeling in steatotic liver disease</h3>
+<p>The 2023 NAFLD study demonstrates a direct <strong>clinical-genetic application</strong>: SAMM50 SNPs can contribute to <strong>risk stratification</strong> and multi-locus predictive models for NAFLD in specific populations/age groups, with effect sizes in the ~1.5–2.0 OR range for the highlighted alleles in their cohort. (zhao2023samm50rs2073082rs738491and pages 1-2)</p>
+<h3 id="42-functional-genomics-and-mitochondrial-biology-toolchains">4.2 Functional genomics and mitochondrial biology toolchains</h3>
+<p>Because SAMM50 is central to β-barrel biogenesis and a contact-site hub (TOM–SAM, SAM–MICOS), it is routinely used in:<br />
+- <strong>Mitochondrial import/assembly assays</strong> (tracking TOM→SAM assembly of Tom40/VDAC) and perturbation experiments to link β-barrel insertion defects to OMM proteostasis.<br />
+- <strong>Cristae architecture studies</strong>, leveraging the SAM–MICOS link to test how outer-membrane machineries influence inner-membrane ultrastructure and respiratory complex organization. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)</p>
+<h3 id="43-translational-concepts-targeting-mitochondrial-organization-rather-than-a-catalytic-activity">4.3 Translational concepts: targeting mitochondrial organization rather than a catalytic activity</h3>
+<p>SAMM50 is <strong>not an enzyme</strong> with a specific substrate turnover reaction; it is a <strong>membrane insertase/chaperone and organizational hub</strong>. Thus translational strategies tend to focus on:<br />
+- Correcting upstream drivers (e.g., metabolic stress) that dysregulate SAMM50-linked pathways.<br />
+- Interpreting SAMM50 variation as part of polygenic or pathway-level risk rather than targeting SAMM50 directly with inhibitors. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)</p>
+<h2 id="5-expert-opinion-and-analysis-authoritative-synthesis">5) Expert opinion and analysis (authoritative synthesis)</h2>
+<h3 id="51-samsam50-as-more-than-a-barrel-insertase">5.1 SAM/Sam50 as more than a β-barrel insertase</h3>
+<p>A 2025 Biochemistry review (useful as expert synthesis, though outside the requested 2023–2024 window) argues that although β-barrel assembly is the canonical function, Sam50/SAMM50 participates broadly in OMM interactomes that connect protein biogenesis to <strong>cristae morphology (via MICOS)</strong>, <strong>lipid exchange at contact sites (via ORP5/8)</strong>, and <strong>mitophagy regulation (via PINK1)</strong>. This framing helps interpret why SAMM50 perturbations can have pleiotropic effects that still trace back to its primary role in OMM organization and β-barrel biogenesis. (Publication date: Jan 2025; https://doi.org/10.1021/acs.biochem.4c00727) (ravi2025mitochondrialsortingand pages 30-35)</p>
+<h3 id="52-mechanistic-caution-association-vs-causality-in-human-disease">5.2 Mechanistic caution: association vs causality in human disease</h3>
+<p>While common variants in SAMM50 associate with NAFLD risk in specific cohorts (and Open Targets aggregates broader disease associations), these do not by themselves establish SAMM50 as a monogenic disease gene with a well-defined pathogenic mechanism in humans. Current evidence supports SAMM50 as an essential mitochondrial organization factor; complete loss is plausibly incompatible with viability, and disease links may often be mediated through partial changes in expression/function in metabolic stress contexts. (ravi2025mitochondrialsortingand pages 13-15, zhao2023samm50rs2073082rs738491and pages 1-2)</p>
+<h2 id="6-relevant-statistics-and-data-highlights-recent-studies">6) Relevant statistics and data highlights (recent studies)</h2>
+<ul>
+<li><strong>NAFLD cohort size and prevalence:</strong> 1,053 elderly participants; <strong>590 NAFLD cases (56.03%)</strong>. (zhao2023samm50rs2073082rs738491and pages 4-5)</li>
+<li><strong>Effect sizes for SAMM50 alleles (NAFLD risk):</strong> rs2073082 G: <strong>OR 1.962</strong>; rs738491 T: <strong>OR 1.532</strong>. (zhao2023samm50rs2073082rs738491and pages 1-2)</li>
+<li><strong>Fibrosis proxy association:</strong> rs738491 T and rs3761472 G associated with increased <strong>liver stiffness measurement (LSM)</strong> in the cohort. (zhao2023samm50rs2073082rs738491and pages 1-2)</li>
+</ul>
+<h2 id="7-concise-functional-annotation-summary">7) Concise functional annotation (summary)</h2>
+<p>SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a <strong>mitochondrial outer membrane Omp85-family β-barrel insertase</strong> and the <strong>core subunit of the SAM complex</strong>. Its primary, experimentally grounded role is the <strong>assembly/insertion of OMM β-barrel proteins</strong> (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via <strong>β-signal recognition</strong>, <strong>lateral gating</strong>, and <strong>β-barrel switching</strong>. SAMM50 also serves as an organizational hub by forming <strong>TOM–SAM</strong> supercomplexes and participating in <strong>SAM–MICOS</strong> contact sites that connect outer-membrane protein biogenesis to <strong>cristae junction organization</strong>. In human populations, common SAMM50 variants show reproducible associations with <strong>NAFLD risk</strong> in some cohorts, supporting a role for mitochondrial membrane architecture pathways in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)</p>
+<h2 id="evidence-table-quick-reference">Evidence table (quick reference)</h2>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Concise finding for human SAMM50 (UniProt Q9Y512)</th>
+<th>Supporting citations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Verified identity / synonyms</td>
+<td><strong>SAMM50</strong> encodes human <strong>sorting and assembly machinery component 50 homolog</strong> (<strong>SAM50</strong>), also called <strong>TRG-3 / transformation-related gene 3 protein</strong>; it is the conserved human Omp85-family core subunit of the mitochondrial <strong>SAM complex</strong> in the outer membrane.</td>
+<td>(ravi2025mitochondrialsortingand pages 1-3)</td>
+</tr>
+<tr>
+<td>Protein family / domains / topology</td>
+<td>SAMM50 belongs to the <strong>SAM50/Omp85 family</strong> and is a <strong>16-stranded β-barrel</strong> outer-membrane protein with a single <strong>N-terminal POTRA domain</strong>; available structural summaries indicate a <strong>non-closed barrel seam</strong> between β1 and β16 consistent with a <strong>lateral gate</strong>, and loop <strong>L6</strong> contains the conserved <strong>(V/I)RG(F/Y)</strong> motif involved in substrate handling.</td>
+<td>(ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 2-4)</td>
+</tr>
+<tr>
+<td>Subcellular localization</td>
+<td>SAMM50 localizes to the <strong>mitochondrial outer membrane (OMM)</strong>, with the <strong>POTRA domain exposed to the intermembrane space</strong> and cytosolic surfaces engaging accessory factors; it also participates in <strong>outer–inner membrane contact sites</strong> with MICOS and at <strong>ER–mitochondria contact sites</strong>.</td>
+<td>(ravi2025mitochondrialsortingand pages 35-36, ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial media 50bb168a)</td>
+</tr>
+<tr>
+<td>Core molecular function / mechanism</td>
+<td>Canonical function: <strong>assembly/insertion of mitochondrial β-barrel proteins</strong> such as <strong>Tom40</strong> and <strong>VDACs</strong>. Precursor route is <strong>cytosol → TOM complex → IMS small Tim chaperones (Tim9/10 or Tim8/13) → SAM complex</strong>. Mechanistically, the precursor <strong>β-signal</strong> engages Sam50, insertion occurs at the <strong>lateral gate</strong>, and current models favor <strong>β-barrel switching</strong>, where a nascent barrel forms a <strong>Sam50–preprotein hybrid barrel</strong> before release into the OMM.</td>
+<td>(ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4, ravi2025mitochondrialsortingand pages 7-8)</td>
+</tr>
+<tr>
+<td>Key complexes / partners</td>
+<td>SAMM50 is the central subunit of the <strong>SAM complex</strong>; in humans, <strong>metaxins MTX1/MTX2</strong> replace yeast Sam35/37-like accessory functions. It functionally couples with the <strong>TOM complex</strong>, forms a <strong>SAM–MICOS / MIB axis</strong> with <strong>Mic60/Mic19</strong> for cristae organization, and associates with <strong>ORP5/ORP8</strong> at ER–mitochondria contact sites to support lipid transfer.</td>
+<td>(ravi2025mitochondrialsortingand pages 16-17, ravi2025mitochondrialsortingand pages 8-10, ravi2025mitochondrialsortingand pages 1-3)</td>
+</tr>
+<tr>
+<td>Phenotypes when perturbed</td>
+<td>SAMM50 loss/depletion disrupts <strong>β-barrel biogenesis</strong>, causes <strong>cristae loss/disorganization</strong>, abnormal <strong>spherical/enlarged mitochondria</strong>, loss of respiratory complexes, altered lipid homeostasis, and <strong>PINK1 stabilization</strong> with increased <strong>PINK1–Parkin mitophagy</strong>; the review literature also notes that complete loss is likely <strong>lethal/essential</strong>.</td>
+<td>(ravi2025mitochondrialsortingand pages 8-10, ravi2025mitochondrialsortingand pages 30-35, ravi2025mitochondrialsortingand pages 1-3)</td>
+</tr>
+<tr>
+<td>2023–2024 human genetics associations</td>
+<td>In an elderly Chinese cohort of <strong>1,053</strong> individuals (<strong>590 NAFLD cases</strong>), <strong>SAMM50 rs2073082 G</strong> was associated with higher NAFLD risk (<strong>OR 1.962, 95% CI 1.448–2.659, p&lt;0.001</strong>) and <strong>rs738491 T</strong> with higher NAFLD risk (<strong>OR 1.532, 95% CI 1.246–1.884, p=0.021</strong>). <strong>rs738491 T</strong> and <strong>rs3761472 G</strong> were associated with higher <strong>liver stiffness</strong>, and the <strong>three-SNP model</strong> (rs2073082/rs738491/rs3761472) gave the best NAFLD prediction, with carriers of all three risk alleles showing roughly <strong>two-fold higher risk</strong>. Open Targets also summarizes associations of SAMM50 with <strong>liver disease/NAFLD</strong>.</td>
+<td>(zhao2023samm50rs2073082rs738491and pages 1-2, zhao2023samm50rs2073082rs738491and pages 4-5, OpenTargets Search: -SAMM50)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the verified identity, structure, localization, mechanism, interaction partners, perturbation phenotypes, and recent human genetic associations for human SAMM50. It is useful as a compact evidence-backed reference for functional annotation of UniProt Q9Y512.</em></p>
+<h2 id="key-urls-most-used-sources">Key URLs (most used sources)</h2>
+<ul>
+<li>Ganesan et al., <strong>“Biogenesis of mitochondrial β‐barrel membrane proteins”</strong>, FEBS Open Bio, <strong>Sep 2024</strong>. https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2)</li>
+<li>Zhao et al., <strong>“SAMM50-rs2073082, -rs738491 and -rs3761472 interactions…”</strong>, Biomedicines, <strong>Aug 2023</strong>. https://doi.org/10.3390/biomedicines11092416 (zhao2023samm50rs2073082rs738491and pages 1-2)</li>
+<li>Open Targets association summary for SAMM50 (accessed via Open Targets tool output in this run). https://platform.opentargets.org/ (OpenTargets Search: -SAMM50)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(ravi2025mitochondrialsortingand pages 1-3): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ganesan2024biogenesisofmitochondrial pages 1-2): Iniyan Ganesan, Jon V. Busto, Nikolaus Pfanner, and Nils Wiedemann. Biogenesis of mitochondrial β‐barrel membrane proteins. FEBS Open Bio, 14:1595-1609, Sep 2024. URL: https://doi.org/10.1002/2211-5463.13905, doi:10.1002/2211-5463.13905. This article has 20 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ganesan2024biogenesisofmitochondrial pages 2-4): Iniyan Ganesan, Jon V. Busto, Nikolaus Pfanner, and Nils Wiedemann. Biogenesis of mitochondrial β‐barrel membrane proteins. FEBS Open Bio, 14:1595-1609, Sep 2024. URL: https://doi.org/10.1002/2211-5463.13905, doi:10.1002/2211-5463.13905. This article has 20 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ravi2025mitochondrialsortingand pages 20-24): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ravi2025mitochondrialsortingand pages 16-17): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ganesan2024biogenesisofmitochondrial media a6c2469b): Iniyan Ganesan, Jon V. Busto, Nikolaus Pfanner, and Nils Wiedemann. Biogenesis of mitochondrial β‐barrel membrane proteins. FEBS Open Bio, 14:1595-1609, Sep 2024. URL: https://doi.org/10.1002/2211-5463.13905, doi:10.1002/2211-5463.13905. This article has 20 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ravi2025mitochondrialsortingand pages 8-10): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ravi2025mitochondrialsortingand pages 30-35): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ganesan2024biogenesisofmitochondrial media 50bb168a): Iniyan Ganesan, Jon V. Busto, Nikolaus Pfanner, and Nils Wiedemann. Biogenesis of mitochondrial β‐barrel membrane proteins. FEBS Open Bio, 14:1595-1609, Sep 2024. URL: https://doi.org/10.1002/2211-5463.13905, doi:10.1002/2211-5463.13905. This article has 20 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhao2023samm50rs2073082rs738491and pages 2-4): Jinhan Zhao, Xiaoyi Xu, Xinhuan Wei, Shuang Zhang, Hangfei Xu, Xiaodie Wei, Yang Zhang, and Jing Zhang. Samm50-rs2073082, -rs738491 and -rs3761472 interactions enhancement of susceptibility to non-alcoholic fatty liver disease. Biomedicines, 11:2416, Aug 2023. URL: https://doi.org/10.3390/biomedicines11092416, doi:10.3390/biomedicines11092416. This article has 5 citations.</p>
+</li>
+<li>
+<p>(zhao2023samm50rs2073082rs738491and pages 1-2): Jinhan Zhao, Xiaoyi Xu, Xinhuan Wei, Shuang Zhang, Hangfei Xu, Xiaodie Wei, Yang Zhang, and Jing Zhang. Samm50-rs2073082, -rs738491 and -rs3761472 interactions enhancement of susceptibility to non-alcoholic fatty liver disease. Biomedicines, 11:2416, Aug 2023. URL: https://doi.org/10.3390/biomedicines11092416, doi:10.3390/biomedicines11092416. This article has 5 citations.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -SAMM50): Open Targets Query (-SAMM50, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(ravi2025mitochondrialsortingand pages 13-15): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhao2023samm50rs2073082rs738491and pages 4-5): Jinhan Zhao, Xiaoyi Xu, Xinhuan Wei, Shuang Zhang, Hangfei Xu, Xiaodie Wei, Yang Zhang, and Jing Zhang. Samm50-rs2073082, -rs738491 and -rs3761472 interactions enhancement of susceptibility to non-alcoholic fatty liver disease. Biomedicines, 11:2416, Aug 2023. URL: https://doi.org/10.3390/biomedicines11092416, doi:10.3390/biomedicines11092416. This article has 5 citations.</p>
+</li>
+<li>
+<p>(ravi2025mitochondrialsortingand pages 35-36): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ravi2025mitochondrialsortingand pages 7-8): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>ravi2025mitochondrialsortingand pages 20-24</li>
+<li>ganesan2024biogenesisofmitochondrial pages 1-2</li>
+<li>ravi2025mitochondrialsortingand pages 30-35</li>
+<li>ravi2025mitochondrialsortingand pages 1-3</li>
+<li>ganesan2024biogenesisofmitochondrial pages 2-4</li>
+<li>ravi2025mitochondrialsortingand pages 16-17</li>
+<li>ravi2025mitochondrialsortingand pages 8-10</li>
+<li>ravi2025mitochondrialsortingand pages 13-15</li>
+<li>ravi2025mitochondrialsortingand pages 35-36</li>
+<li>ravi2025mitochondrialsortingand pages 7-8</li>
+<li>https://doi.org/10.1002/2211-5463.13905</li>
+<li>https://doi.org/10.3390/biomedicines11092416</li>
+<li>https://doi.org/10.1021/acs.biochem.4c00727</li>
+<li>https://platform.opentargets.org/</li>
+<li>https://doi.org/10.1021/acs.biochem.4c00727,</li>
+<li>https://doi.org/10.1002/2211-5463.13905,</li>
+<li>https://doi.org/10.3390/biomedicines11092416,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: Q9Y512
+gene_symbol: SAMM50
+product_type: PROTEIN
+status: COMPLETE
+taxon:
+  id: NCBITaxon:9606
+  label: Homo sapiens
+description: &gt;-
+  SAMM50 encodes the human Sam50/SAM50 Omp85-family beta-barrel subunit of the mitochondrial sorting and assembly machinery
+  (SAM) complex. It is an outer mitochondrial membrane insertase for beta-barrel proteins such as TOM40 and VDACs
+  and also participates in SAM-MICOS/MIB contact sites that link outer-membrane beta-barrel biogenesis to cristae organization.
+existing_annotations:
+  - term:
+      id: GO:0001401
+      label: SAM complex
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: &gt;-
+        SAMM50 is the conserved core beta-barrel subunit of the mitochondrial SAM complex.
+      action: ACCEPT
+      reason: &gt;-
+        SAM complex membership is a core cellular component annotation for SAMM50.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery
+            component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging
+            to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized
+            below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and
+            Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous
+            to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial
+            pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly
+            of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family
+            β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the
+            accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2,
+            ravi2025mitochondrialsortingand pages 1-3)
+  - term:
+      id: GO:0045040
+      label: protein insertion into mitochondrial outer membrane
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: &gt;-
+        SAMM50/SAM inserts and assembles mitochondrial outer-membrane beta-barrel proteins such as TOM40 and VDAC.
+      action: ACCEPT
+      reason: &gt;-
+        Protein insertion into the mitochondrial outer membrane captures the central biological process of SAMM50.
+      supported_by: &amp;id002
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly
+            of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family
+            β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the
+            accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2,
+            ravi2025mitochondrialsortingand pages 1-3)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            **Primary function:** SAMM50 is the core insertase/chaperone of the SAM complex that assembles **mitochondrial
+            outer membrane β-barrel proteins** (including **Tom40** and **VDACs**) in an **energy-independent** manner. (ravi2025mitochondrialsortingand
+            pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    review:
+      summary: &gt;-
+        SAMM50 is an outer mitochondrial membrane beta-barrel protein, not a cytoplasmic protein.
+      action: REMOVE
+      reason: &gt;-
+        The cytoplasm annotation conflicts with the curated outer mitochondrial membrane localization and likely reflects
+        a broad or transferred location call.
+      supported_by: &amp;id001
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery
+            component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging
+            to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized
+            below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and
+            Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous
+            to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial
+            pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane
+            β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate
+            in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand
+            pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    review:
+      summary: &gt;-
+        SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+      action: MODIFY
+      reason: &gt;-
+        Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0005741
+      label: mitochondrial outer membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    review:
+      summary: &gt;-
+        SAMM50 is an outer mitochondrial membrane Omp85-family beta-barrel protein.
+      action: ACCEPT
+      reason: &gt;-
+        Outer mitochondrial membrane localization is central to SAMM50 topology and function.
+      supported_by: *id001
+  - term:
+      id: GO:0019867
+      label: outer membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    review:
+      summary: &gt;-
+        SAMM50 is in an outer membrane, specifically the mitochondrial outer membrane.
+      action: MODIFY
+      reason: &gt;-
+        The taxon/gene-specific evidence supports mitochondrial outer membrane as the precise location.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:25416956
+    review:
+      summary: &gt;-
+        SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding
+        is less informative than its insertase and complex annotations.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            **SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub
+            forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS
+            subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial
+            architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:27059175
+    review:
+      summary: &gt;-
+        SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding
+        is less informative than its insertase and complex annotations.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            **SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub
+            forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS
+            subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial
+            architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:32296183
+    review:
+      summary: &gt;-
+        SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding
+        is less informative than its insertase and complex annotations.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            **SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub
+            forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS
+            subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial
+            architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:33961781
+    review:
+      summary: &gt;-
+        SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding
+        is less informative than its insertase and complex annotations.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            **SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub
+            forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS
+            subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial
+            architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: IDA
+    original_reference_id: GO_REF:0000052
+    review:
+      summary: &gt;-
+        SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+      action: MODIFY
+      reason: &gt;-
+        Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: ISS
+    original_reference_id: GO_REF:0000024
+    review:
+      summary: &gt;-
+        SAMM50 is an outer mitochondrial membrane beta-barrel protein, not a cytoplasmic protein.
+      action: REMOVE
+      reason: &gt;-
+        The cytoplasm annotation conflicts with the curated outer mitochondrial membrane localization and likely reflects
+        a broad or transferred location call.
+      supported_by: *id001
+  - term:
+      id: GO:0001401
+      label: SAM complex
+    evidence_type: IPI
+    original_reference_id: PMID:17510655
+    review:
+      summary: &gt;-
+        SAMM50 is the conserved core beta-barrel subunit of the mitochondrial SAM complex.
+      action: ACCEPT
+      reason: &gt;-
+        SAM complex membership is a core cellular component annotation for SAMM50.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery
+            component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging
+            to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized
+            below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and
+            Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous
+            to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial
+            pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly
+            of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family
+            β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the
+            accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2,
+            ravi2025mitochondrialsortingand pages 1-3)
+  - term:
+      id: GO:0005741
+      label: mitochondrial outer membrane
+    evidence_type: NAS
+    original_reference_id: PMID:31387448
+    review:
+      summary: &gt;-
+        SAMM50 is an outer mitochondrial membrane Omp85-family beta-barrel protein.
+      action: ACCEPT
+      reason: &gt;-
+        Outer mitochondrial membrane localization is central to SAMM50 topology and function.
+      supported_by: *id001
+  - term:
+      id: GO:0045040
+      label: protein insertion into mitochondrial outer membrane
+    evidence_type: NAS
+    original_reference_id: PMID:31387448
+    review:
+      summary: &gt;-
+        SAMM50/SAM inserts and assembles mitochondrial outer-membrane beta-barrel proteins such as TOM40 and VDAC.
+      action: ACCEPT
+      reason: &gt;-
+        Protein insertion into the mitochondrial outer membrane captures the central biological process of SAMM50.
+      supported_by: *id002
+  - term:
+      id: GO:0030150
+      label: protein import into mitochondrial matrix
+    evidence_type: IDA
+    original_reference_id: PMID:15644312
+    review:
+      summary: &gt;-
+        SAMM50 handles outer-membrane beta-barrel substrates after TOM translocation, not matrix-targeted presequence import
+        through TIM23.
+      action: MODIFY
+      reason: &gt;-
+        The original Tom40 pathway evidence is better captured by protein insertion into mitochondrial outer membrane.
+      proposed_replacement_terms:
+        - id: GO:0045040
+          label: protein insertion into mitochondrial outer membrane
+      supported_by: *id002
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: HTP
+    original_reference_id: PMID:34800366
+    review:
+      summary: &gt;-
+        SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+      action: MODIFY
+      reason: &gt;-
+        Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:31644573
+    review:
+      summary: &gt;-
+        SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding
+        is less informative than its insertase and complex annotations.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            **SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub
+            forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS
+            subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial
+            architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
+  - term:
+      id: GO:0001401
+      label: SAM complex
+    evidence_type: HDA
+    original_reference_id: PMID:26477565
+    review:
+      summary: &gt;-
+        SAMM50 is the conserved core beta-barrel subunit of the mitochondrial SAM complex.
+      action: ACCEPT
+      reason: &gt;-
+        SAM complex membership is a core cellular component annotation for SAMM50.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery
+            component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging
+            to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized
+            below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and
+            Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous
+            to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial
+            pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly
+            of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family
+            β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the
+            accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2,
+            ravi2025mitochondrialsortingand pages 1-3)
+  - term:
+      id: GO:0007007
+      label: inner mitochondrial membrane organization
+    evidence_type: IC
+    original_reference_id: PMID:26477565
+    review:
+      summary: &gt;-
+        SAMM50 contributes to inner-membrane/cristae architecture through SAM-MICOS/MIB contact sites, but this is secondary
+        to its core SAM insertase role.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        The annotation is supported as a downstream organizational role of the MIB/SAM-MICOS axis rather than the primary
+        evolved molecular function.
+      supported_by: &amp;id003
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            **SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub
+            forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS
+            subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial
+            architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
+  - term:
+      id: GO:0140275
+      label: MIB complex
+    evidence_type: HDA
+    original_reference_id: PMID:26477565
+    review:
+      summary: &gt;-
+        SAMM50 participates in the mitochondrial intermembrane-space bridging (MIB) complex/contact-site axis with MICOS components.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        MIB complex association is supported but is treated as a contact-site/architecture role secondary to SAM beta-barrel
+        insertion.
+      supported_by: *id003
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: IDA
+    original_reference_id: PMID:25781180
+    review:
+      summary: &gt;-
+        SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+      action: MODIFY
+      reason: &gt;-
+        Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0042407
+      label: cristae formation
+    evidence_type: IMP
+    original_reference_id: PMID:22252321
+    review:
+      summary: &gt;-
+        SAMM50 perturbation affects cristae organization through SAM-MICOS/MIB contact sites.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Cristae formation is a supported cellular architecture consequence, but the core SAMM50 function remains outer-membrane
+        beta-barrel insertion.
+      supported_by: *id003
+  - term:
+      id: GO:0042407
+      label: cristae formation
+    evidence_type: IMP
+    original_reference_id: PMID:25781180
+    review:
+      summary: &gt;-
+        SAMM50 perturbation affects cristae organization through SAM-MICOS/MIB contact sites.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        Cristae formation is a supported cellular architecture consequence, but the core SAMM50 function remains outer-membrane
+        beta-barrel insertion.
+      supported_by: *id003
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: HDA
+    original_reference_id: PMID:20833797
+    review:
+      summary: &gt;-
+        SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+      action: MODIFY
+      reason: &gt;-
+        Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0070062
+      label: extracellular exosome
+    evidence_type: HDA
+    original_reference_id: PMID:19056867
+    review:
+      summary: &gt;-
+        The curated literature supports mitochondrial outer membrane localization and SAM complex function, not extracellular
+        exosome localization.
+      action: REMOVE
+      reason: &gt;-
+        This high-throughput exosome annotation is not supported by gene-specific functional evidence for SAMM50.
+      supported_by: *id001
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: IDA
+    original_reference_id: PMID:15644312
+    review:
+      summary: &gt;-
+        SAMM50 is a membrane protein, specifically a mitochondrial outer membrane beta-barrel protein.
+      action: MODIFY
+      reason: &gt;-
+        Use mitochondrial outer membrane rather than generic membrane.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:21081504
+    review:
+      summary: &gt;-
+        SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding
+        is less informative than its insertase and complex annotations.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            **SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub
+            forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS
+            subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial
+            architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
+  - term:
+      id: GO:0001401
+      label: SAM complex
+    evidence_type: IMP
+    original_reference_id: PMID:15644312
+    review:
+      summary: &gt;-
+        SAMM50 is the conserved core beta-barrel subunit of the mitochondrial SAM complex.
+      action: ACCEPT
+      reason: &gt;-
+        SAM complex membership is a core cellular component annotation for SAMM50.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery
+            component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging
+            to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized
+            below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and
+            Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous
+            to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial
+            pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly
+            of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family
+            β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the
+            accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2,
+            ravi2025mitochondrialsortingand pages 1-3)
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: IDA
+    original_reference_id: PMID:15644312
+    review:
+      summary: &gt;-
+        SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+      action: MODIFY
+      reason: &gt;-
+        Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0005741
+      label: mitochondrial outer membrane
+    evidence_type: IDA
+    original_reference_id: PMID:15644312
+    review:
+      summary: &gt;-
+        SAMM50 is an outer mitochondrial membrane Omp85-family beta-barrel protein.
+      action: ACCEPT
+      reason: &gt;-
+        Outer mitochondrial membrane localization is central to SAMM50 topology and function.
+      supported_by: *id001
+  - term:
+      id: GO:0032977
+      label: membrane insertase activity
+    evidence_type: NAS
+    original_reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+    review:
+      summary: &gt;-
+        SAMM50 is the core Sam50/SAM50 membrane insertase subunit that inserts and assembles mitochondrial outer-membrane
+        beta-barrel proteins.
+      action: NEW
+      reason: &gt;-
+        The current GOA captures the biological process and complex but lacks the precise molecular function membrane insertase
+        activity for SAMM50.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly
+            of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family
+            β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the
+            accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2,
+            ravi2025mitochondrialsortingand pages 1-3)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            **Primary function:** SAMM50 is the core insertase/chaperone of the SAM complex that assembles **mitochondrial
+            outer membrane β-barrel proteins** (including **Tom40** and **VDACs**) in an **energy-independent** manner. (ravi2025mitochondrialsortingand
+            pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: &gt;-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
+references:
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000024
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of
+      sequence similarity
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+      by conservative changes to GO terms applied by UniProt
+    findings: []
+  - id: GO_REF:0000052
+    title: Gene Ontology annotation based on curation of immunofluorescence data
+    findings: []
+  - id: PMID:15644312
+    title: Dissection of the mitochondrial import and assembly pathway for human Tom40.
+    findings: []
+  - id: PMID:17510655
+    title: Conserved roles of Sam50 and metaxins in VDAC biogenesis.
+    findings: []
+  - id: PMID:19056867
+    title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
+    findings: []
+  - id: PMID:20833797
+    title: Phosphoproteome analysis of functional mitochondria isolated from resting human muscle reveals extensive
+      phosphorylation of inner membrane protein complexes and enzymes.
+    findings: []
+  - id: PMID:21081504
+    title: ChChd3, an inner mitochondrial membrane protein, is essential for maintaining crista integrity and
+      mitochondrial function.
+    findings: []
+  - id: PMID:22252321
+    title: Sam50 functions in mitochondrial intermembrane space bridging and biogenesis of respiratory complexes.
+    findings: []
+  - id: PMID:25416956
+    title: A proteome-scale map of the human interactome network.
+    findings: []
+  - id: PMID:25781180
+    title: Detailed analysis of the human mitochondrial contact site complex indicate a hierarchy of subunits.
+    findings: []
+  - id: PMID:26477565
+    title: Evolution and structural organization of the mitochondrial contact site (MICOS) complex and the mitochondrial
+      intermembrane space bridging (MIB) complex.
+    findings: []
+  - id: PMID:27059175
+    title: SAMM50 Affects Mitochondrial Morphology through the Association of Drp1 in Mammalian Cells.
+    findings: []
+  - id: PMID:31387448
+    title: &#39;Mitochondria-hubs for regulating cellular biochemistry: emerging concepts and networks.&#39;
+    findings: []
+  - id: PMID:31644573
+    title: Armadillo repeat-containing protein 1 is a dual localization protein associated with mitochondrial
+      intermembrane space bridging complex.
+    findings: []
+  - id: PMID:32296183
+    title: A reference map of the human binary protein interactome.
+    findings: []
+  - id: PMID:33961781
+    title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
+    findings: []
+  - id: PMID:34800366
+    title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
+    findings: []
+  - id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+    title: Falcon deep research on SAMM50 function
+    findings:
+      - statement: SAMM50 is the core Omp85-family beta-barrel subunit of the mitochondrial SAM complex.
+      - statement: SAMM50/SAM mediates insertion and assembly of mitochondrial outer-membrane beta-barrel proteins.
+      - statement: SAMM50 participates in SAM-MICOS/MIB contacts that affect cristae organization, but this is secondary
+          to its core insertase role.
+core_functions:
+  - molecular_function:
+      id: GO:0032977
+      label: membrane insertase activity
+    description: &gt;-
+      SAMM50 is the core Omp85-family membrane insertase of the mitochondrial SAM complex. It recognizes and assembles beta-barrel
+      precursor proteins delivered by the TOM/IMS chaperone pathway and releases mature beta-barrels such as TOM40 and VDAC
+      into the outer mitochondrial membrane.
+    directly_involved_in:
+      - id: GO:0045040
+        label: protein insertion into mitochondrial outer membrane
+    locations:
+      - id: GO:0005741
+        label: mitochondrial outer membrane
+    in_complex:
+      id: GO:0001401
+      label: SAM complex
+    supported_by:
+      - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+        supporting_text: &gt;-
+          The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly
+          of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family β-barrel
+          protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the accessory
+          subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2, ravi2025mitochondrialsortingand
+          pages 1-3)
+      - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+        supporting_text: &gt;-
+          **Primary function:** SAMM50 is the core insertase/chaperone of the SAM complex that assembles **mitochondrial outer
+          membrane β-barrel proteins** (including **Tom40** and **VDACs**) in an **energy-independent** manner. (ravi2025mitochondrialsortingand
+          pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)
+      - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+        supporting_text: &gt;-
+          SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane
+          β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate
+          in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand
+          pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)
+      - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+        supporting_text: &gt;-
+          SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and the
+          **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion of OMM
+          β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via
+          **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+          hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+          protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+          associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+          in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+          pages 1-2)
+proposed_new_terms: []
+suggested_questions:
+  - question: &gt;-
+      Should human SAMM50 be annotated directly to membrane insertase activity in GOA, and should that annotation be made
+      with a contributes_to qualifier for the SAM complex or as enabled by the Sam50 subunit itself?
+suggested_experiments:
+  - description: &gt;-
+      Reconstitute the human SAMM50-MTX SAM complex with purified human TOM40 or VDAC beta-barrel precursors and assay insertion
+      intermediates, lateral-gate mutants, and beta-signal dependence.
+    hypothesis: &gt;-
+      Human SAMM50 provides the core membrane insertase activity for outer-membrane beta-barrel substrate assembly.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/genes/human/SAMM50/SAMM50-ai-review.yaml
+++ b/genes/human/SAMM50/SAMM50-ai-review.yaml
@@ -1,333 +1,805 @@
 id: Q9Y512
 gene_symbol: SAMM50
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for SAMM50'
+description: >-
+  SAMM50 encodes the human Sam50/SAM50 Omp85-family beta-barrel subunit of the mitochondrial sorting and assembly machinery
+  (SAM) complex. It is an outer mitochondrial membrane insertase for beta-barrel proteins such as TOM40 and VDACs
+  and also participates in SAM-MICOS/MIB contact sites that link outer-membrane beta-barrel biogenesis to cristae organization.
 existing_annotations:
-- term:
-    id: GO:0001401
-    label: SAM complex
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0045040
-    label: protein insertion into mitochondrial outer membrane
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005739
-    label: mitochondrion
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005741
-    label: mitochondrial outer membrane
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0019867
-    label: outer membrane
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:25416956
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:27059175
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:32296183
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:33961781
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005739
-    label: mitochondrion
-  evidence_type: IDA
-  original_reference_id: GO_REF:0000052
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: ISS
-  original_reference_id: GO_REF:0000024
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0001401
-    label: SAM complex
-  evidence_type: IPI
-  original_reference_id: PMID:17510655
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005741
-    label: mitochondrial outer membrane
-  evidence_type: NAS
-  original_reference_id: PMID:31387448
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0045040
-    label: protein insertion into mitochondrial outer membrane
-  evidence_type: NAS
-  original_reference_id: PMID:31387448
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0030150
-    label: protein import into mitochondrial matrix
-  evidence_type: IDA
-  original_reference_id: PMID:15644312
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005739
-    label: mitochondrion
-  evidence_type: HTP
-  original_reference_id: PMID:34800366
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:31644573
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0001401
-    label: SAM complex
-  evidence_type: HDA
-  original_reference_id: PMID:26477565
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0007007
-    label: inner mitochondrial membrane organization
-  evidence_type: IC
-  original_reference_id: PMID:26477565
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0140275
-    label: MIB complex
-  evidence_type: HDA
-  original_reference_id: PMID:26477565
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005739
-    label: mitochondrion
-  evidence_type: IDA
-  original_reference_id: PMID:25781180
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0042407
-    label: cristae formation
-  evidence_type: IMP
-  original_reference_id: PMID:22252321
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0042407
-    label: cristae formation
-  evidence_type: IMP
-  original_reference_id: PMID:25781180
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005739
-    label: mitochondrion
-  evidence_type: HDA
-  original_reference_id: PMID:20833797
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0070062
-    label: extracellular exosome
-  evidence_type: HDA
-  original_reference_id: PMID:19056867
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0016020
-    label: membrane
-  evidence_type: IDA
-  original_reference_id: PMID:15644312
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:21081504
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0001401
-    label: SAM complex
-  evidence_type: IMP
-  original_reference_id: PMID:15644312
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005739
-    label: mitochondrion
-  evidence_type: IDA
-  original_reference_id: PMID:15644312
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005741
-    label: mitochondrial outer membrane
-  evidence_type: IDA
-  original_reference_id: PMID:15644312
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+  - term:
+      id: GO:0001401
+      label: SAM complex
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: >-
+        SAMM50 is the conserved core beta-barrel subunit of the mitochondrial SAM complex.
+      action: ACCEPT
+      reason: >-
+        SAM complex membership is a core cellular component annotation for SAMM50.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery
+            component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging
+            to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized
+            below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and
+            Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous
+            to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial
+            pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly
+            of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family
+            β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the
+            accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2,
+            ravi2025mitochondrialsortingand pages 1-3)
+  - term:
+      id: GO:0045040
+      label: protein insertion into mitochondrial outer membrane
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: >-
+        SAMM50/SAM inserts and assembles mitochondrial outer-membrane beta-barrel proteins such as TOM40 and VDAC.
+      action: ACCEPT
+      reason: >-
+        Protein insertion into the mitochondrial outer membrane captures the central biological process of SAMM50.
+      supported_by: &id002
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly
+            of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family
+            β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the
+            accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2,
+            ravi2025mitochondrialsortingand pages 1-3)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            **Primary function:** SAMM50 is the core insertase/chaperone of the SAM complex that assembles **mitochondrial
+            outer membrane β-barrel proteins** (including **Tom40** and **VDACs**) in an **energy-independent** manner. (ravi2025mitochondrialsortingand
+            pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    review:
+      summary: >-
+        SAMM50 is an outer mitochondrial membrane beta-barrel protein, not a cytoplasmic protein.
+      action: REMOVE
+      reason: >-
+        The cytoplasm annotation conflicts with the curated outer mitochondrial membrane localization and likely reflects
+        a broad or transferred location call.
+      supported_by: &id001
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery
+            component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging
+            to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized
+            below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and
+            Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous
+            to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial
+            pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane
+            β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate
+            in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand
+            pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    review:
+      summary: >-
+        SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+      action: MODIFY
+      reason: >-
+        Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0005741
+      label: mitochondrial outer membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    review:
+      summary: >-
+        SAMM50 is an outer mitochondrial membrane Omp85-family beta-barrel protein.
+      action: ACCEPT
+      reason: >-
+        Outer mitochondrial membrane localization is central to SAMM50 topology and function.
+      supported_by: *id001
+  - term:
+      id: GO:0019867
+      label: outer membrane
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    review:
+      summary: >-
+        SAMM50 is in an outer membrane, specifically the mitochondrial outer membrane.
+      action: MODIFY
+      reason: >-
+        The taxon/gene-specific evidence supports mitochondrial outer membrane as the precise location.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:25416956
+    review:
+      summary: >-
+        SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding
+        is less informative than its insertase and complex annotations.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            **SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub
+            forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS
+            subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial
+            architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:27059175
+    review:
+      summary: >-
+        SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding
+        is less informative than its insertase and complex annotations.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            **SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub
+            forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS
+            subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial
+            architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:32296183
+    review:
+      summary: >-
+        SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding
+        is less informative than its insertase and complex annotations.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            **SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub
+            forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS
+            subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial
+            architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:33961781
+    review:
+      summary: >-
+        SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding
+        is less informative than its insertase and complex annotations.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            **SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub
+            forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS
+            subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial
+            architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: IDA
+    original_reference_id: GO_REF:0000052
+    review:
+      summary: >-
+        SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+      action: MODIFY
+      reason: >-
+        Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: ISS
+    original_reference_id: GO_REF:0000024
+    review:
+      summary: >-
+        SAMM50 is an outer mitochondrial membrane beta-barrel protein, not a cytoplasmic protein.
+      action: REMOVE
+      reason: >-
+        The cytoplasm annotation conflicts with the curated outer mitochondrial membrane localization and likely reflects
+        a broad or transferred location call.
+      supported_by: *id001
+  - term:
+      id: GO:0001401
+      label: SAM complex
+    evidence_type: IPI
+    original_reference_id: PMID:17510655
+    review:
+      summary: >-
+        SAMM50 is the conserved core beta-barrel subunit of the mitochondrial SAM complex.
+      action: ACCEPT
+      reason: >-
+        SAM complex membership is a core cellular component annotation for SAMM50.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery
+            component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging
+            to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized
+            below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and
+            Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous
+            to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial
+            pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly
+            of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family
+            β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the
+            accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2,
+            ravi2025mitochondrialsortingand pages 1-3)
+  - term:
+      id: GO:0005741
+      label: mitochondrial outer membrane
+    evidence_type: NAS
+    original_reference_id: PMID:31387448
+    review:
+      summary: >-
+        SAMM50 is an outer mitochondrial membrane Omp85-family beta-barrel protein.
+      action: ACCEPT
+      reason: >-
+        Outer mitochondrial membrane localization is central to SAMM50 topology and function.
+      supported_by: *id001
+  - term:
+      id: GO:0045040
+      label: protein insertion into mitochondrial outer membrane
+    evidence_type: NAS
+    original_reference_id: PMID:31387448
+    review:
+      summary: >-
+        SAMM50/SAM inserts and assembles mitochondrial outer-membrane beta-barrel proteins such as TOM40 and VDAC.
+      action: ACCEPT
+      reason: >-
+        Protein insertion into the mitochondrial outer membrane captures the central biological process of SAMM50.
+      supported_by: *id002
+  - term:
+      id: GO:0030150
+      label: protein import into mitochondrial matrix
+    evidence_type: IDA
+    original_reference_id: PMID:15644312
+    review:
+      summary: >-
+        SAMM50 handles outer-membrane beta-barrel substrates after TOM translocation, not matrix-targeted presequence import
+        through TIM23.
+      action: MODIFY
+      reason: >-
+        The original Tom40 pathway evidence is better captured by protein insertion into mitochondrial outer membrane.
+      proposed_replacement_terms:
+        - id: GO:0045040
+          label: protein insertion into mitochondrial outer membrane
+      supported_by: *id002
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: HTP
+    original_reference_id: PMID:34800366
+    review:
+      summary: >-
+        SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+      action: MODIFY
+      reason: >-
+        Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:31644573
+    review:
+      summary: >-
+        SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding
+        is less informative than its insertase and complex annotations.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            **SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub
+            forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS
+            subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial
+            architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
+  - term:
+      id: GO:0001401
+      label: SAM complex
+    evidence_type: HDA
+    original_reference_id: PMID:26477565
+    review:
+      summary: >-
+        SAMM50 is the conserved core beta-barrel subunit of the mitochondrial SAM complex.
+      action: ACCEPT
+      reason: >-
+        SAM complex membership is a core cellular component annotation for SAMM50.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery
+            component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging
+            to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized
+            below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and
+            Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous
+            to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial
+            pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly
+            of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family
+            β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the
+            accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2,
+            ravi2025mitochondrialsortingand pages 1-3)
+  - term:
+      id: GO:0007007
+      label: inner mitochondrial membrane organization
+    evidence_type: IC
+    original_reference_id: PMID:26477565
+    review:
+      summary: >-
+        SAMM50 contributes to inner-membrane/cristae architecture through SAM-MICOS/MIB contact sites, but this is secondary
+        to its core SAM insertase role.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        The annotation is supported as a downstream organizational role of the MIB/SAM-MICOS axis rather than the primary
+        evolved molecular function.
+      supported_by: &id003
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            **SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub
+            forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS
+            subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial
+            architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
+  - term:
+      id: GO:0140275
+      label: MIB complex
+    evidence_type: HDA
+    original_reference_id: PMID:26477565
+    review:
+      summary: >-
+        SAMM50 participates in the mitochondrial intermembrane-space bridging (MIB) complex/contact-site axis with MICOS components.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        MIB complex association is supported but is treated as a contact-site/architecture role secondary to SAM beta-barrel
+        insertion.
+      supported_by: *id003
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: IDA
+    original_reference_id: PMID:25781180
+    review:
+      summary: >-
+        SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+      action: MODIFY
+      reason: >-
+        Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0042407
+      label: cristae formation
+    evidence_type: IMP
+    original_reference_id: PMID:22252321
+    review:
+      summary: >-
+        SAMM50 perturbation affects cristae organization through SAM-MICOS/MIB contact sites.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        Cristae formation is a supported cellular architecture consequence, but the core SAMM50 function remains outer-membrane
+        beta-barrel insertion.
+      supported_by: *id003
+  - term:
+      id: GO:0042407
+      label: cristae formation
+    evidence_type: IMP
+    original_reference_id: PMID:25781180
+    review:
+      summary: >-
+        SAMM50 perturbation affects cristae organization through SAM-MICOS/MIB contact sites.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        Cristae formation is a supported cellular architecture consequence, but the core SAMM50 function remains outer-membrane
+        beta-barrel insertion.
+      supported_by: *id003
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: HDA
+    original_reference_id: PMID:20833797
+    review:
+      summary: >-
+        SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+      action: MODIFY
+      reason: >-
+        Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0070062
+      label: extracellular exosome
+    evidence_type: HDA
+    original_reference_id: PMID:19056867
+    review:
+      summary: >-
+        The curated literature supports mitochondrial outer membrane localization and SAM complex function, not extracellular
+        exosome localization.
+      action: REMOVE
+      reason: >-
+        This high-throughput exosome annotation is not supported by gene-specific functional evidence for SAMM50.
+      supported_by: *id001
+  - term:
+      id: GO:0016020
+      label: membrane
+    evidence_type: IDA
+    original_reference_id: PMID:15644312
+    review:
+      summary: >-
+        SAMM50 is a membrane protein, specifically a mitochondrial outer membrane beta-barrel protein.
+      action: MODIFY
+      reason: >-
+        Use mitochondrial outer membrane rather than generic membrane.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:21081504
+    review:
+      summary: >-
+        SAMM50 has many physical partners in SAM, TOM, MICOS/MIB, and contact-site assemblies, but generic protein binding
+        is less informative than its insertase and complex annotations.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        Retain specific SAM complex, MIB/contact-site, and membrane insertase annotations rather than broad protein binding.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            **SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub
+            forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS
+            subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial
+            architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
+  - term:
+      id: GO:0001401
+      label: SAM complex
+    evidence_type: IMP
+    original_reference_id: PMID:15644312
+    review:
+      summary: >-
+        SAMM50 is the conserved core beta-barrel subunit of the mitochondrial SAM complex.
+      action: ACCEPT
+      reason: >-
+        SAM complex membership is a core cellular component annotation for SAMM50.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery
+            component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging
+            to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized
+            below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and
+            Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous
+            to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial
+            pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly
+            of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family
+            β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the
+            accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2,
+            ravi2025mitochondrialsortingand pages 1-3)
+  - term:
+      id: GO:0005739
+      label: mitochondrion
+    evidence_type: IDA
+    original_reference_id: PMID:15644312
+    review:
+      summary: >-
+        SAMM50 is mitochondrial, but the literature supports the more specific outer mitochondrial membrane localization.
+      action: MODIFY
+      reason: >-
+        Use mitochondrial outer membrane rather than the broad parent term mitochondrion.
+      proposed_replacement_terms:
+        - id: GO:0005741
+          label: mitochondrial outer membrane
+      supported_by: *id001
+  - term:
+      id: GO:0005741
+      label: mitochondrial outer membrane
+    evidence_type: IDA
+    original_reference_id: PMID:15644312
+    review:
+      summary: >-
+        SAMM50 is an outer mitochondrial membrane Omp85-family beta-barrel protein.
+      action: ACCEPT
+      reason: >-
+        Outer mitochondrial membrane localization is central to SAMM50 topology and function.
+      supported_by: *id001
+  - term:
+      id: GO:0032977
+      label: membrane insertase activity
+    evidence_type: NAS
+    original_reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+    review:
+      summary: >-
+        SAMM50 is the core Sam50/SAM50 membrane insertase subunit that inserts and assembles mitochondrial outer-membrane
+        beta-barrel proteins.
+      action: NEW
+      reason: >-
+        The current GOA captures the biological process and complex but lacks the precise molecular function membrane insertase
+        activity for SAMM50.
+      supported_by:
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly
+            of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family
+            β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the
+            accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2,
+            ravi2025mitochondrialsortingand pages 1-3)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            **Primary function:** SAMM50 is the core insertase/chaperone of the SAM complex that assembles **mitochondrial
+            outer membrane β-barrel proteins** (including **Tom40** and **VDACs**) in an **energy-independent** manner. (ravi2025mitochondrialsortingand
+            pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)
+        - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+          supporting_text: >-
+            SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and
+            the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion
+            of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled
+            via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+            hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+            protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+            associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+            in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+            pages 1-2)
 references:
-- id: GO_REF:0000002
-  title: Gene Ontology annotation through association of InterPro records with GO
-    terms
-  findings: []
-- id: GO_REF:0000024
-  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
-    by curator judgment of sequence similarity
-  findings: []
-- id: GO_REF:0000033
-  title: Annotation inferences using phylogenetic trees
-  findings: []
-- id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
-    vocabulary mapping, accompanied by conservative changes to GO terms applied by
-    UniProt
-  findings: []
-- id: GO_REF:0000052
-  title: Gene Ontology annotation based on curation of immunofluorescence data
-  findings: []
-- id: PMID:15644312
-  title: Dissection of the mitochondrial import and assembly pathway for human Tom40.
-  findings: []
-- id: PMID:17510655
-  title: Conserved roles of Sam50 and metaxins in VDAC biogenesis.
-  findings: []
-- id: PMID:19056867
-  title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
-  findings: []
-- id: PMID:20833797
-  title: Phosphoproteome analysis of functional mitochondria isolated from resting
-    human muscle reveals extensive phosphorylation of inner membrane protein complexes
-    and enzymes.
-  findings: []
-- id: PMID:21081504
-  title: ChChd3, an inner mitochondrial membrane protein, is essential for maintaining
-    crista integrity and mitochondrial function.
-  findings: []
-- id: PMID:22252321
-  title: Sam50 functions in mitochondrial intermembrane space bridging and biogenesis
-    of respiratory complexes.
-  findings: []
-- id: PMID:25416956
-  title: A proteome-scale map of the human interactome network.
-  findings: []
-- id: PMID:25781180
-  title: Detailed analysis of the human mitochondrial contact site complex indicate
-    a hierarchy of subunits.
-  findings: []
-- id: PMID:26477565
-  title: Evolution and structural organization of the mitochondrial contact site (MICOS)
-    complex and the mitochondrial intermembrane space bridging (MIB) complex.
-  findings: []
-- id: PMID:27059175
-  title: SAMM50 Affects Mitochondrial Morphology through the Association of Drp1 in
-    Mammalian Cells.
-  findings: []
-- id: PMID:31387448
-  title: 'Mitochondria-hubs for regulating cellular biochemistry: emerging concepts
-    and networks.'
-  findings: []
-- id: PMID:31644573
-  title: Armadillo repeat-containing protein 1 is a dual localization protein associated
-    with mitochondrial intermembrane space bridging complex.
-  findings: []
-- id: PMID:32296183
-  title: A reference map of the human binary protein interactome.
-  findings: []
-- id: PMID:33961781
-  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
-    interactome.
-  findings: []
-- id: PMID:34800366
-  title: Quantitative high-confidence human mitochondrial proteome and its dynamics
-    in cellular context.
-  findings: []
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO terms
+    findings: []
+  - id: GO_REF:0000024
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of
+      sequence similarity
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied
+      by conservative changes to GO terms applied by UniProt
+    findings: []
+  - id: GO_REF:0000052
+    title: Gene Ontology annotation based on curation of immunofluorescence data
+    findings: []
+  - id: PMID:15644312
+    title: Dissection of the mitochondrial import and assembly pathway for human Tom40.
+    findings: []
+  - id: PMID:17510655
+    title: Conserved roles of Sam50 and metaxins in VDAC biogenesis.
+    findings: []
+  - id: PMID:19056867
+    title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
+    findings: []
+  - id: PMID:20833797
+    title: Phosphoproteome analysis of functional mitochondria isolated from resting human muscle reveals extensive
+      phosphorylation of inner membrane protein complexes and enzymes.
+    findings: []
+  - id: PMID:21081504
+    title: ChChd3, an inner mitochondrial membrane protein, is essential for maintaining crista integrity and
+      mitochondrial function.
+    findings: []
+  - id: PMID:22252321
+    title: Sam50 functions in mitochondrial intermembrane space bridging and biogenesis of respiratory complexes.
+    findings: []
+  - id: PMID:25416956
+    title: A proteome-scale map of the human interactome network.
+    findings: []
+  - id: PMID:25781180
+    title: Detailed analysis of the human mitochondrial contact site complex indicate a hierarchy of subunits.
+    findings: []
+  - id: PMID:26477565
+    title: Evolution and structural organization of the mitochondrial contact site (MICOS) complex and the mitochondrial
+      intermembrane space bridging (MIB) complex.
+    findings: []
+  - id: PMID:27059175
+    title: SAMM50 Affects Mitochondrial Morphology through the Association of Drp1 in Mammalian Cells.
+    findings: []
+  - id: PMID:31387448
+    title: 'Mitochondria-hubs for regulating cellular biochemistry: emerging concepts and networks.'
+    findings: []
+  - id: PMID:31644573
+    title: Armadillo repeat-containing protein 1 is a dual localization protein associated with mitochondrial
+      intermembrane space bridging complex.
+    findings: []
+  - id: PMID:32296183
+    title: A reference map of the human binary protein interactome.
+    findings: []
+  - id: PMID:33961781
+    title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
+    findings: []
+  - id: PMID:34800366
+    title: Quantitative high-confidence human mitochondrial proteome and its dynamics in cellular context.
+    findings: []
+  - id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+    title: Falcon deep research on SAMM50 function
+    findings:
+      - statement: SAMM50 is the core Omp85-family beta-barrel subunit of the mitochondrial SAM complex.
+      - statement: SAMM50/SAM mediates insertion and assembly of mitochondrial outer-membrane beta-barrel proteins.
+      - statement: SAMM50 participates in SAM-MICOS/MIB contacts that affect cristae organization, but this is secondary
+          to its core insertase role.
+core_functions:
+  - molecular_function:
+      id: GO:0032977
+      label: membrane insertase activity
+    description: >-
+      SAMM50 is the core Omp85-family membrane insertase of the mitochondrial SAM complex. It recognizes and assembles beta-barrel
+      precursor proteins delivered by the TOM/IMS chaperone pathway and releases mature beta-barrels such as TOM40 and VDAC
+      into the outer mitochondrial membrane.
+    directly_involved_in:
+      - id: GO:0045040
+        label: protein insertion into mitochondrial outer membrane
+    locations:
+      - id: GO:0005741
+        label: mitochondrial outer membrane
+    in_complex:
+      id: GO:0001401
+      label: SAM complex
+    supported_by:
+      - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+        supporting_text: >-
+          The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly
+          of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family β-barrel
+          protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the accessory
+          subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2, ravi2025mitochondrialsortingand
+          pages 1-3)
+      - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+        supporting_text: >-
+          **Primary function:** SAMM50 is the core insertase/chaperone of the SAM complex that assembles **mitochondrial outer
+          membrane β-barrel proteins** (including **Tom40** and **VDACs**) in an **energy-independent** manner. (ravi2025mitochondrialsortingand
+          pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)
+      - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+        supporting_text: >-
+          SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane
+          β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate
+          in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand
+          pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)
+      - reference_id: file:human/SAMM50/SAMM50-deep-research-falcon.md
+        supporting_text: >-
+          SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and the
+          **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion of OMM
+          β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via
+          **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational
+          hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane
+          protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible
+          associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways
+          in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and
+          pages 1-2)
+proposed_new_terms: []
+suggested_questions:
+  - question: >-
+      Should human SAMM50 be annotated directly to membrane insertase activity in GOA, and should that annotation be made
+      with a contributes_to qualifier for the SAM complex or as enabled by the Sam50 subunit itself?
+suggested_experiments:
+  - description: >-
+      Reconstitute the human SAMM50-MTX SAM complex with purified human TOM40 or VDAC beta-barrel precursors and assay insertion
+      intermediates, lateral-gate mutants, and beta-signal dependence.
+    hypothesis: >-
+      Human SAMM50 provides the core membrane insertase activity for outer-membrane beta-barrel substrate assembly.

--- a/genes/human/SAMM50/SAMM50-deep-research-falcon.md
+++ b/genes/human/SAMM50/SAMM50-deep-research-falcon.md
@@ -1,0 +1,299 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T19:29:00.008552'
+end_time: '2026-05-11T19:39:19.210275'
+duration_seconds: 619.2
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: SAMM50
+  gene_symbol: SAMM50
+  uniprot_accession: Q9Y512
+  protein_description: 'RecName: Full=Sorting and assembly machinery component 50
+    homolog; AltName: Full=Transformation-related gene 3 protein; Short=TRG-3;'
+  gene_info: Name=SAMM50; Synonyms=SAM50; ORFNames=CGI-51, TRG3;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the SAM50/omp85 family. .
+  protein_domains: Bac_surfAg_D15. (IPR000184); D15-like. (IPR039910); POTRA. (IPR034746);
+    Omp85 (PF01103)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 17
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9Y512
+- **Protein Description:** RecName: Full=Sorting and assembly machinery component 50 homolog; AltName: Full=Transformation-related gene 3 protein; Short=TRG-3;
+- **Gene Information:** Name=SAMM50; Synonyms=SAM50; ORFNames=CGI-51, TRG3;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the SAM50/omp85 family. .
+- **Key Domains:** Bac_surfAg_D15. (IPR000184); D15-like. (IPR039910); POTRA. (IPR034746); Omp85 (PF01103)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "SAMM50" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'SAMM50' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **SAMM50** (gene ID: SAMM50, UniProt: Q9Y512) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9Y512
+- **Protein Description:** RecName: Full=Sorting and assembly machinery component 50 homolog; AltName: Full=Transformation-related gene 3 protein; Short=TRG-3;
+- **Gene Information:** Name=SAMM50; Synonyms=SAM50; ORFNames=CGI-51, TRG3;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the SAM50/omp85 family. .
+- **Key Domains:** Bac_surfAg_D15. (IPR000184); D15-like. (IPR039910); POTRA. (IPR034746); Omp85 (PF01103)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "SAMM50" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'SAMM50' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **SAMM50** (gene ID: SAMM50, UniProt: Q9Y512) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Comprehensive research report: Human **SAMM50 / SAM50** (UniProt **Q9Y512**) — functional annotation
+
+## 0) Mandatory identity verification (disambiguation)
+The target in this report is **human SAMM50** (UniProt **Q9Y512**), annotated as **Sorting and assembly machinery component 50 homolog** (also called **SAM50**; synonym **TRG-3 / transformation-related gene 3**) and belonging to the **SAM50/Omp85** family that mediates mitochondrial outer-membrane β-barrel biogenesis. The literature summarized below consistently describes **Sam50/SAMM50** as the **core β-barrel subunit of the mitochondrial Sorting and Assembly Machinery (SAM) complex**, localized to the **mitochondrial outer membrane (OMM)** and functionally homologous to bacterial **BamA** (Omp85 family). (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)
+
+## 1) Key concepts and definitions (current understanding)
+
+### 1.1 What is the SAM complex?
+The **Sorting and Assembly Machinery (SAM)** is the **mitochondrial outer-membrane insertase** required for insertion/assembly of **β-barrel proteins** into the OMM. Its core subunit **Sam50 (SAMM50 in humans)** is itself an Omp85-family β-barrel protein; yeast SAM includes additional subunits (e.g., Sam35/Sam37/Mdm10/Mco6), whereas in mammals the accessory subunits are functionally replaced by **metaxins**. (ganesan2024biogenesisofmitochondrial pages 1-2, ravi2025mitochondrialsortingand pages 1-3)
+
+### 1.2 What are mitochondrial β-barrel proteins and why are they important?
+Mitochondrial β-barrel proteins (e.g., **Tom40** and **VDAC**) reside in the OMM, where they mediate metabolite exchange and/or serve as key import pores (Tom40) for nuclear-encoded mitochondrial proteins. Their correct insertion requires the TOM→SAM pathway. (ganesan2024biogenesisofmitochondrial pages 1-2, ravi2025mitochondrialsortingand pages 1-3)
+
+### 1.3 “β-signal”, lateral gate, and “β-barrel switching” (mechanistic vocabulary)
+Recent review syntheses describe the following mechanistic framework:
+- **β-signal**: a C-terminal signal in β-barrel precursors recognized by Sam50; Sam50 loop features (including a conserved **IRGF**-like motif in loop 6) participate in recognition and folding initiation. (ganesan2024biogenesisofmitochondrial pages 2-4, ravi2025mitochondrialsortingand pages 20-24)
+- **Lateral gate**: the site at the Sam50 barrel “seam” (β1–β16) that can open laterally to allow β-strand insertion; Sam50 is described as **not fully closed** (no β1–β16 H-bonds in available structures), consistent with lateral gating. (ravi2025mitochondrialsortingand pages 20-24)
+- **β-barrel switching**: a model in which β-strands of the precursor assemble at Sam50 to form a **Sam50–preprotein hybrid barrel**, then the nascent barrel is released into the OMM via displacement/switching. (ganesan2024biogenesisofmitochondrial pages 1-2)
+
+## 2) Molecular function and mechanism (experimental + inference)
+
+### 2.1 Subcellular localization and topology
+SAMM50/Sam50 is an **outer mitochondrial membrane (OMM)** protein. It is described as a **16-stranded transmembrane β-barrel** with a single N-terminal **POTRA** domain. In mitochondria, the POTRA domain is positioned to participate in intermembrane-space (IMS) interactions and outer–inner membrane contacts (e.g., with MICOS). (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 1-2)
+
+### 2.2 Core function: insertion/assembly of OMM β-barrel proteins
+**Primary function:** SAMM50 is the core insertase/chaperone of the SAM complex that assembles **mitochondrial outer membrane β-barrel proteins** (including **Tom40** and **VDACs**) in an **energy-independent** manner. (ravi2025mitochondrialsortingand pages 1-3, ganesan2024biogenesisofmitochondrial pages 1-2)
+
+**Import/assembly pathway (current consensus):**
+1. Precursor β-barrel proteins are synthesized in the cytosol and targeted to mitochondria.
+2. They are translocated across the OMM by the **TOM complex** into the **intermembrane space (IMS)**.
+3. IMS chaperones (small Tims, e.g., **Tim9/10** or **Tim8/13**) prevent aggregation and deliver precursors to SAM.
+4. SAM (via Sam50/SAMM50) inserts/assembles the β-barrel in the OMM, with models emphasizing **β-signal recognition**, **lateral gating**, and **β-barrel switching** as key mechanistic steps. (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4)
+
+### 2.3 Key binding partners and multi-complex organization
+**Accessory SAM partners in mammals:** Mammalian SAM is described as using **metaxins (MTX1/MTX2)** as functional analogs of yeast Sam35/Sam37 on the cytosolic face of Sam50, consistent with the conserved cytosolic loop interaction surfaces on Sam50. (ravi2025mitochondrialsortingand pages 16-17, ravi2025mitochondrialsortingand pages 20-24)
+
+**TOM–SAM coupling:** SAM forms **TOM–SAM supercomplexes** that couple translocation through TOM to assembly by SAM, supporting efficient β-barrel biogenesis. (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial media a6c2469b)
+
+**SAM–MICOS contact site / MIB axis (cristae junction biology):** SAM is also described as an interaction hub forming a defined **outer–inner membrane contact** with **MICOS**, notably via interaction between Sam50 and MICOS subunits (e.g., Mic60/Mic19), thereby linking β-barrel biogenesis to **cristae organization** and mitochondrial architecture. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+
+**ER–mitochondria contacts and lipid transfer:** Review synthesis also connects Sam50/SAMM50 with ER proteins **ORP5/ORP8** at ER–mitochondria contact sites (MERCS), proposing a structural/functional contribution to phospholipid transfer (e.g., PS→PE conversion pathways) that can indirectly impact inner-membrane structure and cristae. (ravi2025mitochondrialsortingand pages 30-35, ravi2025mitochondrialsortingand pages 1-3)
+
+## 3) Recent developments (prioritizing 2023–2024)
+
+### 3.1 2024 review synthesis: β-barrel biogenesis and SAM as a multi-pathway hub
+A 2024 FEBS Open Bio review emphasizes that SAM is required for β-barrel insertion, describes the **Sam50 lateral gate** and **β-barrel switching** mechanism, and highlights that SAM forms **TOM–SAM supercomplexes** and contacts **MICOS**, placing SAMM50 at the intersection of protein import, membrane contact-site biology, and mitochondrial architecture. (Publication date: Sep 2024; https://doi.org/10.1002/2211-5463.13905) (ganesan2024biogenesisofmitochondrial pages 1-2)
+
+**Visual evidence (mechanism and connectivity):** The same review includes schematics of (i) **β-barrel switching** and (ii) **TOM–SAM** and **SAM–MICOS** contact-site architecture. (ganesan2024biogenesisofmitochondrial media 50bb168a, ganesan2024biogenesisofmitochondrial media a6c2469b)
+
+### 3.2 2024 human genetics: SAMM50 variants associated with NAFLD risk and fibrosis proxy
+A 2023 community-based case–control study in an elderly Chinese cohort (**n=1,053; 590 NAFLD cases**) reported associations between SAMM50 variants and NAFLD risk:
+- **rs2073082 G**: NAFLD risk **OR 1.962** (95% CI 1.448–2.659; p<0.001)
+- **rs738491 T**: NAFLD risk **OR 1.532** (95% CI 1.246–1.884; p=0.021)
+The study also reported increased **liver stiffness measurement (LSM)** in carriers of **rs738491 T** and **rs3761472 G**, and found that a three-SNP interaction model (rs2073082/rs738491/rs3761472) had the best NAFLD predictive performance in their GMDR analysis. (Publication date: Aug 2023; https://doi.org/10.3390/biomedicines11092416) (zhao2023samm50rs2073082rs738491and pages 2-4, zhao2023samm50rs2073082rs738491and pages 1-2)
+
+### 3.3 2023–2024 disease/phenotype landscape (knowledge graph summary)
+Open Targets aggregates genetic/functional evidence linking **SAMM50** to **liver disease/NAFLD**, **type 2 diabetes mellitus**, **hypercholesterolemia**, and **neurodegenerative disease** (association-level summaries rather than mechanistic proof). (OpenTargets Search: -SAMM50)
+
+## 4) Current applications and real-world implementations
+
+### 4.1 Variant interpretation and genetic risk modeling in steatotic liver disease
+The 2023 NAFLD study demonstrates a direct **clinical-genetic application**: SAMM50 SNPs can contribute to **risk stratification** and multi-locus predictive models for NAFLD in specific populations/age groups, with effect sizes in the ~1.5–2.0 OR range for the highlighted alleles in their cohort. (zhao2023samm50rs2073082rs738491and pages 1-2)
+
+### 4.2 Functional genomics and mitochondrial biology toolchains
+Because SAMM50 is central to β-barrel biogenesis and a contact-site hub (TOM–SAM, SAM–MICOS), it is routinely used in:
+- **Mitochondrial import/assembly assays** (tracking TOM→SAM assembly of Tom40/VDAC) and perturbation experiments to link β-barrel insertion defects to OMM proteostasis.
+- **Cristae architecture studies**, leveraging the SAM–MICOS link to test how outer-membrane machineries influence inner-membrane ultrastructure and respiratory complex organization. (ravi2025mitochondrialsortingand pages 8-10, ganesan2024biogenesisofmitochondrial pages 1-2)
+
+### 4.3 Translational concepts: targeting mitochondrial organization rather than a catalytic activity
+SAMM50 is **not an enzyme** with a specific substrate turnover reaction; it is a **membrane insertase/chaperone and organizational hub**. Thus translational strategies tend to focus on:
+- Correcting upstream drivers (e.g., metabolic stress) that dysregulate SAMM50-linked pathways.
+- Interpreting SAMM50 variation as part of polygenic or pathway-level risk rather than targeting SAMM50 directly with inhibitors. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)
+
+## 5) Expert opinion and analysis (authoritative synthesis)
+
+### 5.1 SAM/Sam50 as more than a β-barrel insertase
+A 2025 Biochemistry review (useful as expert synthesis, though outside the requested 2023–2024 window) argues that although β-barrel assembly is the canonical function, Sam50/SAMM50 participates broadly in OMM interactomes that connect protein biogenesis to **cristae morphology (via MICOS)**, **lipid exchange at contact sites (via ORP5/8)**, and **mitophagy regulation (via PINK1)**. This framing helps interpret why SAMM50 perturbations can have pleiotropic effects that still trace back to its primary role in OMM organization and β-barrel biogenesis. (Publication date: Jan 2025; https://doi.org/10.1021/acs.biochem.4c00727) (ravi2025mitochondrialsortingand pages 30-35)
+
+### 5.2 Mechanistic caution: association vs causality in human disease
+While common variants in SAMM50 associate with NAFLD risk in specific cohorts (and Open Targets aggregates broader disease associations), these do not by themselves establish SAMM50 as a monogenic disease gene with a well-defined pathogenic mechanism in humans. Current evidence supports SAMM50 as an essential mitochondrial organization factor; complete loss is plausibly incompatible with viability, and disease links may often be mediated through partial changes in expression/function in metabolic stress contexts. (ravi2025mitochondrialsortingand pages 13-15, zhao2023samm50rs2073082rs738491and pages 1-2)
+
+## 6) Relevant statistics and data highlights (recent studies)
+- **NAFLD cohort size and prevalence:** 1,053 elderly participants; **590 NAFLD cases (56.03%)**. (zhao2023samm50rs2073082rs738491and pages 4-5)
+- **Effect sizes for SAMM50 alleles (NAFLD risk):** rs2073082 G: **OR 1.962**; rs738491 T: **OR 1.532**. (zhao2023samm50rs2073082rs738491and pages 1-2)
+- **Fibrosis proxy association:** rs738491 T and rs3761472 G associated with increased **liver stiffness measurement (LSM)** in the cohort. (zhao2023samm50rs2073082rs738491and pages 1-2)
+
+## 7) Concise functional annotation (summary)
+SAMM50 (UniProt Q9Y512; SAM50/TRG-3) is a **mitochondrial outer membrane Omp85-family β-barrel insertase** and the **core subunit of the SAM complex**. Its primary, experimentally grounded role is the **assembly/insertion of OMM β-barrel proteins** (e.g., Tom40 and VDAC) delivered through the TOM→IMS chaperone→SAM pathway and assembled via **β-signal recognition**, **lateral gating**, and **β-barrel switching**. SAMM50 also serves as an organizational hub by forming **TOM–SAM** supercomplexes and participating in **SAM–MICOS** contact sites that connect outer-membrane protein biogenesis to **cristae junction organization**. In human populations, common SAMM50 variants show reproducible associations with **NAFLD risk** in some cohorts, supporting a role for mitochondrial membrane architecture pathways in metabolic liver disease susceptibility. (ganesan2024biogenesisofmitochondrial pages 1-2, zhao2023samm50rs2073082rs738491and pages 1-2)
+
+## Evidence table (quick reference)
+| Aspect | Concise finding for human SAMM50 (UniProt Q9Y512) | Supporting citations |
+|---|---|---|
+| Verified identity / synonyms | **SAMM50** encodes human **sorting and assembly machinery component 50 homolog** (**SAM50**), also called **TRG-3 / transformation-related gene 3 protein**; it is the conserved human Omp85-family core subunit of the mitochondrial **SAM complex** in the outer membrane. | (ravi2025mitochondrialsortingand pages 1-3) |
+| Protein family / domains / topology | SAMM50 belongs to the **SAM50/Omp85 family** and is a **16-stranded β-barrel** outer-membrane protein with a single **N-terminal POTRA domain**; available structural summaries indicate a **non-closed barrel seam** between β1 and β16 consistent with a **lateral gate**, and loop **L6** contains the conserved **(V/I)RG(F/Y)** motif involved in substrate handling. | (ravi2025mitochondrialsortingand pages 20-24, ganesan2024biogenesisofmitochondrial pages 2-4) |
+| Subcellular localization | SAMM50 localizes to the **mitochondrial outer membrane (OMM)**, with the **POTRA domain exposed to the intermembrane space** and cytosolic surfaces engaging accessory factors; it also participates in **outer–inner membrane contact sites** with MICOS and at **ER–mitochondria contact sites**. | (ravi2025mitochondrialsortingand pages 35-36, ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial media 50bb168a) |
+| Core molecular function / mechanism | Canonical function: **assembly/insertion of mitochondrial β-barrel proteins** such as **Tom40** and **VDACs**. Precursor route is **cytosol → TOM complex → IMS small Tim chaperones (Tim9/10 or Tim8/13) → SAM complex**. Mechanistically, the precursor **β-signal** engages Sam50, insertion occurs at the **lateral gate**, and current models favor **β-barrel switching**, where a nascent barrel forms a **Sam50–preprotein hybrid barrel** before release into the OMM. | (ganesan2024biogenesisofmitochondrial pages 1-2, ganesan2024biogenesisofmitochondrial pages 2-4, ravi2025mitochondrialsortingand pages 7-8) |
+| Key complexes / partners | SAMM50 is the central subunit of the **SAM complex**; in humans, **metaxins MTX1/MTX2** replace yeast Sam35/37-like accessory functions. It functionally couples with the **TOM complex**, forms a **SAM–MICOS / MIB axis** with **Mic60/Mic19** for cristae organization, and associates with **ORP5/ORP8** at ER–mitochondria contact sites to support lipid transfer. | (ravi2025mitochondrialsortingand pages 16-17, ravi2025mitochondrialsortingand pages 8-10, ravi2025mitochondrialsortingand pages 1-3) |
+| Phenotypes when perturbed | SAMM50 loss/depletion disrupts **β-barrel biogenesis**, causes **cristae loss/disorganization**, abnormal **spherical/enlarged mitochondria**, loss of respiratory complexes, altered lipid homeostasis, and **PINK1 stabilization** with increased **PINK1–Parkin mitophagy**; the review literature also notes that complete loss is likely **lethal/essential**. | (ravi2025mitochondrialsortingand pages 8-10, ravi2025mitochondrialsortingand pages 30-35, ravi2025mitochondrialsortingand pages 1-3) |
+| 2023–2024 human genetics associations | In an elderly Chinese cohort of **1,053** individuals (**590 NAFLD cases**), **SAMM50 rs2073082 G** was associated with higher NAFLD risk (**OR 1.962, 95% CI 1.448–2.659, p<0.001**) and **rs738491 T** with higher NAFLD risk (**OR 1.532, 95% CI 1.246–1.884, p=0.021**). **rs738491 T** and **rs3761472 G** were associated with higher **liver stiffness**, and the **three-SNP model** (rs2073082/rs738491/rs3761472) gave the best NAFLD prediction, with carriers of all three risk alleles showing roughly **two-fold higher risk**. Open Targets also summarizes associations of SAMM50 with **liver disease/NAFLD**. | (zhao2023samm50rs2073082rs738491and pages 1-2, zhao2023samm50rs2073082rs738491and pages 4-5, OpenTargets Search: -SAMM50) |
+
+
+*Table: This table summarizes the verified identity, structure, localization, mechanism, interaction partners, perturbation phenotypes, and recent human genetic associations for human SAMM50. It is useful as a compact evidence-backed reference for functional annotation of UniProt Q9Y512.*
+
+## Key URLs (most used sources)
+- Ganesan et al., **“Biogenesis of mitochondrial β‐barrel membrane proteins”**, FEBS Open Bio, **Sep 2024**. https://doi.org/10.1002/2211-5463.13905 (ganesan2024biogenesisofmitochondrial pages 1-2)
+- Zhao et al., **“SAMM50-rs2073082, -rs738491 and -rs3761472 interactions…”**, Biomedicines, **Aug 2023**. https://doi.org/10.3390/biomedicines11092416 (zhao2023samm50rs2073082rs738491and pages 1-2)
+- Open Targets association summary for SAMM50 (accessed via Open Targets tool output in this run). https://platform.opentargets.org/ (OpenTargets Search: -SAMM50)
+
+
+References
+
+1. (ravi2025mitochondrialsortingand pages 1-3): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.
+
+2. (ganesan2024biogenesisofmitochondrial pages 1-2): Iniyan Ganesan, Jon V. Busto, Nikolaus Pfanner, and Nils Wiedemann. Biogenesis of mitochondrial β‐barrel membrane proteins. FEBS Open Bio, 14:1595-1609, Sep 2024. URL: https://doi.org/10.1002/2211-5463.13905, doi:10.1002/2211-5463.13905. This article has 20 citations and is from a peer-reviewed journal.
+
+3. (ganesan2024biogenesisofmitochondrial pages 2-4): Iniyan Ganesan, Jon V. Busto, Nikolaus Pfanner, and Nils Wiedemann. Biogenesis of mitochondrial β‐barrel membrane proteins. FEBS Open Bio, 14:1595-1609, Sep 2024. URL: https://doi.org/10.1002/2211-5463.13905, doi:10.1002/2211-5463.13905. This article has 20 citations and is from a peer-reviewed journal.
+
+4. (ravi2025mitochondrialsortingand pages 20-24): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.
+
+5. (ravi2025mitochondrialsortingand pages 16-17): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.
+
+6. (ganesan2024biogenesisofmitochondrial media a6c2469b): Iniyan Ganesan, Jon V. Busto, Nikolaus Pfanner, and Nils Wiedemann. Biogenesis of mitochondrial β‐barrel membrane proteins. FEBS Open Bio, 14:1595-1609, Sep 2024. URL: https://doi.org/10.1002/2211-5463.13905, doi:10.1002/2211-5463.13905. This article has 20 citations and is from a peer-reviewed journal.
+
+7. (ravi2025mitochondrialsortingand pages 8-10): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.
+
+8. (ravi2025mitochondrialsortingand pages 30-35): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.
+
+9. (ganesan2024biogenesisofmitochondrial media 50bb168a): Iniyan Ganesan, Jon V. Busto, Nikolaus Pfanner, and Nils Wiedemann. Biogenesis of mitochondrial β‐barrel membrane proteins. FEBS Open Bio, 14:1595-1609, Sep 2024. URL: https://doi.org/10.1002/2211-5463.13905, doi:10.1002/2211-5463.13905. This article has 20 citations and is from a peer-reviewed journal.
+
+10. (zhao2023samm50rs2073082rs738491and pages 2-4): Jinhan Zhao, Xiaoyi Xu, Xinhuan Wei, Shuang Zhang, Hangfei Xu, Xiaodie Wei, Yang Zhang, and Jing Zhang. Samm50-rs2073082, -rs738491 and -rs3761472 interactions enhancement of susceptibility to non-alcoholic fatty liver disease. Biomedicines, 11:2416, Aug 2023. URL: https://doi.org/10.3390/biomedicines11092416, doi:10.3390/biomedicines11092416. This article has 5 citations.
+
+11. (zhao2023samm50rs2073082rs738491and pages 1-2): Jinhan Zhao, Xiaoyi Xu, Xinhuan Wei, Shuang Zhang, Hangfei Xu, Xiaodie Wei, Yang Zhang, and Jing Zhang. Samm50-rs2073082, -rs738491 and -rs3761472 interactions enhancement of susceptibility to non-alcoholic fatty liver disease. Biomedicines, 11:2416, Aug 2023. URL: https://doi.org/10.3390/biomedicines11092416, doi:10.3390/biomedicines11092416. This article has 5 citations.
+
+12. (OpenTargets Search: -SAMM50): Open Targets Query (-SAMM50, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+13. (ravi2025mitochondrialsortingand pages 13-15): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.
+
+14. (zhao2023samm50rs2073082rs738491and pages 4-5): Jinhan Zhao, Xiaoyi Xu, Xinhuan Wei, Shuang Zhang, Hangfei Xu, Xiaodie Wei, Yang Zhang, and Jing Zhang. Samm50-rs2073082, -rs738491 and -rs3761472 interactions enhancement of susceptibility to non-alcoholic fatty liver disease. Biomedicines, 11:2416, Aug 2023. URL: https://doi.org/10.3390/biomedicines11092416, doi:10.3390/biomedicines11092416. This article has 5 citations.
+
+15. (ravi2025mitochondrialsortingand pages 35-36): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.
+
+16. (ravi2025mitochondrialsortingand pages 7-8): Roshika Ravi, Deepsikha Routray, and Radhakrishnan Mahalakshmi. Mitochondrial sorting and assembly machinery: chaperoning a moonlighting role? Biochemistry, 64:312-328, Jan 2025. URL: https://doi.org/10.1021/acs.biochem.4c00727, doi:10.1021/acs.biochem.4c00727. This article has 4 citations and is from a peer-reviewed journal.
+
+## Citations
+
+1. ravi2025mitochondrialsortingand pages 20-24
+2. ganesan2024biogenesisofmitochondrial pages 1-2
+3. ravi2025mitochondrialsortingand pages 30-35
+4. ravi2025mitochondrialsortingand pages 1-3
+5. ganesan2024biogenesisofmitochondrial pages 2-4
+6. ravi2025mitochondrialsortingand pages 16-17
+7. ravi2025mitochondrialsortingand pages 8-10
+8. ravi2025mitochondrialsortingand pages 13-15
+9. ravi2025mitochondrialsortingand pages 35-36
+10. ravi2025mitochondrialsortingand pages 7-8
+11. https://doi.org/10.1002/2211-5463.13905
+12. https://doi.org/10.3390/biomedicines11092416
+13. https://doi.org/10.1021/acs.biochem.4c00727
+14. https://platform.opentargets.org/
+15. https://doi.org/10.1021/acs.biochem.4c00727,
+16. https://doi.org/10.1002/2211-5463.13905,
+17. https://doi.org/10.3390/biomedicines11092416,


### PR DESCRIPTION
## Summary

Adds Falcon deep-research reports and completed AI gene reviews for three human genes:

- PMPCA: alpha substrate-recognition subunit of the mitochondrial processing peptidase complex; separates PMPCA adaptor/substrate-positioning role from PMPCB catalytic metalloendopeptidase activity.
- SAMM50: core SAM complex/Omp85-family mitochondrial outer-membrane beta-barrel insertase; keeps SAM-MICOS/MIB cristae roles as non-core architecture effects.
- MORC3: nuclear/PML-body chromatin ATPase/scaffold; retains antiviral, chromatin-reader, PML-body, and IFNB1-repression annotations while removing kinase-like over-annotations.

Rendered updated review HTML where applicable.

## Validation

- `uv run python scripts/validate_deep_research.py genes/human/PMPCA/PMPCA-deep-research-falcon.md genes/human/SAMM50/SAMM50-deep-research-falcon.md genes/human/MORC3/MORC3-deep-research-falcon.md`
- `just validate human PMPCA`
- `just validate human SAMM50`
- `just validate human MORC3`
- `just render human PMPCA`
- `just render human SAMM50`
- `just render human MORC3`
- custom supporting_text audit: 211 snippets checked against local source files
- `git diff --check origin/main...HEAD`