### PR TITLE
Add Falcon deep research reviews for ARIH1, IGFBP3, and LIMD1

### DIFF
--- a/genes/human/ARIH1/ARIH1-ai-review.html
+++ b/genes/human/ARIH1/ARIH1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>ARIH1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q9Y4X5" target="_blank" class="term-link">
                         Q9Y4X5
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-initialized">
-                    INITIALIZED
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="Q9Y4X5" data-a="DESCRIPTION: TODO: Add description for ARIH1..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="Q9Y4X5" data-a="DESCRIPTION: ARIH1 encodes HHARI, an intracellular Ariadne/RBR ..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for ARIH1</p>
+        <p>ARIH1 encodes HHARI, an intracellular Ariadne/RBR E3 ubiquitin ligase that catalyzes ubiquitin transfer through a RING1-IBR-RING2 mechanism and is activated by neddylated cullin-RING ligase complexes, especially SCF assemblies, to prime ubiquitination of constrained CRL substrates.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,4485 +758,6910 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytoplasm localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031624" target="_blank" class="term-link">
                                     GO:0031624
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin conjugating enzyme binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031624" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031624" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ARIH1 binding to ubiquitin-conjugating enzymes is part of its core RBR catalytic cycle, with UBE2L3/UbcH7 the best-supported donor E2.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006511" target="_blank" class="term-link">
                                     GO:0006511
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin-dependent protein catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0006511" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0006511" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ubiquitin-dependent protein catabolic process is supported by the catalytic role of ARIH1 in ubiquitination and downstream ubiquitin-dependent substrate turnover, especially as a CRL-associated priming E3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061630" target="_blank" class="term-link">
                                     GO:0061630
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061630" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061630" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ubiquitin protein ligase activity is a core ARIH1 function: ARIH1/HHARI is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine to substrates.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RBR E3 ligases are defined by a **RING1–IBR–RING2** module and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2, ubiquitin is transferred from the E3~Ub thioester to a substrate lysine (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as a canonical member.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000151" target="_blank" class="term-link">
                                     GO:0000151
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin ligase complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0000151" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0000151" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ARIH1 forms functional ubiquitin ligase assemblies with neddylated CRLs; this broad complex annotation captures that E3-ligase-complex context.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleus localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004842" target="_blank" class="term-link">
                                     GO:0004842
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin-protein transferase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0004842" data-r="GO_REF:0000002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0004842" data-r="GO_REF:0000002" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine to substrates.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RBR E3 ligases are defined by a **RING1–IBR–RING2** module and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2, ubiquitin is transferred from the E3~Ub thioester to a substrate lysine (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as a canonical member.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleus localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytoplasm localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0008270" data-r="GO_REF:0000002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0008270" data-r="GO_REF:0000002" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ARIH1 contains RING/IBR/RING zinc-finger domains required for its RBR E3 mechanism, so zinc ion binding is supported.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015030" target="_blank" class="term-link">
                                     GO:0015030
                                 </a>
                             </span>
                             <span class="term-label">Cajal body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0015030" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0015030" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cajal body is retained as a reported localization or colocalization but is not part of the core ARIH1 ubiquitin-ligase mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Nucleus, Cajal body</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Present in Lewy body</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016567" target="_blank" class="term-link">
                                     GO:0016567
                                 </a>
                             </span>
                             <span class="term-label">protein ubiquitination</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016567" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016567" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> protein ubiquitination is supported by the catalytic role of ARIH1 in ubiquitination and downstream ubiquitin-dependent substrate turnover, especially as a CRL-associated priming E3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0046872" data-r="GO_REF:0000002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0046872" data-r="GO_REF:0000002" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The metal-binding evidence is specifically zinc binding by RING/IBR/RING domains; the broad metal ion binding term should be replaced by zinc ion binding.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Specific zinc-binding domains are known; the generic metal ion binding term is less informative.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                                    zinc ion binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061630" target="_blank" class="term-link">
                                     GO:0061630
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000003
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061630" data-r="GO_REF:0000003" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061630" data-r="GO_REF:0000003" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ubiquitin protein ligase activity is a core ARIH1 function: ARIH1/HHARI is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine to substrates.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RBR E3 ligases are defined by a **RING1–IBR–RING2** module and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2, ubiquitin is transferred from the E3~Ub thioester to a substrate lysine (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as a canonical member.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21145461" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21145461
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dynamics of cullin-RING ubiquitin ligase network revealed by...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:21145461" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:21145461" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for ARIH1. The informative interaction annotations are E2 binding and CRL/SCF association.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic binding with mechanistically specific E2 or ubiquitin-ligase-complex binding where possible.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21532592" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21532592
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     UBCH7 reactivity profile reveals parkin and HHARI to be RING...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:21532592" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:21532592" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for ARIH1. The informative interaction annotations are E2 binding and CRL/SCF association.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic binding with mechanistically specific E2 or ubiquitin-ligase-complex binding where possible.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23707686" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23707686
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure of HHARI, a RING-IBR-RING ubiquitin ligase: autoin...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:23707686" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:23707686" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for ARIH1. The informative interaction annotations are E2 binding and CRL/SCF association.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic binding with mechanistically specific E2 or ubiquitin-ligase-complex binding where possible.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24076655" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24076655
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TRIAD1 and HHARI bind to and are activated by distinct neddy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:24076655" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:24076655" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for ARIH1. The informative interaction annotations are E2 binding and CRL/SCF association.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic binding with mechanistically specific E2 or ubiquitin-ligase-complex binding where possible.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the human interactome defines protein commun...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:28514442" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for ARIH1. The informative interaction annotations are E2 binding and CRL/SCF association.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic binding with mechanistically specific E2 or ubiquitin-ligase-complex binding where possible.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:33961781" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for ARIH1. The informative interaction annotations are E2 binding and CRL/SCF association.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic binding with mechanistically specific E2 or ubiquitin-ligase-complex binding where possible.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005654" data-r="GO_REF:0000052" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005654" data-r="GO_REF:0000052" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0039585" target="_blank" class="term-link">
                                     GO:0039585
                                 </a>
                             </span>
                             <span class="term-label">PKR/eIFalpha signaling</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9833482
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0039585" data-r="Reactome:R-HSA-9833482" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0039585" data-r="Reactome:R-HSA-9833482" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> PKR/eIFalpha signaling is a pathway-level consequence in Reactome rather than the core molecular role of ARIH1; keep it as non-core while prioritizing ubiquitin/ubiquitin-like ligase activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acts as the ligase involved in ISGylation of EIF4E2 (PubMed:17289916).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061662" target="_blank" class="term-link">
                                     GO:0061662
                                 </a>
                             </span>
                             <span class="term-label">ISG15 ligase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1169394
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061662" data-r="Reactome:R-HSA-1169394" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061662" data-r="Reactome:R-HSA-1169394" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acts as the ligase involved in ISGylation of EIF4E2 (PubMed:17289916).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">older literature reported interaction with **UBE2L3 and UBE2L6**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061662" target="_blank" class="term-link">
                                     GO:0061662
                                 </a>
                             </span>
                             <span class="term-label">ISG15 ligase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1169395
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061662" data-r="Reactome:R-HSA-1169395" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061662" data-r="Reactome:R-HSA-1169395" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acts as the ligase involved in ISGylation of EIF4E2 (PubMed:17289916).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">older literature reported interaction with **UBE2L3 and UBE2L6**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061662" target="_blank" class="term-link">
                                     GO:0061662
                                 </a>
                             </span>
                             <span class="term-label">ISG15 ligase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1169398
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061662" data-r="Reactome:R-HSA-1169398" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061662" data-r="Reactome:R-HSA-1169398" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acts as the ligase involved in ISGylation of EIF4E2 (PubMed:17289916).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">older literature reported interaction with **UBE2L3 and UBE2L6**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061662" target="_blank" class="term-link">
                                     GO:0061662
                                 </a>
                             </span>
                             <span class="term-label">ISG15 ligase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1169402
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061662" data-r="Reactome:R-HSA-1169402" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061662" data-r="Reactome:R-HSA-1169402" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acts as the ligase involved in ISGylation of EIF4E2 (PubMed:17289916).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">older literature reported interaction with **UBE2L3 and UBE2L6**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061662" target="_blank" class="term-link">
                                     GO:0061662
                                 </a>
                             </span>
                             <span class="term-label">ISG15 ligase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1169405
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061662" data-r="Reactome:R-HSA-1169405" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061662" data-r="Reactome:R-HSA-1169405" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acts as the ligase involved in ISGylation of EIF4E2 (PubMed:17289916).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">older literature reported interaction with **UBE2L3 and UBE2L6**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061662" target="_blank" class="term-link">
                                     GO:0061662
                                 </a>
                             </span>
                             <span class="term-label">ISG15 ligase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1169406
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061662" data-r="Reactome:R-HSA-1169406" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061662" data-r="Reactome:R-HSA-1169406" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acts as the ligase involved in ISGylation of EIF4E2 (PubMed:17289916).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">older literature reported interaction with **UBE2L3 and UBE2L6**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061662" target="_blank" class="term-link">
                                     GO:0061662
                                 </a>
                             </span>
                             <span class="term-label">ISG15 ligase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9833973
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061662" data-r="Reactome:R-HSA-9833973" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0061662" data-r="Reactome:R-HSA-9833973" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acts as the ligase involved in ISGylation of EIF4E2 (PubMed:17289916).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">older literature reported interaction with **UBE2L3 and UBE2L6**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004842" target="_blank" class="term-link">
                                     GO:0004842
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin-protein transferase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23707686" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23707686
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure of HHARI, a RING-IBR-RING ubiquitin ligase: autoin...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0004842" data-r="PMID:23707686" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0004842" data-r="PMID:23707686" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine to substrates.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RBR E3 ligases are defined by a **RING1–IBR–RING2** module and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2, ubiquitin is transferred from the E3~Ub thioester to a substrate lysine (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as a canonical member.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004842" target="_blank" class="term-link">
                                     GO:0004842
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin-protein transferase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24076655" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24076655
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TRIAD1 and HHARI bind to and are activated by distinct neddy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0004842" data-r="PMID:24076655" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0004842" data-r="PMID:24076655" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine to substrates.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RBR E3 ligases are defined by a **RING1–IBR–RING2** module and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2, ubiquitin is transferred from the E3~Ub thioester to a substrate lysine (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as a canonical member.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004842" target="_blank" class="term-link">
                                     GO:0004842
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin-protein transferase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27565346" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27565346
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Two Distinct Types of E3 Ligases Work in Unison to Regulate ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0004842" data-r="PMID:27565346" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0004842" data-r="PMID:27565346" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine to substrates.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RBR E3 ligases are defined by a **RING1–IBR–RING2** module and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2, ubiquitin is transferred from the E3~Ub thioester to a substrate lysine (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as a canonical member.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23059369" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23059369
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human Homolog of Drosophila Ariadne (HHARI) is a marker of c...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005737" data-r="PMID:23059369" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005737" data-r="PMID:23059369" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytoplasm localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23707686" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23707686
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure of HHARI, a RING-IBR-RING ubiquitin ligase: autoin...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0008270" data-r="PMID:23707686" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0008270" data-r="PMID:23707686" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ARIH1 contains RING/IBR/RING zinc-finger domains required for its RBR E3 mechanism, so zinc ion binding is supported.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016567" target="_blank" class="term-link">
                                     GO:0016567
                                 </a>
                             </span>
                             <span class="term-label">protein ubiquitination</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23707686" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23707686
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure of HHARI, a RING-IBR-RING ubiquitin ligase: autoin...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016567" data-r="PMID:23707686" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016567" data-r="PMID:23707686" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> protein ubiquitination is supported by the catalytic role of ARIH1 in ubiquitination and downstream ubiquitin-dependent substrate turnover, especially as a CRL-associated priming E3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016567" target="_blank" class="term-link">
                                     GO:0016567
                                 </a>
                             </span>
                             <span class="term-label">protein ubiquitination</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24076655" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24076655
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TRIAD1 and HHARI bind to and are activated by distinct neddy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016567" data-r="PMID:24076655" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016567" data-r="PMID:24076655" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> protein ubiquitination is supported by the catalytic role of ARIH1 in ubiquitination and downstream ubiquitin-dependent substrate turnover, especially as a CRL-associated priming E3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016567" target="_blank" class="term-link">
                                     GO:0016567
                                 </a>
                             </span>
                             <span class="term-label">protein ubiquitination</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27565346" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27565346
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Two Distinct Types of E3 Ligases Work in Unison to Regulate ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016567" data-r="PMID:27565346" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016567" data-r="PMID:27565346" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> protein ubiquitination is supported by the catalytic role of ARIH1 in ubiquitination and downstream ubiquitin-dependent substrate turnover, especially as a CRL-associated priming E3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016604" target="_blank" class="term-link">
                                     GO:0016604
                                 </a>
                             </span>
                             <span class="term-label">nuclear body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23059369" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23059369
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human Homolog of Drosophila Ariadne (HHARI) is a marker of c...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016604" data-r="PMID:23059369" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016604" data-r="PMID:23059369" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nuclear body is retained as a reported localization or colocalization but is not part of the core ARIH1 ubiquitin-ligase mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Nucleus, Cajal body</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Present in Lewy body</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019005" target="_blank" class="term-link">
                                     GO:0019005
                                 </a>
                             </span>
                             <span class="term-label">SCF ubiquitin ligase complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24076655" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24076655
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TRIAD1 and HHARI bind to and are activated by distinct neddy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0019005" data-r="PMID:24076655" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0019005" data-r="PMID:24076655" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> SCF ubiquitin ligase complex association is part of the best-supported ARIH1 mechanism: ARIH1 cooperates with neddylated SCF complexes as a catalytic E3-E3 super-assembly for CRL substrate ubiquitination.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Associates with cullin-RING ubiquitin ligase (CRL) complexes containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL4A (PubMed:24076655).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019005" target="_blank" class="term-link">
                                     GO:0019005
                                 </a>
                             </span>
                             <span class="term-label">SCF ubiquitin ligase complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27565346" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27565346
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Two Distinct Types of E3 Ligases Work in Unison to Regulate ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0019005" data-r="PMID:27565346" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0019005" data-r="PMID:27565346" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> SCF ubiquitin ligase complex association is part of the best-supported ARIH1 mechanism: ARIH1 cooperates with neddylated SCF complexes as a catalytic E3-E3 super-assembly for CRL substrate ubiquitination.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Associates with cullin-RING ubiquitin ligase (CRL) complexes containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL4A (PubMed:24076655).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031462" target="_blank" class="term-link">
                                     GO:0031462
                                 </a>
                             </span>
                             <span class="term-label">Cul2-RING ubiquitin ligase complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
+
                         <span class="not-badge" title="This is a NOT annotation - gene does NOT have this function">NOT</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27565346" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27565346
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Two Distinct Types of E3 Ligases Work in Unison to Regulate ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031462" data-r="PMID:27565346" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031462" data-r="PMID:27565346" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This NOT-qualified CRL-complex annotation should be retained for the specific experimental context, while broader evidence supports ARIH1 cooperation with other neddylated cullin complexes.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Associates with cullin-RING ubiquitin ligase (CRL) complexes containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL4A (PubMed:24076655).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031462" target="_blank" class="term-link">
                                     GO:0031462
                                 </a>
                             </span>
                             <span class="term-label">Cul2-RING ubiquitin ligase complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24076655" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24076655
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TRIAD1 and HHARI bind to and are activated by distinct neddy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031462" data-r="PMID:24076655" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031462" data-r="PMID:24076655" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cul2-RING ubiquitin ligase complex association is supported as a CRL partnership for ARIH1; it is retained as a non-core complex context rather than the core catalytic activity itself.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Associates with cullin-RING ubiquitin ligase (CRL) complexes containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL4A (PubMed:24076655).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031463" target="_blank" class="term-link">
                                     GO:0031463
                                 </a>
                             </span>
                             <span class="term-label">Cul3-RING ubiquitin ligase complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24076655" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24076655
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TRIAD1 and HHARI bind to and are activated by distinct neddy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031463" data-r="PMID:24076655" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031463" data-r="PMID:24076655" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cul3-RING ubiquitin ligase complex association is supported as a CRL partnership for ARIH1; it is retained as a non-core complex context rather than the core catalytic activity itself.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Associates with cullin-RING ubiquitin ligase (CRL) complexes containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL4A (PubMed:24076655).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031463" target="_blank" class="term-link">
                                     GO:0031463
                                 </a>
                             </span>
                             <span class="term-label">Cul3-RING ubiquitin ligase complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27565346" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27565346
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Two Distinct Types of E3 Ligases Work in Unison to Regulate ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031463" data-r="PMID:27565346" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031463" data-r="PMID:27565346" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cul3-RING ubiquitin ligase complex association is supported as a CRL partnership for ARIH1; it is retained as a non-core complex context rather than the core catalytic activity itself.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Associates with cullin-RING ubiquitin ligase (CRL) complexes containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL4A (PubMed:24076655).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031464" target="_blank" class="term-link">
                                     GO:0031464
                                 </a>
                             </span>
                             <span class="term-label">Cul4A-RING E3 ubiquitin ligase complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24076655" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24076655
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TRIAD1 and HHARI bind to and are activated by distinct neddy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031464" data-r="PMID:24076655" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031464" data-r="PMID:24076655" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cul4A-RING E3 ubiquitin ligase complex association is supported as a CRL partnership for ARIH1; it is retained as a non-core complex context rather than the core catalytic activity itself.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Associates with cullin-RING ubiquitin ligase (CRL) complexes containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL4A (PubMed:24076655).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031624" target="_blank" class="term-link">
                                     GO:0031624
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin conjugating enzyme binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23707686" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23707686
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure of HHARI, a RING-IBR-RING ubiquitin ligase: autoin...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031624" data-r="PMID:23707686" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031624" data-r="PMID:23707686" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ARIH1 binding to ubiquitin-conjugating enzymes is part of its core RBR catalytic cycle, with UBE2L3/UbcH7 the best-supported donor E2.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031624" target="_blank" class="term-link">
                                     GO:0031624
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin conjugating enzyme binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24076655" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24076655
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TRIAD1 and HHARI bind to and are activated by distinct neddy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031624" data-r="PMID:24076655" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031624" data-r="PMID:24076655" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ARIH1 binding to ubiquitin-conjugating enzymes is part of its core RBR catalytic cycle, with UBE2L3/UbcH7 the best-supported donor E2.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031624" target="_blank" class="term-link">
                                     GO:0031624
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin conjugating enzyme binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27565346" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27565346
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Two Distinct Types of E3 Ligases Work in Unison to Regulate ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031624" data-r="PMID:27565346" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031624" data-r="PMID:27565346" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ARIH1 binding to ubiquitin-conjugating enzymes is part of its core RBR catalytic cycle, with UBE2L3/UbcH7 the best-supported donor E2.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097413" target="_blank" class="term-link">
                                     GO:0097413
                                 </a>
                             </span>
                             <span class="term-label">Lewy body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21590270" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21590270
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The parkin-like human homolog of Drosophila ariadne-1 (HHARI...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0097413" data-r="PMID:21590270" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0097413" data-r="PMID:21590270" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Lewy body is retained as a reported localization or colocalization but is not part of the core ARIH1 ubiquitin-ligase mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Nucleus, Cajal body</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Present in Lewy body</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1169394
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1169394" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1169394" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1169395
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1169395" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1169395" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1169398
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1169398" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1169398" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1169402
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1169402" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1169402" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1169403
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1169403" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1169403" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1169405
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1169405" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1169405" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1169406
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1169406" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1169406" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1678843
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1678843" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-1678843" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9833973
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-9833973" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-9833973" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9837231
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-9837231" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-9837231" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9927247
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-9927247" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005829" data-r="Reactome:R-HSA-9927247" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004842" target="_blank" class="term-link">
                                     GO:0004842
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin-protein transferase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14623119" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14623119
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human homologue of ariadne promotes the ubiquitylation of tr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0004842" data-r="PMID:14623119" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0004842" data-r="PMID:14623119" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine to substrates.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RBR E3 ligases are defined by a **RING1–IBR–RING2** module and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2, ubiquitin is transferred from the E3~Ub thioester to a substrate lysine (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as a canonical member.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004842" target="_blank" class="term-link">
                                     GO:0004842
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin-protein transferase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15236971" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15236971
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure of the C-terminal RING finger from a RING-IBR-RING...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0004842" data-r="PMID:15236971" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0004842" data-r="PMID:15236971" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine to substrates.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RBR E3 ligases are defined by a **RING1–IBR–RING2** module and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2, ubiquitin is transferred from the E3~Ub thioester to a substrate lysine (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as a canonical member.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004842" target="_blank" class="term-link">
                                     GO:0004842
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin-protein transferase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21532592" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21532592
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     UBCH7 reactivity profile reveals parkin and HHARI to be RING...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0004842" data-r="PMID:21532592" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0004842" data-r="PMID:21532592" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine to substrates.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RBR E3 ligases are defined by a **RING1–IBR–RING2** module and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2, ubiquitin is transferred from the E3~Ub thioester to a substrate lysine (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as a canonical member.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14623119" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14623119
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human homologue of ariadne promotes the ubiquitylation of tr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:14623119" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:14623119" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for ARIH1. The informative interaction annotations are E2 binding and CRL/SCF association.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic binding with mechanistically specific E2 or ubiquitin-ligase-complex binding where possible.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11278816" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11278816
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Features of the parkin/ariadne-like ubiquitin ligase, HHARI,...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005737" data-r="PMID:11278816" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005737" data-r="PMID:11278816" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytoplasm localization is supported for intracellular ARIH1; the most relevant functional locations are cytoplasm/cytosol and nucleus.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15236971" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15236971
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure of the C-terminal RING finger from a RING-IBR-RING...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0008270" data-r="PMID:15236971" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0008270" data-r="PMID:15236971" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ARIH1 contains RING/IBR/RING zinc-finger domains required for its RBR E3 mechanism, so zinc ion binding is supported.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">bind E2s via the first RING-type zinc finger</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016567" target="_blank" class="term-link">
                                     GO:0016567
                                 </a>
                             </span>
                             <span class="term-label">protein ubiquitination</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14623119" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14623119
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human homologue of ariadne promotes the ubiquitylation of tr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016567" data-r="PMID:14623119" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016567" data-r="PMID:14623119" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> protein ubiquitination is supported by the catalytic role of ARIH1 in ubiquitination and downstream ubiquitin-dependent substrate turnover, especially as a CRL-associated priming E3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016567" target="_blank" class="term-link">
                                     GO:0016567
                                 </a>
                             </span>
                             <span class="term-label">protein ubiquitination</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15236971" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15236971
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure of the C-terminal RING finger from a RING-IBR-RING...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016567" data-r="PMID:15236971" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016567" data-r="PMID:15236971" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> protein ubiquitination is supported by the catalytic role of ARIH1 in ubiquitination and downstream ubiquitin-dependent substrate turnover, especially as a CRL-associated priming E3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016567" target="_blank" class="term-link">
                                     GO:0016567
                                 </a>
                             </span>
                             <span class="term-label">protein ubiquitination</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21532592" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21532592
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     UBCH7 reactivity profile reveals parkin and HHARI to be RING...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016567" data-r="PMID:21532592" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0016567" data-r="PMID:21532592" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> protein ubiquitination is supported by the catalytic role of ARIH1 in ubiquitination and downstream ubiquitin-dependent substrate turnover, especially as a CRL-associated priming E3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031625" target="_blank" class="term-link">
                                     GO:0031625
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11278816" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11278816
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Features of the parkin/ariadne-like ubiquitin ligase, HHARI,...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031625" data-r="PMID:11278816" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031625" data-r="PMID:11278816" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Specific binding to ubiquitin ligase complexes is supported through ARIH1 cooperation with neddylated CRLs, but it is a complex-association context rather than the primary catalytic function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Associates with cullin-RING ubiquitin ligase (CRL) complexes containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL4A (PubMed:24076655).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031625" target="_blank" class="term-link">
                                     GO:0031625
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21532592" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21532592
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     UBCH7 reactivity profile reveals parkin and HHARI to be RING...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031625" data-r="PMID:21532592" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0031625" data-r="PMID:21532592" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Specific binding to ubiquitin ligase complexes is supported through ARIH1 cooperation with neddylated CRLs, but it is a complex-association context rather than the primary catalytic function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Associates with cullin-RING ubiquitin ligase (CRL) complexes containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with neddylated CUL4A (PubMed:24076655).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10521492" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10521492
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ubiquitin-conjugating enzymes UbcH7 and UbcH8 interact w...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:10521492" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0005515" data-r="PMID:10521492" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for ARIH1. The informative interaction annotations are E2 binding and CRL/SCF association.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace generic binding with mechanistically specific E2 or ubiquitin-ligase-complex binding where possible.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000151" target="_blank" class="term-link">
                                     GO:0000151
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin ligase complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10521492" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10521492
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ubiquitin-conjugating enzymes UbcH7 and UbcH8 interact w...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0000151" data-r="PMID:10521492" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0000151" data-r="PMID:10521492" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ARIH1 forms functional ubiquitin ligase assemblies with neddylated CRLs; this broad complex annotation captures that E3-ligase-complex context.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006511" target="_blank" class="term-link">
                                     GO:0006511
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin-dependent protein catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10521492" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10521492
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ubiquitin-conjugating enzymes UbcH7 and UbcH8 interact w...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0006511" data-r="PMID:10521492" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0006511" data-r="PMID:10521492" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ubiquitin-dependent protein catabolic process is supported by the catalytic role of ARIH1 in ubiquitination and downstream ubiquitin-dependent substrate turnover, especially as a CRL-associated priming E3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019787" target="_blank" class="term-link">
                                     GO:0019787
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin-like protein transferase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10521492" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10521492
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ubiquitin-conjugating enzymes UbcH7 and UbcH8 interact w...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0019787" data-r="PMID:10521492" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9Y4X5" data-a="GO:0019787" data-r="PMID:10521492" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ubiquitin-like protein transferase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Acts as the ligase involved in ISGylation of EIF4E2 (PubMed:17289916).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">older literature reported interaction with **UBE2L3 and UBE2L6**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>RBR E3 ubiquitin-protein ligase activity that primes ubiquitination of CRL-bound substrates in neddylated SCF/CRL assemblies.</h3>
+                <span class="vote-buttons" data-g="Q9Y4X5" data-a="FUNCTION: RBR E3 ubiquitin-protein ligase activity that prim..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061630" target="_blank" class="term-link">
+                            ubiquitin protein ligase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016567" target="_blank" class="term-link">
+                                protein ubiquitination
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006511" target="_blank" class="term-link">
+                                ubiquitin-dependent protein catabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019005" target="_blank" class="term-link">
+                            SCF ubiquitin ligase complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>UBE2L3/UbcH7 binding as the E2-recruitment step of ARIH1 RBR ubiquitin transfer.</h3>
+                <span class="vote-buttons" data-g="Q9Y4X5" data-a="FUNCTION: UBE2L3/UbcH7 binding as the E2-recruitment step of..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031624" target="_blank" class="term-link">
+                            ubiquitin conjugating enzyme binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016567" target="_blank" class="term-link">
+                                protein ubiquitination
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/ARIH1/ARIH1-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">bind E2s via the first RING-type zinc finger</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000003.md" target="_blank" class="term-link">
                             GO_REF:0000003
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on Enzyme Commission mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10521492" target="_blank" class="term-link">
                             PMID:10521492
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The ubiquitin-conjugating enzymes UbcH7 and UbcH8 interact with RING finger/IBR motif-containing domains of HHARI and H7-AP1.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11278816" target="_blank" class="term-link">
                             PMID:11278816
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Features of the parkin/ariadne-like ubiquitin ligase, HHARI, that regulate its interaction with the ubiquitin-conjugating enzyme, Ubch7.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14623119" target="_blank" class="term-link">
                             PMID:14623119
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human homologue of ariadne promotes the ubiquitylation of translation initiation factor 4E homologous protein, 4EHP.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15236971" target="_blank" class="term-link">
                             PMID:15236971
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structure of the C-terminal RING finger from a RING-IBR-RING/TRIAD motif reveals a novel zinc-binding domain distinct from a RING.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21145461" target="_blank" class="term-link">
                             PMID:21145461
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dynamics of cullin-RING ubiquitin ligase network revealed by systematic quantitative proteomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21532592" target="_blank" class="term-link">
                             PMID:21532592
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">UBCH7 reactivity profile reveals parkin and HHARI to be RING/HECT hybrids.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21590270" target="_blank" class="term-link">
                             PMID:21590270
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The parkin-like human homolog of Drosophila ariadne-1 (HHARI) can induce aggresome formation in mammalian cells and is immunologically detectable in Lewy bodies.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23059369" target="_blank" class="term-link">
                             PMID:23059369
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human Homolog of Drosophila Ariadne (HHARI) is a marker of cellular proliferation associated with nuclear bodies.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23707686" target="_blank" class="term-link">
                             PMID:23707686
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structure of HHARI, a RING-IBR-RING ubiquitin ligase: autoinhibition of an Ariadne-family E3 and insights into ligation mechanism.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24076655" target="_blank" class="term-link">
                             PMID:24076655
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TRIAD1 and HHARI bind to and are activated by distinct neddylated Cullin-RING ligase complexes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27565346" target="_blank" class="term-link">
                             PMID:27565346
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Two Distinct Types of E3 Ligases Work in Unison to Regulate Substrate Ubiquitylation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1169394
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ISGylation of IRF3</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1169395
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ISGylation of viral protein NS1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1169398
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ISGylation of host protein filamin B</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1169402
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ISGylation of E2 conjugating enzymes</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1169403
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interaction of E3 ligase with ISG15:E2 complex</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1169405
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ISGylation of protein phosphatase 1 beta (PP2CB)</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1169406
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ISGylation of host proteins</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1678843
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ISGylation of protein translation regulator 4EHP</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9833482
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PKR-mediated signaling</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9833973
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ISGylation of PKR</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9837231
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ISGylation of BECN1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9927247
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ISGylation of DDX58 (RIG-I)</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/ARIH1/ARIH1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research synthesis for ARIH1</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/ARIH1/ARIH1-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt record for ARIH1</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(ARIH1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9Y4X5" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: true<br />
+start_time: '2026-05-11T21:17:56.304844'<br />
+end_time: '2026-05-11T21:17:56.306599'<br />
+duration_seconds: 0.0<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: ARIH1<br />
+  gene_symbol: ARIH1<br />
+  uniprot_accession: Q9Y4X5<br />
+  protein_description: 'RecName: Full=E3 ubiquitin-protein ligase ARIH1; EC=2.3.2.31<br />
+    {ECO:0000269|PubMed:15236971, ECO:0000269|PubMed:21532592, ECO:0000269|PubMed:27565346};<br />
+    AltName: Full=H7-AP2 {ECO:0000303|PubMed:10521492}; AltName: Full=HHARI {ECO:0000303|PubMed:11278816};<br />
+    AltName: Full=Monocyte protein 6 {ECO:0000303|Ref.10}; Short=MOP-6 {ECO:0000303|Ref.10};<br />
+    AltName: Full=Protein ariadne-1 homolog {ECO:0000303|Ref.3}; Short=ARI-1 {ECO:0000303|Ref.3};<br />
+    AltName: Full=UbcH7-binding protein {ECO:0000303|PubMed:11278816}; AltName: Full=UbcM4-interacting<br />
+    protein; AltName: Full=Ubiquitin-conjugating enzyme E2-binding protein 1 {ECO:0000303|PubMed:10521492};'<br />
+  gene_info: Name=ARIH1 {ECO:0000312|HGNC:HGNC:689}; Synonyms=ARI, MOP6 {ECO:0000303|Ref.10},<br />
+    UBCH7BP {ECO:0000303|PubMed:11278816}; ORFNames=HUSSY-27 {ECO:0000303|PubMed:11124703};<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the RBR family. Ariadne subfamily.<br />
+  protein_domains: Ariadne. (IPR045840); ARIH1-like_UBL. (IPR048962); E3_UB_ligase_RBR.<br />
+    (IPR031127); IBR_dom. (IPR002867); TRIAD_supradom. (IPR044066)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 30</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9Y4X5</li>
+<li><strong>Protein Description:</strong> RecName: Full=E3 ubiquitin-protein ligase ARIH1; EC=2.3.2.31 {ECO:0000269|PubMed:15236971, ECO:0000269|PubMed:21532592, ECO:0000269|PubMed:27565346}; AltName: Full=H7-AP2 {ECO:0000303|PubMed:10521492}; AltName: Full=HHARI {ECO:0000303|PubMed:11278816}; AltName: Full=Monocyte protein 6 {ECO:0000303|Ref.10}; Short=MOP-6 {ECO:0000303|Ref.10}; AltName: Full=Protein ariadne-1 homolog {ECO:0000303|Ref.3}; Short=ARI-1 {ECO:0000303|Ref.3}; AltName: Full=UbcH7-binding protein {ECO:0000303|PubMed:11278816}; AltName: Full=UbcM4-interacting protein; AltName: Full=Ubiquitin-conjugating enzyme E2-binding protein 1 {ECO:0000303|PubMed:10521492};</li>
+<li><strong>Gene Information:</strong> Name=ARIH1 {ECO:0000312|HGNC:HGNC:689}; Synonyms=ARI, MOP6 {ECO:0000303|Ref.10}, UBCH7BP {ECO:0000303|PubMed:11278816}; ORFNames=HUSSY-27 {ECO:0000303|PubMed:11124703};</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the RBR family. Ariadne subfamily.</li>
+<li><strong>Key Domains:</strong> Ariadne. (IPR045840); ARIH1-like_UBL. (IPR048962); E3_UB_ligase_RBR. (IPR031127); IBR_dom. (IPR002867); TRIAD_supradom. (IPR044066)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "ARIH1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'ARIH1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>ARIH1</strong> (gene ID: ARIH1, UniProt: Q9Y4X5) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9Y4X5</li>
+<li><strong>Protein Description:</strong> RecName: Full=E3 ubiquitin-protein ligase ARIH1; EC=2.3.2.31 {ECO:0000269|PubMed:15236971, ECO:0000269|PubMed:21532592, ECO:0000269|PubMed:27565346}; AltName: Full=H7-AP2 {ECO:0000303|PubMed:10521492}; AltName: Full=HHARI {ECO:0000303|PubMed:11278816}; AltName: Full=Monocyte protein 6 {ECO:0000303|Ref.10}; Short=MOP-6 {ECO:0000303|Ref.10}; AltName: Full=Protein ariadne-1 homolog {ECO:0000303|Ref.3}; Short=ARI-1 {ECO:0000303|Ref.3}; AltName: Full=UbcH7-binding protein {ECO:0000303|PubMed:11278816}; AltName: Full=UbcM4-interacting protein; AltName: Full=Ubiquitin-conjugating enzyme E2-binding protein 1 {ECO:0000303|PubMed:10521492};</li>
+<li><strong>Gene Information:</strong> Name=ARIH1 {ECO:0000312|HGNC:HGNC:689}; Synonyms=ARI, MOP6 {ECO:0000303|Ref.10}, UBCH7BP {ECO:0000303|PubMed:11278816}; ORFNames=HUSSY-27 {ECO:0000303|PubMed:11124703};</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the RBR family. Ariadne subfamily.</li>
+<li><strong>Key Domains:</strong> Ariadne. (IPR045840); ARIH1-like_UBL. (IPR048962); E3_UB_ligase_RBR. (IPR031127); IBR_dom. (IPR002867); TRIAD_supradom. (IPR044066)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "ARIH1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'ARIH1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>ARIH1</strong> (gene ID: ARIH1, UniProt: Q9Y4X5) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h1 id="research-report-human-arih1-hhari-functional-annotation-uniprot-q9y4x5">Research Report: Human <strong>ARIH1 (HHARI)</strong> Functional Annotation (UniProt Q9Y4X5)</h1>
+<h2 id="0-target-verification-critical">0) Target verification (critical)</h2>
+<p>The literature retrieved here consistently uses <strong>ARIH1</strong> to denote the human RBR-family E3 ligase <strong>HHARI</strong>, matching UniProt <strong>Q9Y4X5</strong> and the described <strong>Ariadne/RBR</strong> domain organization (RING1–IBR–RING2 plus Ariadne autoinhibitory region). (wang2023theunifyingcatalytic pages 1-2, smit2013ubiquitinchainformation pages 24-26)</p>
+<h2 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h2>
+<h3 id="11-arih1-is-an-rbr-ring-between-ring-e3-ubiquitin-ligase">1.1 ARIH1 is an RBR (RING-between-RING) E3 ubiquitin ligase</h3>
+<p>RBR E3 ligases are defined by a <strong>RING1–IBR–RING2</strong> module and use a <strong>two-step</strong> RING/HECT-hybrid catalytic mechanism. In step 1, a ubiquitin-charged E2 binds <strong>RING1</strong> and transfers ubiquitin to the E3’s <strong>RING2 catalytic cysteine</strong> (a <strong>transthiolation</strong> reaction). In step 2, ubiquitin is transferred from the E3~Ub thioester to a substrate lysine (aminolysis). This general mechanism explicitly includes <strong>HHARI/ARIH1</strong> as a canonical member. (wang2023theunifyingcatalytic pages 1-2)</p>
+<h3 id="12-core-reaction-catalyzed-and-substrate-specificity-functional-definition">1.2 Core reaction catalyzed and substrate specificity (functional definition)</h3>
+<p><strong>Reaction (EC 2.3.2.31)</strong>: transfer of ubiquitin from an E2 conjugating enzyme to substrate proteins via an ARIH1~Ub thioester intermediate. In physiological contexts, the strongest mechanistic evidence supports ARIH1’s role as a <strong>CRL-associated “priming” E3</strong>, placing an activated ubiquitin transfer module next to substrates bound to <strong>neddylated cullin-RING ligases (CRLs)</strong>—particularly <strong>SCF (CUL1–RBX1–SKP1–F-box)</strong> complexes. This geometry is proposed to be especially important for <strong>folded/spatially constrained substrates</strong> that canonical RING-only mechanisms cannot efficiently ubiquitinate. (hornghetko2021ubiquitinligationto pages 1-2, lin2024diversityofstructure pages 1-3)</p>
+<h3 id="13-neddylation-and-crlrbr-e3e3-cooperation">1.3 Neddylation and CRL–RBR “E3–E3” cooperation</h3>
+<p>A major current paradigm is that <strong>neddylated CRLs recruit and activate ARIH-family RBR ligases</strong>. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning. (hornghetko2021ubiquitinligationto pages 1-2, lin2024diversityofstructure pages 1-3)</p>
+<h2 id="2-molecular-mechanism-of-arih1-what-it-does-and-how">2) Molecular mechanism of ARIH1 (what it does and how)</h2>
+<h3 id="21-autoinhibition-and-activation">2.1 Autoinhibition and activation</h3>
+<p>ARIH1/HHARI is <strong>autoinhibited</strong> by its <strong>Ariadne domain</strong> and becomes activated through interactions with <strong>neddylated cullins/CRLs</strong> (and in broader RBR literature, phosphorylation is also described as an activating input for HHARI). (wang2023theunifyingcatalytic pages 1-2, hornghetko2024noncanonicalassemblyneddylation pages 2-3)</p>
+<h3 id="22-e2-partners-e2-to-e3-handoff">2.2 E2 partners (E2-to-E3 handoff)</h3>
+<p>In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from <strong>UBE2L3 (UbcH7)</strong> to the <strong>ARIH1 catalytic cysteine</strong> and then to an SCF-bound substrate. (hornghetko2021ubiquitinligationto pages 1-2)</p>
+<h3 id="23-structural-mechanism-scfarih1-e3e3-super-assembly">2.3 Structural mechanism: SCF–ARIH1 E3–E3 super-assembly</h3>
+<p>Horn-Ghetko et al. resolved intermediates by cryo-EM that visualize the sequence: <strong>E2~Ub → ARIH1 catalytic cysteine → substrate</strong> in the context of a <strong>neddylated SCF complex</strong>. This provides direct mechanistic support that ARIH1 can function as a <strong>catalytic partner</strong> of CRLs rather than acting solely as a standalone E3. (hornghetko2021ubiquitinligationto pages 1-2)</p>
+<p>Visual evidence supporting this mechanism is shown in the extracted figure panels (transition states and cycle schematic). (hornghetko2021ubiquitinligationto media a3b226ac, hornghetko2021ubiquitinligationto media f3b6a2dc)</p>
+<h3 id="24-2023-mechanistic-consolidation-for-rbrs-including-arih1">2.4 2023 mechanistic consolidation for RBRs (including ARIH1)</h3>
+<p>A 2023 Nature Communications study synthesized “unifying” RBR features, including the requirement for an <strong>open E2~Ub</strong> and alignment of the <strong>RING2 catalytic cysteine</strong> for transthiolation. HHARI/ARIH1 is explicitly included among RBRs whose activation involves interactions with <strong>neddylated cullins</strong>. (wang2023theunifyingcatalytic pages 1-2)</p>
+<h2 id="3-biological-roles-pathways-and-cellular-localization">3) Biological roles, pathways, and cellular localization</h2>
+<h3 id="31-proteostasis-and-cell-cycle-control-via-crl-substrates">3.1 Proteostasis and cell-cycle control via CRL substrates</h3>
+<p>In the SCF context, ARIH1 supports ubiquitination of substrates presented by F-box proteins (examples include <strong>phosphorylated cyclin E</strong> and <strong>p27</strong>), and perturbations stabilize multiple CRL substrates; genome-scale screening evidence places ARIH1 among genes important for cell viability in the same neighborhood as core SCF/neddylation components. (hornghetko2021ubiquitinligationto pages 1-2)</p>
+<h3 id="32-emt-and-cancer-progression-via-hnrnp-e1pcbp1-stability">3.2 EMT and cancer progression via hnRNP E1/PCBP1 stability</h3>
+<p>A mechanistically focused cancer study identified <strong>hnRNP E1 (PCBP1)</strong> as a direct ARIH1 substrate: ARIH1 promotes <strong>K48-linked ubiquitination</strong> and proteasomal degradation of hnRNP E1, and mutational analysis highlighted ubiquitinated lysines including <strong>K23, K314, K351</strong> with <strong>K314R</strong> increasing stability and reducing ubiquitination. (howley2022theubiquitine3 pages 1-3, howley2022theubiquitine3 pages 8-9)</p>
+<p>Functionally, ARIH1 knockdown delayed EMT and reduced invasion/stemness and tumor outcomes, whereas ARIH1 overexpression promoted EMT/invasion phenotypes; the study reports quantitative elements including <strong>74 enriched ARIH1 proximity interactors</strong> and statistically significant in vivo/clinical comparisons (e.g., paired tumor vs metastasis IHC and xenograft endpoints with reported P-values). (howley2022theubiquitine3 pages 8-9, howley2022theubiquitine3 pages 6-8)</p>
+<h3 id="33-translation-control-connections-context-and-evidence-base">3.3 Translation control connections (context and evidence base)</h3>
+<p>ARIH1 has been linked to translation control contexts (including DNA damage–related translation arrest) in the cancer-focused ARIH1 study, and ARIH1/HHARI has been discussed in the 4EHP/eIF4E2 literature as associating with 4EHP under specific cellular conditions. However, in the retrieved evidence set, the most direct substrate-level and phenotype-level support is for <strong>hnRNP E1</strong> and <strong>CRL/SCF substrates</strong> rather than for a single definitive translation-factor substrate. (howley2022theubiquitine3 pages 1-3, smit2013ubiquitinchainformation pages 26-29)</p>
+<h3 id="34-innate-immune-signaling-emergingless-mature-evidence">3.4 Innate immune signaling (emerging/less mature evidence)</h3>
+<p>A recent preprint reports HHARI/ARIH1 as an activator of <strong>RIG-I–mediated type I interferon</strong> signaling in a <strong>neddylation-dependent</strong> manner. It reports that the <strong>RING2 catalytic cysteine mutant (C357A)</strong> abolishes the phenotype, that HHARI physically interacts with RIG-I, and that inhibiting neddylation (NAE inhibitor <strong>MLN4924</strong>) suppresses HHARI-driven responses (including IFNβ secretion and downstream signaling readouts). This supports a model where HHARI’s regulation by neddylated CRLs can be functionally coupled to antiviral signaling. Because this is a preprint, it should be treated as emerging rather than fully consolidated. (kontra2025theacidicnterminus pages 33-35, kontra2025theacidicnterminus pages 9-12)</p>
+<h3 id="35-subcellular-localization">3.5 Subcellular localization</h3>
+<p>In tumor/pathology and cell-based studies, ARIH1 was detected in both <strong>cytoplasm and nucleus</strong> by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through <strong>complex formation</strong> with neddylated CRL assemblies (e.g., SCF). (howley2022theubiquitine3 pages 6-8, hornghetko2021ubiquitinligationto pages 1-2)</p>
+<h2 id="4-recent-developments-prioritize-20232024">4) Recent developments (prioritize 2023–2024)</h2>
+<h3 id="41-2024-refined-view-of-crl-geometry-and-catalytic-partnering">4.1 2024: refined view of CRL geometry and catalytic partnering</h3>
+<p>A 2024 Current Opinion in Structural Biology review highlights ARIH1/ARIH2 as CRL-associated RBR ligases that can perform <strong>priming</strong> ubiquitination and emphasizes that neddylation can strongly accelerate CRL reactions (including an example of <strong>~2000-fold acceleration</strong> for a UBE2D-mediated reaction in the CRL context). It also articulates a functional division where ARIH1 is favored for substrates that are geometrically hard to reach for the E2 in a RING-only mechanism. (lin2024diversityofstructure pages 3-5)</p>
+<h3 id="42-2024-broader-cullinrbr-chimeric-assemblies">4.2 2024: broader cullin–RBR chimeric assemblies</h3>
+<p>A 2024 Nature Structural &amp; Molecular Biology study on the vertebrate-specific CUL9 complex discusses ARIH-family RBR catalytic principles and emphasizes ARIH1-like autoinhibition/activation logic involving <strong>neddylated cullins</strong> and <strong>RBX RING</strong> interactions, underscoring that cullin–RBR cooperation is a recurring design in the ubiquitin system. (hornghetko2024noncanonicalassemblyneddylation pages 2-3)</p>
+<h3 id="43-2023-mechanistic-unification-of-the-rbr-family-including-hhari">4.3 2023: mechanistic unification of the RBR family including HHARI</h3>
+<p>The 2023 Nature Communications paper consolidated structural/biochemical principles underlying RBR catalysis, explicitly positioning HHARI/ARIH1 as part of an RBR family that uses a conserved transthiolation-centered catalytic cycle and can be activated in the context of neddylated cullins. (wang2023theunifyingcatalytic pages 1-2)</p>
+<h2 id="5-current-applications-and-real-world-implementations">5) Current applications and real-world implementations</h2>
+<h3 id="51-targeted-protein-degradation-tpd-and-protac-ecosystem-arih1-adjacent">5.1 Targeted protein degradation (TPD) and PROTAC ecosystem (ARIH1-adjacent)</h3>
+<p>While ARIH1 itself is not yet a common recruited ligase in marketed degraders, its core partner system—<strong>cullin-RING ligases</strong>—is central to real-world TPD. The 2024 structural review notes that <strong>CRL2\u1d5bVHL</strong> is a commonly used E3 ligase scaffold in PROTAC designs, highlighting the clinical/biotech relevance of CRLs. Because ARIH1 can act as a CRL catalytic partner for certain substrates, mechanistic understanding of ARIH1 expands the design space for how CRL-based ubiquitination can be engineered or inhibited. (lin2024diversityofstructure pages 3-5)</p>
+<h3 id="52-neddylation-as-a-pharmacologic-lever-relevant-to-arih1-activation">5.2 Neddylation as a pharmacologic lever (relevant to ARIH1 activation)</h3>
+<p>Because ARIH1 activation in multiple contexts depends on <strong>neddylated CRLs</strong>, neddylation is an actionable upstream node. In immune signaling experiments, neddylation inhibition with <strong>MLN4924</strong> suppressed HHARI/ARIH1-dependent phenotypes (preprint evidence). Conceptually, this points to neddylation as a potential therapeutic control point for processes where ARIH1 cooperates with CRLs, including CRL-driven proteostasis/cell-cycle and possibly innate immune signaling. (kontra2025theacidicnterminus pages 33-35)</p>
+<h3 id="53-disease-oriented-implementation-cancer-progression-mechanisms">5.3 Disease-oriented implementation: cancer progression mechanisms</h3>
+<p>ARIH1’s role in EMT and metastasis-like phenotypes (via hnRNP E1 stability control) positions it as a mechanistically grounded node for biomarker development or pathway intervention in oncology research settings. (howley2022theubiquitine3 pages 6-8, howley2022theubiquitine3 pages 1-3)</p>
+<h2 id="6-expert-synthesis-and-analysis-what-authoritative-sources-imply">6) Expert synthesis and analysis (what authoritative sources imply)</h2>
+<h3 id="61-primary-function-most-strongly-supported">6.1 Primary function (most strongly supported)</h3>
+<p>The strongest convergent evidence supports ARIH1 as a <strong>catalytic RBR E3 that cooperates with neddylated CRLs</strong> to enable ubiquitination of otherwise geometrically challenging substrates—acting as a “catalytic extender/primer” of CRL ubiquitination capacity rather than merely a standalone ligase. (hornghetko2021ubiquitinligationto pages 1-2, lin2024diversityofstructure pages 1-3)</p>
+<h3 id="62-where-the-field-is-still-uncertain">6.2 Where the field is still uncertain</h3>
+<p><em>Substrate scope:</em> Beyond SCF-presented substrates and hnRNP E1, ARIH1 substrate identification remains incomplete; reviews emphasize context dependence (substrate geometry, cullin identity, E2 choice). (lin2024diversityofstructure pages 1-3)</p>
+<p><em>Innate immunity:</em> HHARI/ARIH1–RIG-I signaling is supported by mechanistic perturbation in a preprint but awaits broader replication and peer-reviewed consolidation. (kontra2025theacidicnterminus pages 33-35)</p>
+<h3 id="63-constraintessentiality">6.3 Constraint/essentiality</h3>
+<p>Multiple lines of evidence are consistent with ARIH1 being fitness-relevant/essential: it appears as essential in cell-viability CRISPR screens in mechanistic work, and human population constraint commentary notes predicted loss-of-function variants are rare (preprint). (hornghetko2021ubiquitinligationto pages 1-2, kontra2025theacidicnterminus pages 9-12)</p>
+<h2 id="7-relevant-recent-statistics-and-quantitative-data-from-available-sources">7) Relevant recent statistics and quantitative data (from available sources)</h2>
+<ul>
+<li>Human E3 ligase repertoire: <strong>&gt;600 E3 ligases</strong> cited in a 2023 review, providing scale/context for ARIH1 within the UPS. (jeong2023targetinge3ubiquitin pages 1-2)</li>
+<li>NEDD8 impact on CRL catalysis: a 2024 structural review reports neddylation can accelerate a UBE2D-mediated CRL reaction by <strong>~2000-fold</strong> (context for why neddylation-dependent ARIH activation is biologically potent). (lin2024diversityofstructure pages 3-5)</li>
+<li>ARIH1 interactome size in a focused cancer study: <strong>74 enriched ARIH1 interactors</strong> via miniTurboID proximity labeling/MS. (howley2022theubiquitine3 pages 8-9)</li>
+<li>Quantitative/statistical phenotypes in cancer models: reported significant differences across IHC comparisons (paired tests) and in vivo tumor/colonization outcomes with reported P-values and group sizes in the ARIH1–hnRNP E1 study. (howley2022theubiquitine3 pages 6-8)</li>
+<li>Innate immune signaling readouts (emerging): IFNβ ELISA plots show outputs scaled up to approximately <strong>6,000 pg/mL</strong> and suppression by <strong>MLN4924 10 μM</strong> in HHARI-driven assays (preprint). (kontra2025theacidicnterminus pages 36-36, kontra2025theacidicnterminus pages 33-35)</li>
+</ul>
+<h2 id="8-database-level-disease-associations-hypothesis-generating">8) Database-level disease associations (hypothesis-generating)</h2>
+<p>Open Targets lists ARIH1 associations (varying strength and evidence counts) with broad disease categories including <strong>neoplasm</strong>, <strong>aortic aneurysm</strong>, <strong>thoracic aortic aneurysm</strong>, and <strong>neurodegenerative disease</strong>. These should be used as starting points for targeted literature review rather than as definitive causal claims. (OpenTargets Search: -ARIH1)</p>
+<h2 id="summary-table">Summary table</h2>
+<p>The following table consolidates ARIH1’s identity, mechanism, regulation, substrates, roles, and recent developments (with URLs and publication dates).</p>
+<table>
+<thead>
+<tr>
+<th>Functional aspect</th>
+<th>Specific details</th>
+<th>Key evidence type</th>
+<th>Primary supporting citations</th>
+<th>Source URL + publication date</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity / verified target</td>
+<td>Human <strong>ARIH1</strong> encodes <strong>HHARI</strong> (also called Ariadne RBR E3 ubiquitin protein ligase 1), an <strong>RBR-family</strong> E3 ligase with <strong>RING1–IBR–RING2</strong> catalytic core plus an <strong>Ariadne</strong> autoinhibitory region; this matches UniProt Q9Y4X5 and the Ariadne subfamily annotation.</td>
+<td>Structural/mechanistic paper; review</td>
+<td>(wang2023theunifyingcatalytic pages 1-2, smit2013ubiquitinchainformation pages 24-26)</td>
+<td>Wang et al., <em>Nat Commun</em> (2023-01), https://doi.org/10.1038/s41467-023-35871-z; Smit (2013, thesis/review-style source)</td>
+</tr>
+<tr>
+<td>Domain architecture</td>
+<td>RING1 recruits E2~Ub, IBR links the RBR scaffold, and RING2 contains the <strong>catalytic cysteine</strong> for transthiolation; the <strong>Ariadne domain</strong> restrains the catalytic module in an autoinhibited state until activation.</td>
+<td>Structural biology; biochemical mechanism</td>
+<td>(wang2023theunifyingcatalytic pages 1-2, hornghetko2024noncanonicalassemblyneddylation pages 2-3)</td>
+<td>Wang et al., <em>Nat Commun</em> (2023-01), https://doi.org/10.1038/s41467-023-35871-z; Horn-Ghetko et al., <em>Nat Struct Mol Biol</em> (2024-04), https://doi.org/10.1038/s41594-024-01257-y</td>
+</tr>
+<tr>
+<td>Catalytic mechanism</td>
+<td>ARIH1 uses the canonical <strong>RBR two-step mechanism</strong>: ubiquitin is transferred from an E2 to the <strong>RING2 catalytic cysteine</strong> of ARIH1 by <strong>transthiolation</strong>, then from ARIH1 to substrate by aminolysis.</td>
+<td>Cryo-EM; biochemistry; mechanistic review</td>
+<td>(wang2023theunifyingcatalytic pages 1-2, hornghetko2021ubiquitinligationto pages 1-2)</td>
+<td>Wang et al., <em>Nat Commun</em> (2023-01), https://doi.org/10.1038/s41467-023-35871-z; Horn-Ghetko et al., <em>Nature</em> (2021-02), https://doi.org/10.1038/s41586-021-03197-9</td>
+</tr>
+<tr>
+<td>Activation by neddylated CRLs</td>
+<td>A key current model is that <strong>neddylated cullin-RING ligases (CRLs)</strong> activate ARIH1 by relieving autoinhibition and positioning ARIH1 for substrate ubiquitination. ARIH1 cooperates especially with <strong>RBX1-containing CUL1/CUL2/CUL3</strong> complexes.</td>
+<td>Cryo-EM; structural/mechanistic review</td>
+<td>(hornghetko2024noncanonicalassemblyneddylation pages 2-3, wang2023theunifyingcatalytic pages 1-2, lin2024diversityofstructure pages 1-3)</td>
+<td>Horn-Ghetko et al., <em>Nat Struct Mol Biol</em> (2024-04), https://doi.org/10.1038/s41594-024-01257-y; Wang et al., <em>Nat Commun</em> (2023-01), https://doi.org/10.1038/s41467-023-35871-z; Lin &amp; Komives, <em>Curr Opin Struct Biol</em> (2024-10), https://doi.org/10.1016/j.sbi.2024.102879</td>
+</tr>
+<tr>
+<td>E3–E3 super-assembly with SCF ligases</td>
+<td>In a landmark model, <strong>neddylated SCF (CUL1–RBX1–SKP1–F-box) complexes</strong> and ARIH1 form an <strong>E3–E3 super-assembly</strong>. Cryo-EM visualized transfer from <strong>UBE2L3 to the ARIH1 catalytic cysteine and then to SCF-bound substrate</strong>, explaining how CRLs ubiquitinate geometrically difficult substrates.</td>
+<td>Cryo-EM; chemical probes; biochemistry</td>
+<td>(hornghetko2021ubiquitinligationto pages 1-2, hornghetko2021ubiquitinligationto media a3b226ac, hornghetko2021ubiquitinligationto media f3b6a2dc)</td>
+<td>Horn-Ghetko et al., <em>Nature</em> (2021-02), https://doi.org/10.1038/s41586-021-03197-9</td>
+</tr>
+<tr>
+<td>E2 partners</td>
+<td>ARIH1 is most strongly linked to <strong>UBE2L3/UbcH7</strong> as the donor E2 in the SCF–ARIH1 pathway; broader RBR work also uses <strong>UbcH5B/UBE2D-family</strong> conjugates to interrogate RBR catalysis, and older literature reported interaction with <strong>UBE2L3 and UBE2L6</strong>.</td>
+<td>Cryo-EM; ITC/biochemistry; older interaction literature</td>
+<td>(hornghetko2021ubiquitinligationto pages 1-2, wang2023theunifyingcatalytic pages 1-2, smit2013ubiquitinchainformation pages 26-29, kontra2025theacidicnterminus pages 37-37)</td>
+<td>Horn-Ghetko et al., <em>Nature</em> (2021-02), https://doi.org/10.1038/s41586-021-03197-9; Wang et al., <em>Nat Commun</em> (2023-01), https://doi.org/10.1038/s41467-023-35871-z</td>
+</tr>
+<tr>
+<td>Substrate class specificity</td>
+<td>ARIH1 appears particularly important for <strong>folded or spatially constrained CRL substrates</strong> that a canonical RING E2 cannot easily reach; by contrast, some extended or disordered substrates can be ubiquitinated without ARIH1.</td>
+<td>Mechanistic study; structural review</td>
+<td>(hornghetko2021ubiquitinligationto pages 1-2, lin2024diversityofstructure pages 1-3)</td>
+<td>Horn-Ghetko et al., <em>Nature</em> (2021-02), https://doi.org/10.1038/s41586-021-03197-9; Lin &amp; Komives, <em>Curr Opin Struct Biol</em> (2024-10), https://doi.org/10.1016/j.sbi.2024.102879</td>
+</tr>
+<tr>
+<td>Representative CRL-linked substrates</td>
+<td>In the SCF context, ARIH1 contributes to ubiquitination of substrates such as <strong>phosphorylated cyclin E</strong> and <strong>p27</strong>, and ARIH1 knockdown stabilizes multiple CRL substrates.</td>
+<td>Cryo-EM; biochemical and cellular perturbation</td>
+<td>(hornghetko2021ubiquitinligationto pages 1-2)</td>
+<td>Horn-Ghetko et al., <em>Nature</em> (2021-02), https://doi.org/10.1038/s41586-021-03197-9</td>
+</tr>
+<tr>
+<td>Direct substrate: hnRNP E1 (PCBP1)</td>
+<td><strong>hnRNP E1</strong> is a validated ARIH1 substrate in breast cancer models. ARIH1 promotes <strong>K48-linked ubiquitination</strong> and proteasomal degradation; ubiquitinated lysines include <strong>K23, K314, K351</strong>, with <strong>K314R</strong> increasing stability and reducing ubiquitination.</td>
+<td>Yeast 2-hybrid; miniTurboID proteomics; CHX chase; IP/immunoblot; mutagenesis</td>
+<td>(howley2022theubiquitine3 pages 8-9, howley2022theubiquitine3 pages 1-3)</td>
+<td>Howley et al., <em>Oncogene</em> (2022-01), https://doi.org/10.1038/s41388-022-02199-9</td>
+</tr>
+<tr>
+<td>Putative or previous substrate links</td>
+<td>Earlier literature associated HHARI/ARIH1 with <strong>4EHP/eIF4E2</strong> and with degradation of <strong>synphilin-1</strong> and <strong>SIM2</strong> in cells, but these links are less central and generally less definitive than the CRL-priming and hnRNP E1 data.</td>
+<td>Earlier cell-based studies; review</td>
+<td>(smit2013ubiquitinchainformation pages 26-29)</td>
+<td>Smit (2013, thesis/review-style source)</td>
+</tr>
+<tr>
+<td>Translation control / proteostasis</td>
+<td>Reviews of <strong>4EHP/eIF4E2</strong> note that under stress or DNA-damage contexts <strong>HHARI/ARIH1 accumulates and associates with 4EHP</strong>, linking ARIH1 to translational repression pathways; ARIH1 has also been implicated in DNA damage-induced translational arrest in cancer cells.</td>
+<td>Review; prior cell biology</td>
+<td>(howley2022theubiquitine3 pages 8-9)</td>
+<td>Christie &amp; Igreja, <em>FEBS J</em> (2023-11), https://doi.org/10.1111/febs.16275; Howley et al., <em>Oncogene</em> (2022-01), https://doi.org/10.1038/s41388-022-02199-9</td>
+</tr>
+<tr>
+<td>EMT / cancer progression</td>
+<td>ARIH1 promotes <strong>EMT</strong>, invasion, stemness, and tumor progression in breast cancer models; ARIH1 knockdown delays EMT, reduces invasion, and lowers tumor formation, while overexpression has the opposite effect.</td>
+<td>Cell assays; xenografts; IHC; proteomics</td>
+<td>(howley2022theubiquitine3 pages 1-3, howley2022theubiquitine3 pages 6-8)</td>
+<td>Howley et al., <em>Oncogene</em> (2022-01), https://doi.org/10.1038/s41388-022-02199-9</td>
+</tr>
+<tr>
+<td>Quantitative cancer-related findings</td>
+<td>MiniTurboID proximity labeling identified <strong>74 enriched ARIH1 interactors</strong>; metastasis IHC analyses in matched samples reported significant ARIH1 elevation (<strong>paired t-test P&lt;0.05</strong>), and xenograft or lung-colonization effects included significant differences (<strong>for example, two-way ANOVA with Bonferroni, P&lt;0.001 in reported experiments</strong>).</td>
+<td>Quantitative proteomics; pathology; in vivo assays</td>
+<td>(howley2022theubiquitine3 pages 8-9, howley2022theubiquitine3 pages 6-8)</td>
+<td>Howley et al., <em>Oncogene</em> (2022-01), https://doi.org/10.1038/s41388-022-02199-9</td>
+</tr>
+<tr>
+<td>Innate immunity / RIG-I signaling</td>
+<td>Recent work links HHARI/ARIH1 to <strong>RIG-I-mediated type I interferon signaling</strong>. Catalytic activity is required (<strong>C357A inactive</strong>), the acidic N-terminus is important, HHARI can interact with <strong>RIG-I</strong>, and responses are strongly <strong>neddylation-dependent</strong>.</td>
+<td>Preprint; cell signaling assays; co-IP; ELISA; microscopy</td>
+<td>(kontra2025theacidicnterminus pages 9-12, kontra2025theacidicnterminus pages 33-35, kontra2025theacidicnterminus pages 36-37)</td>
+<td>Kontra et al., <em>bioRxiv</em> (2025-02), https://doi.org/10.1101/2025.02.01.636034</td>
+</tr>
+<tr>
+<td>Quantitative immune findings</td>
+<td>In interferon assays, HHARI increased <strong>IFNβ secretion</strong> with readouts scaled up to about <strong>6,000 pg/mL</strong> in figures; <strong>MLN4924 (10 μM)</strong> suppressed HHARI-dependent signaling, and <strong>30 nM siRNA</strong> against <strong>DDX58/RIG-I</strong> or <strong>MAVS</strong> reduced HHARI-driven responses.</td>
+<td>ELISA; inhibitor studies; siRNA perturbation</td>
+<td>(kontra2025theacidicnterminus pages 36-36, kontra2025theacidicnterminus pages 33-35, kontra2025theacidicnterminus pages 36-37)</td>
+<td>Kontra et al., <em>bioRxiv</em> (2025-02), https://doi.org/10.1101/2025.02.01.636034</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>ARIH1 is primarily an <strong>intracellular</strong> ligase acting in the <strong>cytoplasm and nucleus</strong>; tumor studies detected ARIH1 staining in both compartments, and functionally ARIH1 operates in multiprotein complexes with CRLs, RNA-binding factors, and signaling proteins.</td>
+<td>IHC/cell biology; structural complex data</td>
+<td>(howley2022theubiquitine3 pages 6-8, hornghetko2021ubiquitinligationto pages 1-2)</td>
+<td>Howley et al., <em>Oncogene</em> (2022-01), https://doi.org/10.1038/s41388-022-02199-9; Horn-Ghetko et al., <em>Nature</em> (2021-02), https://doi.org/10.1038/s41586-021-03197-9</td>
+</tr>
+<tr>
+<td>Essentiality / constraint</td>
+<td>ARIH1 behaves like an <strong>essential or fitness-relevant UPS component</strong> in several datasets: genome-wide CRISPR screens identified ARIH1 as important for cell viability, and gnomAD-based commentary notes that predicted human <strong>loss-of-function variants are very rare</strong>.</td>
+<td>CRISPR screens; population genetics commentary</td>
+<td>(hornghetko2021ubiquitinligationto pages 1-2, kontra2025theacidicnterminus pages 9-12)</td>
+<td>Horn-Ghetko et al., <em>Nature</em> (2021-02), https://doi.org/10.1038/s41586-021-03197-9; Kontra et al., <em>bioRxiv</em> (2025-02), https://doi.org/10.1101/2025.02.01.636034</td>
+</tr>
+<tr>
+<td>Disease links / database-level associations</td>
+<td>Open Targets lists low-to-moderate evidence links between ARIH1 and <strong>neoplasm</strong>, <strong>aortic aneurysm</strong>, <strong>thoracic aortic aneurysm</strong>, <strong>neurodegenerative disease</strong>, and <strong>abruptio placentae</strong>; these are hypothesis-generating rather than definitive functional assignments.</td>
+<td>Database aggregation</td>
+<td>(OpenTargets Search: -ARIH1)</td>
+<td>Open Targets Platform query for ARIH1 (accessed via tool context; no publication date provided)</td>
+</tr>
+<tr>
+<td>Key 2023 development</td>
+<td>The 2023 mechanistic synthesis strengthened the view that <strong>HHARI/ARIH1 conforms to a unifying RBR catalytic mechanism</strong>, emphasizing the open E2~Ub conformation and allosteric activation features shared across RBR ligases.</td>
+<td>High-impact mechanistic paper</td>
+<td>(wang2023theunifyingcatalytic pages 1-2)</td>
+<td>Wang et al., <em>Nat Commun</em> (2023-01), https://doi.org/10.1038/s41467-023-35871-z</td>
+</tr>
+<tr>
+<td>Key 2024 developments</td>
+<td>2024 studies and reviews extended ARIH1 functional annotation by framing it as a <strong>geometrically optimized catalytic partner for CRLs</strong> and by generalizing ARIH-type cooperation across cullin ligase systems, including noncanonical cullin–RBR assemblies.</td>
+<td>Structural review; primary structural paper</td>
+<td>(hornghetko2024noncanonicalassemblyneddylation pages 2-3, lin2024diversityofstructure pages 1-3)</td>
+<td>Horn-Ghetko et al., <em>Nat Struct Mol Biol</em> (2024-04), https://doi.org/10.1038/s41594-024-01257-y; Lin &amp; Komives, <em>Curr Opin Struct Biol</em> (2024-10), https://doi.org/10.1016/j.sbi.2024.102879</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes verified identity, catalytic mechanism, activation, substrate biology, pathway roles, localization, and recent developments for human ARIH1/HHARI. It prioritizes 2023–2024 sources while retaining the key 2021 and 2022 primary papers that established major mechanistic and disease-relevant functions.</em></p>
+<h2 id="key-visual-evidence">Key visual evidence</h2>
+<p>Cryo-EM intermediates and cycle schematics supporting the <strong>SCF–ARIH1 E3–E3</strong> ubiquitination mechanism (E2~Ub → ARIH1 catalytic cysteine → substrate) are shown in extracted panels. (hornghetko2021ubiquitinligationto media a3b226ac, hornghetko2021ubiquitinligationto media f3b6a2dc)</p>
+<p>References</p>
+<ol>
+<li>
+<p>(wang2023theunifyingcatalytic pages 1-2): Xiangyi S. Wang, Thomas R. Cotton, Sarah J. Trevelyan, Lachlan W. Richardson, Wei Ting Lee, John Silke, and Bernhard C. Lechtenberg. The unifying catalytic mechanism of the ring-between-ring e3 ubiquitin ligase family. Nature Communications, Jan 2023. URL: https://doi.org/10.1038/s41467-023-35871-z, doi:10.1038/s41467-023-35871-z. This article has 65 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(smit2013ubiquitinchainformation pages 24-26): J Smit. Ubiquitin chain formation by rbr e3-ligases. Unknown journal, 2013.</p>
+</li>
+<li>
+<p>(hornghetko2021ubiquitinligationto pages 1-2): Daniel Horn-Ghetko, David T. Krist, J. Rajan Prabu, Kheewoong Baek, Monique P. C. Mulder, Maren Klügel, Daniel C. Scott, Huib Ovaa, Gary Kleiger, and Brenda A. Schulman. Ubiquitin ligation to f-box protein targets by scf–rbr e3–e3 super-assembly. Nature, 590:671-676, Feb 2021. URL: https://doi.org/10.1038/s41586-021-03197-9, doi:10.1038/s41586-021-03197-9. This article has 199 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lin2024diversityofstructure pages 1-3): Calvin P. Lin and Elizabeth A. Komives. Diversity of structure and function in cullin e3 ligases. Current Opinion in Structural Biology, 88:102879, Oct 2024. URL: https://doi.org/10.1016/j.sbi.2024.102879, doi:10.1016/j.sbi.2024.102879. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hornghetko2024noncanonicalassemblyneddylation pages 2-3): Daniel Horn-Ghetko, Linus V. M. Hopf, Ishita Tripathi-Giesgen, Jiale Du, Sebastian Kostrhon, D. Tung Vu, Viola Beier, Barbara Steigenberger, J. Rajan Prabu, Luca Stier, Elias M. Bruss, Matthias Mann, Yue Xiong, and Brenda A. Schulman. Noncanonical assembly, neddylation and chimeric cullin–ring/rbr ubiquitylation by the 1.8 mda cul9 e3 ligase complex. Nature Structural &amp; Molecular Biology, 31:1083-1094, Apr 2024. URL: https://doi.org/10.1038/s41594-024-01257-y, doi:10.1038/s41594-024-01257-y. This article has 13 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hornghetko2021ubiquitinligationto media a3b226ac): Daniel Horn-Ghetko, David T. Krist, J. Rajan Prabu, Kheewoong Baek, Monique P. C. Mulder, Maren Klügel, Daniel C. Scott, Huib Ovaa, Gary Kleiger, and Brenda A. Schulman. Ubiquitin ligation to f-box protein targets by scf–rbr e3–e3 super-assembly. Nature, 590:671-676, Feb 2021. URL: https://doi.org/10.1038/s41586-021-03197-9, doi:10.1038/s41586-021-03197-9. This article has 199 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hornghetko2021ubiquitinligationto media f3b6a2dc): Daniel Horn-Ghetko, David T. Krist, J. Rajan Prabu, Kheewoong Baek, Monique P. C. Mulder, Maren Klügel, Daniel C. Scott, Huib Ovaa, Gary Kleiger, and Brenda A. Schulman. Ubiquitin ligation to f-box protein targets by scf–rbr e3–e3 super-assembly. Nature, 590:671-676, Feb 2021. URL: https://doi.org/10.1038/s41586-021-03197-9, doi:10.1038/s41586-021-03197-9. This article has 199 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(howley2022theubiquitine3 pages 1-3): Breege V. Howley, Bidyut Mohanty, Annamarie Dalton, Simon Grelet, Joseph Karam, Toros Dincman, and Philip H. Howe. The ubiquitin e3 ligase arih1 regulates hnrnp e1 protein stability, emt and breast cancer progression. Oncogene, 41:1679-1690, Jan 2022. URL: https://doi.org/10.1038/s41388-022-02199-9, doi:10.1038/s41388-022-02199-9. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(howley2022theubiquitine3 pages 8-9): Breege V. Howley, Bidyut Mohanty, Annamarie Dalton, Simon Grelet, Joseph Karam, Toros Dincman, and Philip H. Howe. The ubiquitin e3 ligase arih1 regulates hnrnp e1 protein stability, emt and breast cancer progression. Oncogene, 41:1679-1690, Jan 2022. URL: https://doi.org/10.1038/s41388-022-02199-9, doi:10.1038/s41388-022-02199-9. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(howley2022theubiquitine3 pages 6-8): Breege V. Howley, Bidyut Mohanty, Annamarie Dalton, Simon Grelet, Joseph Karam, Toros Dincman, and Philip H. Howe. The ubiquitin e3 ligase arih1 regulates hnrnp e1 protein stability, emt and breast cancer progression. Oncogene, 41:1679-1690, Jan 2022. URL: https://doi.org/10.1038/s41388-022-02199-9, doi:10.1038/s41388-022-02199-9. This article has 40 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(smit2013ubiquitinchainformation pages 26-29): J Smit. Ubiquitin chain formation by rbr e3-ligases. Unknown journal, 2013.</p>
+</li>
+<li>
+<p>(kontra2025theacidicnterminus pages 33-35): Ioanna Kontra, Harry Ward, Faith Vinluan, Rachel Lau, Vinothini Rajeeve, Pedro Cutillas, Benjamin Stieglitz, and Myles J. Lewis. The acidic n-terminus of hhari and neddylation are essential for the activation and maintenance of rig-i-mediated type i interferon response. bioRxiv, Feb 2025. URL: https://doi.org/10.1101/2025.02.01.636034, doi:10.1101/2025.02.01.636034. This article has 0 citations.</p>
+</li>
+<li>
+<p>(kontra2025theacidicnterminus pages 9-12): Ioanna Kontra, Harry Ward, Faith Vinluan, Rachel Lau, Vinothini Rajeeve, Pedro Cutillas, Benjamin Stieglitz, and Myles J. Lewis. The acidic n-terminus of hhari and neddylation are essential for the activation and maintenance of rig-i-mediated type i interferon response. bioRxiv, Feb 2025. URL: https://doi.org/10.1101/2025.02.01.636034, doi:10.1101/2025.02.01.636034. This article has 0 citations.</p>
+</li>
+<li>
+<p>(lin2024diversityofstructure pages 3-5): Calvin P. Lin and Elizabeth A. Komives. Diversity of structure and function in cullin e3 ligases. Current Opinion in Structural Biology, 88:102879, Oct 2024. URL: https://doi.org/10.1016/j.sbi.2024.102879, doi:10.1016/j.sbi.2024.102879. This article has 14 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jeong2023targetinge3ubiquitin pages 1-2): Yelin Jeong, Ah-Reum Oh, Young Hoon Jung, HyunJoon Gi, Young Un Kim, and KyeongJin Kim. Targeting e3 ubiquitin ligases and their adaptors as a therapeutic strategy for metabolic diseases. Experimental &amp; Molecular Medicine, 55:2097-2104, Oct 2023. URL: https://doi.org/10.1038/s12276-023-01087-w, doi:10.1038/s12276-023-01087-w. This article has 56 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kontra2025theacidicnterminus pages 36-36): Ioanna Kontra, Harry Ward, Faith Vinluan, Rachel Lau, Vinothini Rajeeve, Pedro Cutillas, Benjamin Stieglitz, and Myles J. Lewis. The acidic n-terminus of hhari and neddylation are essential for the activation and maintenance of rig-i-mediated type i interferon response. bioRxiv, Feb 2025. URL: https://doi.org/10.1101/2025.02.01.636034, doi:10.1101/2025.02.01.636034. This article has 0 citations.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -ARIH1): Open Targets Query (-ARIH1, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(kontra2025theacidicnterminus pages 37-37): Ioanna Kontra, Harry Ward, Faith Vinluan, Rachel Lau, Vinothini Rajeeve, Pedro Cutillas, Benjamin Stieglitz, and Myles J. Lewis. The acidic n-terminus of hhari and neddylation are essential for the activation and maintenance of rig-i-mediated type i interferon response. bioRxiv, Feb 2025. URL: https://doi.org/10.1101/2025.02.01.636034, doi:10.1101/2025.02.01.636034. This article has 0 citations.</p>
+</li>
+<li>
+<p>(kontra2025theacidicnterminus pages 36-37): Ioanna Kontra, Harry Ward, Faith Vinluan, Rachel Lau, Vinothini Rajeeve, Pedro Cutillas, Benjamin Stieglitz, and Myles J. Lewis. The acidic n-terminus of hhari and neddylation are essential for the activation and maintenance of rig-i-mediated type i interferon response. bioRxiv, Feb 2025. URL: https://doi.org/10.1101/2025.02.01.636034, doi:10.1101/2025.02.01.636034. This article has 0 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>wang2023theunifyingcatalytic pages 1-2</li>
+<li>hornghetko2021ubiquitinligationto pages 1-2</li>
+<li>lin2024diversityofstructure pages 3-5</li>
+<li>hornghetko2024noncanonicalassemblyneddylation pages 2-3</li>
+<li>kontra2025theacidicnterminus pages 33-35</li>
+<li>lin2024diversityofstructure pages 1-3</li>
+<li>smit2013ubiquitinchainformation pages 26-29</li>
+<li>smit2013ubiquitinchainformation pages 24-26</li>
+<li>kontra2025theacidicnterminus pages 9-12</li>
+<li>kontra2025theacidicnterminus pages 36-36</li>
+<li>kontra2025theacidicnterminus pages 37-37</li>
+<li>kontra2025theacidicnterminus pages 36-37</li>
+<li>https://doi.org/10.1038/s41467-023-35871-z;</li>
+<li>https://doi.org/10.1038/s41594-024-01257-y</li>
+<li>https://doi.org/10.1038/s41586-021-03197-9</li>
+<li>https://doi.org/10.1038/s41594-024-01257-y;</li>
+<li>https://doi.org/10.1016/j.sbi.2024.102879</li>
+<li>https://doi.org/10.1038/s41586-021-03197-9;</li>
+<li>https://doi.org/10.1038/s41467-023-35871-z</li>
+<li>https://doi.org/10.1038/s41388-022-02199-9</li>
+<li>https://doi.org/10.1111/febs.16275;</li>
+<li>https://doi.org/10.1101/2025.02.01.636034</li>
+<li>https://doi.org/10.1038/s41388-022-02199-9;</li>
+<li>https://doi.org/10.1038/s41467-023-35871-z,</li>
+<li>https://doi.org/10.1038/s41586-021-03197-9,</li>
+<li>https://doi.org/10.1016/j.sbi.2024.102879,</li>
+<li>https://doi.org/10.1038/s41594-024-01257-y,</li>
+<li>https://doi.org/10.1038/s41388-022-02199-9,</li>
+<li>https://doi.org/10.1101/2025.02.01.636034,</li>
+<li>https://doi.org/10.1038/s12276-023-01087-w,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -5248,729 +7673,1554 @@
                 <pre><code>id: Q9Y4X5
 gene_symbol: ARIH1
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: &#39;TODO: Add description for ARIH1&#39;
+description: &#39;ARIH1 encodes HHARI, an intracellular Ariadne/RBR E3 ubiquitin ligase that catalyzes
+  ubiquitin transfer through a RING1-IBR-RING2 mechanism and is activated by neddylated cullin-RING
+  ligase complexes, especially SCF assemblies, to prime ubiquitination of constrained CRL
+  substrates.&#39;
 existing_annotations:
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0031624
-    label: ubiquitin conjugating enzyme binding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0006511
-    label: ubiquitin-dependent protein catabolic process
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0061630
-    label: ubiquitin protein ligase activity
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0000151
-    label: ubiquitin ligase complex
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005634
-    label: nucleus
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0004842
-    label: ubiquitin-protein transferase activity
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005634
-    label: nucleus
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0008270
-    label: zinc ion binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0015030
-    label: Cajal body
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0016567
-    label: protein ubiquitination
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0046872
-    label: metal ion binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0061630
-    label: ubiquitin protein ligase activity
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000003
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:21145461
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:21532592
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:23707686
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:24076655
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:28514442
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:33961781
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005654
-    label: nucleoplasm
-  evidence_type: IDA
-  original_reference_id: GO_REF:0000052
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0039585
-    label: PKR/eIFalpha signaling
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-9833482
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0061662
-    label: ISG15 ligase activity
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169394
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0061662
-    label: ISG15 ligase activity
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169395
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0061662
-    label: ISG15 ligase activity
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169398
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0061662
-    label: ISG15 ligase activity
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169402
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0061662
-    label: ISG15 ligase activity
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169405
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0061662
-    label: ISG15 ligase activity
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169406
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0061662
-    label: ISG15 ligase activity
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-9833973
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0004842
-    label: ubiquitin-protein transferase activity
-  evidence_type: IDA
-  original_reference_id: PMID:23707686
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0004842
-    label: ubiquitin-protein transferase activity
-  evidence_type: IDA
-  original_reference_id: PMID:24076655
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0004842
-    label: ubiquitin-protein transferase activity
-  evidence_type: IDA
-  original_reference_id: PMID:27565346
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: IDA
-  original_reference_id: PMID:23059369
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0008270
-    label: zinc ion binding
-  evidence_type: IDA
-  original_reference_id: PMID:23707686
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0016567
-    label: protein ubiquitination
-  evidence_type: IDA
-  original_reference_id: PMID:23707686
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0016567
-    label: protein ubiquitination
-  evidence_type: IDA
-  original_reference_id: PMID:24076655
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0016567
-    label: protein ubiquitination
-  evidence_type: IDA
-  original_reference_id: PMID:27565346
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0016604
-    label: nuclear body
-  evidence_type: IDA
-  original_reference_id: PMID:23059369
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0019005
-    label: SCF ubiquitin ligase complex
-  evidence_type: IDA
-  original_reference_id: PMID:24076655
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0019005
-    label: SCF ubiquitin ligase complex
-  evidence_type: IDA
-  original_reference_id: PMID:27565346
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0031462
-    label: Cul2-RING ubiquitin ligase complex
-  evidence_type: IDA
-  original_reference_id: PMID:27565346
-  negated: true
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0031462
-    label: Cul2-RING ubiquitin ligase complex
-  evidence_type: IDA
-  original_reference_id: PMID:24076655
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0031463
-    label: Cul3-RING ubiquitin ligase complex
-  evidence_type: IDA
-  original_reference_id: PMID:24076655
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0031463
-    label: Cul3-RING ubiquitin ligase complex
-  evidence_type: IDA
-  original_reference_id: PMID:27565346
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0031464
-    label: Cul4A-RING E3 ubiquitin ligase complex
-  evidence_type: IDA
-  original_reference_id: PMID:24076655
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0031624
-    label: ubiquitin conjugating enzyme binding
-  evidence_type: IPI
-  original_reference_id: PMID:23707686
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0031624
-    label: ubiquitin conjugating enzyme binding
-  evidence_type: IPI
-  original_reference_id: PMID:24076655
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0031624
-    label: ubiquitin conjugating enzyme binding
-  evidence_type: IPI
-  original_reference_id: PMID:27565346
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0097413
-    label: Lewy body
-  evidence_type: IDA
-  original_reference_id: PMID:21590270
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169394
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169395
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169398
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169402
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169403
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169405
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169406
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1678843
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-9833973
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-9837231
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-9927247
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0004842
-    label: ubiquitin-protein transferase activity
-  evidence_type: IDA
-  original_reference_id: PMID:14623119
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0004842
-    label: ubiquitin-protein transferase activity
-  evidence_type: IDA
-  original_reference_id: PMID:15236971
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0004842
-    label: ubiquitin-protein transferase activity
-  evidence_type: IDA
-  original_reference_id: PMID:21532592
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:14623119
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: IDA
-  original_reference_id: PMID:11278816
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0008270
-    label: zinc ion binding
-  evidence_type: IDA
-  original_reference_id: PMID:15236971
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0016567
-    label: protein ubiquitination
-  evidence_type: IDA
-  original_reference_id: PMID:14623119
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0016567
-    label: protein ubiquitination
-  evidence_type: IDA
-  original_reference_id: PMID:15236971
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0016567
-    label: protein ubiquitination
-  evidence_type: IDA
-  original_reference_id: PMID:21532592
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0031625
-    label: ubiquitin protein ligase binding
-  evidence_type: IPI
-  original_reference_id: PMID:11278816
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0031625
-    label: ubiquitin protein ligase binding
-  evidence_type: IPI
-  original_reference_id: PMID:21532592
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:10521492
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0000151
-    label: ubiquitin ligase complex
-  evidence_type: TAS
-  original_reference_id: PMID:10521492
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0006511
-    label: ubiquitin-dependent protein catabolic process
-  evidence_type: TAS
-  original_reference_id: PMID:10521492
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
-- term:
-    id: GO:0019787
-    label: ubiquitin-like protein transferase activity
-  evidence_type: TAS
-  original_reference_id: PMID:10521492
-  review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: cytoplasm localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0031624
+      label: ubiquitin conjugating enzyme binding
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: ARIH1 binding to ubiquitin-conjugating enzymes is part of its core RBR
+        catalytic cycle, with UBE2L3/UbcH7 the best-supported donor E2.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0006511
+      label: ubiquitin-dependent protein catabolic process
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: ubiquitin-dependent protein catabolic process is supported by the
+        catalytic role of ARIH1 in ubiquitination and downstream ubiquitin-dependent
+        substrate turnover, especially as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0061630
+      label: ubiquitin protein ligase activity
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: &#39;ubiquitin protein ligase activity is a core ARIH1 function: ARIH1/HHARI is
+        an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.&#39;
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0000151
+      label: ubiquitin ligase complex
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: ARIH1 forms functional ubiquitin ligase assemblies with neddylated CRLs;
+        this broad complex annotation captures that E3-ligase-complex context.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: nucleus localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0004842
+      label: ubiquitin-protein transferase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    review:
+      summary: &#39;ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI
+        is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.&#39;
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    review:
+      summary: nucleus localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    review:
+      summary: cytoplasm localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0008270
+      label: zinc ion binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    review:
+      summary: ARIH1 contains RING/IBR/RING zinc-finger domains required for its RBR E3
+        mechanism, so zinc ion binding is supported.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0015030
+      label: Cajal body
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    review:
+      summary: Cajal body is retained as a reported localization or colocalization but
+        is not part of the core ARIH1 ubiquitin-ligase mechanism.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Nucleus, Cajal body
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Present in Lewy body
+  - term:
+      id: GO:0016567
+      label: protein ubiquitination
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    review:
+      summary: protein ubiquitination is supported by the catalytic role of ARIH1 in
+        ubiquitination and downstream ubiquitin-dependent substrate turnover, especially
+        as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0046872
+      label: metal ion binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    review:
+      summary: The metal-binding evidence is specifically zinc binding by RING/IBR/RING
+        domains; the broad metal ion binding term should be replaced by zinc ion
+        binding.
+      action: MODIFY
+      reason: Specific zinc-binding domains are known; the generic metal ion binding
+        term is less informative.
+      proposed_replacement_terms:
+        - id: GO:0008270
+          label: zinc ion binding
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0061630
+      label: ubiquitin protein ligase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000003
+    review:
+      summary: &#39;ubiquitin protein ligase activity is a core ARIH1 function: ARIH1/HHARI is
+        an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.&#39;
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:21145461
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:21532592
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:23707686
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:24076655
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:28514442
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:33961781
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005654
+      label: nucleoplasm
+    evidence_type: IDA
+    original_reference_id: GO_REF:0000052
+    review:
+      summary: nucleoplasm localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0039585
+      label: PKR/eIFalpha signaling
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-9833482
+    review:
+      summary: PKR/eIFalpha signaling is a pathway-level consequence in Reactome rather
+        than the core molecular role of ARIH1; keep it as non-core while prioritizing
+        ubiquitin/ubiquitin-like ligase activity.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+  - term:
+      id: GO:0061662
+      label: ISG15 ligase activity
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169394
+    review:
+      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
+        activity in Reactome/UniProt, but the strongest mechanistic literature supports
+        ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
+  - term:
+      id: GO:0061662
+      label: ISG15 ligase activity
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169395
+    review:
+      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
+        activity in Reactome/UniProt, but the strongest mechanistic literature supports
+        ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
+  - term:
+      id: GO:0061662
+      label: ISG15 ligase activity
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169398
+    review:
+      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
+        activity in Reactome/UniProt, but the strongest mechanistic literature supports
+        ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
+  - term:
+      id: GO:0061662
+      label: ISG15 ligase activity
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169402
+    review:
+      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
+        activity in Reactome/UniProt, but the strongest mechanistic literature supports
+        ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
+  - term:
+      id: GO:0061662
+      label: ISG15 ligase activity
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169405
+    review:
+      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
+        activity in Reactome/UniProt, but the strongest mechanistic literature supports
+        ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
+  - term:
+      id: GO:0061662
+      label: ISG15 ligase activity
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169406
+    review:
+      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
+        activity in Reactome/UniProt, but the strongest mechanistic literature supports
+        ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
+  - term:
+      id: GO:0061662
+      label: ISG15 ligase activity
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-9833973
+    review:
+      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
+        activity in Reactome/UniProt, but the strongest mechanistic literature supports
+        ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
+  - term:
+      id: GO:0004842
+      label: ubiquitin-protein transferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:23707686
+    review:
+      summary: &#39;ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI
+        is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.&#39;
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0004842
+      label: ubiquitin-protein transferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:24076655
+    review:
+      summary: &#39;ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI
+        is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.&#39;
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0004842
+      label: ubiquitin-protein transferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:27565346
+    review:
+      summary: &#39;ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI
+        is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.&#39;
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IDA
+    original_reference_id: PMID:23059369
+    review:
+      summary: cytoplasm localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0008270
+      label: zinc ion binding
+    evidence_type: IDA
+    original_reference_id: PMID:23707686
+    review:
+      summary: ARIH1 contains RING/IBR/RING zinc-finger domains required for its RBR E3
+        mechanism, so zinc ion binding is supported.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0016567
+      label: protein ubiquitination
+    evidence_type: IDA
+    original_reference_id: PMID:23707686
+    review:
+      summary: protein ubiquitination is supported by the catalytic role of ARIH1 in
+        ubiquitination and downstream ubiquitin-dependent substrate turnover, especially
+        as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0016567
+      label: protein ubiquitination
+    evidence_type: IDA
+    original_reference_id: PMID:24076655
+    review:
+      summary: protein ubiquitination is supported by the catalytic role of ARIH1 in
+        ubiquitination and downstream ubiquitin-dependent substrate turnover, especially
+        as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0016567
+      label: protein ubiquitination
+    evidence_type: IDA
+    original_reference_id: PMID:27565346
+    review:
+      summary: protein ubiquitination is supported by the catalytic role of ARIH1 in
+        ubiquitination and downstream ubiquitin-dependent substrate turnover, especially
+        as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0016604
+      label: nuclear body
+    evidence_type: IDA
+    original_reference_id: PMID:23059369
+    review:
+      summary: nuclear body is retained as a reported localization or colocalization but
+        is not part of the core ARIH1 ubiquitin-ligase mechanism.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Nucleus, Cajal body
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Present in Lewy body
+  - term:
+      id: GO:0019005
+      label: SCF ubiquitin ligase complex
+    evidence_type: IDA
+    original_reference_id: PMID:24076655
+    review:
+      summary: &#39;SCF ubiquitin ligase complex association is part of the best-supported ARIH1
+        mechanism: ARIH1 cooperates with neddylated SCF complexes as a catalytic E3-E3 super-assembly
+        for CRL substrate ubiquitination.&#39;
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0019005
+      label: SCF ubiquitin ligase complex
+    evidence_type: IDA
+    original_reference_id: PMID:27565346
+    review:
+      summary: &#39;SCF ubiquitin ligase complex association is part of the best-supported ARIH1
+        mechanism: ARIH1 cooperates with neddylated SCF complexes as a catalytic E3-E3 super-assembly
+        for CRL substrate ubiquitination.&#39;
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0031462
+      label: Cul2-RING ubiquitin ligase complex
+    evidence_type: IDA
+    original_reference_id: PMID:27565346
+    negated: true
+    review:
+      summary: This NOT-qualified CRL-complex annotation should be retained for the
+        specific experimental context, while broader evidence supports ARIH1 cooperation
+        with other neddylated cullin complexes.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0031462
+      label: Cul2-RING ubiquitin ligase complex
+    evidence_type: IDA
+    original_reference_id: PMID:24076655
+    review:
+      summary: Cul2-RING ubiquitin ligase complex association is supported as a CRL
+        partnership for ARIH1; it is retained as a non-core complex context rather than
+        the core catalytic activity itself.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0031463
+      label: Cul3-RING ubiquitin ligase complex
+    evidence_type: IDA
+    original_reference_id: PMID:24076655
+    review:
+      summary: Cul3-RING ubiquitin ligase complex association is supported as a CRL
+        partnership for ARIH1; it is retained as a non-core complex context rather than
+        the core catalytic activity itself.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0031463
+      label: Cul3-RING ubiquitin ligase complex
+    evidence_type: IDA
+    original_reference_id: PMID:27565346
+    review:
+      summary: Cul3-RING ubiquitin ligase complex association is supported as a CRL
+        partnership for ARIH1; it is retained as a non-core complex context rather than
+        the core catalytic activity itself.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0031464
+      label: Cul4A-RING E3 ubiquitin ligase complex
+    evidence_type: IDA
+    original_reference_id: PMID:24076655
+    review:
+      summary: Cul4A-RING E3 ubiquitin ligase complex association is supported as a CRL
+        partnership for ARIH1; it is retained as a non-core complex context rather than
+        the core catalytic activity itself.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0031624
+      label: ubiquitin conjugating enzyme binding
+    evidence_type: IPI
+    original_reference_id: PMID:23707686
+    review:
+      summary: ARIH1 binding to ubiquitin-conjugating enzymes is part of its core RBR
+        catalytic cycle, with UBE2L3/UbcH7 the best-supported donor E2.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0031624
+      label: ubiquitin conjugating enzyme binding
+    evidence_type: IPI
+    original_reference_id: PMID:24076655
+    review:
+      summary: ARIH1 binding to ubiquitin-conjugating enzymes is part of its core RBR
+        catalytic cycle, with UBE2L3/UbcH7 the best-supported donor E2.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0031624
+      label: ubiquitin conjugating enzyme binding
+    evidence_type: IPI
+    original_reference_id: PMID:27565346
+    review:
+      summary: ARIH1 binding to ubiquitin-conjugating enzymes is part of its core RBR
+        catalytic cycle, with UBE2L3/UbcH7 the best-supported donor E2.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0097413
+      label: Lewy body
+    evidence_type: IDA
+    original_reference_id: PMID:21590270
+    review:
+      summary: Lewy body is retained as a reported localization or colocalization but is
+        not part of the core ARIH1 ubiquitin-ligase mechanism.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Nucleus, Cajal body
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Present in Lewy body
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169394
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169395
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169398
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169402
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169403
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169405
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169406
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1678843
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-9833973
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-9837231
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-9927247
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0004842
+      label: ubiquitin-protein transferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:14623119
+    review:
+      summary: &#39;ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI
+        is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.&#39;
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0004842
+      label: ubiquitin-protein transferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:15236971
+    review:
+      summary: &#39;ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI
+        is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.&#39;
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0004842
+      label: ubiquitin-protein transferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:21532592
+    review:
+      summary: &#39;ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI
+        is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.&#39;
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:14623119
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IDA
+    original_reference_id: PMID:11278816
+    review:
+      summary: cytoplasm localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0008270
+      label: zinc ion binding
+    evidence_type: IDA
+    original_reference_id: PMID:15236971
+    review:
+      summary: ARIH1 contains RING/IBR/RING zinc-finger domains required for its RBR E3
+        mechanism, so zinc ion binding is supported.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+  - term:
+      id: GO:0016567
+      label: protein ubiquitination
+    evidence_type: IDA
+    original_reference_id: PMID:14623119
+    review:
+      summary: protein ubiquitination is supported by the catalytic role of ARIH1 in
+        ubiquitination and downstream ubiquitin-dependent substrate turnover, especially
+        as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0016567
+      label: protein ubiquitination
+    evidence_type: IDA
+    original_reference_id: PMID:15236971
+    review:
+      summary: protein ubiquitination is supported by the catalytic role of ARIH1 in
+        ubiquitination and downstream ubiquitin-dependent substrate turnover, especially
+        as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0016567
+      label: protein ubiquitination
+    evidence_type: IDA
+    original_reference_id: PMID:21532592
+    review:
+      summary: protein ubiquitination is supported by the catalytic role of ARIH1 in
+        ubiquitination and downstream ubiquitin-dependent substrate turnover, especially
+        as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0031625
+      label: ubiquitin protein ligase binding
+    evidence_type: IPI
+    original_reference_id: PMID:11278816
+    review:
+      summary: Specific binding to ubiquitin ligase complexes is supported through ARIH1
+        cooperation with neddylated CRLs, but it is a complex-association context rather
+        than the primary catalytic function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0031625
+      label: ubiquitin protein ligase binding
+    evidence_type: IPI
+    original_reference_id: PMID:21532592
+    review:
+      summary: Specific binding to ubiquitin ligase complexes is supported through ARIH1
+        cooperation with neddylated CRLs, but it is a complex-association context rather
+        than the primary catalytic function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:10521492
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0000151
+      label: ubiquitin ligase complex
+    evidence_type: TAS
+    original_reference_id: PMID:10521492
+    review:
+      summary: ARIH1 forms functional ubiquitin ligase assemblies with neddylated CRLs;
+        this broad complex annotation captures that E3-ligase-complex context.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0006511
+      label: ubiquitin-dependent protein catabolic process
+    evidence_type: TAS
+    original_reference_id: PMID:10521492
+    review:
+      summary: ubiquitin-dependent protein catabolic process is supported by the
+        catalytic role of ARIH1 in ubiquitination and downstream ubiquitin-dependent
+        substrate turnover, especially as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0019787
+      label: ubiquitin-like protein transferase activity
+    evidence_type: TAS
+    original_reference_id: PMID:10521492
+    review:
+      summary: ubiquitin-like protein transferase activity is supported as a
+        ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest
+        mechanistic literature supports ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
 references:
-- id: GO_REF:0000002
-  title: Gene Ontology annotation through association of InterPro records with GO
-    terms
-  findings: []
-- id: GO_REF:0000003
-  title: Gene Ontology annotation based on Enzyme Commission mapping
-  findings: []
-- id: GO_REF:0000033
-  title: Annotation inferences using phylogenetic trees
-  findings: []
-- id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
-    vocabulary mapping, accompanied by conservative changes to GO terms applied by
-    UniProt
-  findings: []
-- id: GO_REF:0000052
-  title: Gene Ontology annotation based on curation of immunofluorescence data
-  findings: []
-- id: GO_REF:0000120
-  title: Combined Automated Annotation using Multiple IEA Methods
-  findings: []
-- id: PMID:10521492
-  title: The ubiquitin-conjugating enzymes UbcH7 and UbcH8 interact with RING finger/IBR
-    motif-containing domains of HHARI and H7-AP1.
-  findings: []
-- id: PMID:11278816
-  title: Features of the parkin/ariadne-like ubiquitin ligase, HHARI, that regulate
-    its interaction with the ubiquitin-conjugating enzyme, Ubch7.
-  findings: []
-- id: PMID:14623119
-  title: Human homologue of ariadne promotes the ubiquitylation of translation initiation
-    factor 4E homologous protein, 4EHP.
-  findings: []
-- id: PMID:15236971
-  title: Structure of the C-terminal RING finger from a RING-IBR-RING/TRIAD motif
-    reveals a novel zinc-binding domain distinct from a RING.
-  findings: []
-- id: PMID:21145461
-  title: Dynamics of cullin-RING ubiquitin ligase network revealed by systematic quantitative
-    proteomics.
-  findings: []
-- id: PMID:21532592
-  title: UBCH7 reactivity profile reveals parkin and HHARI to be RING/HECT hybrids.
-  findings: []
-- id: PMID:21590270
-  title: The parkin-like human homolog of Drosophila ariadne-1 (HHARI) can induce
-    aggresome formation in mammalian cells and is immunologically detectable in Lewy
-    bodies.
-  findings: []
-- id: PMID:23059369
-  title: Human Homolog of Drosophila Ariadne (HHARI) is a marker of cellular proliferation
-    associated with nuclear bodies.
-  findings: []
-- id: PMID:23707686
-  title: &#39;Structure of HHARI, a RING-IBR-RING ubiquitin ligase: autoinhibition of
-    an Ariadne-family E3 and insights into ligation mechanism.&#39;
-  findings: []
-- id: PMID:24076655
-  title: TRIAD1 and HHARI bind to and are activated by distinct neddylated Cullin-RING
-    ligase complexes.
-  findings: []
-- id: PMID:27565346
-  title: Two Distinct Types of E3 Ligases Work in Unison to Regulate Substrate Ubiquitylation.
-  findings: []
-- id: PMID:28514442
-  title: Architecture of the human interactome defines protein communities and disease
-    networks.
-  findings: []
-- id: PMID:33961781
-  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
-    interactome.
-  findings: []
-- id: Reactome:R-HSA-1169394
-  title: ISGylation of IRF3
-  findings: []
-- id: Reactome:R-HSA-1169395
-  title: ISGylation of viral protein NS1
-  findings: []
-- id: Reactome:R-HSA-1169398
-  title: ISGylation of host protein filamin B
-  findings: []
-- id: Reactome:R-HSA-1169402
-  title: ISGylation of E2 conjugating enzymes
-  findings: []
-- id: Reactome:R-HSA-1169403
-  title: Interaction of E3 ligase with ISG15:E2 complex
-  findings: []
-- id: Reactome:R-HSA-1169405
-  title: ISGylation of protein phosphatase 1 beta (PP2CB)
-  findings: []
-- id: Reactome:R-HSA-1169406
-  title: ISGylation of host proteins
-  findings: []
-- id: Reactome:R-HSA-1678843
-  title: ISGylation of protein translation regulator 4EHP
-  findings: []
-- id: Reactome:R-HSA-9833482
-  title: PKR-mediated signaling
-  findings: []
-- id: Reactome:R-HSA-9833973
-  title: ISGylation of PKR
-  findings: []
-- id: Reactome:R-HSA-9837231
-  title: ISGylation of BECN1
-  findings: []
-- id: Reactome:R-HSA-9927247
-  title: ISGylation of DDX58 (RIG-I)
-  findings: []
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO
+      terms
+    findings: []
+  - id: GO_REF:0000003
+    title: Gene Ontology annotation based on Enzyme Commission mapping
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+  - id: GO_REF:0000052
+    title: Gene Ontology annotation based on curation of immunofluorescence data
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: PMID:10521492
+    title: The ubiquitin-conjugating enzymes UbcH7 and UbcH8 interact with RING
+      finger/IBR motif-containing domains of HHARI and H7-AP1.
+    findings: []
+  - id: PMID:11278816
+    title: Features of the parkin/ariadne-like ubiquitin ligase, HHARI, that regulate
+      its interaction with the ubiquitin-conjugating enzyme, Ubch7.
+    findings: []
+  - id: PMID:14623119
+    title: Human homologue of ariadne promotes the ubiquitylation of translation
+      initiation factor 4E homologous protein, 4EHP.
+    findings: []
+  - id: PMID:15236971
+    title: Structure of the C-terminal RING finger from a RING-IBR-RING/TRIAD motif
+      reveals a novel zinc-binding domain distinct from a RING.
+    findings: []
+  - id: PMID:21145461
+    title: Dynamics of cullin-RING ubiquitin ligase network revealed by systematic
+      quantitative proteomics.
+    findings: []
+  - id: PMID:21532592
+    title: UBCH7 reactivity profile reveals parkin and HHARI to be RING/HECT hybrids.
+    findings: []
+  - id: PMID:21590270
+    title: The parkin-like human homolog of Drosophila ariadne-1 (HHARI) can induce
+      aggresome formation in mammalian cells and is immunologically detectable in Lewy
+      bodies.
+    findings: []
+  - id: PMID:23059369
+    title: Human Homolog of Drosophila Ariadne (HHARI) is a marker of cellular
+      proliferation associated with nuclear bodies.
+    findings: []
+  - id: PMID:23707686
+    title: &#39;Structure of HHARI, a RING-IBR-RING ubiquitin ligase: autoinhibition of an Ariadne-family
+      E3 and insights into ligation mechanism.&#39;
+    findings: []
+  - id: PMID:24076655
+    title: TRIAD1 and HHARI bind to and are activated by distinct neddylated Cullin-RING
+      ligase complexes.
+    findings: []
+  - id: PMID:27565346
+    title: Two Distinct Types of E3 Ligases Work in Unison to Regulate Substrate
+      Ubiquitylation.
+    findings: []
+  - id: PMID:28514442
+    title: Architecture of the human interactome defines protein communities and disease
+      networks.
+    findings: []
+  - id: PMID:33961781
+    title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+      interactome.
+    findings: []
+  - id: Reactome:R-HSA-1169394
+    title: ISGylation of IRF3
+    findings: []
+  - id: Reactome:R-HSA-1169395
+    title: ISGylation of viral protein NS1
+    findings: []
+  - id: Reactome:R-HSA-1169398
+    title: ISGylation of host protein filamin B
+    findings: []
+  - id: Reactome:R-HSA-1169402
+    title: ISGylation of E2 conjugating enzymes
+    findings: []
+  - id: Reactome:R-HSA-1169403
+    title: Interaction of E3 ligase with ISG15:E2 complex
+    findings: []
+  - id: Reactome:R-HSA-1169405
+    title: ISGylation of protein phosphatase 1 beta (PP2CB)
+    findings: []
+  - id: Reactome:R-HSA-1169406
+    title: ISGylation of host proteins
+    findings: []
+  - id: Reactome:R-HSA-1678843
+    title: ISGylation of protein translation regulator 4EHP
+    findings: []
+  - id: Reactome:R-HSA-9833482
+    title: PKR-mediated signaling
+    findings: []
+  - id: Reactome:R-HSA-9833973
+    title: ISGylation of PKR
+    findings: []
+  - id: Reactome:R-HSA-9837231
+    title: ISGylation of BECN1
+    findings: []
+  - id: Reactome:R-HSA-9927247
+    title: ISGylation of DDX58 (RIG-I)
+    findings: []
+  - id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+    title: Falcon deep research synthesis for ARIH1
+    findings: []
+  - id: file:human/ARIH1/ARIH1-uniprot.txt
+    title: UniProt record for ARIH1
+    findings: []
+core_functions:
+  - description: RBR E3 ubiquitin-protein ligase activity that primes ubiquitination of
+      CRL-bound substrates in neddylated SCF/CRL assemblies.
+    molecular_function:
+      id: GO:0061630
+      label: ubiquitin protein ligase activity
+    directly_involved_in:
+      - id: GO:0016567
+        label: protein ubiquitination
+      - id: GO:0006511
+        label: ubiquitin-dependent protein catabolic process
+    locations:
+      - id: GO:0005737
+        label: cytoplasm
+      - id: GO:0005829
+        label: cytosol
+      - id: GO:0005634
+        label: nucleus
+    in_complex:
+      id: GO:0019005
+      label: SCF ubiquitin ligase complex
+    supported_by:
+      - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+        supporting_text: A major current paradigm is that **neddylated CRLs recruit and
+          activate ARIH-family RBR ligases**. Neddylation-induced conformational changes
+          in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then
+          performs the catalytic ubiquitin transfer while the CRL scaffold handles
+          substrate recruitment and E2 positioning.
+      - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+        supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+          E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the
+          **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - description: UBE2L3/UbcH7 binding as the E2-recruitment step of ARIH1 RBR ubiquitin
+      transfer.
+    molecular_function:
+      id: GO:0031624
+      label: ubiquitin conjugating enzyme binding
+    directly_involved_in:
+      - id: GO:0016567
+        label: protein ubiquitination
+    locations:
+      - id: GO:0005737
+        label: cytoplasm
+      - id: GO:0005634
+        label: nucleus
+    supported_by:
+      - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+        supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+          E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the
+          **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+      - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+        supporting_text: &#39;bind E2s via the first RING-type zinc finger&#39;
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/ARIH1/ARIH1-ai-review.html
+++ b/genes/human/ARIH1/ARIH1-ai-review.html
@@ -2376,9 +2376,13 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
+                            <strong>Summary:</strong> ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated CRLs.
                         </div>
 
+
+                        <div>
+                            <strong>Reason:</strong> Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core activity synthesized from current CRL/RBR literature.
+                        </div>
 
 
 
@@ -2450,9 +2454,13 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
+                            <strong>Summary:</strong> ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated CRLs.
                         </div>
 
+
+                        <div>
+                            <strong>Reason:</strong> Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core activity synthesized from current CRL/RBR literature.
+                        </div>
 
 
 
@@ -2524,9 +2532,13 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
+                            <strong>Summary:</strong> ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated CRLs.
                         </div>
 
+
+                        <div>
+                            <strong>Reason:</strong> Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core activity synthesized from current CRL/RBR literature.
+                        </div>
 
 
 
@@ -2598,9 +2610,13 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
+                            <strong>Summary:</strong> ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated CRLs.
                         </div>
 
+
+                        <div>
+                            <strong>Reason:</strong> Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core activity synthesized from current CRL/RBR literature.
+                        </div>
 
 
 
@@ -2672,9 +2688,13 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
+                            <strong>Summary:</strong> ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated CRLs.
                         </div>
 
+
+                        <div>
+                            <strong>Reason:</strong> Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core activity synthesized from current CRL/RBR literature.
+                        </div>
 
 
 
@@ -2746,9 +2766,13 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
+                            <strong>Summary:</strong> ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated CRLs.
                         </div>
 
+
+                        <div>
+                            <strong>Reason:</strong> Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core activity synthesized from current CRL/RBR literature.
+                        </div>
 
 
 
@@ -2820,9 +2844,13 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
+                            <strong>Summary:</strong> ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated CRLs.
                         </div>
 
+
+                        <div>
+                            <strong>Reason:</strong> Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core activity synthesized from current CRL/RBR literature.
+                        </div>
 
 
 
@@ -3820,9 +3848,13 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This NOT-qualified CRL-complex annotation should be retained for the specific experimental context, while broader evidence supports ARIH1 cooperation with other neddylated cullin complexes.
+                            <strong>Summary:</strong> This NOT-qualified Cul2-RING complex annotation is retained as a non-core, experiment-specific negative result from PMID:27565346, but it conflicts with positive CUL2 interaction evidence from PMID:24076655 and with UniProt text citing both PMID:24076655 and PMID:27565346 for neddylated CUL2 interaction. The most defensible interpretation is context-dependent assay behavior rather than a global absence of CUL2 association.
                         </div>
 
+
+                        <div>
+                            <strong>Reason:</strong> Preserve the GOA NOT qualifier while explicitly flagging the conflict with broader positive CUL2 evidence.
+                        </div>
 
 
 
@@ -3905,9 +3937,13 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Cul2-RING ubiquitin ligase complex association is supported as a CRL partnership for ARIH1; it is retained as a non-core complex context rather than the core catalytic activity itself.
+                            <strong>Summary:</strong> Positive Cul2-RING complex association is retained as a non-core CRL context for ARIH1. This should be read alongside the separate NOT-qualified PMID:27565346 annotation, which likely reflects a context-specific negative assay rather than a global absence of CUL2 interaction.
                         </div>
 
+
+                        <div>
+                            <strong>Reason:</strong> ARIH1-CRL cooperation is well supported, but individual cullin-complex annotations are context annotations rather than the core catalytic function.
+                        </div>
 
 
 
@@ -6432,9 +6468,13 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> ubiquitin-like protein transferase activity is supported as a ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest mechanistic literature supports ubiquitin transfer as the core function.
+                            <strong>Summary:</strong> ubiquitin-like protein transferase activity is retained as a confirmed secondary ubiquitin-like/ISGylation function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated CRLs.
                         </div>
 
+
+                        <div>
+                            <strong>Reason:</strong> Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core activity synthesized from current CRL/RBR literature.
+                        </div>
 
 
 
@@ -8063,9 +8103,10 @@ existing_annotations:
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1169394
     review:
-      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
-        activity in Reactome/UniProt, but the strongest mechanistic literature supports
-        ubiquitin transfer as the core function.
+      summary: &#39;ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation
+        function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation
+        of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated
+        CRLs.&#39;
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -8074,15 +8115,18 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
   - term:
       id: GO:0061662
       label: ISG15 ligase activity
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1169395
     review:
-      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
-        activity in Reactome/UniProt, but the strongest mechanistic literature supports
-        ubiquitin transfer as the core function.
+      summary: &#39;ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation
+        function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation
+        of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated
+        CRLs.&#39;
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -8091,15 +8135,18 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
   - term:
       id: GO:0061662
       label: ISG15 ligase activity
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1169398
     review:
-      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
-        activity in Reactome/UniProt, but the strongest mechanistic literature supports
-        ubiquitin transfer as the core function.
+      summary: &#39;ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation
+        function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation
+        of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated
+        CRLs.&#39;
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -8108,15 +8155,18 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
   - term:
       id: GO:0061662
       label: ISG15 ligase activity
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1169402
     review:
-      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
-        activity in Reactome/UniProt, but the strongest mechanistic literature supports
-        ubiquitin transfer as the core function.
+      summary: &#39;ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation
+        function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation
+        of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated
+        CRLs.&#39;
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -8125,15 +8175,18 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
   - term:
       id: GO:0061662
       label: ISG15 ligase activity
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1169405
     review:
-      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
-        activity in Reactome/UniProt, but the strongest mechanistic literature supports
-        ubiquitin transfer as the core function.
+      summary: &#39;ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation
+        function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation
+        of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated
+        CRLs.&#39;
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -8142,15 +8195,18 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
   - term:
       id: GO:0061662
       label: ISG15 ligase activity
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1169406
     review:
-      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
-        activity in Reactome/UniProt, but the strongest mechanistic literature supports
-        ubiquitin transfer as the core function.
+      summary: &#39;ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation
+        function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation
+        of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated
+        CRLs.&#39;
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -8159,15 +8215,18 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
   - term:
       id: GO:0061662
       label: ISG15 ligase activity
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-9833973
     review:
-      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
-        activity in Reactome/UniProt, but the strongest mechanistic literature supports
-        ubiquitin transfer as the core function.
+      summary: &#39;ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation
+        function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation
+        of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated
+        CRLs.&#39;
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -8176,6 +8235,8 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
   - term:
       id: GO:0004842
       label: ubiquitin-protein transferase activity
@@ -8399,9 +8460,12 @@ existing_annotations:
     original_reference_id: PMID:27565346
     negated: true
     review:
-      summary: This NOT-qualified CRL-complex annotation should be retained for the
-        specific experimental context, while broader evidence supports ARIH1 cooperation
-        with other neddylated cullin complexes.
+      summary: This NOT-qualified Cul2-RING complex annotation is retained as a
+        non-core, experiment-specific negative result from PMID:27565346, but it
+        conflicts with positive CUL2 interaction evidence from PMID:24076655 and with
+        UniProt text citing both PMID:24076655 and PMID:27565346 for neddylated CUL2
+        interaction. The most defensible interpretation is context-dependent assay
+        behavior rather than a global absence of CUL2 association.
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
@@ -8417,15 +8481,18 @@ existing_annotations:
             neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
             neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
             neddylated CUL4A (PubMed:24076655).
+      reason: Preserve the GOA NOT qualifier while explicitly flagging the conflict with
+        broader positive CUL2 evidence.
   - term:
       id: GO:0031462
       label: Cul2-RING ubiquitin ligase complex
     evidence_type: IDA
     original_reference_id: PMID:24076655
     review:
-      summary: Cul2-RING ubiquitin ligase complex association is supported as a CRL
-        partnership for ARIH1; it is retained as a non-core complex context rather than
-        the core catalytic activity itself.
+      summary: Positive Cul2-RING complex association is retained as a non-core CRL
+        context for ARIH1. This should be read alongside the separate NOT-qualified
+        PMID:27565346 annotation, which likely reflects a context-specific negative
+        assay rather than a global absence of CUL2 interaction.
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
@@ -8441,6 +8508,8 @@ existing_annotations:
             neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
             neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
             neddylated CUL4A (PubMed:24076655).
+      reason: ARIH1-CRL cooperation is well supported, but individual cullin-complex
+        annotations are context annotations rather than the core catalytic function.
   - term:
       id: GO:0031463
       label: Cul3-RING ubiquitin ligase complex
@@ -9032,9 +9101,10 @@ existing_annotations:
     evidence_type: TAS
     original_reference_id: PMID:10521492
     review:
-      summary: ubiquitin-like protein transferase activity is supported as a
-        ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest
-        mechanistic literature supports ubiquitin transfer as the core function.
+      summary: &#39;ubiquitin-like protein transferase activity is retained as a confirmed secondary
+        ubiquitin-like/ISGylation function: UniProt explicitly states that ARIH1 acts as the
+        ligase involved in ISGylation of EIF4E2, while the dominant core function remains
+        ubiquitin transfer with neddylated CRLs.&#39;
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -9043,6 +9113,8 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
 references:
   - id: GO_REF:0000002
     title: Gene Ontology annotation through association of InterPro records with GO

--- a/genes/human/ARIH1/ARIH1-ai-review.yaml
+++ b/genes/human/ARIH1/ARIH1-ai-review.yaml
@@ -391,9 +391,10 @@ existing_annotations:
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1169394
     review:
-      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
-        activity in Reactome/UniProt, but the strongest mechanistic literature supports
-        ubiquitin transfer as the core function.
+      summary: 'ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation
+        function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation
+        of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated
+        CRLs.'
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -402,15 +403,18 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
   - term:
       id: GO:0061662
       label: ISG15 ligase activity
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1169395
     review:
-      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
-        activity in Reactome/UniProt, but the strongest mechanistic literature supports
-        ubiquitin transfer as the core function.
+      summary: 'ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation
+        function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation
+        of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated
+        CRLs.'
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -419,15 +423,18 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
   - term:
       id: GO:0061662
       label: ISG15 ligase activity
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1169398
     review:
-      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
-        activity in Reactome/UniProt, but the strongest mechanistic literature supports
-        ubiquitin transfer as the core function.
+      summary: 'ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation
+        function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation
+        of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated
+        CRLs.'
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -436,15 +443,18 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
   - term:
       id: GO:0061662
       label: ISG15 ligase activity
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1169402
     review:
-      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
-        activity in Reactome/UniProt, but the strongest mechanistic literature supports
-        ubiquitin transfer as the core function.
+      summary: 'ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation
+        function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation
+        of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated
+        CRLs.'
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -453,15 +463,18 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
   - term:
       id: GO:0061662
       label: ISG15 ligase activity
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1169405
     review:
-      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
-        activity in Reactome/UniProt, but the strongest mechanistic literature supports
-        ubiquitin transfer as the core function.
+      summary: 'ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation
+        function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation
+        of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated
+        CRLs.'
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -470,15 +483,18 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
   - term:
       id: GO:0061662
       label: ISG15 ligase activity
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1169406
     review:
-      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
-        activity in Reactome/UniProt, but the strongest mechanistic literature supports
-        ubiquitin transfer as the core function.
+      summary: 'ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation
+        function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation
+        of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated
+        CRLs.'
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -487,15 +503,18 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
   - term:
       id: GO:0061662
       label: ISG15 ligase activity
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-9833973
     review:
-      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
-        activity in Reactome/UniProt, but the strongest mechanistic literature supports
-        ubiquitin transfer as the core function.
+      summary: 'ISG15 ligase activity is retained as a confirmed secondary ubiquitin-like/ISGylation
+        function: UniProt explicitly states that ARIH1 acts as the ligase involved in ISGylation
+        of EIF4E2, while the dominant core function remains ubiquitin transfer with neddylated
+        CRLs.'
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -504,6 +523,8 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
   - term:
       id: GO:0004842
       label: ubiquitin-protein transferase activity
@@ -727,9 +748,12 @@ existing_annotations:
     original_reference_id: PMID:27565346
     negated: true
     review:
-      summary: This NOT-qualified CRL-complex annotation should be retained for the
-        specific experimental context, while broader evidence supports ARIH1 cooperation
-        with other neddylated cullin complexes.
+      summary: This NOT-qualified Cul2-RING complex annotation is retained as a
+        non-core, experiment-specific negative result from PMID:27565346, but it
+        conflicts with positive CUL2 interaction evidence from PMID:24076655 and with
+        UniProt text citing both PMID:24076655 and PMID:27565346 for neddylated CUL2
+        interaction. The most defensible interpretation is context-dependent assay
+        behavior rather than a global absence of CUL2 association.
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
@@ -745,15 +769,18 @@ existing_annotations:
             neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
             neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
             neddylated CUL4A (PubMed:24076655).
+      reason: Preserve the GOA NOT qualifier while explicitly flagging the conflict with
+        broader positive CUL2 evidence.
   - term:
       id: GO:0031462
       label: Cul2-RING ubiquitin ligase complex
     evidence_type: IDA
     original_reference_id: PMID:24076655
     review:
-      summary: Cul2-RING ubiquitin ligase complex association is supported as a CRL
-        partnership for ARIH1; it is retained as a non-core complex context rather than
-        the core catalytic activity itself.
+      summary: Positive Cul2-RING complex association is retained as a non-core CRL
+        context for ARIH1. This should be read alongside the separate NOT-qualified
+        PMID:27565346 annotation, which likely reflects a context-specific negative
+        assay rather than a global absence of CUL2 interaction.
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
@@ -769,6 +796,8 @@ existing_annotations:
             neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
             neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
             neddylated CUL4A (PubMed:24076655).
+      reason: ARIH1-CRL cooperation is well supported, but individual cullin-complex
+        annotations are context annotations rather than the core catalytic function.
   - term:
       id: GO:0031463
       label: Cul3-RING ubiquitin ligase complex
@@ -1360,9 +1389,10 @@ existing_annotations:
     evidence_type: TAS
     original_reference_id: PMID:10521492
     review:
-      summary: ubiquitin-like protein transferase activity is supported as a
-        ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest
-        mechanistic literature supports ubiquitin transfer as the core function.
+      summary: 'ubiquitin-like protein transferase activity is retained as a confirmed secondary
+        ubiquitin-like/ISGylation function: UniProt explicitly states that ARIH1 acts as the
+        ligase involved in ISGylation of EIF4E2, while the dominant core function remains
+        ubiquitin transfer with neddylated CRLs.'
       action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
@@ -1371,6 +1401,8 @@ existing_annotations:
         - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
           supporting_text: older literature reported interaction with **UBE2L3 and
             UBE2L6**
+      reason: Secondary confirmed ubiquitin-like function, not the dominant ARIH1 core
+        activity synthesized from current CRL/RBR literature.
 references:
   - id: GO_REF:0000002
     title: Gene Ontology annotation through association of InterPro records with GO

--- a/genes/human/ARIH1/ARIH1-ai-review.yaml
+++ b/genes/human/ARIH1/ARIH1-ai-review.yaml
@@ -1,719 +1,1544 @@
 id: Q9Y4X5
 gene_symbol: ARIH1
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for ARIH1'
+description: 'ARIH1 encodes HHARI, an intracellular Ariadne/RBR E3 ubiquitin ligase that catalyzes
+  ubiquitin transfer through a RING1-IBR-RING2 mechanism and is activated by neddylated cullin-RING
+  ligase complexes, especially SCF assemblies, to prime ubiquitination of constrained CRL
+  substrates.'
 existing_annotations:
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0031624
-    label: ubiquitin conjugating enzyme binding
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0006511
-    label: ubiquitin-dependent protein catabolic process
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0061630
-    label: ubiquitin protein ligase activity
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0000151
-    label: ubiquitin ligase complex
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005634
-    label: nucleus
-  evidence_type: IBA
-  original_reference_id: GO_REF:0000033
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0004842
-    label: ubiquitin-protein transferase activity
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005634
-    label: nucleus
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0008270
-    label: zinc ion binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0015030
-    label: Cajal body
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000044
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0016567
-    label: protein ubiquitination
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000120
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0046872
-    label: metal ion binding
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000002
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0061630
-    label: ubiquitin protein ligase activity
-  evidence_type: IEA
-  original_reference_id: GO_REF:0000003
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:21145461
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:21532592
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:23707686
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:24076655
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:28514442
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:33961781
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005654
-    label: nucleoplasm
-  evidence_type: IDA
-  original_reference_id: GO_REF:0000052
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0039585
-    label: PKR/eIFalpha signaling
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-9833482
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0061662
-    label: ISG15 ligase activity
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169394
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0061662
-    label: ISG15 ligase activity
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169395
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0061662
-    label: ISG15 ligase activity
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169398
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0061662
-    label: ISG15 ligase activity
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169402
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0061662
-    label: ISG15 ligase activity
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169405
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0061662
-    label: ISG15 ligase activity
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169406
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0061662
-    label: ISG15 ligase activity
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-9833973
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0004842
-    label: ubiquitin-protein transferase activity
-  evidence_type: IDA
-  original_reference_id: PMID:23707686
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0004842
-    label: ubiquitin-protein transferase activity
-  evidence_type: IDA
-  original_reference_id: PMID:24076655
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0004842
-    label: ubiquitin-protein transferase activity
-  evidence_type: IDA
-  original_reference_id: PMID:27565346
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: IDA
-  original_reference_id: PMID:23059369
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0008270
-    label: zinc ion binding
-  evidence_type: IDA
-  original_reference_id: PMID:23707686
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0016567
-    label: protein ubiquitination
-  evidence_type: IDA
-  original_reference_id: PMID:23707686
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0016567
-    label: protein ubiquitination
-  evidence_type: IDA
-  original_reference_id: PMID:24076655
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0016567
-    label: protein ubiquitination
-  evidence_type: IDA
-  original_reference_id: PMID:27565346
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0016604
-    label: nuclear body
-  evidence_type: IDA
-  original_reference_id: PMID:23059369
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0019005
-    label: SCF ubiquitin ligase complex
-  evidence_type: IDA
-  original_reference_id: PMID:24076655
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0019005
-    label: SCF ubiquitin ligase complex
-  evidence_type: IDA
-  original_reference_id: PMID:27565346
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0031462
-    label: Cul2-RING ubiquitin ligase complex
-  evidence_type: IDA
-  original_reference_id: PMID:27565346
-  negated: true
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0031462
-    label: Cul2-RING ubiquitin ligase complex
-  evidence_type: IDA
-  original_reference_id: PMID:24076655
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0031463
-    label: Cul3-RING ubiquitin ligase complex
-  evidence_type: IDA
-  original_reference_id: PMID:24076655
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0031463
-    label: Cul3-RING ubiquitin ligase complex
-  evidence_type: IDA
-  original_reference_id: PMID:27565346
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0031464
-    label: Cul4A-RING E3 ubiquitin ligase complex
-  evidence_type: IDA
-  original_reference_id: PMID:24076655
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0031624
-    label: ubiquitin conjugating enzyme binding
-  evidence_type: IPI
-  original_reference_id: PMID:23707686
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0031624
-    label: ubiquitin conjugating enzyme binding
-  evidence_type: IPI
-  original_reference_id: PMID:24076655
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0031624
-    label: ubiquitin conjugating enzyme binding
-  evidence_type: IPI
-  original_reference_id: PMID:27565346
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0097413
-    label: Lewy body
-  evidence_type: IDA
-  original_reference_id: PMID:21590270
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169394
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169395
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169398
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169402
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169403
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169405
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1169406
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-1678843
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-9833973
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-9837231
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005829
-    label: cytosol
-  evidence_type: TAS
-  original_reference_id: Reactome:R-HSA-9927247
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0004842
-    label: ubiquitin-protein transferase activity
-  evidence_type: IDA
-  original_reference_id: PMID:14623119
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0004842
-    label: ubiquitin-protein transferase activity
-  evidence_type: IDA
-  original_reference_id: PMID:15236971
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0004842
-    label: ubiquitin-protein transferase activity
-  evidence_type: IDA
-  original_reference_id: PMID:21532592
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:14623119
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005737
-    label: cytoplasm
-  evidence_type: IDA
-  original_reference_id: PMID:11278816
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0008270
-    label: zinc ion binding
-  evidence_type: IDA
-  original_reference_id: PMID:15236971
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0016567
-    label: protein ubiquitination
-  evidence_type: IDA
-  original_reference_id: PMID:14623119
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0016567
-    label: protein ubiquitination
-  evidence_type: IDA
-  original_reference_id: PMID:15236971
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0016567
-    label: protein ubiquitination
-  evidence_type: IDA
-  original_reference_id: PMID:21532592
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0031625
-    label: ubiquitin protein ligase binding
-  evidence_type: IPI
-  original_reference_id: PMID:11278816
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0031625
-    label: ubiquitin protein ligase binding
-  evidence_type: IPI
-  original_reference_id: PMID:21532592
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0005515
-    label: protein binding
-  evidence_type: IPI
-  original_reference_id: PMID:10521492
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0000151
-    label: ubiquitin ligase complex
-  evidence_type: TAS
-  original_reference_id: PMID:10521492
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0006511
-    label: ubiquitin-dependent protein catabolic process
-  evidence_type: TAS
-  original_reference_id: PMID:10521492
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
-- term:
-    id: GO:0019787
-    label: ubiquitin-like protein transferase activity
-  evidence_type: TAS
-  original_reference_id: PMID:10521492
-  review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: cytoplasm localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0031624
+      label: ubiquitin conjugating enzyme binding
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: ARIH1 binding to ubiquitin-conjugating enzymes is part of its core RBR
+        catalytic cycle, with UBE2L3/UbcH7 the best-supported donor E2.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0006511
+      label: ubiquitin-dependent protein catabolic process
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: ubiquitin-dependent protein catabolic process is supported by the
+        catalytic role of ARIH1 in ubiquitination and downstream ubiquitin-dependent
+        substrate turnover, especially as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0061630
+      label: ubiquitin protein ligase activity
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: 'ubiquitin protein ligase activity is a core ARIH1 function: ARIH1/HHARI is
+        an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.'
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0000151
+      label: ubiquitin ligase complex
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: ARIH1 forms functional ubiquitin ligase assemblies with neddylated CRLs;
+        this broad complex annotation captures that E3-ligase-complex context.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: IBA
+    original_reference_id: GO_REF:0000033
+    review:
+      summary: nucleus localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0004842
+      label: ubiquitin-protein transferase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    review:
+      summary: 'ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI
+        is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.'
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0005634
+      label: nucleus
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    review:
+      summary: nucleus localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    review:
+      summary: cytoplasm localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0008270
+      label: zinc ion binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    review:
+      summary: ARIH1 contains RING/IBR/RING zinc-finger domains required for its RBR E3
+        mechanism, so zinc ion binding is supported.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0015030
+      label: Cajal body
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000044
+    review:
+      summary: Cajal body is retained as a reported localization or colocalization but
+        is not part of the core ARIH1 ubiquitin-ligase mechanism.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Nucleus, Cajal body
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Present in Lewy body
+  - term:
+      id: GO:0016567
+      label: protein ubiquitination
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000120
+    review:
+      summary: protein ubiquitination is supported by the catalytic role of ARIH1 in
+        ubiquitination and downstream ubiquitin-dependent substrate turnover, especially
+        as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0046872
+      label: metal ion binding
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000002
+    review:
+      summary: The metal-binding evidence is specifically zinc binding by RING/IBR/RING
+        domains; the broad metal ion binding term should be replaced by zinc ion
+        binding.
+      action: MODIFY
+      reason: Specific zinc-binding domains are known; the generic metal ion binding
+        term is less informative.
+      proposed_replacement_terms:
+        - id: GO:0008270
+          label: zinc ion binding
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0061630
+      label: ubiquitin protein ligase activity
+    evidence_type: IEA
+    original_reference_id: GO_REF:0000003
+    review:
+      summary: 'ubiquitin protein ligase activity is a core ARIH1 function: ARIH1/HHARI is
+        an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.'
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:21145461
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:21532592
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:23707686
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:24076655
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:28514442
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:33961781
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005654
+      label: nucleoplasm
+    evidence_type: IDA
+    original_reference_id: GO_REF:0000052
+    review:
+      summary: nucleoplasm localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0039585
+      label: PKR/eIFalpha signaling
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-9833482
+    review:
+      summary: PKR/eIFalpha signaling is a pathway-level consequence in Reactome rather
+        than the core molecular role of ARIH1; keep it as non-core while prioritizing
+        ubiquitin/ubiquitin-like ligase activity.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+  - term:
+      id: GO:0061662
+      label: ISG15 ligase activity
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169394
+    review:
+      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
+        activity in Reactome/UniProt, but the strongest mechanistic literature supports
+        ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
+  - term:
+      id: GO:0061662
+      label: ISG15 ligase activity
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169395
+    review:
+      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
+        activity in Reactome/UniProt, but the strongest mechanistic literature supports
+        ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
+  - term:
+      id: GO:0061662
+      label: ISG15 ligase activity
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169398
+    review:
+      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
+        activity in Reactome/UniProt, but the strongest mechanistic literature supports
+        ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
+  - term:
+      id: GO:0061662
+      label: ISG15 ligase activity
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169402
+    review:
+      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
+        activity in Reactome/UniProt, but the strongest mechanistic literature supports
+        ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
+  - term:
+      id: GO:0061662
+      label: ISG15 ligase activity
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169405
+    review:
+      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
+        activity in Reactome/UniProt, but the strongest mechanistic literature supports
+        ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
+  - term:
+      id: GO:0061662
+      label: ISG15 ligase activity
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169406
+    review:
+      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
+        activity in Reactome/UniProt, but the strongest mechanistic literature supports
+        ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
+  - term:
+      id: GO:0061662
+      label: ISG15 ligase activity
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-9833973
+    review:
+      summary: ISG15 ligase activity is supported as a ubiquitin-like/ISG15-related
+        activity in Reactome/UniProt, but the strongest mechanistic literature supports
+        ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
+  - term:
+      id: GO:0004842
+      label: ubiquitin-protein transferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:23707686
+    review:
+      summary: 'ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI
+        is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.'
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0004842
+      label: ubiquitin-protein transferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:24076655
+    review:
+      summary: 'ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI
+        is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.'
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0004842
+      label: ubiquitin-protein transferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:27565346
+    review:
+      summary: 'ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI
+        is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.'
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IDA
+    original_reference_id: PMID:23059369
+    review:
+      summary: cytoplasm localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0008270
+      label: zinc ion binding
+    evidence_type: IDA
+    original_reference_id: PMID:23707686
+    review:
+      summary: ARIH1 contains RING/IBR/RING zinc-finger domains required for its RBR E3
+        mechanism, so zinc ion binding is supported.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0016567
+      label: protein ubiquitination
+    evidence_type: IDA
+    original_reference_id: PMID:23707686
+    review:
+      summary: protein ubiquitination is supported by the catalytic role of ARIH1 in
+        ubiquitination and downstream ubiquitin-dependent substrate turnover, especially
+        as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0016567
+      label: protein ubiquitination
+    evidence_type: IDA
+    original_reference_id: PMID:24076655
+    review:
+      summary: protein ubiquitination is supported by the catalytic role of ARIH1 in
+        ubiquitination and downstream ubiquitin-dependent substrate turnover, especially
+        as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0016567
+      label: protein ubiquitination
+    evidence_type: IDA
+    original_reference_id: PMID:27565346
+    review:
+      summary: protein ubiquitination is supported by the catalytic role of ARIH1 in
+        ubiquitination and downstream ubiquitin-dependent substrate turnover, especially
+        as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0016604
+      label: nuclear body
+    evidence_type: IDA
+    original_reference_id: PMID:23059369
+    review:
+      summary: nuclear body is retained as a reported localization or colocalization but
+        is not part of the core ARIH1 ubiquitin-ligase mechanism.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Nucleus, Cajal body
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Present in Lewy body
+  - term:
+      id: GO:0019005
+      label: SCF ubiquitin ligase complex
+    evidence_type: IDA
+    original_reference_id: PMID:24076655
+    review:
+      summary: 'SCF ubiquitin ligase complex association is part of the best-supported ARIH1
+        mechanism: ARIH1 cooperates with neddylated SCF complexes as a catalytic E3-E3 super-assembly
+        for CRL substrate ubiquitination.'
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0019005
+      label: SCF ubiquitin ligase complex
+    evidence_type: IDA
+    original_reference_id: PMID:27565346
+    review:
+      summary: 'SCF ubiquitin ligase complex association is part of the best-supported ARIH1
+        mechanism: ARIH1 cooperates with neddylated SCF complexes as a catalytic E3-E3 super-assembly
+        for CRL substrate ubiquitination.'
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0031462
+      label: Cul2-RING ubiquitin ligase complex
+    evidence_type: IDA
+    original_reference_id: PMID:27565346
+    negated: true
+    review:
+      summary: This NOT-qualified CRL-complex annotation should be retained for the
+        specific experimental context, while broader evidence supports ARIH1 cooperation
+        with other neddylated cullin complexes.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0031462
+      label: Cul2-RING ubiquitin ligase complex
+    evidence_type: IDA
+    original_reference_id: PMID:24076655
+    review:
+      summary: Cul2-RING ubiquitin ligase complex association is supported as a CRL
+        partnership for ARIH1; it is retained as a non-core complex context rather than
+        the core catalytic activity itself.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0031463
+      label: Cul3-RING ubiquitin ligase complex
+    evidence_type: IDA
+    original_reference_id: PMID:24076655
+    review:
+      summary: Cul3-RING ubiquitin ligase complex association is supported as a CRL
+        partnership for ARIH1; it is retained as a non-core complex context rather than
+        the core catalytic activity itself.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0031463
+      label: Cul3-RING ubiquitin ligase complex
+    evidence_type: IDA
+    original_reference_id: PMID:27565346
+    review:
+      summary: Cul3-RING ubiquitin ligase complex association is supported as a CRL
+        partnership for ARIH1; it is retained as a non-core complex context rather than
+        the core catalytic activity itself.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0031464
+      label: Cul4A-RING E3 ubiquitin ligase complex
+    evidence_type: IDA
+    original_reference_id: PMID:24076655
+    review:
+      summary: Cul4A-RING E3 ubiquitin ligase complex association is supported as a CRL
+        partnership for ARIH1; it is retained as a non-core complex context rather than
+        the core catalytic activity itself.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0031624
+      label: ubiquitin conjugating enzyme binding
+    evidence_type: IPI
+    original_reference_id: PMID:23707686
+    review:
+      summary: ARIH1 binding to ubiquitin-conjugating enzymes is part of its core RBR
+        catalytic cycle, with UBE2L3/UbcH7 the best-supported donor E2.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0031624
+      label: ubiquitin conjugating enzyme binding
+    evidence_type: IPI
+    original_reference_id: PMID:24076655
+    review:
+      summary: ARIH1 binding to ubiquitin-conjugating enzymes is part of its core RBR
+        catalytic cycle, with UBE2L3/UbcH7 the best-supported donor E2.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0031624
+      label: ubiquitin conjugating enzyme binding
+    evidence_type: IPI
+    original_reference_id: PMID:27565346
+    review:
+      summary: ARIH1 binding to ubiquitin-conjugating enzymes is part of its core RBR
+        catalytic cycle, with UBE2L3/UbcH7 the best-supported donor E2.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0097413
+      label: Lewy body
+    evidence_type: IDA
+    original_reference_id: PMID:21590270
+    review:
+      summary: Lewy body is retained as a reported localization or colocalization but is
+        not part of the core ARIH1 ubiquitin-ligase mechanism.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Nucleus, Cajal body
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Present in Lewy body
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169394
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169395
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169398
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169402
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169403
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169405
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1169406
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-1678843
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-9833973
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-9837231
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0005829
+      label: cytosol
+    evidence_type: TAS
+    original_reference_id: Reactome:R-HSA-9927247
+    review:
+      summary: cytosol localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0004842
+      label: ubiquitin-protein transferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:14623119
+    review:
+      summary: 'ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI
+        is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.'
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0004842
+      label: ubiquitin-protein transferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:15236971
+    review:
+      summary: 'ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI
+        is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.'
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0004842
+      label: ubiquitin-protein transferase activity
+    evidence_type: IDA
+    original_reference_id: PMID:21532592
+    review:
+      summary: 'ubiquitin-protein transferase activity is a core ARIH1 function: ARIH1/HHARI
+        is an RBR E3 that transfers ubiquitin from an E2 enzyme through its catalytic cysteine
+        to substrates.'
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: RBR E3 ligases are defined by a **RING1–IBR–RING2** module
+            and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a
+            ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s
+            **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2,
+            ubiquitin is transferred from the E3~Ub thioester to a substrate lysine
+            (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as
+            a canonical member.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:14623119
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0005737
+      label: cytoplasm
+    evidence_type: IDA
+    original_reference_id: PMID:11278816
+    review:
+      summary: cytoplasm localization is supported for intracellular ARIH1; the most
+        relevant functional locations are cytoplasm/cytosol and nucleus.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In tumor/pathology and cell-based studies, ARIH1 was detected
+            in both **cytoplasm and nucleus** by staining, consistent with a role in
+            diverse protein quality control and regulatory circuits. In the core
+            mechanistic work, ARIH1 localizes functionally through **complex formation**
+            with neddylated CRL assemblies (e.g., SCF).
+  - term:
+      id: GO:0008270
+      label: zinc ion binding
+    evidence_type: IDA
+    original_reference_id: PMID:15236971
+    review:
+      summary: ARIH1 contains RING/IBR/RING zinc-finger domains required for its RBR E3
+        mechanism, so zinc ion binding is supported.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: 'bind E2s via the first RING-type zinc finger'
+  - term:
+      id: GO:0016567
+      label: protein ubiquitination
+    evidence_type: IDA
+    original_reference_id: PMID:14623119
+    review:
+      summary: protein ubiquitination is supported by the catalytic role of ARIH1 in
+        ubiquitination and downstream ubiquitin-dependent substrate turnover, especially
+        as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0016567
+      label: protein ubiquitination
+    evidence_type: IDA
+    original_reference_id: PMID:15236971
+    review:
+      summary: protein ubiquitination is supported by the catalytic role of ARIH1 in
+        ubiquitination and downstream ubiquitin-dependent substrate turnover, especially
+        as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0016567
+      label: protein ubiquitination
+    evidence_type: IDA
+    original_reference_id: PMID:21532592
+    review:
+      summary: protein ubiquitination is supported by the catalytic role of ARIH1 in
+        ubiquitination and downstream ubiquitin-dependent substrate turnover, especially
+        as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0031625
+      label: ubiquitin protein ligase binding
+    evidence_type: IPI
+    original_reference_id: PMID:11278816
+    review:
+      summary: Specific binding to ubiquitin ligase complexes is supported through ARIH1
+        cooperation with neddylated CRLs, but it is a complex-association context rather
+        than the primary catalytic function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0031625
+      label: ubiquitin protein ligase binding
+    evidence_type: IPI
+    original_reference_id: PMID:21532592
+    review:
+      summary: Specific binding to ubiquitin ligase complexes is supported through ARIH1
+        cooperation with neddylated CRLs, but it is a complex-association context rather
+        than the primary catalytic function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Associates with cullin-RING ubiquitin ligase (CRL) complexes
+            containing CUL1, CUL2 and CUL3 (PubMed:24076655, PubMed:27565346). Interacts
+            with neddylated CUL1 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL2 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL3 (PubMed:24076655, PubMed:27565346). Interacts with
+            neddylated CUL4A (PubMed:24076655).
+  - term:
+      id: GO:0005515
+      label: protein binding
+    evidence_type: IPI
+    original_reference_id: PMID:10521492
+    review:
+      summary: Generic protein binding is over-broad for ARIH1. The informative
+        interaction annotations are E2 binding and CRL/SCF association.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Replace generic binding with mechanistically specific E2 or
+        ubiquitin-ligase-complex binding where possible.
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0000151
+      label: ubiquitin ligase complex
+    evidence_type: TAS
+    original_reference_id: PMID:10521492
+    review:
+      summary: ARIH1 forms functional ubiquitin ligase assemblies with neddylated CRLs;
+        this broad complex annotation captures that E3-ligase-complex context.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0006511
+      label: ubiquitin-dependent protein catabolic process
+    evidence_type: TAS
+    original_reference_id: PMID:10521492
+    review:
+      summary: ubiquitin-dependent protein catabolic process is supported by the
+        catalytic role of ARIH1 in ubiquitination and downstream ubiquitin-dependent
+        substrate turnover, especially as a CRL-associated priming E3.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: A major current paradigm is that **neddylated CRLs recruit
+            and activate ARIH-family RBR ligases**. Neddylation-induced conformational
+            changes in cullins enable catalysis and can relieve ARIH autoinhibition;
+            ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold
+            handles substrate recruitment and E2 positioning.
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+            E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to
+            the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - term:
+      id: GO:0019787
+      label: ubiquitin-like protein transferase activity
+    evidence_type: TAS
+    original_reference_id: PMID:10521492
+    review:
+      summary: ubiquitin-like protein transferase activity is supported as a
+        ubiquitin-like/ISG15-related activity in Reactome/UniProt, but the strongest
+        mechanistic literature supports ubiquitin transfer as the core function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+          supporting_text: Acts as the ligase involved in ISGylation of EIF4E2
+            (PubMed:17289916).
+        - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+          supporting_text: older literature reported interaction with **UBE2L3 and
+            UBE2L6**
 references:
-- id: GO_REF:0000002
-  title: Gene Ontology annotation through association of InterPro records with GO
-    terms
-  findings: []
-- id: GO_REF:0000003
-  title: Gene Ontology annotation based on Enzyme Commission mapping
-  findings: []
-- id: GO_REF:0000033
-  title: Annotation inferences using phylogenetic trees
-  findings: []
-- id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
-    vocabulary mapping, accompanied by conservative changes to GO terms applied by
-    UniProt
-  findings: []
-- id: GO_REF:0000052
-  title: Gene Ontology annotation based on curation of immunofluorescence data
-  findings: []
-- id: GO_REF:0000120
-  title: Combined Automated Annotation using Multiple IEA Methods
-  findings: []
-- id: PMID:10521492
-  title: The ubiquitin-conjugating enzymes UbcH7 and UbcH8 interact with RING finger/IBR
-    motif-containing domains of HHARI and H7-AP1.
-  findings: []
-- id: PMID:11278816
-  title: Features of the parkin/ariadne-like ubiquitin ligase, HHARI, that regulate
-    its interaction with the ubiquitin-conjugating enzyme, Ubch7.
-  findings: []
-- id: PMID:14623119
-  title: Human homologue of ariadne promotes the ubiquitylation of translation initiation
-    factor 4E homologous protein, 4EHP.
-  findings: []
-- id: PMID:15236971
-  title: Structure of the C-terminal RING finger from a RING-IBR-RING/TRIAD motif
-    reveals a novel zinc-binding domain distinct from a RING.
-  findings: []
-- id: PMID:21145461
-  title: Dynamics of cullin-RING ubiquitin ligase network revealed by systematic quantitative
-    proteomics.
-  findings: []
-- id: PMID:21532592
-  title: UBCH7 reactivity profile reveals parkin and HHARI to be RING/HECT hybrids.
-  findings: []
-- id: PMID:21590270
-  title: The parkin-like human homolog of Drosophila ariadne-1 (HHARI) can induce
-    aggresome formation in mammalian cells and is immunologically detectable in Lewy
-    bodies.
-  findings: []
-- id: PMID:23059369
-  title: Human Homolog of Drosophila Ariadne (HHARI) is a marker of cellular proliferation
-    associated with nuclear bodies.
-  findings: []
-- id: PMID:23707686
-  title: 'Structure of HHARI, a RING-IBR-RING ubiquitin ligase: autoinhibition of
-    an Ariadne-family E3 and insights into ligation mechanism.'
-  findings: []
-- id: PMID:24076655
-  title: TRIAD1 and HHARI bind to and are activated by distinct neddylated Cullin-RING
-    ligase complexes.
-  findings: []
-- id: PMID:27565346
-  title: Two Distinct Types of E3 Ligases Work in Unison to Regulate Substrate Ubiquitylation.
-  findings: []
-- id: PMID:28514442
-  title: Architecture of the human interactome defines protein communities and disease
-    networks.
-  findings: []
-- id: PMID:33961781
-  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
-    interactome.
-  findings: []
-- id: Reactome:R-HSA-1169394
-  title: ISGylation of IRF3
-  findings: []
-- id: Reactome:R-HSA-1169395
-  title: ISGylation of viral protein NS1
-  findings: []
-- id: Reactome:R-HSA-1169398
-  title: ISGylation of host protein filamin B
-  findings: []
-- id: Reactome:R-HSA-1169402
-  title: ISGylation of E2 conjugating enzymes
-  findings: []
-- id: Reactome:R-HSA-1169403
-  title: Interaction of E3 ligase with ISG15:E2 complex
-  findings: []
-- id: Reactome:R-HSA-1169405
-  title: ISGylation of protein phosphatase 1 beta (PP2CB)
-  findings: []
-- id: Reactome:R-HSA-1169406
-  title: ISGylation of host proteins
-  findings: []
-- id: Reactome:R-HSA-1678843
-  title: ISGylation of protein translation regulator 4EHP
-  findings: []
-- id: Reactome:R-HSA-9833482
-  title: PKR-mediated signaling
-  findings: []
-- id: Reactome:R-HSA-9833973
-  title: ISGylation of PKR
-  findings: []
-- id: Reactome:R-HSA-9837231
-  title: ISGylation of BECN1
-  findings: []
-- id: Reactome:R-HSA-9927247
-  title: ISGylation of DDX58 (RIG-I)
-  findings: []
+  - id: GO_REF:0000002
+    title: Gene Ontology annotation through association of InterPro records with GO
+      terms
+    findings: []
+  - id: GO_REF:0000003
+    title: Gene Ontology annotation based on Enzyme Commission mapping
+    findings: []
+  - id: GO_REF:0000033
+    title: Annotation inferences using phylogenetic trees
+    findings: []
+  - id: GO_REF:0000044
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
+    findings: []
+  - id: GO_REF:0000052
+    title: Gene Ontology annotation based on curation of immunofluorescence data
+    findings: []
+  - id: GO_REF:0000120
+    title: Combined Automated Annotation using Multiple IEA Methods
+    findings: []
+  - id: PMID:10521492
+    title: The ubiquitin-conjugating enzymes UbcH7 and UbcH8 interact with RING
+      finger/IBR motif-containing domains of HHARI and H7-AP1.
+    findings: []
+  - id: PMID:11278816
+    title: Features of the parkin/ariadne-like ubiquitin ligase, HHARI, that regulate
+      its interaction with the ubiquitin-conjugating enzyme, Ubch7.
+    findings: []
+  - id: PMID:14623119
+    title: Human homologue of ariadne promotes the ubiquitylation of translation
+      initiation factor 4E homologous protein, 4EHP.
+    findings: []
+  - id: PMID:15236971
+    title: Structure of the C-terminal RING finger from a RING-IBR-RING/TRIAD motif
+      reveals a novel zinc-binding domain distinct from a RING.
+    findings: []
+  - id: PMID:21145461
+    title: Dynamics of cullin-RING ubiquitin ligase network revealed by systematic
+      quantitative proteomics.
+    findings: []
+  - id: PMID:21532592
+    title: UBCH7 reactivity profile reveals parkin and HHARI to be RING/HECT hybrids.
+    findings: []
+  - id: PMID:21590270
+    title: The parkin-like human homolog of Drosophila ariadne-1 (HHARI) can induce
+      aggresome formation in mammalian cells and is immunologically detectable in Lewy
+      bodies.
+    findings: []
+  - id: PMID:23059369
+    title: Human Homolog of Drosophila Ariadne (HHARI) is a marker of cellular
+      proliferation associated with nuclear bodies.
+    findings: []
+  - id: PMID:23707686
+    title: 'Structure of HHARI, a RING-IBR-RING ubiquitin ligase: autoinhibition of an Ariadne-family
+      E3 and insights into ligation mechanism.'
+    findings: []
+  - id: PMID:24076655
+    title: TRIAD1 and HHARI bind to and are activated by distinct neddylated Cullin-RING
+      ligase complexes.
+    findings: []
+  - id: PMID:27565346
+    title: Two Distinct Types of E3 Ligases Work in Unison to Regulate Substrate
+      Ubiquitylation.
+    findings: []
+  - id: PMID:28514442
+    title: Architecture of the human interactome defines protein communities and disease
+      networks.
+    findings: []
+  - id: PMID:33961781
+    title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+      interactome.
+    findings: []
+  - id: Reactome:R-HSA-1169394
+    title: ISGylation of IRF3
+    findings: []
+  - id: Reactome:R-HSA-1169395
+    title: ISGylation of viral protein NS1
+    findings: []
+  - id: Reactome:R-HSA-1169398
+    title: ISGylation of host protein filamin B
+    findings: []
+  - id: Reactome:R-HSA-1169402
+    title: ISGylation of E2 conjugating enzymes
+    findings: []
+  - id: Reactome:R-HSA-1169403
+    title: Interaction of E3 ligase with ISG15:E2 complex
+    findings: []
+  - id: Reactome:R-HSA-1169405
+    title: ISGylation of protein phosphatase 1 beta (PP2CB)
+    findings: []
+  - id: Reactome:R-HSA-1169406
+    title: ISGylation of host proteins
+    findings: []
+  - id: Reactome:R-HSA-1678843
+    title: ISGylation of protein translation regulator 4EHP
+    findings: []
+  - id: Reactome:R-HSA-9833482
+    title: PKR-mediated signaling
+    findings: []
+  - id: Reactome:R-HSA-9833973
+    title: ISGylation of PKR
+    findings: []
+  - id: Reactome:R-HSA-9837231
+    title: ISGylation of BECN1
+    findings: []
+  - id: Reactome:R-HSA-9927247
+    title: ISGylation of DDX58 (RIG-I)
+    findings: []
+  - id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+    title: Falcon deep research synthesis for ARIH1
+    findings: []
+  - id: file:human/ARIH1/ARIH1-uniprot.txt
+    title: UniProt record for ARIH1
+    findings: []
+core_functions:
+  - description: RBR E3 ubiquitin-protein ligase activity that primes ubiquitination of
+      CRL-bound substrates in neddylated SCF/CRL assemblies.
+    molecular_function:
+      id: GO:0061630
+      label: ubiquitin protein ligase activity
+    directly_involved_in:
+      - id: GO:0016567
+        label: protein ubiquitination
+      - id: GO:0006511
+        label: ubiquitin-dependent protein catabolic process
+    locations:
+      - id: GO:0005737
+        label: cytoplasm
+      - id: GO:0005829
+        label: cytosol
+      - id: GO:0005634
+        label: nucleus
+    in_complex:
+      id: GO:0019005
+      label: SCF ubiquitin ligase complex
+    supported_by:
+      - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+        supporting_text: A major current paradigm is that **neddylated CRLs recruit and
+          activate ARIH-family RBR ligases**. Neddylation-induced conformational changes
+          in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then
+          performs the catalytic ubiquitin transfer while the CRL scaffold handles
+          substrate recruitment and E2 positioning.
+      - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+        supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+          E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the
+          **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+  - description: UBE2L3/UbcH7 binding as the E2-recruitment step of ARIH1 RBR ubiquitin
+      transfer.
+    molecular_function:
+      id: GO:0031624
+      label: ubiquitin conjugating enzyme binding
+    directly_involved_in:
+      - id: GO:0016567
+        label: protein ubiquitination
+    locations:
+      - id: GO:0005737
+        label: cytoplasm
+      - id: GO:0005634
+        label: nucleus
+    supported_by:
+      - reference_id: file:human/ARIH1/ARIH1-deep-research-falcon.md
+        supporting_text: In the best-defined structural/biochemical pathway (SCF–ARIH1
+          E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the
+          **ARIH1 catalytic cysteine** and then to an SCF-bound substrate.
+      - reference_id: file:human/ARIH1/ARIH1-uniprot.txt
+        supporting_text: 'bind E2s via the first RING-type zinc finger'
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []

--- a/genes/human/ARIH1/ARIH1-deep-research-falcon.md
+++ b/genes/human/ARIH1/ARIH1-deep-research-falcon.md
@@ -1,0 +1,337 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: true
+start_time: '2026-05-11T21:17:56.304844'
+end_time: '2026-05-11T21:17:56.306599'
+duration_seconds: 0.0
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: ARIH1
+  gene_symbol: ARIH1
+  uniprot_accession: Q9Y4X5
+  protein_description: 'RecName: Full=E3 ubiquitin-protein ligase ARIH1; EC=2.3.2.31
+    {ECO:0000269|PubMed:15236971, ECO:0000269|PubMed:21532592, ECO:0000269|PubMed:27565346};
+    AltName: Full=H7-AP2 {ECO:0000303|PubMed:10521492}; AltName: Full=HHARI {ECO:0000303|PubMed:11278816};
+    AltName: Full=Monocyte protein 6 {ECO:0000303|Ref.10}; Short=MOP-6 {ECO:0000303|Ref.10};
+    AltName: Full=Protein ariadne-1 homolog {ECO:0000303|Ref.3}; Short=ARI-1 {ECO:0000303|Ref.3};
+    AltName: Full=UbcH7-binding protein {ECO:0000303|PubMed:11278816}; AltName: Full=UbcM4-interacting
+    protein; AltName: Full=Ubiquitin-conjugating enzyme E2-binding protein 1 {ECO:0000303|PubMed:10521492};'
+  gene_info: Name=ARIH1 {ECO:0000312|HGNC:HGNC:689}; Synonyms=ARI, MOP6 {ECO:0000303|Ref.10},
+    UBCH7BP {ECO:0000303|PubMed:11278816}; ORFNames=HUSSY-27 {ECO:0000303|PubMed:11124703};
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the RBR family. Ariadne subfamily.
+  protein_domains: Ariadne. (IPR045840); ARIH1-like_UBL. (IPR048962); E3_UB_ligase_RBR.
+    (IPR031127); IBR_dom. (IPR002867); TRIAD_supradom. (IPR044066)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 30
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9Y4X5
+- **Protein Description:** RecName: Full=E3 ubiquitin-protein ligase ARIH1; EC=2.3.2.31 {ECO:0000269|PubMed:15236971, ECO:0000269|PubMed:21532592, ECO:0000269|PubMed:27565346}; AltName: Full=H7-AP2 {ECO:0000303|PubMed:10521492}; AltName: Full=HHARI {ECO:0000303|PubMed:11278816}; AltName: Full=Monocyte protein 6 {ECO:0000303|Ref.10}; Short=MOP-6 {ECO:0000303|Ref.10}; AltName: Full=Protein ariadne-1 homolog {ECO:0000303|Ref.3}; Short=ARI-1 {ECO:0000303|Ref.3}; AltName: Full=UbcH7-binding protein {ECO:0000303|PubMed:11278816}; AltName: Full=UbcM4-interacting protein; AltName: Full=Ubiquitin-conjugating enzyme E2-binding protein 1 {ECO:0000303|PubMed:10521492};
+- **Gene Information:** Name=ARIH1 {ECO:0000312|HGNC:HGNC:689}; Synonyms=ARI, MOP6 {ECO:0000303|Ref.10}, UBCH7BP {ECO:0000303|PubMed:11278816}; ORFNames=HUSSY-27 {ECO:0000303|PubMed:11124703};
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the RBR family. Ariadne subfamily.
+- **Key Domains:** Ariadne. (IPR045840); ARIH1-like_UBL. (IPR048962); E3_UB_ligase_RBR. (IPR031127); IBR_dom. (IPR002867); TRIAD_supradom. (IPR044066)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "ARIH1" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'ARIH1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **ARIH1** (gene ID: ARIH1, UniProt: Q9Y4X5) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9Y4X5
+- **Protein Description:** RecName: Full=E3 ubiquitin-protein ligase ARIH1; EC=2.3.2.31 {ECO:0000269|PubMed:15236971, ECO:0000269|PubMed:21532592, ECO:0000269|PubMed:27565346}; AltName: Full=H7-AP2 {ECO:0000303|PubMed:10521492}; AltName: Full=HHARI {ECO:0000303|PubMed:11278816}; AltName: Full=Monocyte protein 6 {ECO:0000303|Ref.10}; Short=MOP-6 {ECO:0000303|Ref.10}; AltName: Full=Protein ariadne-1 homolog {ECO:0000303|Ref.3}; Short=ARI-1 {ECO:0000303|Ref.3}; AltName: Full=UbcH7-binding protein {ECO:0000303|PubMed:11278816}; AltName: Full=UbcM4-interacting protein; AltName: Full=Ubiquitin-conjugating enzyme E2-binding protein 1 {ECO:0000303|PubMed:10521492};
+- **Gene Information:** Name=ARIH1 {ECO:0000312|HGNC:HGNC:689}; Synonyms=ARI, MOP6 {ECO:0000303|Ref.10}, UBCH7BP {ECO:0000303|PubMed:11278816}; ORFNames=HUSSY-27 {ECO:0000303|PubMed:11124703};
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the RBR family. Ariadne subfamily.
+- **Key Domains:** Ariadne. (IPR045840); ARIH1-like_UBL. (IPR048962); E3_UB_ligase_RBR. (IPR031127); IBR_dom. (IPR002867); TRIAD_supradom. (IPR044066)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "ARIH1" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'ARIH1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **ARIH1** (gene ID: ARIH1, UniProt: Q9Y4X5) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+# Research Report: Human **ARIH1 (HHARI)** Functional Annotation (UniProt Q9Y4X5)
+
+## 0) Target verification (critical)
+The literature retrieved here consistently uses **ARIH1** to denote the human RBR-family E3 ligase **HHARI**, matching UniProt **Q9Y4X5** and the described **Ariadne/RBR** domain organization (RING1–IBR–RING2 plus Ariadne autoinhibitory region). (wang2023theunifyingcatalytic pages 1-2, smit2013ubiquitinchainformation pages 24-26)
+
+## 1) Key concepts and definitions (current understanding)
+### 1.1 ARIH1 is an RBR (RING-between-RING) E3 ubiquitin ligase
+RBR E3 ligases are defined by a **RING1–IBR–RING2** module and use a **two-step** RING/HECT-hybrid catalytic mechanism. In step 1, a ubiquitin-charged E2 binds **RING1** and transfers ubiquitin to the E3’s **RING2 catalytic cysteine** (a **transthiolation** reaction). In step 2, ubiquitin is transferred from the E3~Ub thioester to a substrate lysine (aminolysis). This general mechanism explicitly includes **HHARI/ARIH1** as a canonical member. (wang2023theunifyingcatalytic pages 1-2)
+
+### 1.2 Core reaction catalyzed and substrate specificity (functional definition)
+**Reaction (EC 2.3.2.31)**: transfer of ubiquitin from an E2 conjugating enzyme to substrate proteins via an ARIH1~Ub thioester intermediate. In physiological contexts, the strongest mechanistic evidence supports ARIH1’s role as a **CRL-associated “priming” E3**, placing an activated ubiquitin transfer module next to substrates bound to **neddylated cullin-RING ligases (CRLs)**—particularly **SCF (CUL1–RBX1–SKP1–F-box)** complexes. This geometry is proposed to be especially important for **folded/spatially constrained substrates** that canonical RING-only mechanisms cannot efficiently ubiquitinate. (hornghetko2021ubiquitinligationto pages 1-2, lin2024diversityofstructure pages 1-3)
+
+### 1.3 Neddylation and CRL–RBR “E3–E3” cooperation
+A major current paradigm is that **neddylated CRLs recruit and activate ARIH-family RBR ligases**. Neddylation-induced conformational changes in cullins enable catalysis and can relieve ARIH autoinhibition; ARIH1 then performs the catalytic ubiquitin transfer while the CRL scaffold handles substrate recruitment and E2 positioning. (hornghetko2021ubiquitinligationto pages 1-2, lin2024diversityofstructure pages 1-3)
+
+## 2) Molecular mechanism of ARIH1 (what it does and how)
+### 2.1 Autoinhibition and activation
+ARIH1/HHARI is **autoinhibited** by its **Ariadne domain** and becomes activated through interactions with **neddylated cullins/CRLs** (and in broader RBR literature, phosphorylation is also described as an activating input for HHARI). (wang2023theunifyingcatalytic pages 1-2, hornghetko2024noncanonicalassemblyneddylation pages 2-3)
+
+### 2.2 E2 partners (E2-to-E3 handoff)
+In the best-defined structural/biochemical pathway (SCF–ARIH1 E3–E3 super-assembly), ubiquitin is transferred from **UBE2L3 (UbcH7)** to the **ARIH1 catalytic cysteine** and then to an SCF-bound substrate. (hornghetko2021ubiquitinligationto pages 1-2)
+
+### 2.3 Structural mechanism: SCF–ARIH1 E3–E3 super-assembly
+Horn-Ghetko et al. resolved intermediates by cryo-EM that visualize the sequence: **E2~Ub → ARIH1 catalytic cysteine → substrate** in the context of a **neddylated SCF complex**. This provides direct mechanistic support that ARIH1 can function as a **catalytic partner** of CRLs rather than acting solely as a standalone E3. (hornghetko2021ubiquitinligationto pages 1-2)
+
+Visual evidence supporting this mechanism is shown in the extracted figure panels (transition states and cycle schematic). (hornghetko2021ubiquitinligationto media a3b226ac, hornghetko2021ubiquitinligationto media f3b6a2dc)
+
+### 2.4 2023 mechanistic consolidation for RBRs (including ARIH1)
+A 2023 Nature Communications study synthesized “unifying” RBR features, including the requirement for an **open E2~Ub** and alignment of the **RING2 catalytic cysteine** for transthiolation. HHARI/ARIH1 is explicitly included among RBRs whose activation involves interactions with **neddylated cullins**. (wang2023theunifyingcatalytic pages 1-2)
+
+## 3) Biological roles, pathways, and cellular localization
+### 3.1 Proteostasis and cell-cycle control via CRL substrates
+In the SCF context, ARIH1 supports ubiquitination of substrates presented by F-box proteins (examples include **phosphorylated cyclin E** and **p27**), and perturbations stabilize multiple CRL substrates; genome-scale screening evidence places ARIH1 among genes important for cell viability in the same neighborhood as core SCF/neddylation components. (hornghetko2021ubiquitinligationto pages 1-2)
+
+### 3.2 EMT and cancer progression via hnRNP E1/PCBP1 stability
+A mechanistically focused cancer study identified **hnRNP E1 (PCBP1)** as a direct ARIH1 substrate: ARIH1 promotes **K48-linked ubiquitination** and proteasomal degradation of hnRNP E1, and mutational analysis highlighted ubiquitinated lysines including **K23, K314, K351** with **K314R** increasing stability and reducing ubiquitination. (howley2022theubiquitine3 pages 1-3, howley2022theubiquitine3 pages 8-9)
+
+Functionally, ARIH1 knockdown delayed EMT and reduced invasion/stemness and tumor outcomes, whereas ARIH1 overexpression promoted EMT/invasion phenotypes; the study reports quantitative elements including **74 enriched ARIH1 proximity interactors** and statistically significant in vivo/clinical comparisons (e.g., paired tumor vs metastasis IHC and xenograft endpoints with reported P-values). (howley2022theubiquitine3 pages 8-9, howley2022theubiquitine3 pages 6-8)
+
+### 3.3 Translation control connections (context and evidence base)
+ARIH1 has been linked to translation control contexts (including DNA damage–related translation arrest) in the cancer-focused ARIH1 study, and ARIH1/HHARI has been discussed in the 4EHP/eIF4E2 literature as associating with 4EHP under specific cellular conditions. However, in the retrieved evidence set, the most direct substrate-level and phenotype-level support is for **hnRNP E1** and **CRL/SCF substrates** rather than for a single definitive translation-factor substrate. (howley2022theubiquitine3 pages 1-3, smit2013ubiquitinchainformation pages 26-29)
+
+### 3.4 Innate immune signaling (emerging/less mature evidence)
+A recent preprint reports HHARI/ARIH1 as an activator of **RIG-I–mediated type I interferon** signaling in a **neddylation-dependent** manner. It reports that the **RING2 catalytic cysteine mutant (C357A)** abolishes the phenotype, that HHARI physically interacts with RIG-I, and that inhibiting neddylation (NAE inhibitor **MLN4924**) suppresses HHARI-driven responses (including IFNβ secretion and downstream signaling readouts). This supports a model where HHARI’s regulation by neddylated CRLs can be functionally coupled to antiviral signaling. Because this is a preprint, it should be treated as emerging rather than fully consolidated. (kontra2025theacidicnterminus pages 33-35, kontra2025theacidicnterminus pages 9-12)
+
+### 3.5 Subcellular localization
+In tumor/pathology and cell-based studies, ARIH1 was detected in both **cytoplasm and nucleus** by staining, consistent with a role in diverse protein quality control and regulatory circuits. In the core mechanistic work, ARIH1 localizes functionally through **complex formation** with neddylated CRL assemblies (e.g., SCF). (howley2022theubiquitine3 pages 6-8, hornghetko2021ubiquitinligationto pages 1-2)
+
+## 4) Recent developments (prioritize 2023–2024)
+### 4.1 2024: refined view of CRL geometry and catalytic partnering
+A 2024 Current Opinion in Structural Biology review highlights ARIH1/ARIH2 as CRL-associated RBR ligases that can perform **priming** ubiquitination and emphasizes that neddylation can strongly accelerate CRL reactions (including an example of **~2000-fold acceleration** for a UBE2D-mediated reaction in the CRL context). It also articulates a functional division where ARIH1 is favored for substrates that are geometrically hard to reach for the E2 in a RING-only mechanism. (lin2024diversityofstructure pages 3-5)
+
+### 4.2 2024: broader cullin–RBR chimeric assemblies
+A 2024 Nature Structural & Molecular Biology study on the vertebrate-specific CUL9 complex discusses ARIH-family RBR catalytic principles and emphasizes ARIH1-like autoinhibition/activation logic involving **neddylated cullins** and **RBX RING** interactions, underscoring that cullin–RBR cooperation is a recurring design in the ubiquitin system. (hornghetko2024noncanonicalassemblyneddylation pages 2-3)
+
+### 4.3 2023: mechanistic unification of the RBR family including HHARI
+The 2023 Nature Communications paper consolidated structural/biochemical principles underlying RBR catalysis, explicitly positioning HHARI/ARIH1 as part of an RBR family that uses a conserved transthiolation-centered catalytic cycle and can be activated in the context of neddylated cullins. (wang2023theunifyingcatalytic pages 1-2)
+
+## 5) Current applications and real-world implementations
+### 5.1 Targeted protein degradation (TPD) and PROTAC ecosystem (ARIH1-adjacent)
+While ARIH1 itself is not yet a common recruited ligase in marketed degraders, its core partner system—**cullin-RING ligases**—is central to real-world TPD. The 2024 structural review notes that **CRL2\u1d5bVHL** is a commonly used E3 ligase scaffold in PROTAC designs, highlighting the clinical/biotech relevance of CRLs. Because ARIH1 can act as a CRL catalytic partner for certain substrates, mechanistic understanding of ARIH1 expands the design space for how CRL-based ubiquitination can be engineered or inhibited. (lin2024diversityofstructure pages 3-5)
+
+### 5.2 Neddylation as a pharmacologic lever (relevant to ARIH1 activation)
+Because ARIH1 activation in multiple contexts depends on **neddylated CRLs**, neddylation is an actionable upstream node. In immune signaling experiments, neddylation inhibition with **MLN4924** suppressed HHARI/ARIH1-dependent phenotypes (preprint evidence). Conceptually, this points to neddylation as a potential therapeutic control point for processes where ARIH1 cooperates with CRLs, including CRL-driven proteostasis/cell-cycle and possibly innate immune signaling. (kontra2025theacidicnterminus pages 33-35)
+
+### 5.3 Disease-oriented implementation: cancer progression mechanisms
+ARIH1’s role in EMT and metastasis-like phenotypes (via hnRNP E1 stability control) positions it as a mechanistically grounded node for biomarker development or pathway intervention in oncology research settings. (howley2022theubiquitine3 pages 6-8, howley2022theubiquitine3 pages 1-3)
+
+## 6) Expert synthesis and analysis (what authoritative sources imply)
+### 6.1 Primary function (most strongly supported)
+The strongest convergent evidence supports ARIH1 as a **catalytic RBR E3 that cooperates with neddylated CRLs** to enable ubiquitination of otherwise geometrically challenging substrates—acting as a “catalytic extender/primer” of CRL ubiquitination capacity rather than merely a standalone ligase. (hornghetko2021ubiquitinligationto pages 1-2, lin2024diversityofstructure pages 1-3)
+
+### 6.2 Where the field is still uncertain
+*Substrate scope:* Beyond SCF-presented substrates and hnRNP E1, ARIH1 substrate identification remains incomplete; reviews emphasize context dependence (substrate geometry, cullin identity, E2 choice). (lin2024diversityofstructure pages 1-3)
+
+*Innate immunity:* HHARI/ARIH1–RIG-I signaling is supported by mechanistic perturbation in a preprint but awaits broader replication and peer-reviewed consolidation. (kontra2025theacidicnterminus pages 33-35)
+
+### 6.3 Constraint/essentiality
+Multiple lines of evidence are consistent with ARIH1 being fitness-relevant/essential: it appears as essential in cell-viability CRISPR screens in mechanistic work, and human population constraint commentary notes predicted loss-of-function variants are rare (preprint). (hornghetko2021ubiquitinligationto pages 1-2, kontra2025theacidicnterminus pages 9-12)
+
+## 7) Relevant recent statistics and quantitative data (from available sources)
+- Human E3 ligase repertoire: **>600 E3 ligases** cited in a 2023 review, providing scale/context for ARIH1 within the UPS. (jeong2023targetinge3ubiquitin pages 1-2)
+- NEDD8 impact on CRL catalysis: a 2024 structural review reports neddylation can accelerate a UBE2D-mediated CRL reaction by **~2000-fold** (context for why neddylation-dependent ARIH activation is biologically potent). (lin2024diversityofstructure pages 3-5)
+- ARIH1 interactome size in a focused cancer study: **74 enriched ARIH1 interactors** via miniTurboID proximity labeling/MS. (howley2022theubiquitine3 pages 8-9)
+- Quantitative/statistical phenotypes in cancer models: reported significant differences across IHC comparisons (paired tests) and in vivo tumor/colonization outcomes with reported P-values and group sizes in the ARIH1–hnRNP E1 study. (howley2022theubiquitine3 pages 6-8)
+- Innate immune signaling readouts (emerging): IFNβ ELISA plots show outputs scaled up to approximately **6,000 pg/mL** and suppression by **MLN4924 10 μM** in HHARI-driven assays (preprint). (kontra2025theacidicnterminus pages 36-36, kontra2025theacidicnterminus pages 33-35)
+
+## 8) Database-level disease associations (hypothesis-generating)
+Open Targets lists ARIH1 associations (varying strength and evidence counts) with broad disease categories including **neoplasm**, **aortic aneurysm**, **thoracic aortic aneurysm**, and **neurodegenerative disease**. These should be used as starting points for targeted literature review rather than as definitive causal claims. (OpenTargets Search: -ARIH1)
+
+## Summary table
+The following table consolidates ARIH1’s identity, mechanism, regulation, substrates, roles, and recent developments (with URLs and publication dates).
+
+| Functional aspect | Specific details | Key evidence type | Primary supporting citations | Source URL + publication date |
+|---|---|---|---|---|
+| Identity / verified target | Human **ARIH1** encodes **HHARI** (also called Ariadne RBR E3 ubiquitin protein ligase 1), an **RBR-family** E3 ligase with **RING1–IBR–RING2** catalytic core plus an **Ariadne** autoinhibitory region; this matches UniProt Q9Y4X5 and the Ariadne subfamily annotation. | Structural/mechanistic paper; review | (wang2023theunifyingcatalytic pages 1-2, smit2013ubiquitinchainformation pages 24-26) | Wang et al., *Nat Commun* (2023-01), https://doi.org/10.1038/s41467-023-35871-z; Smit (2013, thesis/review-style source) |
+| Domain architecture | RING1 recruits E2~Ub, IBR links the RBR scaffold, and RING2 contains the **catalytic cysteine** for transthiolation; the **Ariadne domain** restrains the catalytic module in an autoinhibited state until activation. | Structural biology; biochemical mechanism | (wang2023theunifyingcatalytic pages 1-2, hornghetko2024noncanonicalassemblyneddylation pages 2-3) | Wang et al., *Nat Commun* (2023-01), https://doi.org/10.1038/s41467-023-35871-z; Horn-Ghetko et al., *Nat Struct Mol Biol* (2024-04), https://doi.org/10.1038/s41594-024-01257-y |
+| Catalytic mechanism | ARIH1 uses the canonical **RBR two-step mechanism**: ubiquitin is transferred from an E2 to the **RING2 catalytic cysteine** of ARIH1 by **transthiolation**, then from ARIH1 to substrate by aminolysis. | Cryo-EM; biochemistry; mechanistic review | (wang2023theunifyingcatalytic pages 1-2, hornghetko2021ubiquitinligationto pages 1-2) | Wang et al., *Nat Commun* (2023-01), https://doi.org/10.1038/s41467-023-35871-z; Horn-Ghetko et al., *Nature* (2021-02), https://doi.org/10.1038/s41586-021-03197-9 |
+| Activation by neddylated CRLs | A key current model is that **neddylated cullin-RING ligases (CRLs)** activate ARIH1 by relieving autoinhibition and positioning ARIH1 for substrate ubiquitination. ARIH1 cooperates especially with **RBX1-containing CUL1/CUL2/CUL3** complexes. | Cryo-EM; structural/mechanistic review | (hornghetko2024noncanonicalassemblyneddylation pages 2-3, wang2023theunifyingcatalytic pages 1-2, lin2024diversityofstructure pages 1-3) | Horn-Ghetko et al., *Nat Struct Mol Biol* (2024-04), https://doi.org/10.1038/s41594-024-01257-y; Wang et al., *Nat Commun* (2023-01), https://doi.org/10.1038/s41467-023-35871-z; Lin & Komives, *Curr Opin Struct Biol* (2024-10), https://doi.org/10.1016/j.sbi.2024.102879 |
+| E3–E3 super-assembly with SCF ligases | In a landmark model, **neddylated SCF (CUL1–RBX1–SKP1–F-box) complexes** and ARIH1 form an **E3–E3 super-assembly**. Cryo-EM visualized transfer from **UBE2L3 to the ARIH1 catalytic cysteine and then to SCF-bound substrate**, explaining how CRLs ubiquitinate geometrically difficult substrates. | Cryo-EM; chemical probes; biochemistry | (hornghetko2021ubiquitinligationto pages 1-2, hornghetko2021ubiquitinligationto media a3b226ac, hornghetko2021ubiquitinligationto media f3b6a2dc) | Horn-Ghetko et al., *Nature* (2021-02), https://doi.org/10.1038/s41586-021-03197-9 |
+| E2 partners | ARIH1 is most strongly linked to **UBE2L3/UbcH7** as the donor E2 in the SCF–ARIH1 pathway; broader RBR work also uses **UbcH5B/UBE2D-family** conjugates to interrogate RBR catalysis, and older literature reported interaction with **UBE2L3 and UBE2L6**. | Cryo-EM; ITC/biochemistry; older interaction literature | (hornghetko2021ubiquitinligationto pages 1-2, wang2023theunifyingcatalytic pages 1-2, smit2013ubiquitinchainformation pages 26-29, kontra2025theacidicnterminus pages 37-37) | Horn-Ghetko et al., *Nature* (2021-02), https://doi.org/10.1038/s41586-021-03197-9; Wang et al., *Nat Commun* (2023-01), https://doi.org/10.1038/s41467-023-35871-z |
+| Substrate class specificity | ARIH1 appears particularly important for **folded or spatially constrained CRL substrates** that a canonical RING E2 cannot easily reach; by contrast, some extended or disordered substrates can be ubiquitinated without ARIH1. | Mechanistic study; structural review | (hornghetko2021ubiquitinligationto pages 1-2, lin2024diversityofstructure pages 1-3) | Horn-Ghetko et al., *Nature* (2021-02), https://doi.org/10.1038/s41586-021-03197-9; Lin & Komives, *Curr Opin Struct Biol* (2024-10), https://doi.org/10.1016/j.sbi.2024.102879 |
+| Representative CRL-linked substrates | In the SCF context, ARIH1 contributes to ubiquitination of substrates such as **phosphorylated cyclin E** and **p27**, and ARIH1 knockdown stabilizes multiple CRL substrates. | Cryo-EM; biochemical and cellular perturbation | (hornghetko2021ubiquitinligationto pages 1-2) | Horn-Ghetko et al., *Nature* (2021-02), https://doi.org/10.1038/s41586-021-03197-9 |
+| Direct substrate: hnRNP E1 (PCBP1) | **hnRNP E1** is a validated ARIH1 substrate in breast cancer models. ARIH1 promotes **K48-linked ubiquitination** and proteasomal degradation; ubiquitinated lysines include **K23, K314, K351**, with **K314R** increasing stability and reducing ubiquitination. | Yeast 2-hybrid; miniTurboID proteomics; CHX chase; IP/immunoblot; mutagenesis | (howley2022theubiquitine3 pages 8-9, howley2022theubiquitine3 pages 1-3) | Howley et al., *Oncogene* (2022-01), https://doi.org/10.1038/s41388-022-02199-9 |
+| Putative or previous substrate links | Earlier literature associated HHARI/ARIH1 with **4EHP/eIF4E2** and with degradation of **synphilin-1** and **SIM2** in cells, but these links are less central and generally less definitive than the CRL-priming and hnRNP E1 data. | Earlier cell-based studies; review | (smit2013ubiquitinchainformation pages 26-29) | Smit (2013, thesis/review-style source) |
+| Translation control / proteostasis | Reviews of **4EHP/eIF4E2** note that under stress or DNA-damage contexts **HHARI/ARIH1 accumulates and associates with 4EHP**, linking ARIH1 to translational repression pathways; ARIH1 has also been implicated in DNA damage-induced translational arrest in cancer cells. | Review; prior cell biology | (howley2022theubiquitine3 pages 8-9) | Christie & Igreja, *FEBS J* (2023-11), https://doi.org/10.1111/febs.16275; Howley et al., *Oncogene* (2022-01), https://doi.org/10.1038/s41388-022-02199-9 |
+| EMT / cancer progression | ARIH1 promotes **EMT**, invasion, stemness, and tumor progression in breast cancer models; ARIH1 knockdown delays EMT, reduces invasion, and lowers tumor formation, while overexpression has the opposite effect. | Cell assays; xenografts; IHC; proteomics | (howley2022theubiquitine3 pages 1-3, howley2022theubiquitine3 pages 6-8) | Howley et al., *Oncogene* (2022-01), https://doi.org/10.1038/s41388-022-02199-9 |
+| Quantitative cancer-related findings | MiniTurboID proximity labeling identified **74 enriched ARIH1 interactors**; metastasis IHC analyses in matched samples reported significant ARIH1 elevation (**paired t-test P<0.05**), and xenograft or lung-colonization effects included significant differences (**for example, two-way ANOVA with Bonferroni, P<0.001 in reported experiments**). | Quantitative proteomics; pathology; in vivo assays | (howley2022theubiquitine3 pages 8-9, howley2022theubiquitine3 pages 6-8) | Howley et al., *Oncogene* (2022-01), https://doi.org/10.1038/s41388-022-02199-9 |
+| Innate immunity / RIG-I signaling | Recent work links HHARI/ARIH1 to **RIG-I-mediated type I interferon signaling**. Catalytic activity is required (**C357A inactive**), the acidic N-terminus is important, HHARI can interact with **RIG-I**, and responses are strongly **neddylation-dependent**. | Preprint; cell signaling assays; co-IP; ELISA; microscopy | (kontra2025theacidicnterminus pages 9-12, kontra2025theacidicnterminus pages 33-35, kontra2025theacidicnterminus pages 36-37) | Kontra et al., *bioRxiv* (2025-02), https://doi.org/10.1101/2025.02.01.636034 |
+| Quantitative immune findings | In interferon assays, HHARI increased **IFNβ secretion** with readouts scaled up to about **6,000 pg/mL** in figures; **MLN4924 (10 μM)** suppressed HHARI-dependent signaling, and **30 nM siRNA** against **DDX58/RIG-I** or **MAVS** reduced HHARI-driven responses. | ELISA; inhibitor studies; siRNA perturbation | (kontra2025theacidicnterminus pages 36-36, kontra2025theacidicnterminus pages 33-35, kontra2025theacidicnterminus pages 36-37) | Kontra et al., *bioRxiv* (2025-02), https://doi.org/10.1101/2025.02.01.636034 |
+| Localization | ARIH1 is primarily an **intracellular** ligase acting in the **cytoplasm and nucleus**; tumor studies detected ARIH1 staining in both compartments, and functionally ARIH1 operates in multiprotein complexes with CRLs, RNA-binding factors, and signaling proteins. | IHC/cell biology; structural complex data | (howley2022theubiquitine3 pages 6-8, hornghetko2021ubiquitinligationto pages 1-2) | Howley et al., *Oncogene* (2022-01), https://doi.org/10.1038/s41388-022-02199-9; Horn-Ghetko et al., *Nature* (2021-02), https://doi.org/10.1038/s41586-021-03197-9 |
+| Essentiality / constraint | ARIH1 behaves like an **essential or fitness-relevant UPS component** in several datasets: genome-wide CRISPR screens identified ARIH1 as important for cell viability, and gnomAD-based commentary notes that predicted human **loss-of-function variants are very rare**. | CRISPR screens; population genetics commentary | (hornghetko2021ubiquitinligationto pages 1-2, kontra2025theacidicnterminus pages 9-12) | Horn-Ghetko et al., *Nature* (2021-02), https://doi.org/10.1038/s41586-021-03197-9; Kontra et al., *bioRxiv* (2025-02), https://doi.org/10.1101/2025.02.01.636034 |
+| Disease links / database-level associations | Open Targets lists low-to-moderate evidence links between ARIH1 and **neoplasm**, **aortic aneurysm**, **thoracic aortic aneurysm**, **neurodegenerative disease**, and **abruptio placentae**; these are hypothesis-generating rather than definitive functional assignments. | Database aggregation | (OpenTargets Search: -ARIH1) | Open Targets Platform query for ARIH1 (accessed via tool context; no publication date provided) |
+| Key 2023 development | The 2023 mechanistic synthesis strengthened the view that **HHARI/ARIH1 conforms to a unifying RBR catalytic mechanism**, emphasizing the open E2~Ub conformation and allosteric activation features shared across RBR ligases. | High-impact mechanistic paper | (wang2023theunifyingcatalytic pages 1-2) | Wang et al., *Nat Commun* (2023-01), https://doi.org/10.1038/s41467-023-35871-z |
+| Key 2024 developments | 2024 studies and reviews extended ARIH1 functional annotation by framing it as a **geometrically optimized catalytic partner for CRLs** and by generalizing ARIH-type cooperation across cullin ligase systems, including noncanonical cullin–RBR assemblies. | Structural review; primary structural paper | (hornghetko2024noncanonicalassemblyneddylation pages 2-3, lin2024diversityofstructure pages 1-3) | Horn-Ghetko et al., *Nat Struct Mol Biol* (2024-04), https://doi.org/10.1038/s41594-024-01257-y; Lin & Komives, *Curr Opin Struct Biol* (2024-10), https://doi.org/10.1016/j.sbi.2024.102879 |
+
+
+*Table: This table summarizes verified identity, catalytic mechanism, activation, substrate biology, pathway roles, localization, and recent developments for human ARIH1/HHARI. It prioritizes 2023–2024 sources while retaining the key 2021 and 2022 primary papers that established major mechanistic and disease-relevant functions.*
+
+## Key visual evidence
+Cryo-EM intermediates and cycle schematics supporting the **SCF–ARIH1 E3–E3** ubiquitination mechanism (E2~Ub → ARIH1 catalytic cysteine → substrate) are shown in extracted panels. (hornghetko2021ubiquitinligationto media a3b226ac, hornghetko2021ubiquitinligationto media f3b6a2dc)
+
+References
+
+1. (wang2023theunifyingcatalytic pages 1-2): Xiangyi S. Wang, Thomas R. Cotton, Sarah J. Trevelyan, Lachlan W. Richardson, Wei Ting Lee, John Silke, and Bernhard C. Lechtenberg. The unifying catalytic mechanism of the ring-between-ring e3 ubiquitin ligase family. Nature Communications, Jan 2023. URL: https://doi.org/10.1038/s41467-023-35871-z, doi:10.1038/s41467-023-35871-z. This article has 65 citations and is from a highest quality peer-reviewed journal.
+
+2. (smit2013ubiquitinchainformation pages 24-26): J Smit. Ubiquitin chain formation by rbr e3-ligases. Unknown journal, 2013.
+
+3. (hornghetko2021ubiquitinligationto pages 1-2): Daniel Horn-Ghetko, David T. Krist, J. Rajan Prabu, Kheewoong Baek, Monique P. C. Mulder, Maren Klügel, Daniel C. Scott, Huib Ovaa, Gary Kleiger, and Brenda A. Schulman. Ubiquitin ligation to f-box protein targets by scf–rbr e3–e3 super-assembly. Nature, 590:671-676, Feb 2021. URL: https://doi.org/10.1038/s41586-021-03197-9, doi:10.1038/s41586-021-03197-9. This article has 199 citations and is from a highest quality peer-reviewed journal.
+
+4. (lin2024diversityofstructure pages 1-3): Calvin P. Lin and Elizabeth A. Komives. Diversity of structure and function in cullin e3 ligases. Current Opinion in Structural Biology, 88:102879, Oct 2024. URL: https://doi.org/10.1016/j.sbi.2024.102879, doi:10.1016/j.sbi.2024.102879. This article has 14 citations and is from a peer-reviewed journal.
+
+5. (hornghetko2024noncanonicalassemblyneddylation pages 2-3): Daniel Horn-Ghetko, Linus V. M. Hopf, Ishita Tripathi-Giesgen, Jiale Du, Sebastian Kostrhon, D. Tung Vu, Viola Beier, Barbara Steigenberger, J. Rajan Prabu, Luca Stier, Elias M. Bruss, Matthias Mann, Yue Xiong, and Brenda A. Schulman. Noncanonical assembly, neddylation and chimeric cullin–ring/rbr ubiquitylation by the 1.8 mda cul9 e3 ligase complex. Nature Structural & Molecular Biology, 31:1083-1094, Apr 2024. URL: https://doi.org/10.1038/s41594-024-01257-y, doi:10.1038/s41594-024-01257-y. This article has 13 citations and is from a highest quality peer-reviewed journal.
+
+6. (hornghetko2021ubiquitinligationto media a3b226ac): Daniel Horn-Ghetko, David T. Krist, J. Rajan Prabu, Kheewoong Baek, Monique P. C. Mulder, Maren Klügel, Daniel C. Scott, Huib Ovaa, Gary Kleiger, and Brenda A. Schulman. Ubiquitin ligation to f-box protein targets by scf–rbr e3–e3 super-assembly. Nature, 590:671-676, Feb 2021. URL: https://doi.org/10.1038/s41586-021-03197-9, doi:10.1038/s41586-021-03197-9. This article has 199 citations and is from a highest quality peer-reviewed journal.
+
+7. (hornghetko2021ubiquitinligationto media f3b6a2dc): Daniel Horn-Ghetko, David T. Krist, J. Rajan Prabu, Kheewoong Baek, Monique P. C. Mulder, Maren Klügel, Daniel C. Scott, Huib Ovaa, Gary Kleiger, and Brenda A. Schulman. Ubiquitin ligation to f-box protein targets by scf–rbr e3–e3 super-assembly. Nature, 590:671-676, Feb 2021. URL: https://doi.org/10.1038/s41586-021-03197-9, doi:10.1038/s41586-021-03197-9. This article has 199 citations and is from a highest quality peer-reviewed journal.
+
+8. (howley2022theubiquitine3 pages 1-3): Breege V. Howley, Bidyut Mohanty, Annamarie Dalton, Simon Grelet, Joseph Karam, Toros Dincman, and Philip H. Howe. The ubiquitin e3 ligase arih1 regulates hnrnp e1 protein stability, emt and breast cancer progression. Oncogene, 41:1679-1690, Jan 2022. URL: https://doi.org/10.1038/s41388-022-02199-9, doi:10.1038/s41388-022-02199-9. This article has 40 citations and is from a domain leading peer-reviewed journal.
+
+9. (howley2022theubiquitine3 pages 8-9): Breege V. Howley, Bidyut Mohanty, Annamarie Dalton, Simon Grelet, Joseph Karam, Toros Dincman, and Philip H. Howe. The ubiquitin e3 ligase arih1 regulates hnrnp e1 protein stability, emt and breast cancer progression. Oncogene, 41:1679-1690, Jan 2022. URL: https://doi.org/10.1038/s41388-022-02199-9, doi:10.1038/s41388-022-02199-9. This article has 40 citations and is from a domain leading peer-reviewed journal.
+
+10. (howley2022theubiquitine3 pages 6-8): Breege V. Howley, Bidyut Mohanty, Annamarie Dalton, Simon Grelet, Joseph Karam, Toros Dincman, and Philip H. Howe. The ubiquitin e3 ligase arih1 regulates hnrnp e1 protein stability, emt and breast cancer progression. Oncogene, 41:1679-1690, Jan 2022. URL: https://doi.org/10.1038/s41388-022-02199-9, doi:10.1038/s41388-022-02199-9. This article has 40 citations and is from a domain leading peer-reviewed journal.
+
+11. (smit2013ubiquitinchainformation pages 26-29): J Smit. Ubiquitin chain formation by rbr e3-ligases. Unknown journal, 2013.
+
+12. (kontra2025theacidicnterminus pages 33-35): Ioanna Kontra, Harry Ward, Faith Vinluan, Rachel Lau, Vinothini Rajeeve, Pedro Cutillas, Benjamin Stieglitz, and Myles J. Lewis. The acidic n-terminus of hhari and neddylation are essential for the activation and maintenance of rig-i-mediated type i interferon response. bioRxiv, Feb 2025. URL: https://doi.org/10.1101/2025.02.01.636034, doi:10.1101/2025.02.01.636034. This article has 0 citations.
+
+13. (kontra2025theacidicnterminus pages 9-12): Ioanna Kontra, Harry Ward, Faith Vinluan, Rachel Lau, Vinothini Rajeeve, Pedro Cutillas, Benjamin Stieglitz, and Myles J. Lewis. The acidic n-terminus of hhari and neddylation are essential for the activation and maintenance of rig-i-mediated type i interferon response. bioRxiv, Feb 2025. URL: https://doi.org/10.1101/2025.02.01.636034, doi:10.1101/2025.02.01.636034. This article has 0 citations.
+
+14. (lin2024diversityofstructure pages 3-5): Calvin P. Lin and Elizabeth A. Komives. Diversity of structure and function in cullin e3 ligases. Current Opinion in Structural Biology, 88:102879, Oct 2024. URL: https://doi.org/10.1016/j.sbi.2024.102879, doi:10.1016/j.sbi.2024.102879. This article has 14 citations and is from a peer-reviewed journal.
+
+15. (jeong2023targetinge3ubiquitin pages 1-2): Yelin Jeong, Ah-Reum Oh, Young Hoon Jung, HyunJoon Gi, Young Un Kim, and KyeongJin Kim. Targeting e3 ubiquitin ligases and their adaptors as a therapeutic strategy for metabolic diseases. Experimental &amp; Molecular Medicine, 55:2097-2104, Oct 2023. URL: https://doi.org/10.1038/s12276-023-01087-w, doi:10.1038/s12276-023-01087-w. This article has 56 citations and is from a peer-reviewed journal.
+
+16. (kontra2025theacidicnterminus pages 36-36): Ioanna Kontra, Harry Ward, Faith Vinluan, Rachel Lau, Vinothini Rajeeve, Pedro Cutillas, Benjamin Stieglitz, and Myles J. Lewis. The acidic n-terminus of hhari and neddylation are essential for the activation and maintenance of rig-i-mediated type i interferon response. bioRxiv, Feb 2025. URL: https://doi.org/10.1101/2025.02.01.636034, doi:10.1101/2025.02.01.636034. This article has 0 citations.
+
+17. (OpenTargets Search: -ARIH1): Open Targets Query (-ARIH1, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+18. (kontra2025theacidicnterminus pages 37-37): Ioanna Kontra, Harry Ward, Faith Vinluan, Rachel Lau, Vinothini Rajeeve, Pedro Cutillas, Benjamin Stieglitz, and Myles J. Lewis. The acidic n-terminus of hhari and neddylation are essential for the activation and maintenance of rig-i-mediated type i interferon response. bioRxiv, Feb 2025. URL: https://doi.org/10.1101/2025.02.01.636034, doi:10.1101/2025.02.01.636034. This article has 0 citations.
+
+19. (kontra2025theacidicnterminus pages 36-37): Ioanna Kontra, Harry Ward, Faith Vinluan, Rachel Lau, Vinothini Rajeeve, Pedro Cutillas, Benjamin Stieglitz, and Myles J. Lewis. The acidic n-terminus of hhari and neddylation are essential for the activation and maintenance of rig-i-mediated type i interferon response. bioRxiv, Feb 2025. URL: https://doi.org/10.1101/2025.02.01.636034, doi:10.1101/2025.02.01.636034. This article has 0 citations.
+
+## Citations
+
+1. wang2023theunifyingcatalytic pages 1-2
+2. hornghetko2021ubiquitinligationto pages 1-2
+3. lin2024diversityofstructure pages 3-5
+4. hornghetko2024noncanonicalassemblyneddylation pages 2-3
+5. kontra2025theacidicnterminus pages 33-35
+6. lin2024diversityofstructure pages 1-3
+7. smit2013ubiquitinchainformation pages 26-29
+8. smit2013ubiquitinchainformation pages 24-26
+9. kontra2025theacidicnterminus pages 9-12
+10. kontra2025theacidicnterminus pages 36-36
+11. kontra2025theacidicnterminus pages 37-37
+12. kontra2025theacidicnterminus pages 36-37
+13. https://doi.org/10.1038/s41467-023-35871-z;
+14. https://doi.org/10.1038/s41594-024-01257-y
+15. https://doi.org/10.1038/s41586-021-03197-9
+16. https://doi.org/10.1038/s41594-024-01257-y;
+17. https://doi.org/10.1016/j.sbi.2024.102879
+18. https://doi.org/10.1038/s41586-021-03197-9;
+19. https://doi.org/10.1038/s41467-023-35871-z
+20. https://doi.org/10.1038/s41388-022-02199-9
+21. https://doi.org/10.1111/febs.16275;
+22. https://doi.org/10.1101/2025.02.01.636034
+23. https://doi.org/10.1038/s41388-022-02199-9;
+24. https://doi.org/10.1038/s41467-023-35871-z,
+25. https://doi.org/10.1038/s41586-021-03197-9,
+26. https://doi.org/10.1016/j.sbi.2024.102879,
+27. https://doi.org/10.1038/s41594-024-01257-y,
+28. https://doi.org/10.1038/s41388-022-02199-9,
+29. https://doi.org/10.1101/2025.02.01.636034,
+30. https://doi.org/10.1038/s12276-023-01087-w,

--- a/genes/human/IGFBP3/IGFBP3-ai-review.html
+++ b/genes/human/IGFBP3/IGFBP3-ai-review.html
@@ -1008,10 +1008,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0001968" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0001968" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -1019,31 +1019,15 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Fibronectin binding is not a major finding in the synthesized IGFBP3 evidence; extracellular matrix binding is better captured by the specific hyaluronic acid binding evidence.
+                            <strong>Summary:</strong> Fibronectin binding is retained as a non-core transferred annotation, but the Falcon evidence set did not retrieve strong direct IGFBP3-specific support for fibronectin binding. This should not be treated as refuted; it is simply less established than IGF and hyaluronan binding.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The current evidence synthesis supports HA binding, not fibronectin binding, as the informative ECM ligand interaction.
+                            <strong>Reason:</strong> Direct support for fibronectin binding was not established in this review, but the term is not demonstrably false.
                         </div>
 
 
-
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">IGFBP-3 binds HA via a mapped basic C-terminal motif (aa **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA engagement of **CD44**, suppressing HA–CD44 signaling.</div>
-
-                            </div>
-
-                        </div>
 
                     </td>
                 </tr>
@@ -2279,10 +2263,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0001968" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0001968" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2290,31 +2274,15 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Fibronectin binding is not a major finding in the synthesized IGFBP3 evidence; extracellular matrix binding is better captured by the specific hyaluronic acid binding evidence.
+                            <strong>Summary:</strong> Fibronectin binding is retained as a non-core transferred annotation, but the Falcon evidence set did not retrieve strong direct IGFBP3-specific support for fibronectin binding. This should not be treated as refuted; it is simply less established than IGF and hyaluronan binding.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> The current evidence synthesis supports HA binding, not fibronectin binding, as the informative ECM ligand interaction.
+                            <strong>Reason:</strong> Direct support for fibronectin binding was not established in this review, but the term is not demonstrably false.
                         </div>
 
 
-
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">IGFBP-3 binds HA via a mapped basic C-terminal motif (aa **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA engagement of **CD44**, suppressing HA–CD44 signaling.</div>
-
-                            </div>
-
-                        </div>
 
                     </td>
                 </tr>
@@ -3765,9 +3733,13 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> extracellular space is supported by IGFBP3 secretion and its extracellular/circulating IGF complex functions.
+                            <strong>Summary:</strong> Extracellular space localization is accepted because IGFBP3 is a secreted/circulating IGF-binding protein; however, PMID:17119061 is an epidemiological plasma IGF cohort study, so the original IDA evidence/citation is weak for direct localization evidence.
                         </div>
 
+
+                        <div>
+                            <strong>Reason:</strong> Accepted based on the broader secreted-protein evidence while noting the source GOA citation quality issue.
+                        </div>
 
 
 
@@ -3852,10 +3824,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0001933" data-r="PMID:17591901" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0001933" data-r="PMID:17591901" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -3863,9 +3835,13 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> negative regulation of protein phosphorylation is consistent with IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but these are downstream context-specific effects rather than the core ligand-binding activity.
+                            <strong>Summary:</strong> UNDECIDED: the source GOA annotation cites PMID:17591901, but that PMID is a PAX6 postnatal eye-development paper rather than an IGFBP3 phosphorylation/signaling study. This appears to be an erroneous PMID assignment in GOA, so the annotation cannot be accepted or cleanly modified from the cited evidence.
                         </div>
 
+
+                        <div>
+                            <strong>Reason:</strong> The cited publication does not support an IGFBP3 annotation; this should be flagged for source-database review.
+                        </div>
 
 
 
@@ -4972,14 +4948,25 @@
                         </div>
                     </td>
                     <td>
-                        <span class="evidence-code">IC</span>
+                        <span class="evidence-code">IDA</span>
 
 
 
                         <br>
                         <span style="font-size: 0.75rem;">
 
-                            file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/30184438" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:30184438
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Interaction of Insulin-Like Growth Factor-Binding Protein 3 ...
+                                </span>
+
+
 
                         </span>
 
@@ -4988,7 +4975,7 @@
                         <span class="action-badge action-new">
                             NEW
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005540" data-r="file:human/IGFBP3/IGFBP3-deep-research-falcon.md" data-act="NEW">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005540" data-r="PMID:30184438" data-act="NEW">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -4996,18 +4983,31 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> IGFBP3 binds hyaluronan through a mapped basic C-terminal motif and can block HA-CD44 signaling.
+                            <strong>Summary:</strong> IGFBP3 hyaluronic acid binding is directly supported by PMID:30184438, which characterizes HA binding to IGFBP3 and the 215-232 C-terminal peptide and its regulation by humanin/CD44.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Specific HA binding is supported by recent mechanistic work and is absent from current GOA.
+                            <strong>Reason:</strong> Specific HA binding is supported by primary experimental evidence and is absent from current GOA.
                         </div>
 
 
 
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/30184438" target="_blank" class="term-link">
+                                        PMID:30184438
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here, we characterized the binding affinities of the IGFBP-3 protein and peptide (215-KKGFYKKKQCRPSKGRKR-232) to HA and to humanin and found that HA binds with a weaker affinity to this region than does humanin.</div>
+
+                            </div>
 
                             <div class="support-item">
                                 <span class="support-ref">
@@ -6422,17 +6422,13 @@ existing_annotations:
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: Fibronectin binding is not a major finding in the synthesized IGFBP3
-        evidence; extracellular matrix binding is better captured by the specific
-        hyaluronic acid binding evidence.
-      action: MARK_AS_OVER_ANNOTATED
-      reason: The current evidence synthesis supports HA binding, not fibronectin
-        binding, as the informative ECM ligand interaction.
-      supported_by:
-        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
-          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
-            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
-            HA engagement of **CD44**, suppressing HA–CD44 signaling.
+      summary: Fibronectin binding is retained as a non-core transferred annotation, but
+        the Falcon evidence set did not retrieve strong direct IGFBP3-specific support
+        for fibronectin binding. This should not be treated as refuted; it is simply
+        less established than IGF and hyaluronan binding.
+      action: KEEP_AS_NON_CORE
+      reason: Direct support for fibronectin binding was not established in this review,
+        but the term is not demonstrably false.
   - term:
       id: GO:0043567
       label: regulation of insulin-like growth factor receptor signaling pathway
@@ -6773,17 +6769,13 @@ existing_annotations:
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: Fibronectin binding is not a major finding in the synthesized IGFBP3
-        evidence; extracellular matrix binding is better captured by the specific
-        hyaluronic acid binding evidence.
-      action: MARK_AS_OVER_ANNOTATED
-      reason: The current evidence synthesis supports HA binding, not fibronectin
-        binding, as the informative ECM ligand interaction.
-      supported_by:
-        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
-          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
-            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
-            HA engagement of **CD44**, suppressing HA–CD44 signaling.
+      summary: Fibronectin binding is retained as a non-core transferred annotation, but
+        the Falcon evidence set did not retrieve strong direct IGFBP3-specific support
+        for fibronectin binding. This should not be treated as refuted; it is simply
+        less established than IGF and hyaluronan binding.
+      action: KEEP_AS_NON_CORE
+      reason: Direct support for fibronectin binding was not established in this review,
+        but the term is not demonstrably false.
   - term:
       id: GO:0005615
       label: extracellular space
@@ -7170,8 +7162,10 @@ existing_annotations:
     evidence_type: IDA
     original_reference_id: PMID:17119061
     review:
-      summary: extracellular space is supported by IGFBP3 secretion and its
-        extracellular/circulating IGF complex functions.
+      summary: Extracellular space localization is accepted because IGFBP3 is a
+        secreted/circulating IGF-binding protein; however, PMID:17119061 is an
+        epidemiological plasma IGF cohort study, so the original IDA evidence/citation
+        is weak for direct localization evidence.
       action: ACCEPT
       supported_by:
         - reference_id: PMID:17119061
@@ -7188,17 +7182,19 @@ existing_annotations:
             in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
             acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
             circulating IGF.
+      reason: Accepted based on the broader secreted-protein evidence while noting the
+        source GOA citation quality issue.
   - term:
       id: GO:0001933
       label: negative regulation of protein phosphorylation
     evidence_type: IDA
     original_reference_id: PMID:17591901
     review:
-      summary: negative regulation of protein phosphorylation is consistent with IGFBP3
-        modulation of IGF/IGF1R and IGF-independent signaling outputs, but these are
-        downstream context-specific effects rather than the core ligand-binding
-        activity.
-      action: KEEP_AS_NON_CORE
+      summary: &#39;UNDECIDED: the source GOA annotation cites PMID:17591901, but that PMID is
+        a PAX6 postnatal eye-development paper rather than an IGFBP3 phosphorylation/signaling
+        study. This appears to be an erroneous PMID assignment in GOA, so the annotation cannot
+        be accepted or cleanly modified from the cited evidence.&#39;
+      action: UNDECIDED
       supported_by:
         - reference_id: PMID:17591901
           supporting_text: &#39;The requirement of pax6 for postnatal eye development: evidence
@@ -7214,6 +7210,8 @@ existing_annotations:
             factor binding proteins (IGFBPs) whose canonical cellular role is to bind
             **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
             and modulating IGF1R signaling.
+      reason: The cited publication does not support an IGFBP3 annotation; this should
+        be flagged for source-database review.
   - term:
       id: GO:0005634
       label: nucleus
@@ -7472,15 +7470,20 @@ existing_annotations:
   - term:
       id: GO:0005540
       label: hyaluronic acid binding
-    evidence_type: IC
-    original_reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+    evidence_type: IDA
+    original_reference_id: PMID:30184438
     review:
-      summary: IGFBP3 binds hyaluronan through a mapped basic C-terminal motif and can
-        block HA-CD44 signaling.
+      summary: IGFBP3 hyaluronic acid binding is directly supported by PMID:30184438,
+        which characterizes HA binding to IGFBP3 and the 215-232 C-terminal peptide and
+        its regulation by humanin/CD44.
       action: NEW
-      reason: Specific HA binding is supported by recent mechanistic work and is absent
-        from current GOA.
+      reason: Specific HA binding is supported by primary experimental evidence and is
+        absent from current GOA.
       supported_by:
+        - reference_id: PMID:30184438
+          supporting_text: Here, we characterized the binding affinities of the IGFBP-3
+            protein and peptide (215-KKGFYKKKQCRPSKGRKR-232) to HA and to humanin and
+            found that HA binds with a weaker affinity to this region than does humanin.
         - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
           supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
             **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks

--- a/genes/human/IGFBP3/IGFBP3-ai-review.html
+++ b/genes/human/IGFBP3/IGFBP3-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>IGFBP3</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P17936" target="_blank" class="term-link">
                         P17936
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-initialized">
-                    INITIALIZED
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P17936" data-a="DESCRIPTION: TODO: Add description for IGFBP3..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P17936" data-a="DESCRIPTION: IGFBP3 encodes a secreted insulin-like growth fact..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for IGFBP3</p>
+        <p>IGFBP3 encodes a secreted insulin-like growth factor binding protein whose dominant biochemical activity is high-affinity binding of IGF-I and IGF-II, thereby regulating IGF receptor signaling and circulating IGF stability through binary and ALS-containing ternary complexes. It also has context-dependent IGF-independent roles involving nuclear import, RXR/RAR signaling, phosphatase-mediated suppression of IGF pathway mediators, apoptosis, and hyaluronan-CD44 signaling.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,2329 +758,3294 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031994" target="_blank" class="term-link">
                                     GO:0031994
                                 </a>
                             </span>
                             <span class="term-label">insulin-like growth factor I binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0031994" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0031994" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> insulin-like growth factor I binding is a core IGFBP3 molecular function; the literature consistently identifies high-affinity IGF-I/IGF-II binding as the dominant biochemical activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031995" target="_blank" class="term-link">
                                     GO:0031995
                                 </a>
                             </span>
                             <span class="term-label">insulin-like growth factor II binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0031995" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0031995" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> insulin-like growth factor II binding is a core IGFBP3 molecular function; the literature consistently identifies high-affinity IGF-I/IGF-II binding as the dominant biochemical activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005615" target="_blank" class="term-link">
                                     GO:0005615
                                 </a>
                             </span>
                             <span class="term-label">extracellular space</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005615" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005615" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> extracellular space is supported by IGFBP3 secretion and its extracellular/circulating IGF complex functions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001968" target="_blank" class="term-link">
                                     GO:0001968
                                 </a>
                             </span>
                             <span class="term-label">fibronectin binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0001968" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0001968" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Fibronectin binding is not a major finding in the synthesized IGFBP3 evidence; extracellular matrix binding is better captured by the specific hyaluronic acid binding evidence.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The current evidence synthesis supports HA binding, not fibronectin binding, as the informative ECM ligand interaction.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 binds HA via a mapped basic C-terminal motif (aa **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA engagement of **CD44**, suppressing HA–CD44 signaling.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043567" target="_blank" class="term-link">
                                     GO:0043567
                                 </a>
                             </span>
                             <span class="term-label">regulation of insulin-like growth factor receptor signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0043567" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0043567" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> IGFBP3 regulates IGF receptor signaling by sequestering IGF ligands and through IGF-independent signaling crosstalk, so this process annotation is supported.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2023 Endocrine Reviews synthesis describes an IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway mediators including **Akt** and **Ras/MAPK**.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005520" target="_blank" class="term-link">
                                     GO:0005520
                                 </a>
                             </span>
                             <span class="term-label">insulin-like growth factor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005520" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005520" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> insulin-like growth factor binding is a core IGFBP3 molecular function; the literature consistently identifies high-affinity IGF-I/IGF-II binding as the dominant biochemical activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> extracellular region is supported by IGFBP3 secretion and its extracellular/circulating IGF complex functions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Nuclear localization is supported but represents a context-dependent IGF-independent compartment rather than the canonical extracellular IGF-binding role.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Multiple sources support nuclear localization of IGFBP-3. Classic mechanistic evidence indicates IGFBP-3 contains a **basic C-terminal nuclear localization signal (NLS)** and undergoes **NLS-dependent, importin-mediated nuclear translocation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A central IGF-independent nuclear mechanism is the interaction of nuclear IGFBP-3 with **retinoid X receptor alpha (RXRα)**. Classic evidence describes RXR as an IGFBP-3 partner identified by yeast two-hybrid screening and positions this interaction as a conceptual “paradigm shift” for IGFBP actions in transcription and apoptosis.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006915" target="_blank" class="term-link">
                                     GO:0006915
                                 </a>
                             </span>
                             <span class="term-label">apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0006915" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0006915" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> apoptotic process is retained as a context-dependent IGF-independent apoptotic role, including nuclear receptor and cell-death receptor mechanisms, but it is not the canonical core molecular function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A central IGF-independent nuclear mechanism is the interaction of nuclear IGFBP-3 with **retinoid X receptor alpha (RXRα)**. Classic evidence describes RXR as an IGFBP-3 partner identified by yeast two-hybrid screening and positions this interaction as a conceptual “paradigm shift” for IGFBP actions in transcription and apoptosis.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">apoptotic effects mediated by its receptor TMEM219/IGFBP-3R</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0014912" target="_blank" class="term-link">
                                     GO:0014912
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of smooth muscle cell migration</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0014912" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0014912" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> negative regulation of smooth muscle cell migration is consistent with IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but these are downstream context-specific effects rather than the core ligand-binding activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2023 Endocrine Reviews synthesis describes an IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway mediators including **Akt** and **Ras/MAPK**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019838" target="_blank" class="term-link">
                                     GO:0019838
                                 </a>
                             </span>
                             <span class="term-label">growth factor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0019838" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0019838" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Growth factor binding is true but less informative than the specific insulin-like growth factor binding annotations already present.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Use the specific IGF binding term for this protein family.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005520" target="_blank" class="term-link">
+                                    insulin-like growth factor binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031994" target="_blank" class="term-link">
                                     GO:0031994
                                 </a>
                             </span>
                             <span class="term-label">insulin-like growth factor I binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0031994" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0031994" data-r="GO_REF:0000117" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> insulin-like growth factor I binding is a core IGFBP3 molecular function; the literature consistently identifies high-affinity IGF-I/IGF-II binding as the dominant biochemical activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042567" target="_blank" class="term-link">
                                     GO:0042567
                                 </a>
                             </span>
                             <span class="term-label">insulin-like growth factor ternary complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0042567" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0042567" data-r="GO_REF:0000117" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> insulin-like growth factor ternary complex is supported by IGFBP3 formation of binary IGF:IGFBP complexes and ALS-containing ternary complexes in circulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048662" target="_blank" class="term-link">
                                     GO:0048662
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of smooth muscle cell proliferation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0048662" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0048662" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> negative regulation of smooth muscle cell proliferation is consistent with IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but these are downstream context-specific effects rather than the core ligand-binding activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2023 Endocrine Reviews synthesis describes an IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway mediators including **Akt** and **Ras/MAPK**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20353938" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20353938
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of a novel cell death receptor mediating IGFB...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005515" data-r="PMID:20353938" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005515" data-r="PMID:20353938" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for IGFBP3. More informative annotations are IGF binding, hyaluronan binding, ternary complex formation, and specific receptor/importin/nuclear receptor interactions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Avoid retaining generic protein binding when specific molecular interactions are available.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20353938" target="_blank" class="term-link">
                                         PMID:20353938
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2010 Mar 30. Identification of a novel cell death receptor mediating IGFBP-3-induced anti-tumor effects in breast and prostate cancer.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The emerging consensus is therefore not a single “primary function” in all contexts, but a dominant primary biochemical activity—**high-affinity IGF binding**—that acts as a scaffold for diverse regulated functions controlled by **proteolysis** and **phosphorylation**, and by compartment switching between extracellular matrix, membrane microdomains, cytosol, and nucleus.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 binds HA via a mapped basic C-terminal motif (aa **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA engagement of **CD44**, suppressing HA–CD44 signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23178489" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23178489
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The role of insulin-like growth factor binding protein-3 in ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005515" data-r="PMID:23178489" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005515" data-r="PMID:23178489" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for IGFBP3. More informative annotations are IGF binding, hyaluronan binding, ternary complex formation, and specific receptor/importin/nuclear receptor interactions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Avoid retaining generic protein binding when specific molecular interactions are available.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23178489" target="_blank" class="term-link">
                                         PMID:23178489
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The role of insulin-like growth factor binding protein-3 in the breast cancer cell response to DNA-damaging agents.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The emerging consensus is therefore not a single “primary function” in all contexts, but a dominant primary biochemical activity—**high-affinity IGF binding**—that acts as a scaffold for diverse regulated functions controlled by **proteolysis** and **phosphorylation**, and by compartment switching between extracellular matrix, membrane microdomains, cytosol, and nucleus.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 binds HA via a mapped basic C-terminal motif (aa **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA engagement of **CD44**, suppressing HA–CD44 signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30184438" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30184438
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interaction of Insulin-Like Growth Factor-Binding Protein 3 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005515" data-r="PMID:30184438" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005515" data-r="PMID:30184438" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for IGFBP3. More informative annotations are IGF binding, hyaluronan binding, ternary complex formation, and specific receptor/importin/nuclear receptor interactions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Avoid retaining generic protein binding when specific molecular interactions are available.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/30184438" target="_blank" class="term-link">
                                         PMID:30184438
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epub 2018 Sep 17. Interaction of Insulin-Like Growth Factor-Binding Protein 3 With Hyaluronan and Its Regulation by Humanin and CD44.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The emerging consensus is therefore not a single “primary function” in all contexts, but a dominant primary biochemical activity—**high-affinity IGF binding**—that acts as a scaffold for diverse regulated functions controlled by **proteolysis** and **phosphorylation**, and by compartment switching between extracellular matrix, membrane microdomains, cytosol, and nucleus.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 binds HA via a mapped basic C-terminal motif (aa **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA engagement of **CD44**, suppressing HA–CD44 signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005515" data-r="PMID:32814053" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005515" data-r="PMID:32814053" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for IGFBP3. More informative annotations are IGF binding, hyaluronan binding, ternary complex formation, and specific receptor/importin/nuclear receptor interactions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Avoid retaining generic protein binding when specific molecular interactions are available.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                                         PMID:32814053
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The emerging consensus is therefore not a single “primary function” in all contexts, but a dominant primary biochemical activity—**high-affinity IGF binding**—that acts as a scaffold for diverse regulated functions controlled by **proteolysis** and **phosphorylation**, and by compartment switching between extracellular matrix, membrane microdomains, cytosol, and nucleus.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 binds HA via a mapped basic C-terminal motif (aa **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA engagement of **CD44**, suppressing HA–CD44 signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001649" target="_blank" class="term-link">
                                     GO:0001649
                                 </a>
                             </span>
                             <span class="term-label">osteoblast differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0001649" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0001649" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> osteoblast differentiation is retained as a context-specific differentiation phenotype downstream of IGFBP3 signaling rather than the core biochemical function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">including proliferation, differentiation, and apoptosis in a cell-type specific manner</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001968" target="_blank" class="term-link">
                                     GO:0001968
                                 </a>
                             </span>
                             <span class="term-label">fibronectin binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0001968" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0001968" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Fibronectin binding is not a major finding in the synthesized IGFBP3 evidence; extracellular matrix binding is better captured by the specific hyaluronic acid binding evidence.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The current evidence synthesis supports HA binding, not fibronectin binding, as the informative ECM ligand interaction.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 binds HA via a mapped basic C-terminal motif (aa **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA engagement of **CD44**, suppressing HA–CD44 signaling.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005615" target="_blank" class="term-link">
                                     GO:0005615
                                 </a>
                             </span>
                             <span class="term-label">extracellular space</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005615" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005615" data-r="GO_REF:0000107" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> extracellular space is supported by IGFBP3 secretion and its extracellular/circulating IGF complex functions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-381466
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-381466" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-381466" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> extracellular region is supported by IGFBP3 secretion and its extracellular/circulating IGF complex functions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26216267" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26216267
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Humanin Peptide Binds to Insulin-Like Growth Factor-Binding ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005515" data-r="PMID:26216267" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005515" data-r="PMID:26216267" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for IGFBP3. More informative annotations are IGF binding, hyaluronan binding, ternary complex formation, and specific receptor/importin/nuclear receptor interactions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Avoid retaining generic protein binding when specific molecular interactions are available.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/26216267" target="_blank" class="term-link">
                                         PMID:26216267
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Humanin Peptide Binds to Insulin-Like Growth Factor-Binding Protein 3 (IGFBP3) and Regulates Its Interaction with Importin-β.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The emerging consensus is therefore not a single “primary function” in all contexts, but a dominant primary biochemical activity—**high-affinity IGF binding**—that acts as a scaffold for diverse regulated functions controlled by **proteolysis** and **phosphorylation**, and by compartment switching between extracellular matrix, membrane microdomains, cytosol, and nucleus.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 binds HA via a mapped basic C-terminal motif (aa **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA engagement of **CD44**, suppressing HA–CD44 signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005788" target="_blank" class="term-link">
                                     GO:0005788
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8952289
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005788" data-r="Reactome:R-HSA-8952289" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005788" data-r="Reactome:R-HSA-8952289" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Endoplasmic reticulum lumen localization is plausible for a secreted precursor and FAM20C substrate, but it is not the main functional site of mature IGFBP3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042567" target="_blank" class="term-link">
                                     GO:0042567
                                 </a>
                             </span>
                             <span class="term-label">insulin-like growth factor ternary complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9497324" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9497324
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Insulin-like growth factor (IGF)-binding protein 5 forms an ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0042567" data-r="PMID:9497324" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0042567" data-r="PMID:9497324" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> insulin-like growth factor ternary complex is supported by IGFBP3 formation of binary IGF:IGFBP complexes and ALS-containing ternary complexes in circulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9497324" target="_blank" class="term-link">
                                         PMID:9497324
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Insulin-like growth factor (IGF)-binding protein 5 forms an alternative ternary complex with IGFs and the acid-labile subunit.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-381435
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-381435" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-381435" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> extracellular region is supported by IGFBP3 secretion and its extracellular/circulating IGF complex functions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-381446
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-381446" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-381446" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> extracellular region is supported by IGFBP3 secretion and its extracellular/circulating IGF complex functions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-381461
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-381461" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-381461" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> extracellular region is supported by IGFBP3 secretion and its extracellular/circulating IGF complex functions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-381496
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-381496" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-381496" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> extracellular region is supported by IGFBP3 secretion and its extracellular/circulating IGF complex functions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-381500
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-381500" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-381500" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> extracellular region is supported by IGFBP3 secretion and its extracellular/circulating IGF complex functions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6800035
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-6800035" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-6800035" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> extracellular region is supported by IGFBP3 secretion and its extracellular/circulating IGF complex functions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6800044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-6800044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="Reactome:R-HSA-6800044" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> extracellular region is supported by IGFBP3 secretion and its extracellular/circulating IGF complex functions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008285" target="_blank" class="term-link">
                                     GO:0008285
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cell population proliferation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19258508" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19258508
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     NKX3.1 activates expression of insulin-like growth factor bi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0008285" data-r="PMID:19258508" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0008285" data-r="PMID:19258508" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> negative regulation of cell population proliferation is consistent with IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but these are downstream context-specific effects rather than the core ligand-binding activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19258508" target="_blank" class="term-link">
                                         PMID:19258508
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epub 2009 Mar 3. NKX3.1 activates expression of insulin-like growth factor binding protein-3 to mediate insulin-like growth factor-I signaling and cell proliferation.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2023 Endocrine Reviews synthesis describes an IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway mediators including **Akt** and **Ras/MAPK**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0014912" target="_blank" class="term-link">
                                     GO:0014912
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of smooth muscle cell migration</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10766744" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10766744
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Substitutions for hydrophobic amino acids in the N-terminal ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0014912" data-r="PMID:10766744" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0014912" data-r="PMID:10766744" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> negative regulation of smooth muscle cell migration is consistent with IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but these are downstream context-specific effects rather than the core ligand-binding activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10766744" target="_blank" class="term-link">
                                         PMID:10766744
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Substitutions for hydrophobic amino acids in the N-terminal domains of IGFBP-3 and -5 markedly reduce IGF-I binding and alter their biologic actions.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2023 Endocrine Reviews synthesis describes an IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway mediators including **Akt** and **Ras/MAPK**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016942" target="_blank" class="term-link">
                                     GO:0016942
                                 </a>
                             </span>
                             <span class="term-label">insulin-like growth factor binding protein complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IC</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10766744" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10766744
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Substitutions for hydrophobic amino acids in the N-terminal ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0016942" data-r="PMID:10766744" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0016942" data-r="PMID:10766744" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> insulin-like growth factor binding protein complex is supported by IGFBP3 formation of binary IGF:IGFBP complexes and ALS-containing ternary complexes in circulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10766744" target="_blank" class="term-link">
                                         PMID:10766744
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Substitutions for hydrophobic amino acids in the N-terminal domains of IGFBP-3 and -5 markedly reduce IGF-I binding and alter their biologic actions.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031994" target="_blank" class="term-link">
                                     GO:0031994
                                 </a>
                             </span>
                             <span class="term-label">insulin-like growth factor I binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10766744" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10766744
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Substitutions for hydrophobic amino acids in the N-terminal ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0031994" data-r="PMID:10766744" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0031994" data-r="PMID:10766744" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> insulin-like growth factor I binding is a core IGFBP3 molecular function; the literature consistently identifies high-affinity IGF-I/IGF-II binding as the dominant biochemical activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10766744" target="_blank" class="term-link">
                                         PMID:10766744
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Substitutions for hydrophobic amino acids in the N-terminal domains of IGFBP-3 and -5 markedly reduce IGF-I binding and alter their biologic actions.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048662" target="_blank" class="term-link">
                                     GO:0048662
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of smooth muscle cell proliferation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10766744" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10766744
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Substitutions for hydrophobic amino acids in the N-terminal ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0048662" data-r="PMID:10766744" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0048662" data-r="PMID:10766744" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> negative regulation of smooth muscle cell proliferation is consistent with IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but these are downstream context-specific effects rather than the core ligand-binding activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10766744" target="_blank" class="term-link">
                                         PMID:10766744
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Substitutions for hydrophobic amino acids in the N-terminal domains of IGFBP-3 and -5 markedly reduce IGF-I binding and alter their biologic actions.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2023 Endocrine Reviews synthesis describes an IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway mediators including **Akt** and **Ras/MAPK**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005615" target="_blank" class="term-link">
                                     GO:0005615
                                 </a>
                             </span>
                             <span class="term-label">extracellular space</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17119061" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17119061
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Ethnic disparity in the relationship between obesity and pla...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005615" data-r="PMID:17119061" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005615" data-r="PMID:17119061" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> extracellular space is supported by IGFBP3 secretion and its extracellular/circulating IGF complex functions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17119061" target="_blank" class="term-link">
                                         PMID:17119061
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Ethnic disparity in the relationship between obesity and plasma insulin-like growth factors: the multiethnic cohort.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001933" target="_blank" class="term-link">
                                     GO:0001933
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of protein phosphorylation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17591901" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17591901
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The requirement of pax6 for postnatal eye development: evide...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0001933" data-r="PMID:17591901" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0001933" data-r="PMID:17591901" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> negative regulation of protein phosphorylation is consistent with IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but these are downstream context-specific effects rather than the core ligand-binding activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17591901" target="_blank" class="term-link">
                                         PMID:17591901
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The requirement of pax6 for postnatal eye development: evidence from experimental mouse chimeras.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2023 Endocrine Reviews synthesis describes an IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway mediators including **Akt** and **Ras/MAPK**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17434920" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17434920
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Contribution of the orphan nuclear receptor Nur77 to the apo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005634" data-r="PMID:17434920" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005634" data-r="PMID:17434920" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Nuclear localization is supported but represents a context-dependent IGF-independent compartment rather than the canonical extracellular IGF-binding role.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17434920" target="_blank" class="term-link">
                                         PMID:17434920
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Apr 13. Contribution of the orphan nuclear receptor Nur77 to the apoptotic action of IGFBP-3.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Multiple sources support nuclear localization of IGFBP-3. Classic mechanistic evidence indicates IGFBP-3 contains a **basic C-terminal nuclear localization signal (NLS)** and undergoes **NLS-dependent, importin-mediated nuclear translocation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A central IGF-independent nuclear mechanism is the interaction of nuclear IGFBP-3 with **retinoid X receptor alpha (RXRα)**. Classic evidence describes RXR as an IGFBP-3 partner identified by yeast two-hybrid screening and positions this interaction as a conceptual “paradigm shift” for IGFBP actions in transcription and apoptosis.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006468" target="_blank" class="term-link">
                                     GO:0006468
                                 </a>
                             </span>
                             <span class="term-label">protein phosphorylation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17434920" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17434920
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Contribution of the orphan nuclear receptor Nur77 to the apo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3092,1268 +4057,2278 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> OVER-ANNOTATION: IGFBP3 is an IGF-binding protein that modulates IGF signaling. It has NO kinase activity. IGFBP3 affects phosphorylation indirectly by regulating IGF availability and signaling, but doesn&#39;t catalyze phosphorylation itself.
+                            <strong>Summary:</strong> IGFBP3 is not a protein kinase and does not catalyze protein phosphorylation. The supported biology is indirect regulation of phosphorylation/signaling downstream of IGF1R and related pathways.
                         </div>
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Replace a misleading phosphorylation-process annotation with the supported negative regulation of protein phosphorylation/signaling.
+                        </div>
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045859" target="_blank" class="term-link">
-                                    regulation of protein kinase activity
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001933" target="_blank" class="term-link">
+                                    negative regulation of protein phosphorylation
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17434920" target="_blank" class="term-link">
                                         PMID:17434920
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Apr 13. Contribution of the orphan nuclear receptor Nur77 to the apoptotic action of IGFBP-3.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2023 Endocrine Reviews synthesis describes an IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway mediators including **Akt** and **Ras/MAPK**.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14561895" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14561895
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interaction between the Alzheimer&#39;s survival peptide humanin...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005515" data-r="PMID:14561895" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005515" data-r="PMID:14561895" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for IGFBP3. More informative annotations are IGF binding, hyaluronan binding, ternary complex formation, and specific receptor/importin/nuclear receptor interactions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Avoid retaining generic protein binding when specific molecular interactions are available.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14561895" target="_blank" class="term-link">
                                         PMID:14561895
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Interaction between the Alzheimer&#39;s survival peptide humanin and insulin-like growth factor-binding protein 3 regulates cell survival and apoptosis.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The emerging consensus is therefore not a single “primary function” in all contexts, but a dominant primary biochemical activity—**high-affinity IGF binding**—that acts as a scaffold for diverse regulated functions controlled by **proteolysis** and **phosphorylation**, and by compartment switching between extracellular matrix, membrane microdomains, cytosol, and nucleus.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 binds HA via a mapped basic C-terminal motif (aa **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA engagement of **CD44**, suppressing HA–CD44 signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9388210" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9388210
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Inhibition of insulin receptor activation by insulin-like gr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005515" data-r="PMID:9388210" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005515" data-r="PMID:9388210" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for IGFBP3. More informative annotations are IGF binding, hyaluronan binding, ternary complex formation, and specific receptor/importin/nuclear receptor interactions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Avoid retaining generic protein binding when specific molecular interactions are available.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9388210" target="_blank" class="term-link">
                                         PMID:9388210
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Inhibition of insulin receptor activation by insulin-like growth factor binding proteins.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The emerging consensus is therefore not a single “primary function” in all contexts, but a dominant primary biochemical activity—**high-affinity IGF binding**—that acts as a scaffold for diverse regulated functions controlled by **proteolysis** and **phosphorylation**, and by compartment switching between extracellular matrix, membrane microdomains, cytosol, and nucleus.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 binds HA via a mapped basic C-terminal motif (aa **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA engagement of **CD44**, suppressing HA–CD44 signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005520" target="_blank" class="term-link">
                                     GO:0005520
                                 </a>
                             </span>
                             <span class="term-label">insulin-like growth factor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12599210" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12599210
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Role of insulin-like growth factor binding protein-3 (IGFBP-...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005520" data-r="PMID:12599210" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005520" data-r="PMID:12599210" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> insulin-like growth factor binding is a core IGFBP3 molecular function; the literature consistently identifies high-affinity IGF-I/IGF-II binding as the dominant biochemical activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12599210" target="_blank" class="term-link">
                                         PMID:12599210
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Role of insulin-like growth factor binding protein-3 (IGFBP-3) in the differentiation of primary human adult skeletal myoblasts.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008160" target="_blank" class="term-link">
                                     GO:0008160
                                 </a>
                             </span>
                             <span class="term-label">protein tyrosine phosphatase activator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11940579" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11940579
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Insulin-like growth factor-binding protein-3 activates a pho...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0008160" data-r="PMID:11940579" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0008160" data-r="PMID:11940579" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein tyrosine phosphatase activator activity is retained as a non-core IGF-independent signaling mechanism from older experimental evidence, while newer synthesis emphasizes PP2A-mediated dephosphorylation of IGF pathway mediators.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11940579" target="_blank" class="term-link">
                                         PMID:11940579
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2002 Apr 8. Insulin-like growth factor-binding protein-3 activates a phosphotyrosine phosphatase.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2023 Endocrine Reviews synthesis describes an IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway mediators including **Akt** and **Ras/MAPK**.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009968" target="_blank" class="term-link">
                                     GO:0009968
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11940579" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11940579
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Insulin-like growth factor-binding protein-3 activates a pho...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0009968" data-r="PMID:11940579" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0009968" data-r="PMID:11940579" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Negative regulation of signal transduction is supported by IGFBP3 suppression of IGF/IGF1R pathway mediators and by hyaluronan-CD44 signaling blockade; this captures a core signaling output of IGFBP3 ligand binding in extracellular contexts.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11940579" target="_blank" class="term-link">
                                         PMID:11940579
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2002 Apr 8. Insulin-like growth factor-binding protein-3 activates a phosphotyrosine phosphatase.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2023 Endocrine Reviews synthesis describes an IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway mediators including **Akt** and **Ras/MAPK**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043065" target="_blank" class="term-link">
                                     GO:0043065
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11971816" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11971816
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Insulin-like growth factor binding protein-3 mediates tumor ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0043065" data-r="PMID:11971816" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0043065" data-r="PMID:11971816" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> positive regulation of apoptotic process is retained as a context-dependent IGF-independent apoptotic role, including nuclear receptor and cell-death receptor mechanisms, but it is not the canonical core molecular function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11971816" target="_blank" class="term-link">
                                         PMID:11971816
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Insulin-like growth factor binding protein-3 mediates tumor necrosis factor-alpha-induced apoptosis: role of Bcl-2 phosphorylation.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A central IGF-independent nuclear mechanism is the interaction of nuclear IGFBP-3 with **retinoid X receptor alpha (RXRα)**. Classic evidence describes RXR as an IGFBP-3 partner identified by yeast two-hybrid screening and positions this interaction as a conceptual “paradigm shift” for IGFBP actions in transcription and apoptosis.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">apoptotic effects mediated by its receptor TMEM219/IGFBP-3R</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045663" target="_blank" class="term-link">
                                     GO:0045663
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of myoblast differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12599210" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12599210
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Role of insulin-like growth factor binding protein-3 (IGFBP-...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0045663" data-r="PMID:12599210" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0045663" data-r="PMID:12599210" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> positive regulation of myoblast differentiation is retained as a context-specific differentiation phenotype downstream of IGFBP3 signaling rather than the core biochemical function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12599210" target="_blank" class="term-link">
                                         PMID:12599210
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Role of insulin-like growth factor binding protein-3 (IGFBP-3) in the differentiation of primary human adult skeletal myoblasts.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">including proliferation, differentiation, and apoptosis in a cell-type specific manner</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14576163" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14576163
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Insulin-like growth factor-independent effects mediated by a...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0046872" data-r="PMID:14576163" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0046872" data-r="PMID:14576163" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The C-terminal metal-binding domain evidence is retained as a non-core IGF-independent feature.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14576163" target="_blank" class="term-link">
                                         PMID:14576163
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Oct 22. Insulin-like growth factor-independent effects mediated by a C-terminal metal-binding domain of insulin-like growth factor binding protein-3.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14718574" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14718574
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The human plasma proteome: a nonredundant list developed by ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="PMID:14718574" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005576" data-r="PMID:14718574" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> extracellular region is supported by IGFBP3 secretion and its extracellular/circulating IGF complex functions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14718574" target="_blank" class="term-link">
                                         PMID:14718574
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Epub 2004 Jan 12. The human plasma proteome: a nonredundant list developed by combination of four separate sources.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005540" target="_blank" class="term-link">
+                                    GO:0005540
+                                </a>
+                            </span>
+                            <span class="term-label">hyaluronic acid binding</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P17936" data-a="GO:0005540" data-r="file:human/IGFBP3/IGFBP3-deep-research-falcon.md" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IGFBP3 binds hyaluronan through a mapped basic C-terminal motif and can block HA-CD44 signaling.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> Specific HA binding is supported by recent mechanistic work and is absent from current GOA.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">IGFBP-3 binds HA via a mapped basic C-terminal motif (aa **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA engagement of **CD44**, suppressing HA–CD44 signaling.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>High-affinity binding of IGF-I and IGF-II to regulate IGF receptor signaling and stabilize circulating IGF complexes.</h3>
+                <span class="vote-buttons" data-g="P17936" data-a="FUNCTION: High-affinity binding of IGF-I and IGF-II to regul..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005520" target="_blank" class="term-link">
+                            insulin-like growth factor binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043567" target="_blank" class="term-link">
+                                regulation of insulin-like growth factor receptor signaling pathway
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005615" target="_blank" class="term-link">
+                                extracellular space
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                extracellular region
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042567" target="_blank" class="term-link">
+                            insulin-like growth factor ternary complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Hyaluronan binding that modulates extracellular HA-CD44 signaling in a phosphorylation-sensitive manner.</h3>
+                <span class="vote-buttons" data-g="P17936" data-a="FUNCTION: Hyaluronan binding that modulates extracellular HA..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005540" target="_blank" class="term-link">
+                            hyaluronic acid binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009968" target="_blank" class="term-link">
+                                negative regulation of signal transduction
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
+                                extracellular region
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">IGFBP-3 binds HA via a mapped basic C-terminal motif (aa **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA engagement of **CD44**, suppressing HA–CD44 signaling.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10766744" target="_blank" class="term-link">
                             PMID:10766744
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Substitutions for hydrophobic amino acids in the N-terminal domains of IGFBP-3 and -5 markedly reduce IGF-I binding and alter their biologic actions.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11940579" target="_blank" class="term-link">
                             PMID:11940579
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Insulin-like growth factor-binding protein-3 activates a phosphotyrosine phosphatase. Effects on the insulin-like growth factor signaling pathway.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11971816" target="_blank" class="term-link">
                             PMID:11971816
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Insulin-like growth factor binding protein-3 mediates tumor necrosis factor-alpha-induced apoptosis: role of Bcl-2 phosphorylation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12599210" target="_blank" class="term-link">
                             PMID:12599210
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Role of insulin-like growth factor binding protein-3 (IGFBP-3) in the differentiation of primary human adult skeletal myoblasts.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14561895" target="_blank" class="term-link">
                             PMID:14561895
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interaction between the Alzheimer&#39;s survival peptide humanin and insulin-like growth factor-binding protein 3 regulates cell survival and apoptosis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14576163" target="_blank" class="term-link">
                             PMID:14576163
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Insulin-like growth factor-independent effects mediated by a C-terminal metal-binding domain of insulin-like growth factor binding protein-3.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14718574" target="_blank" class="term-link">
                             PMID:14718574
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The human plasma proteome: a nonredundant list developed by combination of four separate sources.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17119061" target="_blank" class="term-link">
                             PMID:17119061
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Ethnic disparity in the relationship between obesity and plasma insulin-like growth factors: the multiethnic cohort.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17434920" target="_blank" class="term-link">
                             PMID:17434920
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Contribution of the orphan nuclear receptor Nur77 to the apoptotic action of IGFBP-3.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17591901" target="_blank" class="term-link">
                             PMID:17591901
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The requirement of pax6 for postnatal eye development: evidence from experimental mouse chimeras.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19258508" target="_blank" class="term-link">
                             PMID:19258508
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NKX3.1 activates expression of insulin-like growth factor binding protein-3 to mediate insulin-like growth factor-I signaling and cell proliferation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20353938" target="_blank" class="term-link">
                             PMID:20353938
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification of a novel cell death receptor mediating IGFBP-3-induced anti-tumor effects in breast and prostate cancer.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23178489" target="_blank" class="term-link">
                             PMID:23178489
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The role of insulin-like growth factor binding protein-3 in the breast cancer cell response to DNA-damaging agents.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26216267" target="_blank" class="term-link">
                             PMID:26216267
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Humanin Peptide Binds to Insulin-Like Growth Factor-Binding Protein 3 (IGFBP3) and Regulates Its Interaction with Importin-β.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30184438" target="_blank" class="term-link">
                             PMID:30184438
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interaction of Insulin-Like Growth Factor-Binding Protein 3 With Hyaluronan and Its Regulation by Humanin and CD44.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9388210" target="_blank" class="term-link">
                             PMID:9388210
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Inhibition of insulin receptor activation by insulin-like growth factor binding proteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9497324" target="_blank" class="term-link">
                             PMID:9497324
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Insulin-like growth factor (IGF)-binding protein 5 forms an alternative ternary complex with IGFs and the acid-labile subunit.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-381435
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Matrix metalloproteinase proteolyzes IGF:IGFBP3:ALS</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-381446
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Thrombin proteolyzes IGF:IGFBP3:ALS</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-381461
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Plasmin proteolyzes IGF:IGFBP-3:ALS</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-381466
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Prostate-specific Antigen proteolyzes IGF:IGFBP3:ALS </div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-381496
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Formation of the IGF:IGFBP3:ALS complex</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-381500
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cathepsin G proteolyzes IGF:IGFBP3:ALS</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6800035
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">IGFBP3 binds TMEM219</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6800044
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TP53 stimulates IGFBP3 expression</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8952289
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">FAM20C phosphorylates FAM20C substrates</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research synthesis for IGFBP3</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/IGFBP3/IGFBP3-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt record for IGFBP3</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(IGFBP3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P17936" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T21:17:54.509803'<br />
+end_time: '2026-05-11T21:32:42.427554'<br />
+duration_seconds: 887.92<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: IGFBP3<br />
+  gene_symbol: IGFBP3<br />
+  uniprot_accession: P17936<br />
+  protein_description: 'RecName: Full=Insulin-like growth factor-binding protein 3;<br />
+    Short=IBP-3; Short=IGF-binding protein 3; Short=IGFBP-3; Flags: Precursor;'<br />
+  gene_info: Name=IGFBP3; Synonyms=IBP3;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Not specified in UniProt<br />
+  protein_domains: Growth_fac_rcpt_cys_sf. (IPR009030); IGFBP-3. (IPR012211); IGFBP-like.<br />
+    (IPR000867); IGFBP_1-6_chordata. (IPR022321); Insulin_GF-bd_Cys-rich_CS. (IPR017891)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 44</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P17936</li>
+<li><strong>Protein Description:</strong> RecName: Full=Insulin-like growth factor-binding protein 3; Short=IBP-3; Short=IGF-binding protein 3; Short=IGFBP-3; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=IGFBP3; Synonyms=IBP3;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> Growth_fac_rcpt_cys_sf. (IPR009030); IGFBP-3. (IPR012211); IGFBP-like. (IPR000867); IGFBP_1-6_chordata. (IPR022321); Insulin_GF-bd_Cys-rich_CS. (IPR017891)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "IGFBP3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'IGFBP3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>IGFBP3</strong> (gene ID: IGFBP3, UniProt: P17936) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> P17936</li>
+<li><strong>Protein Description:</strong> RecName: Full=Insulin-like growth factor-binding protein 3; Short=IBP-3; Short=IGF-binding protein 3; Short=IGFBP-3; Flags: Precursor;</li>
+<li><strong>Gene Information:</strong> Name=IGFBP3; Synonyms=IBP3;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> Growth_fac_rcpt_cys_sf. (IPR009030); IGFBP-3. (IPR012211); IGFBP-like. (IPR000867); IGFBP_1-6_chordata. (IPR022321); Insulin_GF-bd_Cys-rich_CS. (IPR017891)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "IGFBP3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'IGFBP3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>IGFBP3</strong> (gene ID: IGFBP3, UniProt: P17936) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-human-igfbp3-uniprot-p17936-functional-annotation-and-translational-relevance">Research Report: Human <strong>IGFBP3</strong> (UniProt <strong>P17936</strong>) — Functional Annotation and Translational Relevance</h2>
+<h3 id="0-target-verification-critical-disambiguation">0. Target verification (critical disambiguation)</h3>
+<p>The literature retrieved and analyzed explicitly maps <strong>human insulin-like growth factor-binding protein 3 (IGFBP-3; gene IGFBP3)</strong> to <strong>UniProt accession P17936</strong>, confirming that the target in this report matches the UniProt-provided identity. In particular, Mofid et al. state that the <em>Homo sapiens</em> IGFBP-3 amino-acid sequence <strong>(P17936)</strong> was retrieved from UniProt, and Price et al. list IGFBP-3 among studied proteins with UniProt accession <strong>P17936</strong>. (mofid2018insilicointeraction pages 1-3, price2020humaninblocksaggregation pages 1-2)</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1. Key concepts and definitions (current understanding)</h3>
+<h4 id="11-canonical-igf-dependent-function-high-affinity-igf-sequestration-and-igf1r-modulation">1.1 Canonical (IGF-dependent) function: high-affinity IGF sequestration and IGF1R modulation</h4>
+<p>IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind <strong>IGF-1 and IGF-2</strong> with high affinity, thereby <strong>impeding access to IGF1R</strong> and modulating IGF1R signaling. This canonical role can be context-dependent (inhibitory vs sometimes permissive/enhancing) and is regulated by post-translational modifications and proteolysis. (baxter2023signalingpathwaysof pages 1-2, baxter2023signalingpathwaysof pages 2-2)</p>
+<p>Structure-function evidence supports this concept: IGFBP-3 is modular (N-domain, linker, C-domain), and cooperative contributions from the N- and C-termini enable high-affinity IGF binding; binding can sterically hinder IGF-1 receptor interaction. (mofid2018insilicointeraction pages 8-10, mofid2018insilicointeraction pages 11-11)</p>
+<h4 id="12-endocrine-concept-circulating-igf-stabilization-and-ternary-complex-formation">1.2 Endocrine concept: circulating IGF stabilization and ternary complex formation</h4>
+<p>A key systemic concept is that IGFBP-3 is the <strong>most abundant circulating IGFBP</strong> and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a <strong>~150 kDa ternary complex</strong>, increasing circulating IGF. (sechrist2025pathologicsignalingand pages 2-4)</p>
+<h4 id="13-igf-independent-signaling-paradigm">1.3 IGF-independent signaling paradigm</h4>
+<p>A major modern view is that IGFBPs—including IGFBP-3—have substantial <strong>IGF-independent</strong> actions. These include interactions with cell-surface receptors (e.g., integrins; TGFβ-family receptor systems), intracellular partners, and nuclear mechanisms that modulate survival, migration, senescence, and DNA damage responses. (baxter2023signalingpathwaysof pages 1-2, baxter2023signalingpathwaysof pages 2-2)</p>
+<h3 id="2-protein-features-and-localization-where-igfbp-3-acts">2. Protein features and localization: where IGFBP-3 acts</h3>
+<h4 id="21-secreted-precursor-and-extracellular-compartment">2.1 Secreted precursor and extracellular compartment</h4>
+<p>IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a <strong>291-aa</strong> protein comprising a <strong>27-aa signal peptide</strong> and a <strong>264-aa mature chain</strong>, consistent with secretion into extracellular fluids. (mofid2018insilicointeraction pages 1-3)</p>
+<p>In extracellular contexts, IGFBP-3 participates in circulating IGF complexes (including ALS-containing complexes) and can bind extracellular matrix (ECM)-related ligands such as hyaluronan (HA) (see below). (sechrist2025pathologicsignalingand pages 2-4, coleman2023phosphorylationofigfbp3 pages 5-7)</p>
+<h4 id="22-nuclear-localization-and-intracellular-trafficking-importin-energy-dependence">2.2 Nuclear localization and intracellular trafficking (importin-β; energy dependence)</h4>
+<p>Multiple sources support nuclear localization of IGFBP-3. Classic mechanistic evidence indicates IGFBP-3 contains a <strong>basic C-terminal nuclear localization signal (NLS)</strong> and undergoes <strong>NLS-dependent, importin-mediated nuclear translocation</strong>. (lee2002nucleareffectsunexpected pages 3-4)</p>
+<p>A detailed mechanistic review reports that extracellular/full-length IGFBP-3 can enter the nucleus via <strong>direct interaction with importin-β</strong> (not requiring importin-α), and that nuclear import is <strong>blocked by anti–importin-β</strong>, reduced by <strong>GTP-γS</strong>, and requires an ATP-generating system—indicating dependence on the Ran/energy-dependent nuclear import machinery. (shrivastav2020insulinlikegrowthfactor pages 7-8)</p>
+<h3 id="3-pathways-and-mechanisms-recent-and-authoritative-synthesis-prioritized">3. Pathways and mechanisms (recent and authoritative synthesis prioritized)</h3>
+<h4 id="31-igfbp-3lrp1-tgfr-vpp2a-axis-igf-independent-suppression-of-igf1r-pathway-mediators">3.1 IGFBP-3–LRP1 (TGFβR-V)–PP2A axis: IGF-independent suppression of IGF1R pathway mediators</h4>
+<p>A 2023 Endocrine Reviews synthesis describes an IGF-independent mechanism in which IGFBP-3 engages <strong>TGFβ receptor type V (LRP1)</strong> to activate <strong>PP2A</strong> (a serine/threonine phosphatase). PP2A can associate with IGF1R via <strong>RACK1</strong>, and downregulates key IGF1R pathway mediators including <strong>Akt</strong> and <strong>Ras/MAPK</strong>. This provides a mechanistic route by which IGFBP-3 can inhibit proliferative signaling beyond simple IGF sequestration. (baxter2023signalingpathwaysof pages 3-4, baxter2023signalingpathwaysof pages 4-5)</p>
+<h4 id="32-2023-mechanistic-advance-ck2-phosphorylation-switches-igfbp-3ha-interactions-to-enable-hacd44-pro-survival-signaling-in-nsclc">3.2 2023 mechanistic advance: CK2 phosphorylation switches IGFBP-3–HA interactions to enable HA–CD44 pro-survival signaling in NSCLC</h4>
+<p>A 2023 primary study (Cells) provides a detailed, testable mechanism linking a post-translational modification of IGFBP-3 to ECM-mediated oncogenic signaling and chemotherapy response.</p>
+<p><strong>Key findings</strong>:<br />
+- <strong>Casein kinase 2 (CK2)</strong> phosphorylates IGFBP-3 at <strong>S167 and S175</strong>. (coleman2023phosphorylationofigfbp3 pages 5-7)<br />
+- CK2 phosphorylation reduces IGFBP-3 binding to <strong>hyaluronan (HA)</strong>: maximal HA binding of phosphorylated IGFBP-3 is ~<strong>30%</strong> of non-phosphorylated IGFBP-3, and cell-surface association decreases by ~<strong>50%</strong>. (coleman2023phosphorylationofigfbp3 pages 5-7)<br />
+- IGFBP-3 binds HA via a mapped basic C-terminal motif (aa <strong>215–232</strong>, sequence <strong>KKGFYKKKQCRPSKGRKR</strong>), and this interaction blocks HA engagement of <strong>CD44</strong>, suppressing HA–CD44 signaling. (coleman2023phosphorylationofigfbp3 pages 2-4, coleman2023phosphorylationofigfbp3 pages 5-7)<br />
+- When phosphorylated, IGFBP-3’s reduced HA binding permits HA–CD44 signaling, which is linked to activation of the <strong>PI3K → AKT → NFκB</strong> axis and reduced <strong>p53</strong> activity, promoting survival and <strong>cisplatin resistance</strong>. (coleman2023phosphorylationofigfbp3 pages 1-2, coleman2023phosphorylationofigfbp3 pages 19-21)</p>
+<p><strong>Quantitative drug-response results (A549 vs H1299)</strong>:<br />
+- CK2 inhibitor <strong>TBB IC50</strong>: <strong>8 ± 1.5 µM</strong> (A549) and <strong>7 ± 1.3 µM</strong> (H1299). (coleman2023phosphorylationofigfbp3 pages 5-7)<br />
+- <strong>Cisplatin IC50</strong>: <strong>9 ± 1.5 µM</strong> (A549) and <strong>26 ± 4 µM</strong> (H1299). (coleman2023phosphorylationofigfbp3 pages 5-7)<br />
+- <strong>TBB + cisplatin</strong> caused ~<strong>4-fold</strong> viability decrease vs ~<strong>2-fold</strong> for either alone (reported qualitatively as fold differences in viability). (coleman2023phosphorylationofigfbp3 pages 5-7)</p>
+<p>Figure-level visual evidence supporting these results is available in the paper’s figures showing IC50 measurements and reduced HA binding upon phosphorylation. (coleman2023phosphorylationofigfbp3 media 0143ad9b, coleman2023phosphorylationofigfbp3 media 21878636)</p>
+<h4 id="33-nuclear-receptor-pathway-rxrrar-interactions-and-transcriptionalapoptotic-outputs">3.3 Nuclear receptor pathway: RXRα/RAR interactions and transcriptional/apoptotic outputs</h4>
+<p>A central IGF-independent nuclear mechanism is the interaction of nuclear IGFBP-3 with <strong>retinoid X receptor alpha (RXRα)</strong>. Classic evidence describes RXR as an IGFBP-3 partner identified by yeast two-hybrid screening and positions this interaction as a conceptual “paradigm shift” for IGFBP actions in transcription and apoptosis. (lee2002nucleareffectsunexpected pages 3-4)</p>
+<p>A 2023 Endocrine Reviews synthesis further states that IGFBP-3 binds <strong>RXRα</strong> to promote RXR-specific transcription and that RXRα is required for IGFBP-3-dependent apoptosis in some models; IGFBP-3 also binds <strong>RAR</strong> and inhibits RAR signaling, and can interact with other RXRα-binding nuclear receptors. (baxter2023signalingpathwaysof pages 9-9)</p>
+<h3 id="4-recent-developments-prioritizing-20232024-sources">4. Recent developments (prioritizing 2023–2024 sources)</h3>
+<p>1) <strong>System-level mechanistic integration (2023 Endocrine Reviews)</strong>: The field’s current high-authority synthesis emphasizes that IGFBPs (including IGFBP-3) act as multifunctional signaling modulators via post-translational modification, proteolysis, receptor crosstalk (integrins, TGFβ-family systems), and nuclear mechanisms (class II nuclear receptors; DNA damage repair). (baxter2023signalingpathwaysof pages 1-2, baxter2023signalingpathwaysof pages 2-2)</p>
+<p>2) <strong>Post-translational modification controlling ECM signaling and drug resistance (2023 Cells)</strong>: CK2 phosphorylation of IGFBP-3 at S167/S175 functionally “re-wires” HA binding and HA–CD44 signaling, providing a mechanistic rationale for combined pathway inhibition (CK2/CD44/PI3K/AKT/NFκB) to improve cisplatin sensitivity in NSCLC models. (coleman2023phosphorylationofigfbp3 pages 1-2, coleman2023phosphorylationofigfbp3 pages 5-7)</p>
+<p>3) <strong>Nuclear import and receptor crosstalk highlighted in 2023 synthesis</strong>: Nuclear IGFBP-3 is described as predominantly nuclear in some contexts, and its importin-β interaction can be inhibited by humanin—suggesting a regulatable import mechanism connecting stress peptides and IGFBP-3 nuclear action. (baxter2023signalingpathwaysof pages 9-9)</p>
+<h3 id="5-current-applications-and-real-world-implementations">5. Current applications and real-world implementations</h3>
+<h4 id="51-clinicaltranslational-biomarker-serum-igfbp-3-in-cancer-diagnosis-and-prognosis">5.1 Clinical/translational biomarker: serum IGFBP-3 in cancer diagnosis and prognosis</h4>
+<p>A concrete example of real-world implementation is serum IGFBP-3 measurement by ELISA followed by ROC analysis and prognostic modeling.</p>
+<p>In esophagogastric junction adenocarcinoma (EJA), a 2022 study used serum IGFBP-3 to support diagnosis and prognosis:<br />
+- Cohort: <strong>320 participants</strong>, split into training (112 controls; 102 EJA, incl. 24 early-stage) and validation (56 controls; 50 EJA, incl. 12 early-stage). (ding2022seruminsulinlikegrowth pages 1-3)<br />
+- Diagnostic performance:<br />
+  - Training AUC <strong>0.819</strong> (specificity <strong>90.18%</strong>, sensitivity <strong>43.14%</strong>)<br />
+  - Validation AUC <strong>0.804</strong> (specificity <strong>87.50%</strong>, sensitivity <strong>42.00%</strong>). (ding2022seruminsulinlikegrowth pages 1-3)<br />
+- Early-stage EJA performance:<br />
+  - Training AUC <strong>0.822</strong> (specificity <strong>90.18%</strong>, sensitivity <strong>45.83%</strong>)<br />
+  - Validation AUC <strong>0.811</strong> (specificity <strong>84.48%</strong>, sensitivity <strong>50.00%</strong>). (ding2022seruminsulinlikegrowth pages 1-3)<br />
+- Prognosis: IGFBP-3 remained an independent factor in multivariable Cox analysis (<strong>HR = 0.468</strong>, P=0.005), and a nomogram including IGFBP-3 improved C-index (0.625 vs 0.735). (ding2022seruminsulinlikegrowth pages 1-3)</p>
+<p>These findings illustrate current real-world use patterns: IGFBP-3 is most commonly implemented as a blood biomarker (ELISA or proteomics panel component) rather than a direct drug target in routine care. (ding2022seruminsulinlikegrowth pages 1-3, baxter2023signalingpathwaysof pages 1-2)</p>
+<h4 id="52-translational-targeting-opportunities-pathway-based-interventions-instead-of-direct-igfbp-3-drugs">5.2 Translational targeting opportunities: pathway-based interventions instead of direct IGFBP-3 drugs</h4>
+<p>Expert synthesis notes that IGFBPs have been proposed as therapeutic targets, but their ubiquity in circulation and cell contexts creates practical challenges. (baxter2023signalingpathwaysof pages 1-2)</p>
+<p>Nevertheless, the NSCLC mechanism indicates actionable strategies: blocking CK2-mediated phosphorylation or HA–CD44 signaling (and downstream PI3K/AKT/NFκB) may counteract IGFBP-3–associated chemoresistance mechanisms. (coleman2023phosphorylationofigfbp3 pages 1-2, coleman2023phosphorylationofigfbp3 pages 19-21)</p>
+<h3 id="6-expert-opinions-and-interpretive-analysis-authoritative-synthesis">6. Expert opinions and interpretive analysis (authoritative synthesis)</h3>
+<p>A leading expert review (Endocrine Reviews, 2023) frames IGFBP-3 biology as an archetype of multifunctional extracellular proteins that can:<br />
+- inhibit IGF1R activation by IGF sequestration,<br />
+- regulate receptor signaling via phosphatase activation and receptor cross-talk,<br />
+- act in the nucleus by modulating nuclear hormone receptor activity and DNA damage responses,<br />
+- and have immune/senescence implications, creating both therapeutic opportunities and complexity. (baxter2023signalingpathwaysof pages 1-2, baxter2023signalingpathwaysof pages 3-4)</p>
+<p>The emerging consensus is therefore not a single “primary function” in all contexts, but a dominant primary biochemical activity—<strong>high-affinity IGF binding</strong>—that acts as a scaffold for diverse regulated functions controlled by <strong>proteolysis</strong> and <strong>phosphorylation</strong>, and by compartment switching between extracellular matrix, membrane microdomains, cytosol, and nucleus. (baxter2023signalingpathwaysof pages 1-2, baxter2023signalingpathwaysof pages 3-4, coleman2023phosphorylationofigfbp3 pages 5-7)</p>
+<h3 id="7-recent-statistics-and-data-selected-highlights">7. Recent statistics and data (selected highlights)</h3>
+<p>Key quantitative values extracted from recent studies are consolidated in the table below.</p>
+<table>
+<thead>
+<tr>
+<th>Category</th>
+<th>Claim / feature</th>
+<th>Details / quantitative result</th>
+<th>Evidence type</th>
+<th>Key source (year; DOI URL)</th>
+<th>Citation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Identity</td>
+<td>Correct target verified as human IGFBP3 / UniProt P17936</td>
+<td>Explicit mapping reported as <strong>Homo sapiens IGFBP-3 (P17936)</strong>; separate primary study also lists <strong>IGFBP-3 = UniProt P17936</strong></td>
+<td>computational / primary</td>
+<td>Mofid et al., 2018, https://doi.org/10.4103/1735-5362.235160; Price et al., 2020, https://doi.org/10.1021/acs.biochem.0c00274</td>
+<td>(mofid2018insilicointeraction pages 1-3, price2020humaninblocksaggregation pages 1-2)</td>
+</tr>
+<tr>
+<td>Core feature</td>
+<td>Secreted precursor architecture</td>
+<td>IGFBP-3 reported as <strong>291 aa total</strong>, comprising a <strong>27-aa signal peptide</strong> and <strong>264-aa mature chain</strong>, consistent with a secreted precursor</td>
+<td>computational</td>
+<td>Mofid et al., 2018, https://doi.org/10.4103/1735-5362.235160</td>
+<td>(mofid2018insilicointeraction pages 1-3)</td>
+</tr>
+<tr>
+<td>Core feature</td>
+<td>Domain organization</td>
+<td>Modular <strong>N-domain, linker domain, C-domain</strong>; linker is a hotspot for <strong>phosphorylation/proteolysis</strong>, N- and C-termini cooperate in high-affinity IGF binding</td>
+<td>review / computational</td>
+<td>Baxter, 2023, https://doi.org/10.1210/endrev/bnad008; Mofid et al., 2018, https://doi.org/10.4103/1735-5362.235160</td>
+<td>(baxter2023signalingpathwaysof pages 1-2, mofid2018insilicointeraction pages 8-10, sechrist2025pathologicsignalingand pages 1-2, mofid2018insilicointeraction pages 11-11)</td>
+</tr>
+<tr>
+<td>Core feature</td>
+<td>Major circulating role</td>
+<td>IGFBP-3 is the <strong>most abundant circulating IGFBP</strong> and stabilizes IGFs in blood, including formation of <strong>binary complexes</strong> and <strong>ALS-containing ternary complexes (~150 kDa)</strong></td>
+<td>review</td>
+<td>Sechrist et al., 2025, https://doi.org/10.3390/ijms262110248</td>
+<td>(sechrist2025pathologicsignalingand pages 2-4)</td>
+</tr>
+<tr>
+<td>Key binding partners</td>
+<td>Canonical ligand binding</td>
+<td>Binds <strong>IGF-1/IGF-2 with high affinity</strong> to modulate IGF bioavailability and receptor access; sterically hinders IGF-1 interaction with <strong>IGF1R</strong></td>
+<td>review / computational</td>
+<td>Baxter, 2023, https://doi.org/10.1210/endrev/bnad008; Mofid et al., 2018, https://doi.org/10.4103/1735-5362.235160</td>
+<td>(baxter2023signalingpathwaysof pages 1-2, mofid2018insilicointeraction pages 8-10, baxter2023signalingpathwaysof pages 3-4)</td>
+</tr>
+<tr>
+<td>Key binding partners</td>
+<td>Noncanonical partners</td>
+<td>Documented partners/pathway nodes include <strong>LRP1/TGFβR-V</strong>, <strong>PP2A</strong>, <strong>RACK1</strong>, <strong>integrins</strong>, <strong>hyaluronan (HA)</strong>, <strong>CD44</strong>, <strong>importin-β</strong>, <strong>RXRα/RAR</strong>, and <strong>histone H3</strong></td>
+<td>review / primary</td>
+<td>Baxter, 2023, https://doi.org/10.1210/endrev/bnad008; Coleman et al., 2023, https://doi.org/10.3390/cells12030405; Bhardwaj et al., 2021, https://doi.org/10.3390/ijms22010407</td>
+<td>(baxter2023signalingpathwaysof pages 3-4, coleman2023phosphorylationofigfbp3 pages 2-4, shrivastav2020insulinlikegrowthfactor pages 7-8, baxter2023signalingpathwaysof pages 9-9)</td>
+</tr>
+<tr>
+<td>Mechanism / pathway</td>
+<td>IGF sequestration and IGF1R modulation</td>
+<td>Canonical action is to <strong>impede access of IGF-1/2 to IGF1R</strong>; IGFBP-3 can also inhibit IGF1R signaling through phosphatase-mediated mechanisms</td>
+<td>review</td>
+<td>Baxter, 2023, https://doi.org/10.1210/endrev/bnad008</td>
+<td>(baxter2023signalingpathwaysof pages 1-2, baxter2023signalingpathwaysof pages 3-4)</td>
+</tr>
+<tr>
+<td>Mechanism / pathway</td>
+<td>LRP1 / PP2A / RACK1 signaling</td>
+<td>IGFBP-3 acting via <strong>TGFβ receptor type V / LRP1</strong> activates <strong>PP2A</strong>; PP2A associates with <strong>IGF1R via RACK1</strong> and suppresses signaling, with modulation by <strong>β-integrin ligation</strong></td>
+<td>review</td>
+<td>Baxter, 2023, https://doi.org/10.1210/endrev/bnad008</td>
+<td>(baxter2023signalingpathwaysof pages 3-4, baxter2023signalingpathwaysof pages 4-5)</td>
+</tr>
+<tr>
+<td>Mechanism / pathway</td>
+<td>HA-CD44 survival signaling</td>
+<td>IGFBP-3 binds <strong>HA</strong> and can block <strong>HA-CD44</strong> signaling; when IGFBP-3 is phosphorylated by CK2, HA binding falls and <strong>PI3K-AKT-NFκB</strong> survival signaling proceeds with reduced <strong>p53</strong> activity</td>
+<td>primary cell study</td>
+<td>Coleman et al., 2023, https://doi.org/10.3390/cells12030405</td>
+<td>(coleman2023phosphorylationofigfbp3 pages 1-2, coleman2023phosphorylationofigfbp3 pages 19-21, coleman2023phosphorylationofigfbp3 pages 2-4, coleman2023phosphorylationofigfbp3 pages 5-7)</td>
+</tr>
+<tr>
+<td>Mechanism / pathway</td>
+<td>HA-binding region</td>
+<td>HA-binding motif mapped to an <strong>18-aa basic C-terminal region (aa 215–232: KKGFYKKKQCRPSKGRKR)</strong></td>
+<td>primary cell study</td>
+<td>Coleman et al., 2023, https://doi.org/10.3390/cells12030405</td>
+<td>(coleman2023phosphorylationofigfbp3 pages 2-4, coleman2023phosphorylationofigfbp3 pages 5-7)</td>
+</tr>
+<tr>
+<td>Mechanism / pathway</td>
+<td>CK2 phosphorylation sites</td>
+<td><strong>CK2 phosphorylates IGFBP-3 at S167 and S175</strong>; phosphorylation leaves IGF-1 binding intact but blocks ALS interaction and strongly reduces HA/cell-surface association</td>
+<td>primary cell study</td>
+<td>Coleman et al., 2023, https://doi.org/10.3390/cells12030405</td>
+<td>(coleman2023phosphorylationofigfbp3 pages 5-7)</td>
+</tr>
+<tr>
+<td>Quantitative mechanism</td>
+<td>Effect of phosphorylation on HA binding</td>
+<td><strong>Maximal HA binding of phosphorylated IGFBP-3 ≈30%</strong> of non-phosphorylated IGFBP-3; <strong>cell-surface association reduced by ~50%</strong></td>
+<td>primary cell study</td>
+<td>Coleman et al., 2023, https://doi.org/10.3390/cells12030405</td>
+<td>(coleman2023phosphorylationofigfbp3 pages 5-7)</td>
+</tr>
+<tr>
+<td>Mechanism / pathway</td>
+<td>Proteolytic regulation</td>
+<td><strong>Proteolysis lowers IGF–IGFBP affinity</strong>, releasing IGFs and increasing bioactive ligand; the <strong>linker domain</strong> is a major proteolysis-sensitive regulatory region</td>
+<td>review</td>
+<td>Baxter, 2023, https://doi.org/10.1210/endrev/bnad008</td>
+<td>(baxter2023signalingpathwaysof pages 2-2, sechrist2025pathologicsignalingand pages 2-4, sechrist2025pathologicsignalingand pages 1-2, baxter2023signalingpathwaysof pages 3-4)</td>
+</tr>
+<tr>
+<td>Mechanism / pathway</td>
+<td>Nuclear import</td>
+<td>IGFBP-3 contains a <strong>basic C-terminal/bipartite NLS</strong> and can undergo <strong>importin-β-dependent nuclear translocation</strong>; import is blocked by anti-importin-β and requires ATP/GTP</td>
+<td>review</td>
+<td>Shrivastav et al., 2020, https://doi.org/10.3389/fcell.2020.00286; Lee &amp; Cohen, 2002, https://doi.org/10.1677/joe.0.1750033</td>
+<td>(lee2002nucleareffectsunexpected pages 3-4, shrivastav2020insulinlikegrowthfactor pages 7-8, shrivastav2020insulinlikegrowthfactor pages 2-4)</td>
+</tr>
+<tr>
+<td>Mechanism / pathway</td>
+<td>Nuclear receptor interactions</td>
+<td>Nuclear IGFBP-3 binds <strong>RXRα</strong> and <strong>RAR</strong>, promotes <strong>RXR-specific transcription</strong>, inhibits <strong>RAR signaling</strong>, and RXRα is reported as required for IGFBP-3-dependent apoptosis in some models</td>
+<td>review</td>
+<td>Baxter, 2023, https://doi.org/10.1210/endrev/bnad008; Lee &amp; Cohen, 2002, https://doi.org/10.1677/joe.0.1750033</td>
+<td>(baxter2023signalingpathwaysof pages 9-9, lee2002nucleareffectsunexpected pages 1-3)</td>
+</tr>
+<tr>
+<td>Mechanism / pathway</td>
+<td>IGF-independent apoptosis / senescence</td>
+<td>IGFBP-3 can trigger <strong>IGF-independent apoptosis</strong> and senescence-related programs; mutants with little or no IGF binding can still induce apoptosis</td>
+<td>review / primary</td>
+<td>Lee &amp; Cohen, 2002, https://doi.org/10.1677/joe.0.1750033; Kwon et al., 2023, https://doi.org/10.1038/s41598-023-35291-5</td>
+<td>(lee2002nucleareffectsunexpected pages 3-4, skorupa2018igfbp3inducedby pages 19-23)</td>
+</tr>
+<tr>
+<td>Quantitative mechanism</td>
+<td>Senescence phenotype in breast cancer cells</td>
+<td>In MCF-7 cells, induced IGFBP-3 increased <strong>SA-β-gal-positive cells 3.4-fold</strong> over control and reduced telomerase activity by lowering <strong>hTR/hTERT</strong></td>
+<td>primary cell study</td>
+<td>Kwon et al., 2023, https://doi.org/10.1038/s41598-023-35291-5</td>
+<td>(skorupa2018igfbp3inducedby pages 19-23)</td>
+</tr>
+<tr>
+<td>Human biomarker</td>
+<td>EJA diagnostic performance</td>
+<td>In esophagogastric junction adenocarcinoma (EJA), serum IGFBP-3 AUC was <strong>0.819</strong> (training) and <strong>0.804</strong> (validation); specificity/sensitivity <strong>90.18%/43.14%</strong> and <strong>87.50%/42.00%</strong></td>
+<td>human cohort</td>
+<td>Ding et al., 2022, https://doi.org/10.1007/s12672-022-00591-1</td>
+<td>(ding2022seruminsulinlikegrowth pages 1-3)</td>
+</tr>
+<tr>
+<td>Human biomarker</td>
+<td>Early-stage EJA diagnostic performance</td>
+<td>For <strong>early-stage EJA</strong>, AUC was <strong>0.822</strong> (training) and <strong>0.811</strong> (validation); specificity/sensitivity <strong>90.18%/45.83%</strong> and <strong>84.48%/50.00%</strong></td>
+<td>human cohort</td>
+<td>Ding et al., 2022, https://doi.org/10.1007/s12672-022-00591-1</td>
+<td>(ding2022seruminsulinlikegrowth pages 1-3)</td>
+</tr>
+<tr>
+<td>Human biomarker</td>
+<td>EJA prognosis</td>
+<td>Lower serum IGFBP-3 associated with worse survival; multivariable Cox analysis: <strong>HR = 0.468, P = 0.005</strong>. Nomogram including IGFBP-3 improved <strong>C-index from 0.625 to 0.735 (P = 0.001)</strong> vs TNM alone</td>
+<td>human cohort</td>
+<td>Ding et al., 2022, https://doi.org/10.1007/s12672-022-00591-1</td>
+<td>(ding2022seruminsulinlikegrowth pages 1-3)</td>
+</tr>
+<tr>
+<td>Human biomarker</td>
+<td>EJA serum concentrations</td>
+<td>Mean serum IGFBP-3 was lower in controls vs EJA comparisons: training <strong>1664 ng/mL</strong> (controls) vs <strong>1138 ng/mL</strong> (EJA) / <strong>1121 ng/mL</strong> (early-stage EJA); validation <strong>1632 ng/mL</strong> vs <strong>1142 ng/mL</strong> / <strong>1124 ng/mL</strong></td>
+<td>human cohort</td>
+<td>Ding et al., 2022, https://doi.org/10.1007/s12672-022-00591-1</td>
+<td>(ding2022seruminsulinlikegrowth pages 3-5)</td>
+</tr>
+<tr>
+<td>Human biomarker</td>
+<td>Prostate cancer risk association</td>
+<td>Collaborative analysis of <strong>20 prospective studies</strong> (up to <strong>17,009 cases</strong>, including <strong>2,332 aggressive cases</strong>) found higher circulating <strong>IGFBP-3 associated with overall prostate cancer risk: OR per 1 SD = 1.08 (95% CI 1.04–1.11)</strong>; association attenuated after IGF-I adjustment</td>
+<td>human cohort</td>
+<td>Watts et al., 2023, https://doi.org/10.1093/ije/dyac124</td>
+<td>(watts2023circulatinginsulinlikegrowth pages 13-14)</td>
+</tr>
+<tr>
+<td>Quantitative mechanism</td>
+<td>NSCLC drug-response metrics</td>
+<td><strong>TBB IC50:</strong> <strong>8 ± 1.5 µM</strong> (A549), <strong>7 ± 1.3 µM</strong> (H1299); <strong>cisplatin IC50:</strong> <strong>9 ± 1.5 µM</strong> (A549), <strong>26 ± 4 µM</strong> (H1299); combined <strong>TBB + cisplatin</strong> caused <strong>~4-fold viability decrease</strong> vs <strong>~2-fold</strong> for either alone</td>
+<td>primary cell study</td>
+<td>Coleman et al., 2023, https://doi.org/10.3390/cells12030405</td>
+<td>(coleman2023phosphorylationofigfbp3 pages 5-7)</td>
+</tr>
+<tr>
+<td>Translational relevance</td>
+<td>Real-world implementation</td>
+<td>Current real-world use is mainly as a <strong>circulating biomarker/analyte</strong> in clinical or translational studies (e.g., cancer risk/prognosis panels), while therapeutic interest centers on modulating <strong>IGFBP-3 signaling</strong> or downstream pathways rather than established approved IGFBP-3-targeted drugs</td>
+<td>review / human cohort</td>
+<td>Baxter, 2023, https://doi.org/10.1210/endrev/bnad008; Ding et al., 2022, https://doi.org/10.1007/s12672-022-00591-1</td>
+<td>(baxter2023signalingpathwaysof pages 1-2, ding2022seruminsulinlikegrowth pages 1-3)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table condenses verified identity, core biology, major signaling mechanisms, and representative quantitative biomarker findings for human IGFBP3/UniProt P17936. It is useful as a compact evidence map linking functional annotation to recent translational and clinical data.</em></p>
+<h3 id="8-limitations-of-this-evidence-set">8. Limitations of this evidence set</h3>
+<ul>
+<li>Some important “IGFBP-3 standard biology” points (e.g., precise structural domain boundaries from crystallography) are not directly extractable from the retrieved full-text set; however, mechanisms and numeric results are strongly supported by the 2023 Endocrine Reviews synthesis and 2023 mechanistic primary data. (baxter2023signalingpathwaysof pages 1-2, coleman2023phosphorylationofigfbp3 pages 5-7)</li>
+<li>Biomarker evidence here is anchored by a robust 2022 clinical study in EJA and mechanistic 2023 cell-line data; additional 2023–2024 cohort biomarker studies likely exist across diseases, but were not all retrievable within the current tool results. (ding2022seruminsulinlikegrowth pages 1-3)</li>
+</ul>
+<h3 id="key-cited-sources-with-dates-and-urls">Key cited sources (with dates and URLs)</h3>
+<ul>
+<li>Baxter RC. <em>Endocrine Reviews</em> (Mar 2023). “Signaling Pathways of the Insulin-like Growth Factor Binding Proteins.” https://doi.org/10.1210/endrev/bnad008 (baxter2023signalingpathwaysof pages 1-2, baxter2023signalingpathwaysof pages 3-4, baxter2023signalingpathwaysof pages 9-9)</li>
+<li>Coleman K-l et al. <em>Cells</em> (Jan 2023). “Phosphorylation of IGFBP-3 by Casein Kinase 2 Blocks Its Interaction with Hyaluronan…” https://doi.org/10.3390/cells12030405 (coleman2023phosphorylationofigfbp3 pages 1-2, coleman2023phosphorylationofigfbp3 pages 5-7, coleman2023phosphorylationofigfbp3 media 0143ad9b, coleman2023phosphorylationofigfbp3 media 21878636)</li>
+<li>Ding T-Y et al. <em>Discover Oncology</em> (Nov 2022). “Serum IGFBP3 as a diagnostic and prognostic biomarker in esophagogastric junction adenocarcinoma.” https://doi.org/10.1007/s12672-022-00591-1 (ding2022seruminsulinlikegrowth pages 1-3)</li>
+<li>Shrivastav SV et al. <em>Frontiers in Cell and Developmental Biology</em> (May 2020). “IGFBP-3: IGF-independent effects within the cell.” https://doi.org/10.3389/fcell.2020.00286 (shrivastav2020insulinlikegrowthfactor pages 7-8)</li>
+<li>Lee K-W, Cohen P. <em>Journal of Endocrinology</em> (Oct 2002). “Nuclear effects: unexpected intracellular actions of IGFBP-3.” https://doi.org/10.1677/joe.0.1750033 (lee2002nucleareffectsunexpected pages 3-4)</li>
+<li>Mofid MR et al. <em>Research in Pharmaceutical Sciences</em> (Jul 2018). “In silico interaction of IGFBP-3 with IGF-1.” https://doi.org/10.4103/1735-5362.235160 (mofid2018insilicointeraction pages 1-3)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(mofid2018insilicointeraction pages 1-3): MohammadReza Mofid, Elham Jafari, Ali Gheysarzadeh, Karim Mahnam, Rezvan Shahmohammadi, Amir Ansari, and Hadi Bakhtyari. In silico interaction of insulin-like growth factor binding protein 3 with insulin-like growth factor 1. Research in Pharmaceutical Sciences, 13:332-342, Jul 2018. URL: https://doi.org/10.4103/1735-5362.235160, doi:10.4103/1735-5362.235160. This article has 17 citations.</p>
+</li>
+<li>
+<p>(price2020humaninblocksaggregation pages 1-2): Deanna Price, Sadaf Dorandish, Asana Williams, Brandon Iwaniec, Alexis Stephens, Keyan Marshall, Jeffrey Guthrie, Deborah Heyl, and Hedeel Guy Evans. Humanin blocks aggregation of amyloid beta induced by acetylcholinesterase, an effect abolished in the presence of igfbp-3. Biochemistry, 59:1981-2002, May 2020. URL: https://doi.org/10.1021/acs.biochem.0c00274, doi:10.1021/acs.biochem.0c00274. This article has 26 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(baxter2023signalingpathwaysof pages 1-2): Robert C Baxter. Signaling pathways of the insulin-like growth factor binding proteins. Endocrine Reviews, 44:753-778, Mar 2023. URL: https://doi.org/10.1210/endrev/bnad008, doi:10.1210/endrev/bnad008. This article has 144 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(baxter2023signalingpathwaysof pages 2-2): Robert C Baxter. Signaling pathways of the insulin-like growth factor binding proteins. Endocrine Reviews, 44:753-778, Mar 2023. URL: https://doi.org/10.1210/endrev/bnad008, doi:10.1210/endrev/bnad008. This article has 144 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mofid2018insilicointeraction pages 8-10): MohammadReza Mofid, Elham Jafari, Ali Gheysarzadeh, Karim Mahnam, Rezvan Shahmohammadi, Amir Ansari, and Hadi Bakhtyari. In silico interaction of insulin-like growth factor binding protein 3 with insulin-like growth factor 1. Research in Pharmaceutical Sciences, 13:332-342, Jul 2018. URL: https://doi.org/10.4103/1735-5362.235160, doi:10.4103/1735-5362.235160. This article has 17 citations.</p>
+</li>
+<li>
+<p>(mofid2018insilicointeraction pages 11-11): MohammadReza Mofid, Elham Jafari, Ali Gheysarzadeh, Karim Mahnam, Rezvan Shahmohammadi, Amir Ansari, and Hadi Bakhtyari. In silico interaction of insulin-like growth factor binding protein 3 with insulin-like growth factor 1. Research in Pharmaceutical Sciences, 13:332-342, Jul 2018. URL: https://doi.org/10.4103/1735-5362.235160, doi:10.4103/1735-5362.235160. This article has 17 citations.</p>
+</li>
+<li>
+<p>(sechrist2025pathologicsignalingand pages 2-4): Zachary R. Sechrist, Jaeden S. Cortés, Nidhi R. Patel, Zoe J. Pittman, Gayathri Guru Murthy, Guangzhen Zhu, Calvin L. Cole, and Benjamin D. Korman. Pathologic signaling and disease implications of insulin-like growth factor binding proteins in cancer, cardiovascular disease, and fibrosis. International Journal of Molecular Sciences, 26:10248, Oct 2025. URL: https://doi.org/10.3390/ijms262110248, doi:10.3390/ijms262110248. This article has 7 citations.</p>
+</li>
+<li>
+<p>(coleman2023phosphorylationofigfbp3 pages 5-7): Kai-ling Coleman, Michael Chiaramonti, Ben Haddad, Robert Ranzenberger, Heather Henning, Hind Al Khashali, Ravel Ray, Ban Darweesh, Jeffrey Guthrie, Deborah Heyl, and Hedeel Guy Evans. Phosphorylation of igfbp-3 by casein kinase 2 blocks its interaction with hyaluronan, enabling ha-cd44 signaling leading to increased nsclc cell survival and cisplatin resistance. Cells, 12:405, Jan 2023. URL: https://doi.org/10.3390/cells12030405, doi:10.3390/cells12030405. This article has 18 citations.</p>
+</li>
+<li>
+<p>(lee2002nucleareffectsunexpected pages 3-4): KW Lee and P Cohen. Nuclear effects: unexpected intracellular actions of insulin-like growth factor binding protein-3. Journal of Endocrinology, 175:33-40, Oct 2002. URL: https://doi.org/10.1677/joe.0.1750033, doi:10.1677/joe.0.1750033. This article has 127 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(shrivastav2020insulinlikegrowthfactor pages 7-8): Shailly Varma Shrivastav, Apurva Bhardwaj, Kumar Alok Pathak, and Anuraag Shrivastav. Insulin-like growth factor binding protein-3 (igfbp-3): unraveling the role in mediating igf-independent effects within the cell. Frontiers in Cell and Developmental Biology, May 2020. URL: https://doi.org/10.3389/fcell.2020.00286, doi:10.3389/fcell.2020.00286. This article has 175 citations.</p>
+</li>
+<li>
+<p>(baxter2023signalingpathwaysof pages 3-4): Robert C Baxter. Signaling pathways of the insulin-like growth factor binding proteins. Endocrine Reviews, 44:753-778, Mar 2023. URL: https://doi.org/10.1210/endrev/bnad008, doi:10.1210/endrev/bnad008. This article has 144 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(baxter2023signalingpathwaysof pages 4-5): Robert C Baxter. Signaling pathways of the insulin-like growth factor binding proteins. Endocrine Reviews, 44:753-778, Mar 2023. URL: https://doi.org/10.1210/endrev/bnad008, doi:10.1210/endrev/bnad008. This article has 144 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(coleman2023phosphorylationofigfbp3 pages 2-4): Kai-ling Coleman, Michael Chiaramonti, Ben Haddad, Robert Ranzenberger, Heather Henning, Hind Al Khashali, Ravel Ray, Ban Darweesh, Jeffrey Guthrie, Deborah Heyl, and Hedeel Guy Evans. Phosphorylation of igfbp-3 by casein kinase 2 blocks its interaction with hyaluronan, enabling ha-cd44 signaling leading to increased nsclc cell survival and cisplatin resistance. Cells, 12:405, Jan 2023. URL: https://doi.org/10.3390/cells12030405, doi:10.3390/cells12030405. This article has 18 citations.</p>
+</li>
+<li>
+<p>(coleman2023phosphorylationofigfbp3 pages 1-2): Kai-ling Coleman, Michael Chiaramonti, Ben Haddad, Robert Ranzenberger, Heather Henning, Hind Al Khashali, Ravel Ray, Ban Darweesh, Jeffrey Guthrie, Deborah Heyl, and Hedeel Guy Evans. Phosphorylation of igfbp-3 by casein kinase 2 blocks its interaction with hyaluronan, enabling ha-cd44 signaling leading to increased nsclc cell survival and cisplatin resistance. Cells, 12:405, Jan 2023. URL: https://doi.org/10.3390/cells12030405, doi:10.3390/cells12030405. This article has 18 citations.</p>
+</li>
+<li>
+<p>(coleman2023phosphorylationofigfbp3 pages 19-21): Kai-ling Coleman, Michael Chiaramonti, Ben Haddad, Robert Ranzenberger, Heather Henning, Hind Al Khashali, Ravel Ray, Ban Darweesh, Jeffrey Guthrie, Deborah Heyl, and Hedeel Guy Evans. Phosphorylation of igfbp-3 by casein kinase 2 blocks its interaction with hyaluronan, enabling ha-cd44 signaling leading to increased nsclc cell survival and cisplatin resistance. Cells, 12:405, Jan 2023. URL: https://doi.org/10.3390/cells12030405, doi:10.3390/cells12030405. This article has 18 citations.</p>
+</li>
+<li>
+<p>(coleman2023phosphorylationofigfbp3 media 0143ad9b): Kai-ling Coleman, Michael Chiaramonti, Ben Haddad, Robert Ranzenberger, Heather Henning, Hind Al Khashali, Ravel Ray, Ban Darweesh, Jeffrey Guthrie, Deborah Heyl, and Hedeel Guy Evans. Phosphorylation of igfbp-3 by casein kinase 2 blocks its interaction with hyaluronan, enabling ha-cd44 signaling leading to increased nsclc cell survival and cisplatin resistance. Cells, 12:405, Jan 2023. URL: https://doi.org/10.3390/cells12030405, doi:10.3390/cells12030405. This article has 18 citations.</p>
+</li>
+<li>
+<p>(coleman2023phosphorylationofigfbp3 media 21878636): Kai-ling Coleman, Michael Chiaramonti, Ben Haddad, Robert Ranzenberger, Heather Henning, Hind Al Khashali, Ravel Ray, Ban Darweesh, Jeffrey Guthrie, Deborah Heyl, and Hedeel Guy Evans. Phosphorylation of igfbp-3 by casein kinase 2 blocks its interaction with hyaluronan, enabling ha-cd44 signaling leading to increased nsclc cell survival and cisplatin resistance. Cells, 12:405, Jan 2023. URL: https://doi.org/10.3390/cells12030405, doi:10.3390/cells12030405. This article has 18 citations.</p>
+</li>
+<li>
+<p>(baxter2023signalingpathwaysof pages 9-9): Robert C Baxter. Signaling pathways of the insulin-like growth factor binding proteins. Endocrine Reviews, 44:753-778, Mar 2023. URL: https://doi.org/10.1210/endrev/bnad008, doi:10.1210/endrev/bnad008. This article has 144 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ding2022seruminsulinlikegrowth pages 1-3): Tian-Yan Ding, Yu-Hui Peng, Chao-Qun Hong, Bin-Liang Huang, Can-Tong Liu, Yun Luo, Ling-Yu Chu, Biao Zhang, Xin-Hao Li, Qi-Qi Qu, Yi-Wei Xu, and Fang-Cai Wu. Serum insulin-like growth factor binding protein 3 as a promising diagnostic and prognostic biomarker in esophagogastric junction adenocarcinoma. Discover. Oncology, Nov 2022. URL: https://doi.org/10.1007/s12672-022-00591-1, doi:10.1007/s12672-022-00591-1. This article has 5 citations.</p>
+</li>
+<li>
+<p>(sechrist2025pathologicsignalingand pages 1-2): Zachary R. Sechrist, Jaeden S. Cortés, Nidhi R. Patel, Zoe J. Pittman, Gayathri Guru Murthy, Guangzhen Zhu, Calvin L. Cole, and Benjamin D. Korman. Pathologic signaling and disease implications of insulin-like growth factor binding proteins in cancer, cardiovascular disease, and fibrosis. International Journal of Molecular Sciences, 26:10248, Oct 2025. URL: https://doi.org/10.3390/ijms262110248, doi:10.3390/ijms262110248. This article has 7 citations.</p>
+</li>
+<li>
+<p>(shrivastav2020insulinlikegrowthfactor pages 2-4): Shailly Varma Shrivastav, Apurva Bhardwaj, Kumar Alok Pathak, and Anuraag Shrivastav. Insulin-like growth factor binding protein-3 (igfbp-3): unraveling the role in mediating igf-independent effects within the cell. Frontiers in Cell and Developmental Biology, May 2020. URL: https://doi.org/10.3389/fcell.2020.00286, doi:10.3389/fcell.2020.00286. This article has 175 citations.</p>
+</li>
+<li>
+<p>(lee2002nucleareffectsunexpected pages 1-3): KW Lee and P Cohen. Nuclear effects: unexpected intracellular actions of insulin-like growth factor binding protein-3. Journal of Endocrinology, 175:33-40, Oct 2002. URL: https://doi.org/10.1677/joe.0.1750033, doi:10.1677/joe.0.1750033. This article has 127 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(skorupa2018igfbp3inducedby pages 19-23): Jennifer A. Skorupa. Igfbp-3 induced by ribotoxic stress is not secreted prior to nuclear localization in mammary epithelial cells. ArXiv, Jan 2018. URL: https://doi.org/10.7282/t3d50r5w, doi:10.7282/t3d50r5w. This article has 0 citations.</p>
+</li>
+<li>
+<p>(ding2022seruminsulinlikegrowth pages 3-5): Tian-Yan Ding, Yu-Hui Peng, Chao-Qun Hong, Bin-Liang Huang, Can-Tong Liu, Yun Luo, Ling-Yu Chu, Biao Zhang, Xin-Hao Li, Qi-Qi Qu, Yi-Wei Xu, and Fang-Cai Wu. Serum insulin-like growth factor binding protein 3 as a promising diagnostic and prognostic biomarker in esophagogastric junction adenocarcinoma. Discover. Oncology, Nov 2022. URL: https://doi.org/10.1007/s12672-022-00591-1, doi:10.1007/s12672-022-00591-1. This article has 5 citations.</p>
+</li>
+<li>
+<p>(watts2023circulatinginsulinlikegrowth pages 13-14): Eleanor L Watts, Aurora Perez-Cornago, Georgina K Fensom, Karl Smith-Byrne, Urwah Noor, Colm D Andrews, Marc J Gunter, Michael V Holmes, Richard M Martin, Konstantinos K Tsilidis, Demetrius Albanes, Aurelio Barricarte, H Bas Bueno-de-Mesquita, Barbara A Cohn, Melanie Deschasaux-Tanguy, Niki L Dimou, Luigi Ferrucci, Leon Flicker, Neal D Freedman, Graham G Giles, Edward L Giovannucci, Christopher A Haiman, Graham J Hankey, Jeffrey M P Holly, Jiaqi Huang, Wen-Yi Huang, Lauren M Hurwitz, Rudolf Kaaks, Tatsuhiko Kubo, Loic Le Marchand, Robert J MacInnis, Satu Männistö, E Jeffrey Metter, Kazuya Mikami, Lorelei A Mucci, Anja Olsen, Kotaro Ozasa, Domenico Palli, Kathryn L Penney, Elizabeth A Platz, Michael N Pollak, Monique J Roobol, Catherine A Schaefer, Jeannette M Schenk, Pär Stattin, Akiko Tamakoshi, Elin Thysell, Chiaojung Jillian Tsai, Mathilde Touvier, Stephen K Van Den Eeden, Elisabete Weiderpass, Stephanie J Weinstein, Lynne R Wilkens, Bu B Yeap, Rosalind A Eeles, Christopher A Haiman, Zsofia Kote-Jarai, Fredrick R Schumacher, Sara Benlloch, Ali Amin Al Olama, Kenneth R Muir, Sonja I Berndt, David V Conti, Fredrik Wiklund, Stephen Chanock, Ying Wang, Catherine M Tangen, Jyotsna Batra, Judith A Clements, Naomi E Allen, Timothy J Key, and Ruth C Travis. Circulating insulin-like growth factors and risks of overall, aggressive and early-onset prostate cancer: a collaborative analysis of 20 prospective studies and mendelian randomization analysis. International Journal of Epidemiology, 52:71-86, Jun 2023. URL: https://doi.org/10.1093/ije/dyac124, doi:10.1093/ije/dyac124. This article has 60 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>sechrist2025pathologicsignalingand pages 2-4</li>
+<li>mofid2018insilicointeraction pages 1-3</li>
+<li>lee2002nucleareffectsunexpected pages 3-4</li>
+<li>shrivastav2020insulinlikegrowthfactor pages 7-8</li>
+<li>baxter2023signalingpathwaysof pages 9-9</li>
+<li>ding2022seruminsulinlikegrowth pages 1-3</li>
+<li>baxter2023signalingpathwaysof pages 1-2</li>
+<li>ding2022seruminsulinlikegrowth pages 3-5</li>
+<li>watts2023circulatinginsulinlikegrowth pages 13-14</li>
+<li>price2020humaninblocksaggregation pages 1-2</li>
+<li>baxter2023signalingpathwaysof pages 2-2</li>
+<li>mofid2018insilicointeraction pages 8-10</li>
+<li>mofid2018insilicointeraction pages 11-11</li>
+<li>baxter2023signalingpathwaysof pages 3-4</li>
+<li>baxter2023signalingpathwaysof pages 4-5</li>
+<li>sechrist2025pathologicsignalingand pages 1-2</li>
+<li>shrivastav2020insulinlikegrowthfactor pages 2-4</li>
+<li>lee2002nucleareffectsunexpected pages 1-3</li>
+<li>https://doi.org/10.4103/1735-5362.235160;</li>
+<li>https://doi.org/10.1021/acs.biochem.0c00274</li>
+<li>https://doi.org/10.4103/1735-5362.235160</li>
+<li>https://doi.org/10.1210/endrev/bnad008;</li>
+<li>https://doi.org/10.3390/ijms262110248</li>
+<li>https://doi.org/10.3390/cells12030405;</li>
+<li>https://doi.org/10.3390/ijms22010407</li>
+<li>https://doi.org/10.1210/endrev/bnad008</li>
+<li>https://doi.org/10.3390/cells12030405</li>
+<li>https://doi.org/10.3389/fcell.2020.00286;</li>
+<li>https://doi.org/10.1677/joe.0.1750033</li>
+<li>https://doi.org/10.1677/joe.0.1750033;</li>
+<li>https://doi.org/10.1038/s41598-023-35291-5</li>
+<li>https://doi.org/10.1007/s12672-022-00591-1</li>
+<li>https://doi.org/10.1093/ije/dyac124</li>
+<li>https://doi.org/10.3389/fcell.2020.00286</li>
+<li>https://doi.org/10.4103/1735-5362.235160,</li>
+<li>https://doi.org/10.1021/acs.biochem.0c00274,</li>
+<li>https://doi.org/10.1210/endrev/bnad008,</li>
+<li>https://doi.org/10.3390/ijms262110248,</li>
+<li>https://doi.org/10.3390/cells12030405,</li>
+<li>https://doi.org/10.1677/joe.0.1750033,</li>
+<li>https://doi.org/10.3389/fcell.2020.00286,</li>
+<li>https://doi.org/10.1007/s12672-022-00591-1,</li>
+<li>https://doi.org/10.7282/t3d50r5w,</li>
+<li>https://doi.org/10.1093/ije/dyac124,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -4365,11 +6340,16 @@
                 <pre><code>id: P17936
 gene_symbol: IGFBP3
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: &#39;TODO: Add description for IGFBP3&#39;
+description: &#39;IGFBP3 encodes a secreted insulin-like growth factor binding protein whose dominant
+  biochemical activity is high-affinity binding of IGF-I and IGF-II, thereby regulating IGF
+  receptor signaling and circulating IGF stability through binary and ALS-containing ternary
+  complexes. It also has context-dependent IGF-independent roles involving nuclear import,
+  RXR/RAR signaling, phosphatase-mediated suppression of IGF pathway mediators, apoptosis,
+  and hyaluronan-CD44 signaling.&#39;
 existing_annotations:
   - term:
       id: GO:0031994
@@ -4377,549 +6357,1163 @@ existing_annotations:
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: insulin-like growth factor I binding is a core IGFBP3 molecular function;
+        the literature consistently identifies high-affinity IGF-I/IGF-II binding as the
+        dominant biochemical activity.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0031995
       label: insulin-like growth factor II binding
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: insulin-like growth factor II binding is a core IGFBP3 molecular
+        function; the literature consistently identifies high-affinity IGF-I/IGF-II
+        binding as the dominant biochemical activity.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005615
       label: extracellular space
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: extracellular space is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0001968
       label: fibronectin binding
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Fibronectin binding is not a major finding in the synthesized IGFBP3
+        evidence; extracellular matrix binding is better captured by the specific
+        hyaluronic acid binding evidence.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: The current evidence synthesis supports HA binding, not fibronectin
+        binding, as the informative ECM ligand interaction.
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0043567
       label: regulation of insulin-like growth factor receptor signaling pathway
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: IGFBP3 regulates IGF receptor signaling by sequestering IGF ligands and
+        through IGF-independent signaling crosstalk, so this process annotation is
+        supported.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
   - term:
       id: GO:0005520
       label: insulin-like growth factor binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: insulin-like growth factor binding is a core IGFBP3 molecular function;
+        the literature consistently identifies high-affinity IGF-I/IGF-II binding as the
+        dominant biochemical activity.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Nuclear localization is supported but represents a context-dependent
+        IGF-independent compartment rather than the canonical extracellular IGF-binding
+        role.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: Multiple sources support nuclear localization of IGFBP-3.
+            Classic mechanistic evidence indicates IGFBP-3 contains a **basic C-terminal
+            nuclear localization signal (NLS)** and undergoes **NLS-dependent,
+            importin-mediated nuclear translocation**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A central IGF-independent nuclear mechanism is the
+            interaction of nuclear IGFBP-3 with **retinoid X receptor alpha (RXRα)**.
+            Classic evidence describes RXR as an IGFBP-3 partner identified by yeast
+            two-hybrid screening and positions this interaction as a conceptual
+            “paradigm shift” for IGFBP actions in transcription and apoptosis.
   - term:
       id: GO:0006915
       label: apoptotic process
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: apoptotic process is retained as a context-dependent IGF-independent
+        apoptotic role, including nuclear receptor and cell-death receptor mechanisms,
+        but it is not the canonical core molecular function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A central IGF-independent nuclear mechanism is the
+            interaction of nuclear IGFBP-3 with **retinoid X receptor alpha (RXRα)**.
+            Classic evidence describes RXR as an IGFBP-3 partner identified by yeast
+            two-hybrid screening and positions this interaction as a conceptual
+            “paradigm shift” for IGFBP actions in transcription and apoptosis.
+        - reference_id: file:human/IGFBP3/IGFBP3-uniprot.txt
+          supporting_text: apoptotic effects mediated by its receptor TMEM219/IGFBP-3R
   - term:
       id: GO:0014912
       label: negative regulation of smooth muscle cell migration
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: negative regulation of smooth muscle cell migration is consistent with
+        IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but these
+        are downstream context-specific effects rather than the core ligand-binding
+        activity.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0019838
       label: growth factor binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Growth factor binding is true but less informative than the specific
+        insulin-like growth factor binding annotations already present.
+      action: MODIFY
+      reason: Use the specific IGF binding term for this protein family.
+      proposed_replacement_terms:
+        - id: GO:0005520
+          label: insulin-like growth factor binding
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0031994
       label: insulin-like growth factor I binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: insulin-like growth factor I binding is a core IGFBP3 molecular function;
+        the literature consistently identifies high-affinity IGF-I/IGF-II binding as the
+        dominant biochemical activity.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0042567
       label: insulin-like growth factor ternary complex
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: insulin-like growth factor ternary complex is supported by IGFBP3
+        formation of binary IGF:IGFBP complexes and ALS-containing ternary complexes in
+        circulation.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0048662
       label: negative regulation of smooth muscle cell proliferation
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: negative regulation of smooth muscle cell proliferation is consistent
+        with IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but
+        these are downstream context-specific effects rather than the core
+        ligand-binding activity.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:20353938
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Generic protein binding is over-broad for IGFBP3. More informative
+        annotations are IGF binding, hyaluronan binding, ternary complex formation, and
+        specific receptor/importin/nuclear receptor interactions.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid retaining generic protein binding when specific molecular
+        interactions are available.
       supported_by:
         - reference_id: PMID:20353938
-          supporting_text: 2010 Mar 30. Identification of a novel cell death 
-            receptor mediating IGFBP-3-induced anti-tumor effects in breast and 
-            prostate cancer.
+          supporting_text: 2010 Mar 30. Identification of a novel cell death receptor
+            mediating IGFBP-3-induced anti-tumor effects in breast and prostate cancer.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: The emerging consensus is therefore not a single “primary
+            function” in all contexts, but a dominant primary biochemical
+            activity—**high-affinity IGF binding**—that acts as a scaffold for diverse
+            regulated functions controlled by **proteolysis** and **phosphorylation**,
+            and by compartment switching between extracellular matrix, membrane
+            microdomains, cytosol, and nucleus.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:23178489
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Generic protein binding is over-broad for IGFBP3. More informative
+        annotations are IGF binding, hyaluronan binding, ternary complex formation, and
+        specific receptor/importin/nuclear receptor interactions.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid retaining generic protein binding when specific molecular
+        interactions are available.
       supported_by:
         - reference_id: PMID:23178489
-          supporting_text: The role of insulin-like growth factor binding 
-            protein-3 in the breast cancer cell response to DNA-damaging agents.
+          supporting_text: The role of insulin-like growth factor binding protein-3 in
+            the breast cancer cell response to DNA-damaging agents.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: The emerging consensus is therefore not a single “primary
+            function” in all contexts, but a dominant primary biochemical
+            activity—**high-affinity IGF binding**—that acts as a scaffold for diverse
+            regulated functions controlled by **proteolysis** and **phosphorylation**,
+            and by compartment switching between extracellular matrix, membrane
+            microdomains, cytosol, and nucleus.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:30184438
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Generic protein binding is over-broad for IGFBP3. More informative
+        annotations are IGF binding, hyaluronan binding, ternary complex formation, and
+        specific receptor/importin/nuclear receptor interactions.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid retaining generic protein binding when specific molecular
+        interactions are available.
       supported_by:
         - reference_id: PMID:30184438
-          supporting_text: Epub 2018 Sep 17. Interaction of Insulin-Like Growth 
-            Factor-Binding Protein 3 With Hyaluronan and Its Regulation by 
-            Humanin and CD44.
+          supporting_text: Epub 2018 Sep 17. Interaction of Insulin-Like Growth
+            Factor-Binding Protein 3 With Hyaluronan and Its Regulation by Humanin and
+            CD44.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: The emerging consensus is therefore not a single “primary
+            function” in all contexts, but a dominant primary biochemical
+            activity—**high-affinity IGF binding**—that acts as a scaffold for diverse
+            regulated functions controlled by **proteolysis** and **phosphorylation**,
+            and by compartment switching between extracellular matrix, membrane
+            microdomains, cytosol, and nucleus.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:32814053
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Generic protein binding is over-broad for IGFBP3. More informative
+        annotations are IGF binding, hyaluronan binding, ternary complex formation, and
+        specific receptor/importin/nuclear receptor interactions.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid retaining generic protein binding when specific molecular
+        interactions are available.
       supported_by:
         - reference_id: PMID:32814053
-          supporting_text: Interactome Mapping Provides a Network of 
-            Neurodegenerative Disease Proteins and Uncovers Widespread Protein 
-            Aggregation in Affected Brains.
+          supporting_text: Interactome Mapping Provides a Network of Neurodegenerative
+            Disease Proteins and Uncovers Widespread Protein Aggregation in Affected
+            Brains.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: The emerging consensus is therefore not a single “primary
+            function” in all contexts, but a dominant primary biochemical
+            activity—**high-affinity IGF binding**—that acts as a scaffold for diverse
+            regulated functions controlled by **proteolysis** and **phosphorylation**,
+            and by compartment switching between extracellular matrix, membrane
+            microdomains, cytosol, and nucleus.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0001649
       label: osteoblast differentiation
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: osteoblast differentiation is retained as a context-specific
+        differentiation phenotype downstream of IGFBP3 signaling rather than the core
+        biochemical function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-uniprot.txt
+          supporting_text: including proliferation, differentiation, and apoptosis in a
+            cell-type specific manner
   - term:
       id: GO:0001968
       label: fibronectin binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Fibronectin binding is not a major finding in the synthesized IGFBP3
+        evidence; extracellular matrix binding is better captured by the specific
+        hyaluronic acid binding evidence.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: The current evidence synthesis supports HA binding, not fibronectin
+        binding, as the informative ECM ligand interaction.
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0005615
       label: extracellular space
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: extracellular space is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-381466
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:26216267
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Generic protein binding is over-broad for IGFBP3. More informative
+        annotations are IGF binding, hyaluronan binding, ternary complex formation, and
+        specific receptor/importin/nuclear receptor interactions.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid retaining generic protein binding when specific molecular
+        interactions are available.
       supported_by:
         - reference_id: PMID:26216267
-          supporting_text: Humanin Peptide Binds to Insulin-Like Growth 
-            Factor-Binding Protein 3 (IGFBP3) and Regulates Its Interaction with
-            Importin-β.
+          supporting_text: Humanin Peptide Binds to Insulin-Like Growth Factor-Binding
+            Protein 3 (IGFBP3) and Regulates Its Interaction with Importin-β.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: The emerging consensus is therefore not a single “primary
+            function” in all contexts, but a dominant primary biochemical
+            activity—**high-affinity IGF binding**—that acts as a scaffold for diverse
+            regulated functions controlled by **proteolysis** and **phosphorylation**,
+            and by compartment switching between extracellular matrix, membrane
+            microdomains, cytosol, and nucleus.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0005788
       label: endoplasmic reticulum lumen
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-8952289
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Endoplasmic reticulum lumen localization is plausible for a secreted
+        precursor and FAM20C substrate, but it is not the main functional site of mature
+        IGFBP3.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
   - term:
       id: GO:0042567
       label: insulin-like growth factor ternary complex
     evidence_type: IDA
     original_reference_id: PMID:9497324
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: insulin-like growth factor ternary complex is supported by IGFBP3
+        formation of binary IGF:IGFBP complexes and ALS-containing ternary complexes in
+        circulation.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:9497324
-          supporting_text: Insulin-like growth factor (IGF)-binding protein 5 
-            forms an alternative ternary complex with IGFs and the acid-labile 
-            subunit.
+          supporting_text: Insulin-like growth factor (IGF)-binding protein 5 forms an
+            alternative ternary complex with IGFs and the acid-labile subunit.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-381435
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-381446
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-381461
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-381496
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-381500
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-6800035
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-6800044
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0008285
       label: negative regulation of cell population proliferation
     evidence_type: IGI
     original_reference_id: PMID:19258508
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: negative regulation of cell population proliferation is consistent with
+        IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but these
+        are downstream context-specific effects rather than the core ligand-binding
+        activity.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:19258508
-          supporting_text: Epub 2009 Mar 3. NKX3.1 activates expression of 
-            insulin-like growth factor binding protein-3 to mediate insulin-like
-            growth factor-I signaling and cell proliferation.
+          supporting_text: Epub 2009 Mar 3. NKX3.1 activates expression of insulin-like
+            growth factor binding protein-3 to mediate insulin-like growth factor-I
+            signaling and cell proliferation.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0014912
       label: negative regulation of smooth muscle cell migration
     evidence_type: IDA
     original_reference_id: PMID:10766744
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: negative regulation of smooth muscle cell migration is consistent with
+        IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but these
+        are downstream context-specific effects rather than the core ligand-binding
+        activity.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:10766744
-          supporting_text: Substitutions for hydrophobic amino acids in the 
-            N-terminal domains of IGFBP-3 and -5 markedly reduce IGF-I binding 
-            and alter their biologic actions.
+          supporting_text: Substitutions for hydrophobic amino acids in the N-terminal
+            domains of IGFBP-3 and -5 markedly reduce IGF-I binding and alter their
+            biologic actions.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0016942
       label: insulin-like growth factor binding protein complex
     evidence_type: IC
     original_reference_id: PMID:10766744
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: insulin-like growth factor binding protein complex is supported by IGFBP3
+        formation of binary IGF:IGFBP complexes and ALS-containing ternary complexes in
+        circulation.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:10766744
-          supporting_text: Substitutions for hydrophobic amino acids in the 
-            N-terminal domains of IGFBP-3 and -5 markedly reduce IGF-I binding 
-            and alter their biologic actions.
+          supporting_text: Substitutions for hydrophobic amino acids in the N-terminal
+            domains of IGFBP-3 and -5 markedly reduce IGF-I binding and alter their
+            biologic actions.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0031994
       label: insulin-like growth factor I binding
     evidence_type: IPI
     original_reference_id: PMID:10766744
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: insulin-like growth factor I binding is a core IGFBP3 molecular function;
+        the literature consistently identifies high-affinity IGF-I/IGF-II binding as the
+        dominant biochemical activity.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:10766744
-          supporting_text: Substitutions for hydrophobic amino acids in the 
-            N-terminal domains of IGFBP-3 and -5 markedly reduce IGF-I binding 
-            and alter their biologic actions.
+          supporting_text: Substitutions for hydrophobic amino acids in the N-terminal
+            domains of IGFBP-3 and -5 markedly reduce IGF-I binding and alter their
+            biologic actions.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0048662
       label: negative regulation of smooth muscle cell proliferation
     evidence_type: IDA
     original_reference_id: PMID:10766744
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: negative regulation of smooth muscle cell proliferation is consistent
+        with IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but
+        these are downstream context-specific effects rather than the core
+        ligand-binding activity.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:10766744
-          supporting_text: Substitutions for hydrophobic amino acids in the 
-            N-terminal domains of IGFBP-3 and -5 markedly reduce IGF-I binding 
-            and alter their biologic actions.
+          supporting_text: Substitutions for hydrophobic amino acids in the N-terminal
+            domains of IGFBP-3 and -5 markedly reduce IGF-I binding and alter their
+            biologic actions.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0005615
       label: extracellular space
     evidence_type: IDA
     original_reference_id: PMID:17119061
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: extracellular space is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:17119061
-          supporting_text: &#39;Ethnic disparity in the relationship between obesity and
-            plasma insulin-like growth factors: the multiethnic cohort.&#39;
+          supporting_text: &#39;Ethnic disparity in the relationship between obesity and plasma
+            insulin-like growth factors: the multiethnic cohort.&#39;
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0001933
       label: negative regulation of protein phosphorylation
     evidence_type: IDA
     original_reference_id: PMID:17591901
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: negative regulation of protein phosphorylation is consistent with IGFBP3
+        modulation of IGF/IGF1R and IGF-independent signaling outputs, but these are
+        downstream context-specific effects rather than the core ligand-binding
+        activity.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:17591901
-          supporting_text: &#39;The requirement of pax6 for postnatal eye development:
-            evidence from experimental mouse chimeras.&#39;
+          supporting_text: &#39;The requirement of pax6 for postnatal eye development: evidence
+            from experimental mouse chimeras.&#39;
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IDA
     original_reference_id: PMID:17434920
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Nuclear localization is supported but represents a context-dependent
+        IGF-independent compartment rather than the canonical extracellular IGF-binding
+        role.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:17434920
-          supporting_text: Apr 13. Contribution of the orphan nuclear receptor 
-            Nur77 to the apoptotic action of IGFBP-3.
+          supporting_text: Apr 13. Contribution of the orphan nuclear receptor Nur77 to
+            the apoptotic action of IGFBP-3.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: Multiple sources support nuclear localization of IGFBP-3.
+            Classic mechanistic evidence indicates IGFBP-3 contains a **basic C-terminal
+            nuclear localization signal (NLS)** and undergoes **NLS-dependent,
+            importin-mediated nuclear translocation**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A central IGF-independent nuclear mechanism is the
+            interaction of nuclear IGFBP-3 with **retinoid X receptor alpha (RXRα)**.
+            Classic evidence describes RXR as an IGFBP-3 partner identified by yeast
+            two-hybrid screening and positions this interaction as a conceptual
+            “paradigm shift” for IGFBP actions in transcription and apoptosis.
   - term:
       id: GO:0006468
       label: protein phosphorylation
     evidence_type: IDA
     original_reference_id: PMID:17434920
     review:
-      summary: &gt;-
-        OVER-ANNOTATION: IGFBP3 is an IGF-binding protein that modulates IGF signaling.
-        It has NO kinase activity. IGFBP3 affects phosphorylation indirectly by regulating
-        IGF availability and signaling, but doesn&#39;t catalyze phosphorylation itself.
+      summary: IGFBP3 is not a protein kinase and does not catalyze protein
+        phosphorylation. The supported biology is indirect regulation of
+        phosphorylation/signaling downstream of IGF1R and related pathways.
       action: MODIFY
+      reason: Replace a misleading phosphorylation-process annotation with the supported
+        negative regulation of protein phosphorylation/signaling.
       proposed_replacement_terms:
-        - id: GO:0045859
-          label: regulation of protein kinase activity
+        - id: GO:0001933
+          label: negative regulation of protein phosphorylation
       supported_by:
         - reference_id: PMID:17434920
-          supporting_text: Apr 13. Contribution of the orphan nuclear receptor 
-            Nur77 to the apoptotic action of IGFBP-3.
+          supporting_text: Apr 13. Contribution of the orphan nuclear receptor Nur77 to
+            the apoptotic action of IGFBP-3.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:14561895
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Generic protein binding is over-broad for IGFBP3. More informative
+        annotations are IGF binding, hyaluronan binding, ternary complex formation, and
+        specific receptor/importin/nuclear receptor interactions.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid retaining generic protein binding when specific molecular
+        interactions are available.
       supported_by:
         - reference_id: PMID:14561895
-          supporting_text: Interaction between the Alzheimer&#39;s survival peptide 
-            humanin and insulin-like growth factor-binding protein 3 regulates 
-            cell survival and apoptosis.
+          supporting_text: Interaction between the Alzheimer&#39;s survival peptide humanin
+            and insulin-like growth factor-binding protein 3 regulates cell survival and
+            apoptosis.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: The emerging consensus is therefore not a single “primary
+            function” in all contexts, but a dominant primary biochemical
+            activity—**high-affinity IGF binding**—that acts as a scaffold for diverse
+            regulated functions controlled by **proteolysis** and **phosphorylation**,
+            and by compartment switching between extracellular matrix, membrane
+            microdomains, cytosol, and nucleus.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:9388210
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Generic protein binding is over-broad for IGFBP3. More informative
+        annotations are IGF binding, hyaluronan binding, ternary complex formation, and
+        specific receptor/importin/nuclear receptor interactions.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid retaining generic protein binding when specific molecular
+        interactions are available.
       supported_by:
         - reference_id: PMID:9388210
-          supporting_text: Inhibition of insulin receptor activation by 
-            insulin-like growth factor binding proteins.
+          supporting_text: Inhibition of insulin receptor activation by insulin-like
+            growth factor binding proteins.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: The emerging consensus is therefore not a single “primary
+            function” in all contexts, but a dominant primary biochemical
+            activity—**high-affinity IGF binding**—that acts as a scaffold for diverse
+            regulated functions controlled by **proteolysis** and **phosphorylation**,
+            and by compartment switching between extracellular matrix, membrane
+            microdomains, cytosol, and nucleus.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0005520
       label: insulin-like growth factor binding
     evidence_type: NAS
     original_reference_id: PMID:12599210
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: insulin-like growth factor binding is a core IGFBP3 molecular function;
+        the literature consistently identifies high-affinity IGF-I/IGF-II binding as the
+        dominant biochemical activity.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:12599210
-          supporting_text: Role of insulin-like growth factor binding protein-3 
-            (IGFBP-3) in the differentiation of primary human adult skeletal 
-            myoblasts.
+          supporting_text: Role of insulin-like growth factor binding protein-3
+            (IGFBP-3) in the differentiation of primary human adult skeletal myoblasts.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0008160
       label: protein tyrosine phosphatase activator activity
     evidence_type: IDA
     original_reference_id: PMID:11940579
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein tyrosine phosphatase activator activity is retained as a non-core
+        IGF-independent signaling mechanism from older experimental evidence, while
+        newer synthesis emphasizes PP2A-mediated dephosphorylation of IGF pathway
+        mediators.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:11940579
-          supporting_text: 2002 Apr 8. Insulin-like growth factor-binding 
-            protein-3 activates a phosphotyrosine phosphatase.
+          supporting_text: 2002 Apr 8. Insulin-like growth factor-binding protein-3
+            activates a phosphotyrosine phosphatase.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
   - term:
       id: GO:0009968
       label: negative regulation of signal transduction
     evidence_type: NAS
     original_reference_id: PMID:11940579
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Negative regulation of signal transduction is supported by IGFBP3
+        suppression of IGF/IGF1R pathway mediators and by hyaluronan-CD44 signaling
+        blockade; this captures a core signaling output of IGFBP3 ligand binding in
+        extracellular contexts.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:11940579
-          supporting_text: 2002 Apr 8. Insulin-like growth factor-binding 
-            protein-3 activates a phosphotyrosine phosphatase.
+          supporting_text: 2002 Apr 8. Insulin-like growth factor-binding protein-3
+            activates a phosphotyrosine phosphatase.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0043065
       label: positive regulation of apoptotic process
     evidence_type: IMP
     original_reference_id: PMID:11971816
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: positive regulation of apoptotic process is retained as a
+        context-dependent IGF-independent apoptotic role, including nuclear receptor and
+        cell-death receptor mechanisms, but it is not the canonical core molecular
+        function.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:11971816
-          supporting_text: &#39;Insulin-like growth factor binding protein-3 mediates
-            tumor necrosis factor-alpha-induced apoptosis: role of Bcl-2 phosphorylation.&#39;
+          supporting_text: &#39;Insulin-like growth factor binding protein-3 mediates tumor necrosis
+            factor-alpha-induced apoptosis: role of Bcl-2 phosphorylation.&#39;
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A central IGF-independent nuclear mechanism is the
+            interaction of nuclear IGFBP-3 with **retinoid X receptor alpha (RXRα)**.
+            Classic evidence describes RXR as an IGFBP-3 partner identified by yeast
+            two-hybrid screening and positions this interaction as a conceptual
+            “paradigm shift” for IGFBP actions in transcription and apoptosis.
+        - reference_id: file:human/IGFBP3/IGFBP3-uniprot.txt
+          supporting_text: apoptotic effects mediated by its receptor TMEM219/IGFBP-3R
   - term:
       id: GO:0045663
       label: positive regulation of myoblast differentiation
     evidence_type: IDA
     original_reference_id: PMID:12599210
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: positive regulation of myoblast differentiation is retained as a
+        context-specific differentiation phenotype downstream of IGFBP3 signaling rather
+        than the core biochemical function.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:12599210
-          supporting_text: Role of insulin-like growth factor binding protein-3 
-            (IGFBP-3) in the differentiation of primary human adult skeletal 
-            myoblasts.
+          supporting_text: Role of insulin-like growth factor binding protein-3
+            (IGFBP-3) in the differentiation of primary human adult skeletal myoblasts.
+        - reference_id: file:human/IGFBP3/IGFBP3-uniprot.txt
+          supporting_text: including proliferation, differentiation, and apoptosis in a
+            cell-type specific manner
   - term:
       id: GO:0046872
       label: metal ion binding
     evidence_type: NAS
     original_reference_id: PMID:14576163
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: The C-terminal metal-binding domain evidence is retained as a non-core
+        IGF-independent feature.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:14576163
-          supporting_text: Oct 22. Insulin-like growth factor-independent 
-            effects mediated by a C-terminal metal-binding domain of 
-            insulin-like growth factor binding protein-3.
+          supporting_text: Oct 22. Insulin-like growth factor-independent effects
+            mediated by a C-terminal metal-binding domain of insulin-like growth factor
+            binding protein-3.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: NAS
     original_reference_id: PMID:14718574
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:14718574
-          supporting_text: &#39;Epub 2004 Jan 12. The human plasma proteome: a nonredundant
-            list developed by combination of four separate sources.&#39;
+          supporting_text: &#39;Epub 2004 Jan 12. The human plasma proteome: a nonredundant list
+            developed by combination of four separate sources.&#39;
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
+  - term:
+      id: GO:0005540
+      label: hyaluronic acid binding
+    evidence_type: IC
+    original_reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+    review:
+      summary: IGFBP3 binds hyaluronan through a mapped basic C-terminal motif and can
+        block HA-CD44 signaling.
+      action: NEW
+      reason: Specific HA binding is supported by recent mechanistic work and is absent
+        from current GOA.
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
 references:
   - id: GO_REF:0000033
     title: Annotation inferences using phylogenetic trees
     findings: []
   - id: GO_REF:0000043
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword 
-      mapping
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
     findings: []
   - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
     findings: []
   - id: GO_REF:0000107
-    title: Automatic transfer of experimentally verified manual GO annotation 
-      data to orthologs using Ensembl Compara
+    title: Automatic transfer of experimentally verified manual GO annotation data to
+      orthologs using Ensembl Compara
     findings: []
   - id: GO_REF:0000117
-    title: Electronic Gene Ontology annotations created by ARBA machine learning
-      models
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
     findings: []
   - id: GO_REF:0000120
     title: Combined Automated Annotation using Multiple IEA Methods
     findings: []
   - id: PMID:10766744
-    title: Substitutions for hydrophobic amino acids in the N-terminal domains 
-      of IGFBP-3 and -5 markedly reduce IGF-I binding and alter their biologic 
-      actions.
+    title: Substitutions for hydrophobic amino acids in the N-terminal domains of
+      IGFBP-3 and -5 markedly reduce IGF-I binding and alter their biologic actions.
     findings: []
   - id: PMID:11940579
-    title: Insulin-like growth factor-binding protein-3 activates a 
-      phosphotyrosine phosphatase. Effects on the insulin-like growth factor 
-      signaling pathway.
+    title: Insulin-like growth factor-binding protein-3 activates a phosphotyrosine
+      phosphatase. Effects on the insulin-like growth factor signaling pathway.
     findings: []
   - id: PMID:11971816
     title: &#39;Insulin-like growth factor binding protein-3 mediates tumor necrosis factor-alpha-induced
@@ -4930,63 +7524,60 @@ references:
       differentiation of primary human adult skeletal myoblasts.
     findings: []
   - id: PMID:14561895
-    title: Interaction between the Alzheimer&#39;s survival peptide humanin and 
-      insulin-like growth factor-binding protein 3 regulates cell survival and 
-      apoptosis.
+    title: Interaction between the Alzheimer&#39;s survival peptide humanin and insulin-like
+      growth factor-binding protein 3 regulates cell survival and apoptosis.
     findings: []
   - id: PMID:14576163
-    title: Insulin-like growth factor-independent effects mediated by a 
-      C-terminal metal-binding domain of insulin-like growth factor binding 
-      protein-3.
+    title: Insulin-like growth factor-independent effects mediated by a C-terminal
+      metal-binding domain of insulin-like growth factor binding protein-3.
     findings: []
   - id: PMID:14718574
-    title: &#39;The human plasma proteome: a nonredundant list developed by combination
-      of four separate sources.&#39;
+    title: &#39;The human plasma proteome: a nonredundant list developed by combination of four
+      separate sources.&#39;
     findings: []
   - id: PMID:17119061
-    title: &#39;Ethnic disparity in the relationship between obesity and plasma insulin-like
-      growth factors: the multiethnic cohort.&#39;
+    title: &#39;Ethnic disparity in the relationship between obesity and plasma insulin-like growth
+      factors: the multiethnic cohort.&#39;
     findings: []
   - id: PMID:17434920
-    title: Contribution of the orphan nuclear receptor Nur77 to the apoptotic 
-      action of IGFBP-3.
+    title: Contribution of the orphan nuclear receptor Nur77 to the apoptotic action of
+      IGFBP-3.
     findings: []
   - id: PMID:17591901
     title: &#39;The requirement of pax6 for postnatal eye development: evidence from experimental
       mouse chimeras.&#39;
     findings: []
   - id: PMID:19258508
-    title: NKX3.1 activates expression of insulin-like growth factor binding 
-      protein-3 to mediate insulin-like growth factor-I signaling and cell 
-      proliferation.
+    title: NKX3.1 activates expression of insulin-like growth factor binding protein-3
+      to mediate insulin-like growth factor-I signaling and cell proliferation.
     findings: []
   - id: PMID:20353938
-    title: Identification of a novel cell death receptor mediating 
-      IGFBP-3-induced anti-tumor effects in breast and prostate cancer.
+    title: Identification of a novel cell death receptor mediating IGFBP-3-induced
+      anti-tumor effects in breast and prostate cancer.
     findings: []
   - id: PMID:23178489
-    title: The role of insulin-like growth factor binding protein-3 in the 
-      breast cancer cell response to DNA-damaging agents.
+    title: The role of insulin-like growth factor binding protein-3 in the breast cancer
+      cell response to DNA-damaging agents.
     findings: []
   - id: PMID:26216267
     title: Humanin Peptide Binds to Insulin-Like Growth Factor-Binding Protein 3
       (IGFBP3) and Regulates Its Interaction with Importin-β.
     findings: []
   - id: PMID:30184438
-    title: Interaction of Insulin-Like Growth Factor-Binding Protein 3 With 
-      Hyaluronan and Its Regulation by Humanin and CD44.
+    title: Interaction of Insulin-Like Growth Factor-Binding Protein 3 With Hyaluronan
+      and Its Regulation by Humanin and CD44.
     findings: []
   - id: PMID:32814053
-    title: Interactome Mapping Provides a Network of Neurodegenerative Disease 
-      Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.
+    title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins
+      and Uncovers Widespread Protein Aggregation in Affected Brains.
     findings: []
   - id: PMID:9388210
-    title: Inhibition of insulin receptor activation by insulin-like growth 
-      factor binding proteins.
+    title: Inhibition of insulin receptor activation by insulin-like growth factor
+      binding proteins.
     findings: []
   - id: PMID:9497324
-    title: Insulin-like growth factor (IGF)-binding protein 5 forms an 
-      alternative ternary complex with IGFs and the acid-labile subunit.
+    title: Insulin-like growth factor (IGF)-binding protein 5 forms an alternative
+      ternary complex with IGFs and the acid-labile subunit.
     findings: []
   - id: Reactome:R-HSA-381435
     title: Matrix metalloproteinase proteolyzes IGF:IGFBP3:ALS
@@ -5015,13 +7606,72 @@ references:
   - id: Reactome:R-HSA-8952289
     title: FAM20C phosphorylates FAM20C substrates
     findings: []
+  - id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+    title: Falcon deep research synthesis for IGFBP3
+    findings: []
+  - id: file:human/IGFBP3/IGFBP3-uniprot.txt
+    title: UniProt record for IGFBP3
+    findings: []
+core_functions:
+  - description: High-affinity binding of IGF-I and IGF-II to regulate IGF receptor
+      signaling and stabilize circulating IGF complexes.
+    molecular_function:
+      id: GO:0005520
+      label: insulin-like growth factor binding
+    directly_involved_in:
+      - id: GO:0043567
+        label: regulation of insulin-like growth factor receptor signaling pathway
+    locations:
+      - id: GO:0005615
+        label: extracellular space
+      - id: GO:0005576
+        label: extracellular region
+    in_complex:
+      id: GO:0042567
+      label: insulin-like growth factor ternary complex
+    supported_by:
+      - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+        supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+          factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+          **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+          and modulating IGF1R signaling.
+      - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+        supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+          circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+          in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+          acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+          circulating IGF.
+      - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+        supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+          describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+          peptide** and a **264-aa mature chain**, consistent with secretion into
+          extracellular fluids.
+  - description: Hyaluronan binding that modulates extracellular HA-CD44 signaling in a
+      phosphorylation-sensitive manner.
+    molecular_function:
+      id: GO:0005540
+      label: hyaluronic acid binding
+    directly_involved_in:
+      - id: GO:0009968
+        label: negative regulation of signal transduction
+    locations:
+      - id: GO:0005576
+        label: extracellular region
+    supported_by:
+      - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+        supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+          **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA
+          engagement of **CD44**, suppressing HA–CD44 signaling.
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/IGFBP3/IGFBP3-ai-review.yaml
+++ b/genes/human/IGFBP3/IGFBP3-ai-review.yaml
@@ -1,11 +1,16 @@
 id: P17936
 gene_symbol: IGFBP3
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for IGFBP3'
+description: 'IGFBP3 encodes a secreted insulin-like growth factor binding protein whose dominant
+  biochemical activity is high-affinity binding of IGF-I and IGF-II, thereby regulating IGF
+  receptor signaling and circulating IGF stability through binary and ALS-containing ternary
+  complexes. It also has context-dependent IGF-independent roles involving nuclear import,
+  RXR/RAR signaling, phosphatase-mediated suppression of IGF pathway mediators, apoptosis,
+  and hyaluronan-CD44 signaling.'
 existing_annotations:
   - term:
       id: GO:0031994
@@ -13,549 +18,1163 @@ existing_annotations:
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: insulin-like growth factor I binding is a core IGFBP3 molecular function;
+        the literature consistently identifies high-affinity IGF-I/IGF-II binding as the
+        dominant biochemical activity.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0031995
       label: insulin-like growth factor II binding
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: insulin-like growth factor II binding is a core IGFBP3 molecular
+        function; the literature consistently identifies high-affinity IGF-I/IGF-II
+        binding as the dominant biochemical activity.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005615
       label: extracellular space
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: extracellular space is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0001968
       label: fibronectin binding
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Fibronectin binding is not a major finding in the synthesized IGFBP3
+        evidence; extracellular matrix binding is better captured by the specific
+        hyaluronic acid binding evidence.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: The current evidence synthesis supports HA binding, not fibronectin
+        binding, as the informative ECM ligand interaction.
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0043567
       label: regulation of insulin-like growth factor receptor signaling pathway
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: IGFBP3 regulates IGF receptor signaling by sequestering IGF ligands and
+        through IGF-independent signaling crosstalk, so this process annotation is
+        supported.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
   - term:
       id: GO:0005520
       label: insulin-like growth factor binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: insulin-like growth factor binding is a core IGFBP3 molecular function;
+        the literature consistently identifies high-affinity IGF-I/IGF-II binding as the
+        dominant biochemical activity.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Nuclear localization is supported but represents a context-dependent
+        IGF-independent compartment rather than the canonical extracellular IGF-binding
+        role.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: Multiple sources support nuclear localization of IGFBP-3.
+            Classic mechanistic evidence indicates IGFBP-3 contains a **basic C-terminal
+            nuclear localization signal (NLS)** and undergoes **NLS-dependent,
+            importin-mediated nuclear translocation**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A central IGF-independent nuclear mechanism is the
+            interaction of nuclear IGFBP-3 with **retinoid X receptor alpha (RXRα)**.
+            Classic evidence describes RXR as an IGFBP-3 partner identified by yeast
+            two-hybrid screening and positions this interaction as a conceptual
+            “paradigm shift” for IGFBP actions in transcription and apoptosis.
   - term:
       id: GO:0006915
       label: apoptotic process
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: apoptotic process is retained as a context-dependent IGF-independent
+        apoptotic role, including nuclear receptor and cell-death receptor mechanisms,
+        but it is not the canonical core molecular function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A central IGF-independent nuclear mechanism is the
+            interaction of nuclear IGFBP-3 with **retinoid X receptor alpha (RXRα)**.
+            Classic evidence describes RXR as an IGFBP-3 partner identified by yeast
+            two-hybrid screening and positions this interaction as a conceptual
+            “paradigm shift” for IGFBP actions in transcription and apoptosis.
+        - reference_id: file:human/IGFBP3/IGFBP3-uniprot.txt
+          supporting_text: apoptotic effects mediated by its receptor TMEM219/IGFBP-3R
   - term:
       id: GO:0014912
       label: negative regulation of smooth muscle cell migration
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: negative regulation of smooth muscle cell migration is consistent with
+        IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but these
+        are downstream context-specific effects rather than the core ligand-binding
+        activity.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0019838
       label: growth factor binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Growth factor binding is true but less informative than the specific
+        insulin-like growth factor binding annotations already present.
+      action: MODIFY
+      reason: Use the specific IGF binding term for this protein family.
+      proposed_replacement_terms:
+        - id: GO:0005520
+          label: insulin-like growth factor binding
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0031994
       label: insulin-like growth factor I binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: insulin-like growth factor I binding is a core IGFBP3 molecular function;
+        the literature consistently identifies high-affinity IGF-I/IGF-II binding as the
+        dominant biochemical activity.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0042567
       label: insulin-like growth factor ternary complex
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: insulin-like growth factor ternary complex is supported by IGFBP3
+        formation of binary IGF:IGFBP complexes and ALS-containing ternary complexes in
+        circulation.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0048662
       label: negative regulation of smooth muscle cell proliferation
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: negative regulation of smooth muscle cell proliferation is consistent
+        with IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but
+        these are downstream context-specific effects rather than the core
+        ligand-binding activity.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:20353938
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Generic protein binding is over-broad for IGFBP3. More informative
+        annotations are IGF binding, hyaluronan binding, ternary complex formation, and
+        specific receptor/importin/nuclear receptor interactions.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid retaining generic protein binding when specific molecular
+        interactions are available.
       supported_by:
         - reference_id: PMID:20353938
-          supporting_text: 2010 Mar 30. Identification of a novel cell death 
-            receptor mediating IGFBP-3-induced anti-tumor effects in breast and 
-            prostate cancer.
+          supporting_text: 2010 Mar 30. Identification of a novel cell death receptor
+            mediating IGFBP-3-induced anti-tumor effects in breast and prostate cancer.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: The emerging consensus is therefore not a single “primary
+            function” in all contexts, but a dominant primary biochemical
+            activity—**high-affinity IGF binding**—that acts as a scaffold for diverse
+            regulated functions controlled by **proteolysis** and **phosphorylation**,
+            and by compartment switching between extracellular matrix, membrane
+            microdomains, cytosol, and nucleus.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:23178489
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Generic protein binding is over-broad for IGFBP3. More informative
+        annotations are IGF binding, hyaluronan binding, ternary complex formation, and
+        specific receptor/importin/nuclear receptor interactions.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid retaining generic protein binding when specific molecular
+        interactions are available.
       supported_by:
         - reference_id: PMID:23178489
-          supporting_text: The role of insulin-like growth factor binding 
-            protein-3 in the breast cancer cell response to DNA-damaging agents.
+          supporting_text: The role of insulin-like growth factor binding protein-3 in
+            the breast cancer cell response to DNA-damaging agents.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: The emerging consensus is therefore not a single “primary
+            function” in all contexts, but a dominant primary biochemical
+            activity—**high-affinity IGF binding**—that acts as a scaffold for diverse
+            regulated functions controlled by **proteolysis** and **phosphorylation**,
+            and by compartment switching between extracellular matrix, membrane
+            microdomains, cytosol, and nucleus.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:30184438
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Generic protein binding is over-broad for IGFBP3. More informative
+        annotations are IGF binding, hyaluronan binding, ternary complex formation, and
+        specific receptor/importin/nuclear receptor interactions.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid retaining generic protein binding when specific molecular
+        interactions are available.
       supported_by:
         - reference_id: PMID:30184438
-          supporting_text: Epub 2018 Sep 17. Interaction of Insulin-Like Growth 
-            Factor-Binding Protein 3 With Hyaluronan and Its Regulation by 
-            Humanin and CD44.
+          supporting_text: Epub 2018 Sep 17. Interaction of Insulin-Like Growth
+            Factor-Binding Protein 3 With Hyaluronan and Its Regulation by Humanin and
+            CD44.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: The emerging consensus is therefore not a single “primary
+            function” in all contexts, but a dominant primary biochemical
+            activity—**high-affinity IGF binding**—that acts as a scaffold for diverse
+            regulated functions controlled by **proteolysis** and **phosphorylation**,
+            and by compartment switching between extracellular matrix, membrane
+            microdomains, cytosol, and nucleus.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:32814053
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Generic protein binding is over-broad for IGFBP3. More informative
+        annotations are IGF binding, hyaluronan binding, ternary complex formation, and
+        specific receptor/importin/nuclear receptor interactions.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid retaining generic protein binding when specific molecular
+        interactions are available.
       supported_by:
         - reference_id: PMID:32814053
-          supporting_text: Interactome Mapping Provides a Network of 
-            Neurodegenerative Disease Proteins and Uncovers Widespread Protein 
-            Aggregation in Affected Brains.
+          supporting_text: Interactome Mapping Provides a Network of Neurodegenerative
+            Disease Proteins and Uncovers Widespread Protein Aggregation in Affected
+            Brains.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: The emerging consensus is therefore not a single “primary
+            function” in all contexts, but a dominant primary biochemical
+            activity—**high-affinity IGF binding**—that acts as a scaffold for diverse
+            regulated functions controlled by **proteolysis** and **phosphorylation**,
+            and by compartment switching between extracellular matrix, membrane
+            microdomains, cytosol, and nucleus.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0001649
       label: osteoblast differentiation
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: osteoblast differentiation is retained as a context-specific
+        differentiation phenotype downstream of IGFBP3 signaling rather than the core
+        biochemical function.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-uniprot.txt
+          supporting_text: including proliferation, differentiation, and apoptosis in a
+            cell-type specific manner
   - term:
       id: GO:0001968
       label: fibronectin binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Fibronectin binding is not a major finding in the synthesized IGFBP3
+        evidence; extracellular matrix binding is better captured by the specific
+        hyaluronic acid binding evidence.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: The current evidence synthesis supports HA binding, not fibronectin
+        binding, as the informative ECM ligand interaction.
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0005615
       label: extracellular space
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: extracellular space is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-381466
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:26216267
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Generic protein binding is over-broad for IGFBP3. More informative
+        annotations are IGF binding, hyaluronan binding, ternary complex formation, and
+        specific receptor/importin/nuclear receptor interactions.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid retaining generic protein binding when specific molecular
+        interactions are available.
       supported_by:
         - reference_id: PMID:26216267
-          supporting_text: Humanin Peptide Binds to Insulin-Like Growth 
-            Factor-Binding Protein 3 (IGFBP3) and Regulates Its Interaction with
-            Importin-β.
+          supporting_text: Humanin Peptide Binds to Insulin-Like Growth Factor-Binding
+            Protein 3 (IGFBP3) and Regulates Its Interaction with Importin-β.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: The emerging consensus is therefore not a single “primary
+            function” in all contexts, but a dominant primary biochemical
+            activity—**high-affinity IGF binding**—that acts as a scaffold for diverse
+            regulated functions controlled by **proteolysis** and **phosphorylation**,
+            and by compartment switching between extracellular matrix, membrane
+            microdomains, cytosol, and nucleus.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0005788
       label: endoplasmic reticulum lumen
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-8952289
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Endoplasmic reticulum lumen localization is plausible for a secreted
+        precursor and FAM20C substrate, but it is not the main functional site of mature
+        IGFBP3.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
   - term:
       id: GO:0042567
       label: insulin-like growth factor ternary complex
     evidence_type: IDA
     original_reference_id: PMID:9497324
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: insulin-like growth factor ternary complex is supported by IGFBP3
+        formation of binary IGF:IGFBP complexes and ALS-containing ternary complexes in
+        circulation.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:9497324
-          supporting_text: Insulin-like growth factor (IGF)-binding protein 5 
-            forms an alternative ternary complex with IGFs and the acid-labile 
-            subunit.
+          supporting_text: Insulin-like growth factor (IGF)-binding protein 5 forms an
+            alternative ternary complex with IGFs and the acid-labile subunit.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-381435
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-381446
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-381461
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-381496
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-381500
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-6800035
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-6800044
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0008285
       label: negative regulation of cell population proliferation
     evidence_type: IGI
     original_reference_id: PMID:19258508
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: negative regulation of cell population proliferation is consistent with
+        IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but these
+        are downstream context-specific effects rather than the core ligand-binding
+        activity.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:19258508
-          supporting_text: Epub 2009 Mar 3. NKX3.1 activates expression of 
-            insulin-like growth factor binding protein-3 to mediate insulin-like
-            growth factor-I signaling and cell proliferation.
+          supporting_text: Epub 2009 Mar 3. NKX3.1 activates expression of insulin-like
+            growth factor binding protein-3 to mediate insulin-like growth factor-I
+            signaling and cell proliferation.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0014912
       label: negative regulation of smooth muscle cell migration
     evidence_type: IDA
     original_reference_id: PMID:10766744
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: negative regulation of smooth muscle cell migration is consistent with
+        IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but these
+        are downstream context-specific effects rather than the core ligand-binding
+        activity.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:10766744
-          supporting_text: Substitutions for hydrophobic amino acids in the 
-            N-terminal domains of IGFBP-3 and -5 markedly reduce IGF-I binding 
-            and alter their biologic actions.
+          supporting_text: Substitutions for hydrophobic amino acids in the N-terminal
+            domains of IGFBP-3 and -5 markedly reduce IGF-I binding and alter their
+            biologic actions.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0016942
       label: insulin-like growth factor binding protein complex
     evidence_type: IC
     original_reference_id: PMID:10766744
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: insulin-like growth factor binding protein complex is supported by IGFBP3
+        formation of binary IGF:IGFBP complexes and ALS-containing ternary complexes in
+        circulation.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:10766744
-          supporting_text: Substitutions for hydrophobic amino acids in the 
-            N-terminal domains of IGFBP-3 and -5 markedly reduce IGF-I binding 
-            and alter their biologic actions.
+          supporting_text: Substitutions for hydrophobic amino acids in the N-terminal
+            domains of IGFBP-3 and -5 markedly reduce IGF-I binding and alter their
+            biologic actions.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0031994
       label: insulin-like growth factor I binding
     evidence_type: IPI
     original_reference_id: PMID:10766744
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: insulin-like growth factor I binding is a core IGFBP3 molecular function;
+        the literature consistently identifies high-affinity IGF-I/IGF-II binding as the
+        dominant biochemical activity.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:10766744
-          supporting_text: Substitutions for hydrophobic amino acids in the 
-            N-terminal domains of IGFBP-3 and -5 markedly reduce IGF-I binding 
-            and alter their biologic actions.
+          supporting_text: Substitutions for hydrophobic amino acids in the N-terminal
+            domains of IGFBP-3 and -5 markedly reduce IGF-I binding and alter their
+            biologic actions.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0048662
       label: negative regulation of smooth muscle cell proliferation
     evidence_type: IDA
     original_reference_id: PMID:10766744
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: negative regulation of smooth muscle cell proliferation is consistent
+        with IGFBP3 modulation of IGF/IGF1R and IGF-independent signaling outputs, but
+        these are downstream context-specific effects rather than the core
+        ligand-binding activity.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:10766744
-          supporting_text: Substitutions for hydrophobic amino acids in the 
-            N-terminal domains of IGFBP-3 and -5 markedly reduce IGF-I binding 
-            and alter their biologic actions.
+          supporting_text: Substitutions for hydrophobic amino acids in the N-terminal
+            domains of IGFBP-3 and -5 markedly reduce IGF-I binding and alter their
+            biologic actions.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0005615
       label: extracellular space
     evidence_type: IDA
     original_reference_id: PMID:17119061
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: extracellular space is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:17119061
-          supporting_text: 'Ethnic disparity in the relationship between obesity and
-            plasma insulin-like growth factors: the multiethnic cohort.'
+          supporting_text: 'Ethnic disparity in the relationship between obesity and plasma
+            insulin-like growth factors: the multiethnic cohort.'
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0001933
       label: negative regulation of protein phosphorylation
     evidence_type: IDA
     original_reference_id: PMID:17591901
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: negative regulation of protein phosphorylation is consistent with IGFBP3
+        modulation of IGF/IGF1R and IGF-independent signaling outputs, but these are
+        downstream context-specific effects rather than the core ligand-binding
+        activity.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:17591901
-          supporting_text: 'The requirement of pax6 for postnatal eye development:
-            evidence from experimental mouse chimeras.'
+          supporting_text: 'The requirement of pax6 for postnatal eye development: evidence
+            from experimental mouse chimeras.'
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IDA
     original_reference_id: PMID:17434920
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Nuclear localization is supported but represents a context-dependent
+        IGF-independent compartment rather than the canonical extracellular IGF-binding
+        role.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:17434920
-          supporting_text: Apr 13. Contribution of the orphan nuclear receptor 
-            Nur77 to the apoptotic action of IGFBP-3.
+          supporting_text: Apr 13. Contribution of the orphan nuclear receptor Nur77 to
+            the apoptotic action of IGFBP-3.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: Multiple sources support nuclear localization of IGFBP-3.
+            Classic mechanistic evidence indicates IGFBP-3 contains a **basic C-terminal
+            nuclear localization signal (NLS)** and undergoes **NLS-dependent,
+            importin-mediated nuclear translocation**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A central IGF-independent nuclear mechanism is the
+            interaction of nuclear IGFBP-3 with **retinoid X receptor alpha (RXRα)**.
+            Classic evidence describes RXR as an IGFBP-3 partner identified by yeast
+            two-hybrid screening and positions this interaction as a conceptual
+            “paradigm shift” for IGFBP actions in transcription and apoptosis.
   - term:
       id: GO:0006468
       label: protein phosphorylation
     evidence_type: IDA
     original_reference_id: PMID:17434920
     review:
-      summary: >-
-        OVER-ANNOTATION: IGFBP3 is an IGF-binding protein that modulates IGF signaling.
-        It has NO kinase activity. IGFBP3 affects phosphorylation indirectly by regulating
-        IGF availability and signaling, but doesn't catalyze phosphorylation itself.
+      summary: IGFBP3 is not a protein kinase and does not catalyze protein
+        phosphorylation. The supported biology is indirect regulation of
+        phosphorylation/signaling downstream of IGF1R and related pathways.
       action: MODIFY
+      reason: Replace a misleading phosphorylation-process annotation with the supported
+        negative regulation of protein phosphorylation/signaling.
       proposed_replacement_terms:
-        - id: GO:0045859
-          label: regulation of protein kinase activity
+        - id: GO:0001933
+          label: negative regulation of protein phosphorylation
       supported_by:
         - reference_id: PMID:17434920
-          supporting_text: Apr 13. Contribution of the orphan nuclear receptor 
-            Nur77 to the apoptotic action of IGFBP-3.
+          supporting_text: Apr 13. Contribution of the orphan nuclear receptor Nur77 to
+            the apoptotic action of IGFBP-3.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:14561895
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Generic protein binding is over-broad for IGFBP3. More informative
+        annotations are IGF binding, hyaluronan binding, ternary complex formation, and
+        specific receptor/importin/nuclear receptor interactions.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid retaining generic protein binding when specific molecular
+        interactions are available.
       supported_by:
         - reference_id: PMID:14561895
-          supporting_text: Interaction between the Alzheimer's survival peptide 
-            humanin and insulin-like growth factor-binding protein 3 regulates 
-            cell survival and apoptosis.
+          supporting_text: Interaction between the Alzheimer's survival peptide humanin
+            and insulin-like growth factor-binding protein 3 regulates cell survival and
+            apoptosis.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: The emerging consensus is therefore not a single “primary
+            function” in all contexts, but a dominant primary biochemical
+            activity—**high-affinity IGF binding**—that acts as a scaffold for diverse
+            regulated functions controlled by **proteolysis** and **phosphorylation**,
+            and by compartment switching between extracellular matrix, membrane
+            microdomains, cytosol, and nucleus.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:9388210
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Generic protein binding is over-broad for IGFBP3. More informative
+        annotations are IGF binding, hyaluronan binding, ternary complex formation, and
+        specific receptor/importin/nuclear receptor interactions.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid retaining generic protein binding when specific molecular
+        interactions are available.
       supported_by:
         - reference_id: PMID:9388210
-          supporting_text: Inhibition of insulin receptor activation by 
-            insulin-like growth factor binding proteins.
+          supporting_text: Inhibition of insulin receptor activation by insulin-like
+            growth factor binding proteins.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: The emerging consensus is therefore not a single “primary
+            function” in all contexts, but a dominant primary biochemical
+            activity—**high-affinity IGF binding**—that acts as a scaffold for diverse
+            regulated functions controlled by **proteolysis** and **phosphorylation**,
+            and by compartment switching between extracellular matrix, membrane
+            microdomains, cytosol, and nucleus.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
   - term:
       id: GO:0005520
       label: insulin-like growth factor binding
     evidence_type: NAS
     original_reference_id: PMID:12599210
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: insulin-like growth factor binding is a core IGFBP3 molecular function;
+        the literature consistently identifies high-affinity IGF-I/IGF-II binding as the
+        dominant biochemical activity.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:12599210
-          supporting_text: Role of insulin-like growth factor binding protein-3 
-            (IGFBP-3) in the differentiation of primary human adult skeletal 
-            myoblasts.
+          supporting_text: Role of insulin-like growth factor binding protein-3
+            (IGFBP-3) in the differentiation of primary human adult skeletal myoblasts.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
   - term:
       id: GO:0008160
       label: protein tyrosine phosphatase activator activity
     evidence_type: IDA
     original_reference_id: PMID:11940579
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein tyrosine phosphatase activator activity is retained as a non-core
+        IGF-independent signaling mechanism from older experimental evidence, while
+        newer synthesis emphasizes PP2A-mediated dephosphorylation of IGF pathway
+        mediators.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:11940579
-          supporting_text: 2002 Apr 8. Insulin-like growth factor-binding 
-            protein-3 activates a phosphotyrosine phosphatase.
+          supporting_text: 2002 Apr 8. Insulin-like growth factor-binding protein-3
+            activates a phosphotyrosine phosphatase.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
   - term:
       id: GO:0009968
       label: negative regulation of signal transduction
     evidence_type: NAS
     original_reference_id: PMID:11940579
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Negative regulation of signal transduction is supported by IGFBP3
+        suppression of IGF/IGF1R pathway mediators and by hyaluronan-CD44 signaling
+        blockade; this captures a core signaling output of IGFBP3 ligand binding in
+        extracellular contexts.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:11940579
-          supporting_text: 2002 Apr 8. Insulin-like growth factor-binding 
-            protein-3 activates a phosphotyrosine phosphatase.
+          supporting_text: 2002 Apr 8. Insulin-like growth factor-binding protein-3
+            activates a phosphotyrosine phosphatase.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A 2023 Endocrine Reviews synthesis describes an
+            IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V
+            (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can
+            associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway
+            mediators including **Akt** and **Ras/MAPK**.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+            factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+            **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+            and modulating IGF1R signaling.
   - term:
       id: GO:0043065
       label: positive regulation of apoptotic process
     evidence_type: IMP
     original_reference_id: PMID:11971816
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: positive regulation of apoptotic process is retained as a
+        context-dependent IGF-independent apoptotic role, including nuclear receptor and
+        cell-death receptor mechanisms, but it is not the canonical core molecular
+        function.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:11971816
-          supporting_text: 'Insulin-like growth factor binding protein-3 mediates
-            tumor necrosis factor-alpha-induced apoptosis: role of Bcl-2 phosphorylation.'
+          supporting_text: 'Insulin-like growth factor binding protein-3 mediates tumor necrosis
+            factor-alpha-induced apoptosis: role of Bcl-2 phosphorylation.'
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A central IGF-independent nuclear mechanism is the
+            interaction of nuclear IGFBP-3 with **retinoid X receptor alpha (RXRα)**.
+            Classic evidence describes RXR as an IGFBP-3 partner identified by yeast
+            two-hybrid screening and positions this interaction as a conceptual
+            “paradigm shift” for IGFBP actions in transcription and apoptosis.
+        - reference_id: file:human/IGFBP3/IGFBP3-uniprot.txt
+          supporting_text: apoptotic effects mediated by its receptor TMEM219/IGFBP-3R
   - term:
       id: GO:0045663
       label: positive regulation of myoblast differentiation
     evidence_type: IDA
     original_reference_id: PMID:12599210
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: positive regulation of myoblast differentiation is retained as a
+        context-specific differentiation phenotype downstream of IGFBP3 signaling rather
+        than the core biochemical function.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:12599210
-          supporting_text: Role of insulin-like growth factor binding protein-3 
-            (IGFBP-3) in the differentiation of primary human adult skeletal 
-            myoblasts.
+          supporting_text: Role of insulin-like growth factor binding protein-3
+            (IGFBP-3) in the differentiation of primary human adult skeletal myoblasts.
+        - reference_id: file:human/IGFBP3/IGFBP3-uniprot.txt
+          supporting_text: including proliferation, differentiation, and apoptosis in a
+            cell-type specific manner
   - term:
       id: GO:0046872
       label: metal ion binding
     evidence_type: NAS
     original_reference_id: PMID:14576163
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: The C-terminal metal-binding domain evidence is retained as a non-core
+        IGF-independent feature.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:14576163
-          supporting_text: Oct 22. Insulin-like growth factor-independent 
-            effects mediated by a C-terminal metal-binding domain of 
-            insulin-like growth factor binding protein-3.
+          supporting_text: Oct 22. Insulin-like growth factor-independent effects
+            mediated by a C-terminal metal-binding domain of insulin-like growth factor
+            binding protein-3.
   - term:
       id: GO:0005576
       label: extracellular region
     evidence_type: NAS
     original_reference_id: PMID:14718574
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: extracellular region is supported by IGFBP3 secretion and its
+        extracellular/circulating IGF complex functions.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:14718574
-          supporting_text: 'Epub 2004 Jan 12. The human plasma proteome: a nonredundant
-            list developed by combination of four separate sources.'
+          supporting_text: 'Epub 2004 Jan 12. The human plasma proteome: a nonredundant list
+            developed by combination of four separate sources.'
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+            describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+            peptide** and a **264-aa mature chain**, consistent with secretion into
+            extracellular fluids.
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+            circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+            in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+            acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+            circulating IGF.
+  - term:
+      id: GO:0005540
+      label: hyaluronic acid binding
+    evidence_type: IC
+    original_reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+    review:
+      summary: IGFBP3 binds hyaluronan through a mapped basic C-terminal motif and can
+        block HA-CD44 signaling.
+      action: NEW
+      reason: Specific HA binding is supported by recent mechanistic work and is absent
+        from current GOA.
+      supported_by:
+        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
+            HA engagement of **CD44**, suppressing HA–CD44 signaling.
 references:
   - id: GO_REF:0000033
     title: Annotation inferences using phylogenetic trees
     findings: []
   - id: GO_REF:0000043
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword 
-      mapping
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
     findings: []
   - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
     findings: []
   - id: GO_REF:0000107
-    title: Automatic transfer of experimentally verified manual GO annotation 
-      data to orthologs using Ensembl Compara
+    title: Automatic transfer of experimentally verified manual GO annotation data to
+      orthologs using Ensembl Compara
     findings: []
   - id: GO_REF:0000117
-    title: Electronic Gene Ontology annotations created by ARBA machine learning
-      models
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
     findings: []
   - id: GO_REF:0000120
     title: Combined Automated Annotation using Multiple IEA Methods
     findings: []
   - id: PMID:10766744
-    title: Substitutions for hydrophobic amino acids in the N-terminal domains 
-      of IGFBP-3 and -5 markedly reduce IGF-I binding and alter their biologic 
-      actions.
+    title: Substitutions for hydrophobic amino acids in the N-terminal domains of
+      IGFBP-3 and -5 markedly reduce IGF-I binding and alter their biologic actions.
     findings: []
   - id: PMID:11940579
-    title: Insulin-like growth factor-binding protein-3 activates a 
-      phosphotyrosine phosphatase. Effects on the insulin-like growth factor 
-      signaling pathway.
+    title: Insulin-like growth factor-binding protein-3 activates a phosphotyrosine
+      phosphatase. Effects on the insulin-like growth factor signaling pathway.
     findings: []
   - id: PMID:11971816
     title: 'Insulin-like growth factor binding protein-3 mediates tumor necrosis factor-alpha-induced
@@ -566,63 +1185,60 @@ references:
       differentiation of primary human adult skeletal myoblasts.
     findings: []
   - id: PMID:14561895
-    title: Interaction between the Alzheimer's survival peptide humanin and 
-      insulin-like growth factor-binding protein 3 regulates cell survival and 
-      apoptosis.
+    title: Interaction between the Alzheimer's survival peptide humanin and insulin-like
+      growth factor-binding protein 3 regulates cell survival and apoptosis.
     findings: []
   - id: PMID:14576163
-    title: Insulin-like growth factor-independent effects mediated by a 
-      C-terminal metal-binding domain of insulin-like growth factor binding 
-      protein-3.
+    title: Insulin-like growth factor-independent effects mediated by a C-terminal
+      metal-binding domain of insulin-like growth factor binding protein-3.
     findings: []
   - id: PMID:14718574
-    title: 'The human plasma proteome: a nonredundant list developed by combination
-      of four separate sources.'
+    title: 'The human plasma proteome: a nonredundant list developed by combination of four
+      separate sources.'
     findings: []
   - id: PMID:17119061
-    title: 'Ethnic disparity in the relationship between obesity and plasma insulin-like
-      growth factors: the multiethnic cohort.'
+    title: 'Ethnic disparity in the relationship between obesity and plasma insulin-like growth
+      factors: the multiethnic cohort.'
     findings: []
   - id: PMID:17434920
-    title: Contribution of the orphan nuclear receptor Nur77 to the apoptotic 
-      action of IGFBP-3.
+    title: Contribution of the orphan nuclear receptor Nur77 to the apoptotic action of
+      IGFBP-3.
     findings: []
   - id: PMID:17591901
     title: 'The requirement of pax6 for postnatal eye development: evidence from experimental
       mouse chimeras.'
     findings: []
   - id: PMID:19258508
-    title: NKX3.1 activates expression of insulin-like growth factor binding 
-      protein-3 to mediate insulin-like growth factor-I signaling and cell 
-      proliferation.
+    title: NKX3.1 activates expression of insulin-like growth factor binding protein-3
+      to mediate insulin-like growth factor-I signaling and cell proliferation.
     findings: []
   - id: PMID:20353938
-    title: Identification of a novel cell death receptor mediating 
-      IGFBP-3-induced anti-tumor effects in breast and prostate cancer.
+    title: Identification of a novel cell death receptor mediating IGFBP-3-induced
+      anti-tumor effects in breast and prostate cancer.
     findings: []
   - id: PMID:23178489
-    title: The role of insulin-like growth factor binding protein-3 in the 
-      breast cancer cell response to DNA-damaging agents.
+    title: The role of insulin-like growth factor binding protein-3 in the breast cancer
+      cell response to DNA-damaging agents.
     findings: []
   - id: PMID:26216267
     title: Humanin Peptide Binds to Insulin-Like Growth Factor-Binding Protein 3
       (IGFBP3) and Regulates Its Interaction with Importin-β.
     findings: []
   - id: PMID:30184438
-    title: Interaction of Insulin-Like Growth Factor-Binding Protein 3 With 
-      Hyaluronan and Its Regulation by Humanin and CD44.
+    title: Interaction of Insulin-Like Growth Factor-Binding Protein 3 With Hyaluronan
+      and Its Regulation by Humanin and CD44.
     findings: []
   - id: PMID:32814053
-    title: Interactome Mapping Provides a Network of Neurodegenerative Disease 
-      Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.
+    title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins
+      and Uncovers Widespread Protein Aggregation in Affected Brains.
     findings: []
   - id: PMID:9388210
-    title: Inhibition of insulin receptor activation by insulin-like growth 
-      factor binding proteins.
+    title: Inhibition of insulin receptor activation by insulin-like growth factor
+      binding proteins.
     findings: []
   - id: PMID:9497324
-    title: Insulin-like growth factor (IGF)-binding protein 5 forms an 
-      alternative ternary complex with IGFs and the acid-labile subunit.
+    title: Insulin-like growth factor (IGF)-binding protein 5 forms an alternative
+      ternary complex with IGFs and the acid-labile subunit.
     findings: []
   - id: Reactome:R-HSA-381435
     title: Matrix metalloproteinase proteolyzes IGF:IGFBP3:ALS
@@ -651,3 +1267,62 @@ references:
   - id: Reactome:R-HSA-8952289
     title: FAM20C phosphorylates FAM20C substrates
     findings: []
+  - id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+    title: Falcon deep research synthesis for IGFBP3
+    findings: []
+  - id: file:human/IGFBP3/IGFBP3-uniprot.txt
+    title: UniProt record for IGFBP3
+    findings: []
+core_functions:
+  - description: High-affinity binding of IGF-I and IGF-II to regulate IGF receptor
+      signaling and stabilize circulating IGF complexes.
+    molecular_function:
+      id: GO:0005520
+      label: insulin-like growth factor binding
+    directly_involved_in:
+      - id: GO:0043567
+        label: regulation of insulin-like growth factor receptor signaling pathway
+    locations:
+      - id: GO:0005615
+        label: extracellular space
+      - id: GO:0005576
+        label: extracellular region
+    in_complex:
+      id: GO:0042567
+      label: insulin-like growth factor ternary complex
+    supported_by:
+      - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+        supporting_text: IGFBP-3 is one of six “high-affinity” insulin-like growth
+          factor binding proteins (IGFBPs) whose canonical cellular role is to bind
+          **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
+          and modulating IGF1R signaling.
+      - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+        supporting_text: A key systemic concept is that IGFBP-3 is the **most abundant
+          circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs
+          in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
+          acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
+          circulating IGF.
+      - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+        supporting_text: IGFBP-3 is a secreted precursor protein. A retrieved analysis
+          describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal
+          peptide** and a **264-aa mature chain**, consistent with secretion into
+          extracellular fluids.
+  - description: Hyaluronan binding that modulates extracellular HA-CD44 signaling in a
+      phosphorylation-sensitive manner.
+    molecular_function:
+      id: GO:0005540
+      label: hyaluronic acid binding
+    directly_involved_in:
+      - id: GO:0009968
+        label: negative regulation of signal transduction
+    locations:
+      - id: GO:0005576
+        label: extracellular region
+    supported_by:
+      - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+        supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
+          **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA
+          engagement of **CD44**, suppressing HA–CD44 signaling.
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []

--- a/genes/human/IGFBP3/IGFBP3-ai-review.yaml
+++ b/genes/human/IGFBP3/IGFBP3-ai-review.yaml
@@ -83,17 +83,13 @@ existing_annotations:
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: Fibronectin binding is not a major finding in the synthesized IGFBP3
-        evidence; extracellular matrix binding is better captured by the specific
-        hyaluronic acid binding evidence.
-      action: MARK_AS_OVER_ANNOTATED
-      reason: The current evidence synthesis supports HA binding, not fibronectin
-        binding, as the informative ECM ligand interaction.
-      supported_by:
-        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
-          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
-            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
-            HA engagement of **CD44**, suppressing HA–CD44 signaling.
+      summary: Fibronectin binding is retained as a non-core transferred annotation, but
+        the Falcon evidence set did not retrieve strong direct IGFBP3-specific support
+        for fibronectin binding. This should not be treated as refuted; it is simply
+        less established than IGF and hyaluronan binding.
+      action: KEEP_AS_NON_CORE
+      reason: Direct support for fibronectin binding was not established in this review,
+        but the term is not demonstrably false.
   - term:
       id: GO:0043567
       label: regulation of insulin-like growth factor receptor signaling pathway
@@ -434,17 +430,13 @@ existing_annotations:
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: Fibronectin binding is not a major finding in the synthesized IGFBP3
-        evidence; extracellular matrix binding is better captured by the specific
-        hyaluronic acid binding evidence.
-      action: MARK_AS_OVER_ANNOTATED
-      reason: The current evidence synthesis supports HA binding, not fibronectin
-        binding, as the informative ECM ligand interaction.
-      supported_by:
-        - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
-          supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
-            **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks
-            HA engagement of **CD44**, suppressing HA–CD44 signaling.
+      summary: Fibronectin binding is retained as a non-core transferred annotation, but
+        the Falcon evidence set did not retrieve strong direct IGFBP3-specific support
+        for fibronectin binding. This should not be treated as refuted; it is simply
+        less established than IGF and hyaluronan binding.
+      action: KEEP_AS_NON_CORE
+      reason: Direct support for fibronectin binding was not established in this review,
+        but the term is not demonstrably false.
   - term:
       id: GO:0005615
       label: extracellular space
@@ -831,8 +823,10 @@ existing_annotations:
     evidence_type: IDA
     original_reference_id: PMID:17119061
     review:
-      summary: extracellular space is supported by IGFBP3 secretion and its
-        extracellular/circulating IGF complex functions.
+      summary: Extracellular space localization is accepted because IGFBP3 is a
+        secreted/circulating IGF-binding protein; however, PMID:17119061 is an
+        epidemiological plasma IGF cohort study, so the original IDA evidence/citation
+        is weak for direct localization evidence.
       action: ACCEPT
       supported_by:
         - reference_id: PMID:17119061
@@ -849,17 +843,19 @@ existing_annotations:
             in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the
             acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing
             circulating IGF.
+      reason: Accepted based on the broader secreted-protein evidence while noting the
+        source GOA citation quality issue.
   - term:
       id: GO:0001933
       label: negative regulation of protein phosphorylation
     evidence_type: IDA
     original_reference_id: PMID:17591901
     review:
-      summary: negative regulation of protein phosphorylation is consistent with IGFBP3
-        modulation of IGF/IGF1R and IGF-independent signaling outputs, but these are
-        downstream context-specific effects rather than the core ligand-binding
-        activity.
-      action: KEEP_AS_NON_CORE
+      summary: 'UNDECIDED: the source GOA annotation cites PMID:17591901, but that PMID is
+        a PAX6 postnatal eye-development paper rather than an IGFBP3 phosphorylation/signaling
+        study. This appears to be an erroneous PMID assignment in GOA, so the annotation cannot
+        be accepted or cleanly modified from the cited evidence.'
+      action: UNDECIDED
       supported_by:
         - reference_id: PMID:17591901
           supporting_text: 'The requirement of pax6 for postnatal eye development: evidence
@@ -875,6 +871,8 @@ existing_annotations:
             factor binding proteins (IGFBPs) whose canonical cellular role is to bind
             **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R**
             and modulating IGF1R signaling.
+      reason: The cited publication does not support an IGFBP3 annotation; this should
+        be flagged for source-database review.
   - term:
       id: GO:0005634
       label: nucleus
@@ -1133,15 +1131,20 @@ existing_annotations:
   - term:
       id: GO:0005540
       label: hyaluronic acid binding
-    evidence_type: IC
-    original_reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
+    evidence_type: IDA
+    original_reference_id: PMID:30184438
     review:
-      summary: IGFBP3 binds hyaluronan through a mapped basic C-terminal motif and can
-        block HA-CD44 signaling.
+      summary: IGFBP3 hyaluronic acid binding is directly supported by PMID:30184438,
+        which characterizes HA binding to IGFBP3 and the 215-232 C-terminal peptide and
+        its regulation by humanin/CD44.
       action: NEW
-      reason: Specific HA binding is supported by recent mechanistic work and is absent
-        from current GOA.
+      reason: Specific HA binding is supported by primary experimental evidence and is
+        absent from current GOA.
       supported_by:
+        - reference_id: PMID:30184438
+          supporting_text: Here, we characterized the binding affinities of the IGFBP-3
+            protein and peptide (215-KKGFYKKKQCRPSKGRKR-232) to HA and to humanin and
+            found that HA binds with a weaker affinity to this region than does humanin.
         - reference_id: file:human/IGFBP3/IGFBP3-deep-research-falcon.md
           supporting_text: IGFBP-3 binds HA via a mapped basic C-terminal motif (aa
             **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks

--- a/genes/human/IGFBP3/IGFBP3-deep-research-falcon.md
+++ b/genes/human/IGFBP3/IGFBP3-deep-research-falcon.md
@@ -1,0 +1,376 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T21:17:54.509803'
+end_time: '2026-05-11T21:32:42.427554'
+duration_seconds: 887.92
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: IGFBP3
+  gene_symbol: IGFBP3
+  uniprot_accession: P17936
+  protein_description: 'RecName: Full=Insulin-like growth factor-binding protein 3;
+    Short=IBP-3; Short=IGF-binding protein 3; Short=IGFBP-3; Flags: Precursor;'
+  gene_info: Name=IGFBP3; Synonyms=IBP3;
+  organism_full: Homo sapiens (Human).
+  protein_family: Not specified in UniProt
+  protein_domains: Growth_fac_rcpt_cys_sf. (IPR009030); IGFBP-3. (IPR012211); IGFBP-like.
+    (IPR000867); IGFBP_1-6_chordata. (IPR022321); Insulin_GF-bd_Cys-rich_CS. (IPR017891)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 44
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P17936
+- **Protein Description:** RecName: Full=Insulin-like growth factor-binding protein 3; Short=IBP-3; Short=IGF-binding protein 3; Short=IGFBP-3; Flags: Precursor;
+- **Gene Information:** Name=IGFBP3; Synonyms=IBP3;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** Growth_fac_rcpt_cys_sf. (IPR009030); IGFBP-3. (IPR012211); IGFBP-like. (IPR000867); IGFBP_1-6_chordata. (IPR022321); Insulin_GF-bd_Cys-rich_CS. (IPR017891)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "IGFBP3" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'IGFBP3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **IGFBP3** (gene ID: IGFBP3, UniProt: P17936) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** P17936
+- **Protein Description:** RecName: Full=Insulin-like growth factor-binding protein 3; Short=IBP-3; Short=IGF-binding protein 3; Short=IGFBP-3; Flags: Precursor;
+- **Gene Information:** Name=IGFBP3; Synonyms=IBP3;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** Growth_fac_rcpt_cys_sf. (IPR009030); IGFBP-3. (IPR012211); IGFBP-like. (IPR000867); IGFBP_1-6_chordata. (IPR022321); Insulin_GF-bd_Cys-rich_CS. (IPR017891)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "IGFBP3" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'IGFBP3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **IGFBP3** (gene ID: IGFBP3, UniProt: P17936) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research Report: Human **IGFBP3** (UniProt **P17936**) — Functional Annotation and Translational Relevance
+
+### 0. Target verification (critical disambiguation)
+The literature retrieved and analyzed explicitly maps **human insulin-like growth factor-binding protein 3 (IGFBP-3; gene IGFBP3)** to **UniProt accession P17936**, confirming that the target in this report matches the UniProt-provided identity. In particular, Mofid et al. state that the *Homo sapiens* IGFBP-3 amino-acid sequence **(P17936)** was retrieved from UniProt, and Price et al. list IGFBP-3 among studied proteins with UniProt accession **P17936**. (mofid2018insilicointeraction pages 1-3, price2020humaninblocksaggregation pages 1-2)
+
+### 1. Key concepts and definitions (current understanding)
+
+#### 1.1 Canonical (IGF-dependent) function: high-affinity IGF sequestration and IGF1R modulation
+IGFBP-3 is one of six “high-affinity” insulin-like growth factor binding proteins (IGFBPs) whose canonical cellular role is to bind **IGF-1 and IGF-2** with high affinity, thereby **impeding access to IGF1R** and modulating IGF1R signaling. This canonical role can be context-dependent (inhibitory vs sometimes permissive/enhancing) and is regulated by post-translational modifications and proteolysis. (baxter2023signalingpathwaysof pages 1-2, baxter2023signalingpathwaysof pages 2-2)
+
+Structure-function evidence supports this concept: IGFBP-3 is modular (N-domain, linker, C-domain), and cooperative contributions from the N- and C-termini enable high-affinity IGF binding; binding can sterically hinder IGF-1 receptor interaction. (mofid2018insilicointeraction pages 8-10, mofid2018insilicointeraction pages 11-11)
+
+#### 1.2 Endocrine concept: circulating IGF stabilization and ternary complex formation
+A key systemic concept is that IGFBP-3 is the **most abundant circulating IGFBP** and supports endocrine IGF signaling by stabilizing IGFs in blood. IGFBP-3 forms binary IGF:IGFBP complexes and can bind the acid-labile subunit (ALS) to form a **~150 kDa ternary complex**, increasing circulating IGF. (sechrist2025pathologicsignalingand pages 2-4)
+
+#### 1.3 IGF-independent signaling paradigm
+A major modern view is that IGFBPs—including IGFBP-3—have substantial **IGF-independent** actions. These include interactions with cell-surface receptors (e.g., integrins; TGFβ-family receptor systems), intracellular partners, and nuclear mechanisms that modulate survival, migration, senescence, and DNA damage responses. (baxter2023signalingpathwaysof pages 1-2, baxter2023signalingpathwaysof pages 2-2)
+
+### 2. Protein features and localization: where IGFBP-3 acts
+
+#### 2.1 Secreted precursor and extracellular compartment
+IGFBP-3 is a secreted precursor protein. A retrieved analysis describes IGFBP-3 as a **291-aa** protein comprising a **27-aa signal peptide** and a **264-aa mature chain**, consistent with secretion into extracellular fluids. (mofid2018insilicointeraction pages 1-3)
+
+In extracellular contexts, IGFBP-3 participates in circulating IGF complexes (including ALS-containing complexes) and can bind extracellular matrix (ECM)-related ligands such as hyaluronan (HA) (see below). (sechrist2025pathologicsignalingand pages 2-4, coleman2023phosphorylationofigfbp3 pages 5-7)
+
+#### 2.2 Nuclear localization and intracellular trafficking (importin-β; energy dependence)
+Multiple sources support nuclear localization of IGFBP-3. Classic mechanistic evidence indicates IGFBP-3 contains a **basic C-terminal nuclear localization signal (NLS)** and undergoes **NLS-dependent, importin-mediated nuclear translocation**. (lee2002nucleareffectsunexpected pages 3-4)
+
+A detailed mechanistic review reports that extracellular/full-length IGFBP-3 can enter the nucleus via **direct interaction with importin-β** (not requiring importin-α), and that nuclear import is **blocked by anti–importin-β**, reduced by **GTP-γS**, and requires an ATP-generating system—indicating dependence on the Ran/energy-dependent nuclear import machinery. (shrivastav2020insulinlikegrowthfactor pages 7-8)
+
+### 3. Pathways and mechanisms (recent and authoritative synthesis prioritized)
+
+#### 3.1 IGFBP-3–LRP1 (TGFβR-V)–PP2A axis: IGF-independent suppression of IGF1R pathway mediators
+A 2023 Endocrine Reviews synthesis describes an IGF-independent mechanism in which IGFBP-3 engages **TGFβ receptor type V (LRP1)** to activate **PP2A** (a serine/threonine phosphatase). PP2A can associate with IGF1R via **RACK1**, and downregulates key IGF1R pathway mediators including **Akt** and **Ras/MAPK**. This provides a mechanistic route by which IGFBP-3 can inhibit proliferative signaling beyond simple IGF sequestration. (baxter2023signalingpathwaysof pages 3-4, baxter2023signalingpathwaysof pages 4-5)
+
+#### 3.2 2023 mechanistic advance: CK2 phosphorylation switches IGFBP-3–HA interactions to enable HA–CD44 pro-survival signaling in NSCLC
+A 2023 primary study (Cells) provides a detailed, testable mechanism linking a post-translational modification of IGFBP-3 to ECM-mediated oncogenic signaling and chemotherapy response.
+
+**Key findings**:
+- **Casein kinase 2 (CK2)** phosphorylates IGFBP-3 at **S167 and S175**. (coleman2023phosphorylationofigfbp3 pages 5-7)
+- CK2 phosphorylation reduces IGFBP-3 binding to **hyaluronan (HA)**: maximal HA binding of phosphorylated IGFBP-3 is ~**30%** of non-phosphorylated IGFBP-3, and cell-surface association decreases by ~**50%**. (coleman2023phosphorylationofigfbp3 pages 5-7)
+- IGFBP-3 binds HA via a mapped basic C-terminal motif (aa **215–232**, sequence **KKGFYKKKQCRPSKGRKR**), and this interaction blocks HA engagement of **CD44**, suppressing HA–CD44 signaling. (coleman2023phosphorylationofigfbp3 pages 2-4, coleman2023phosphorylationofigfbp3 pages 5-7)
+- When phosphorylated, IGFBP-3’s reduced HA binding permits HA–CD44 signaling, which is linked to activation of the **PI3K → AKT → NFκB** axis and reduced **p53** activity, promoting survival and **cisplatin resistance**. (coleman2023phosphorylationofigfbp3 pages 1-2, coleman2023phosphorylationofigfbp3 pages 19-21)
+
+**Quantitative drug-response results (A549 vs H1299)**:
+- CK2 inhibitor **TBB IC50**: **8 ± 1.5 µM** (A549) and **7 ± 1.3 µM** (H1299). (coleman2023phosphorylationofigfbp3 pages 5-7)
+- **Cisplatin IC50**: **9 ± 1.5 µM** (A549) and **26 ± 4 µM** (H1299). (coleman2023phosphorylationofigfbp3 pages 5-7)
+- **TBB + cisplatin** caused ~**4-fold** viability decrease vs ~**2-fold** for either alone (reported qualitatively as fold differences in viability). (coleman2023phosphorylationofigfbp3 pages 5-7)
+
+Figure-level visual evidence supporting these results is available in the paper’s figures showing IC50 measurements and reduced HA binding upon phosphorylation. (coleman2023phosphorylationofigfbp3 media 0143ad9b, coleman2023phosphorylationofigfbp3 media 21878636)
+
+#### 3.3 Nuclear receptor pathway: RXRα/RAR interactions and transcriptional/apoptotic outputs
+A central IGF-independent nuclear mechanism is the interaction of nuclear IGFBP-3 with **retinoid X receptor alpha (RXRα)**. Classic evidence describes RXR as an IGFBP-3 partner identified by yeast two-hybrid screening and positions this interaction as a conceptual “paradigm shift” for IGFBP actions in transcription and apoptosis. (lee2002nucleareffectsunexpected pages 3-4)
+
+A 2023 Endocrine Reviews synthesis further states that IGFBP-3 binds **RXRα** to promote RXR-specific transcription and that RXRα is required for IGFBP-3-dependent apoptosis in some models; IGFBP-3 also binds **RAR** and inhibits RAR signaling, and can interact with other RXRα-binding nuclear receptors. (baxter2023signalingpathwaysof pages 9-9)
+
+### 4. Recent developments (prioritizing 2023–2024 sources)
+
+1) **System-level mechanistic integration (2023 Endocrine Reviews)**: The field’s current high-authority synthesis emphasizes that IGFBPs (including IGFBP-3) act as multifunctional signaling modulators via post-translational modification, proteolysis, receptor crosstalk (integrins, TGFβ-family systems), and nuclear mechanisms (class II nuclear receptors; DNA damage repair). (baxter2023signalingpathwaysof pages 1-2, baxter2023signalingpathwaysof pages 2-2)
+
+2) **Post-translational modification controlling ECM signaling and drug resistance (2023 Cells)**: CK2 phosphorylation of IGFBP-3 at S167/S175 functionally “re-wires” HA binding and HA–CD44 signaling, providing a mechanistic rationale for combined pathway inhibition (CK2/CD44/PI3K/AKT/NFκB) to improve cisplatin sensitivity in NSCLC models. (coleman2023phosphorylationofigfbp3 pages 1-2, coleman2023phosphorylationofigfbp3 pages 5-7)
+
+3) **Nuclear import and receptor crosstalk highlighted in 2023 synthesis**: Nuclear IGFBP-3 is described as predominantly nuclear in some contexts, and its importin-β interaction can be inhibited by humanin—suggesting a regulatable import mechanism connecting stress peptides and IGFBP-3 nuclear action. (baxter2023signalingpathwaysof pages 9-9)
+
+### 5. Current applications and real-world implementations
+
+#### 5.1 Clinical/translational biomarker: serum IGFBP-3 in cancer diagnosis and prognosis
+A concrete example of real-world implementation is serum IGFBP-3 measurement by ELISA followed by ROC analysis and prognostic modeling.
+
+In esophagogastric junction adenocarcinoma (EJA), a 2022 study used serum IGFBP-3 to support diagnosis and prognosis:
+- Cohort: **320 participants**, split into training (112 controls; 102 EJA, incl. 24 early-stage) and validation (56 controls; 50 EJA, incl. 12 early-stage). (ding2022seruminsulinlikegrowth pages 1-3)
+- Diagnostic performance:
+  - Training AUC **0.819** (specificity **90.18%**, sensitivity **43.14%**)
+  - Validation AUC **0.804** (specificity **87.50%**, sensitivity **42.00%**). (ding2022seruminsulinlikegrowth pages 1-3)
+- Early-stage EJA performance:
+  - Training AUC **0.822** (specificity **90.18%**, sensitivity **45.83%**)
+  - Validation AUC **0.811** (specificity **84.48%**, sensitivity **50.00%**). (ding2022seruminsulinlikegrowth pages 1-3)
+- Prognosis: IGFBP-3 remained an independent factor in multivariable Cox analysis (**HR = 0.468**, P=0.005), and a nomogram including IGFBP-3 improved C-index (0.625 vs 0.735). (ding2022seruminsulinlikegrowth pages 1-3)
+
+These findings illustrate current real-world use patterns: IGFBP-3 is most commonly implemented as a blood biomarker (ELISA or proteomics panel component) rather than a direct drug target in routine care. (ding2022seruminsulinlikegrowth pages 1-3, baxter2023signalingpathwaysof pages 1-2)
+
+#### 5.2 Translational targeting opportunities: pathway-based interventions instead of direct IGFBP-3 drugs
+Expert synthesis notes that IGFBPs have been proposed as therapeutic targets, but their ubiquity in circulation and cell contexts creates practical challenges. (baxter2023signalingpathwaysof pages 1-2)
+
+Nevertheless, the NSCLC mechanism indicates actionable strategies: blocking CK2-mediated phosphorylation or HA–CD44 signaling (and downstream PI3K/AKT/NFκB) may counteract IGFBP-3–associated chemoresistance mechanisms. (coleman2023phosphorylationofigfbp3 pages 1-2, coleman2023phosphorylationofigfbp3 pages 19-21)
+
+### 6. Expert opinions and interpretive analysis (authoritative synthesis)
+A leading expert review (Endocrine Reviews, 2023) frames IGFBP-3 biology as an archetype of multifunctional extracellular proteins that can:
+- inhibit IGF1R activation by IGF sequestration,
+- regulate receptor signaling via phosphatase activation and receptor cross-talk,
+- act in the nucleus by modulating nuclear hormone receptor activity and DNA damage responses,
+- and have immune/senescence implications, creating both therapeutic opportunities and complexity. (baxter2023signalingpathwaysof pages 1-2, baxter2023signalingpathwaysof pages 3-4)
+
+The emerging consensus is therefore not a single “primary function” in all contexts, but a dominant primary biochemical activity—**high-affinity IGF binding**—that acts as a scaffold for diverse regulated functions controlled by **proteolysis** and **phosphorylation**, and by compartment switching between extracellular matrix, membrane microdomains, cytosol, and nucleus. (baxter2023signalingpathwaysof pages 1-2, baxter2023signalingpathwaysof pages 3-4, coleman2023phosphorylationofigfbp3 pages 5-7)
+
+### 7. Recent statistics and data (selected highlights)
+Key quantitative values extracted from recent studies are consolidated in the table below.
+
+| Category | Claim / feature | Details / quantitative result | Evidence type | Key source (year; DOI URL) | Citation |
+|---|---|---|---|---|---|
+| Identity | Correct target verified as human IGFBP3 / UniProt P17936 | Explicit mapping reported as **Homo sapiens IGFBP-3 (P17936)**; separate primary study also lists **IGFBP-3 = UniProt P17936** | computational / primary | Mofid et al., 2018, https://doi.org/10.4103/1735-5362.235160; Price et al., 2020, https://doi.org/10.1021/acs.biochem.0c00274 | (mofid2018insilicointeraction pages 1-3, price2020humaninblocksaggregation pages 1-2) |
+| Core feature | Secreted precursor architecture | IGFBP-3 reported as **291 aa total**, comprising a **27-aa signal peptide** and **264-aa mature chain**, consistent with a secreted precursor | computational | Mofid et al., 2018, https://doi.org/10.4103/1735-5362.235160 | (mofid2018insilicointeraction pages 1-3) |
+| Core feature | Domain organization | Modular **N-domain, linker domain, C-domain**; linker is a hotspot for **phosphorylation/proteolysis**, N- and C-termini cooperate in high-affinity IGF binding | review / computational | Baxter, 2023, https://doi.org/10.1210/endrev/bnad008; Mofid et al., 2018, https://doi.org/10.4103/1735-5362.235160 | (baxter2023signalingpathwaysof pages 1-2, mofid2018insilicointeraction pages 8-10, sechrist2025pathologicsignalingand pages 1-2, mofid2018insilicointeraction pages 11-11) |
+| Core feature | Major circulating role | IGFBP-3 is the **most abundant circulating IGFBP** and stabilizes IGFs in blood, including formation of **binary complexes** and **ALS-containing ternary complexes (~150 kDa)** | review | Sechrist et al., 2025, https://doi.org/10.3390/ijms262110248 | (sechrist2025pathologicsignalingand pages 2-4) |
+| Key binding partners | Canonical ligand binding | Binds **IGF-1/IGF-2 with high affinity** to modulate IGF bioavailability and receptor access; sterically hinders IGF-1 interaction with **IGF1R** | review / computational | Baxter, 2023, https://doi.org/10.1210/endrev/bnad008; Mofid et al., 2018, https://doi.org/10.4103/1735-5362.235160 | (baxter2023signalingpathwaysof pages 1-2, mofid2018insilicointeraction pages 8-10, baxter2023signalingpathwaysof pages 3-4) |
+| Key binding partners | Noncanonical partners | Documented partners/pathway nodes include **LRP1/TGFβR-V**, **PP2A**, **RACK1**, **integrins**, **hyaluronan (HA)**, **CD44**, **importin-β**, **RXRα/RAR**, and **histone H3** | review / primary | Baxter, 2023, https://doi.org/10.1210/endrev/bnad008; Coleman et al., 2023, https://doi.org/10.3390/cells12030405; Bhardwaj et al., 2021, https://doi.org/10.3390/ijms22010407 | (baxter2023signalingpathwaysof pages 3-4, coleman2023phosphorylationofigfbp3 pages 2-4, shrivastav2020insulinlikegrowthfactor pages 7-8, baxter2023signalingpathwaysof pages 9-9) |
+| Mechanism / pathway | IGF sequestration and IGF1R modulation | Canonical action is to **impede access of IGF-1/2 to IGF1R**; IGFBP-3 can also inhibit IGF1R signaling through phosphatase-mediated mechanisms | review | Baxter, 2023, https://doi.org/10.1210/endrev/bnad008 | (baxter2023signalingpathwaysof pages 1-2, baxter2023signalingpathwaysof pages 3-4) |
+| Mechanism / pathway | LRP1 / PP2A / RACK1 signaling | IGFBP-3 acting via **TGFβ receptor type V / LRP1** activates **PP2A**; PP2A associates with **IGF1R via RACK1** and suppresses signaling, with modulation by **β-integrin ligation** | review | Baxter, 2023, https://doi.org/10.1210/endrev/bnad008 | (baxter2023signalingpathwaysof pages 3-4, baxter2023signalingpathwaysof pages 4-5) |
+| Mechanism / pathway | HA-CD44 survival signaling | IGFBP-3 binds **HA** and can block **HA-CD44** signaling; when IGFBP-3 is phosphorylated by CK2, HA binding falls and **PI3K-AKT-NFκB** survival signaling proceeds with reduced **p53** activity | primary cell study | Coleman et al., 2023, https://doi.org/10.3390/cells12030405 | (coleman2023phosphorylationofigfbp3 pages 1-2, coleman2023phosphorylationofigfbp3 pages 19-21, coleman2023phosphorylationofigfbp3 pages 2-4, coleman2023phosphorylationofigfbp3 pages 5-7) |
+| Mechanism / pathway | HA-binding region | HA-binding motif mapped to an **18-aa basic C-terminal region (aa 215–232: KKGFYKKKQCRPSKGRKR)** | primary cell study | Coleman et al., 2023, https://doi.org/10.3390/cells12030405 | (coleman2023phosphorylationofigfbp3 pages 2-4, coleman2023phosphorylationofigfbp3 pages 5-7) |
+| Mechanism / pathway | CK2 phosphorylation sites | **CK2 phosphorylates IGFBP-3 at S167 and S175**; phosphorylation leaves IGF-1 binding intact but blocks ALS interaction and strongly reduces HA/cell-surface association | primary cell study | Coleman et al., 2023, https://doi.org/10.3390/cells12030405 | (coleman2023phosphorylationofigfbp3 pages 5-7) |
+| Quantitative mechanism | Effect of phosphorylation on HA binding | **Maximal HA binding of phosphorylated IGFBP-3 ≈30%** of non-phosphorylated IGFBP-3; **cell-surface association reduced by ~50%** | primary cell study | Coleman et al., 2023, https://doi.org/10.3390/cells12030405 | (coleman2023phosphorylationofigfbp3 pages 5-7) |
+| Mechanism / pathway | Proteolytic regulation | **Proteolysis lowers IGF–IGFBP affinity**, releasing IGFs and increasing bioactive ligand; the **linker domain** is a major proteolysis-sensitive regulatory region | review | Baxter, 2023, https://doi.org/10.1210/endrev/bnad008 | (baxter2023signalingpathwaysof pages 2-2, sechrist2025pathologicsignalingand pages 2-4, sechrist2025pathologicsignalingand pages 1-2, baxter2023signalingpathwaysof pages 3-4) |
+| Mechanism / pathway | Nuclear import | IGFBP-3 contains a **basic C-terminal/bipartite NLS** and can undergo **importin-β-dependent nuclear translocation**; import is blocked by anti-importin-β and requires ATP/GTP | review | Shrivastav et al., 2020, https://doi.org/10.3389/fcell.2020.00286; Lee & Cohen, 2002, https://doi.org/10.1677/joe.0.1750033 | (lee2002nucleareffectsunexpected pages 3-4, shrivastav2020insulinlikegrowthfactor pages 7-8, shrivastav2020insulinlikegrowthfactor pages 2-4) |
+| Mechanism / pathway | Nuclear receptor interactions | Nuclear IGFBP-3 binds **RXRα** and **RAR**, promotes **RXR-specific transcription**, inhibits **RAR signaling**, and RXRα is reported as required for IGFBP-3-dependent apoptosis in some models | review | Baxter, 2023, https://doi.org/10.1210/endrev/bnad008; Lee & Cohen, 2002, https://doi.org/10.1677/joe.0.1750033 | (baxter2023signalingpathwaysof pages 9-9, lee2002nucleareffectsunexpected pages 1-3) |
+| Mechanism / pathway | IGF-independent apoptosis / senescence | IGFBP-3 can trigger **IGF-independent apoptosis** and senescence-related programs; mutants with little or no IGF binding can still induce apoptosis | review / primary | Lee & Cohen, 2002, https://doi.org/10.1677/joe.0.1750033; Kwon et al., 2023, https://doi.org/10.1038/s41598-023-35291-5 | (lee2002nucleareffectsunexpected pages 3-4, skorupa2018igfbp3inducedby pages 19-23) |
+| Quantitative mechanism | Senescence phenotype in breast cancer cells | In MCF-7 cells, induced IGFBP-3 increased **SA-β-gal-positive cells 3.4-fold** over control and reduced telomerase activity by lowering **hTR/hTERT** | primary cell study | Kwon et al., 2023, https://doi.org/10.1038/s41598-023-35291-5 | (skorupa2018igfbp3inducedby pages 19-23) |
+| Human biomarker | EJA diagnostic performance | In esophagogastric junction adenocarcinoma (EJA), serum IGFBP-3 AUC was **0.819** (training) and **0.804** (validation); specificity/sensitivity **90.18%/43.14%** and **87.50%/42.00%** | human cohort | Ding et al., 2022, https://doi.org/10.1007/s12672-022-00591-1 | (ding2022seruminsulinlikegrowth pages 1-3) |
+| Human biomarker | Early-stage EJA diagnostic performance | For **early-stage EJA**, AUC was **0.822** (training) and **0.811** (validation); specificity/sensitivity **90.18%/45.83%** and **84.48%/50.00%** | human cohort | Ding et al., 2022, https://doi.org/10.1007/s12672-022-00591-1 | (ding2022seruminsulinlikegrowth pages 1-3) |
+| Human biomarker | EJA prognosis | Lower serum IGFBP-3 associated with worse survival; multivariable Cox analysis: **HR = 0.468, P = 0.005**. Nomogram including IGFBP-3 improved **C-index from 0.625 to 0.735 (P = 0.001)** vs TNM alone | human cohort | Ding et al., 2022, https://doi.org/10.1007/s12672-022-00591-1 | (ding2022seruminsulinlikegrowth pages 1-3) |
+| Human biomarker | EJA serum concentrations | Mean serum IGFBP-3 was lower in controls vs EJA comparisons: training **1664 ng/mL** (controls) vs **1138 ng/mL** (EJA) / **1121 ng/mL** (early-stage EJA); validation **1632 ng/mL** vs **1142 ng/mL** / **1124 ng/mL** | human cohort | Ding et al., 2022, https://doi.org/10.1007/s12672-022-00591-1 | (ding2022seruminsulinlikegrowth pages 3-5) |
+| Human biomarker | Prostate cancer risk association | Collaborative analysis of **20 prospective studies** (up to **17,009 cases**, including **2,332 aggressive cases**) found higher circulating **IGFBP-3 associated with overall prostate cancer risk: OR per 1 SD = 1.08 (95% CI 1.04–1.11)**; association attenuated after IGF-I adjustment | human cohort | Watts et al., 2023, https://doi.org/10.1093/ije/dyac124 | (watts2023circulatinginsulinlikegrowth pages 13-14) |
+| Quantitative mechanism | NSCLC drug-response metrics | **TBB IC50:** **8 ± 1.5 µM** (A549), **7 ± 1.3 µM** (H1299); **cisplatin IC50:** **9 ± 1.5 µM** (A549), **26 ± 4 µM** (H1299); combined **TBB + cisplatin** caused **~4-fold viability decrease** vs **~2-fold** for either alone | primary cell study | Coleman et al., 2023, https://doi.org/10.3390/cells12030405 | (coleman2023phosphorylationofigfbp3 pages 5-7) |
+| Translational relevance | Real-world implementation | Current real-world use is mainly as a **circulating biomarker/analyte** in clinical or translational studies (e.g., cancer risk/prognosis panels), while therapeutic interest centers on modulating **IGFBP-3 signaling** or downstream pathways rather than established approved IGFBP-3-targeted drugs | review / human cohort | Baxter, 2023, https://doi.org/10.1210/endrev/bnad008; Ding et al., 2022, https://doi.org/10.1007/s12672-022-00591-1 | (baxter2023signalingpathwaysof pages 1-2, ding2022seruminsulinlikegrowth pages 1-3) |
+
+
+*Table: This table condenses verified identity, core biology, major signaling mechanisms, and representative quantitative biomarker findings for human IGFBP3/UniProt P17936. It is useful as a compact evidence map linking functional annotation to recent translational and clinical data.*
+
+### 8. Limitations of this evidence set
+- Some important “IGFBP-3 standard biology” points (e.g., precise structural domain boundaries from crystallography) are not directly extractable from the retrieved full-text set; however, mechanisms and numeric results are strongly supported by the 2023 Endocrine Reviews synthesis and 2023 mechanistic primary data. (baxter2023signalingpathwaysof pages 1-2, coleman2023phosphorylationofigfbp3 pages 5-7)
+- Biomarker evidence here is anchored by a robust 2022 clinical study in EJA and mechanistic 2023 cell-line data; additional 2023–2024 cohort biomarker studies likely exist across diseases, but were not all retrievable within the current tool results. (ding2022seruminsulinlikegrowth pages 1-3)
+
+### Key cited sources (with dates and URLs)
+- Baxter RC. *Endocrine Reviews* (Mar 2023). “Signaling Pathways of the Insulin-like Growth Factor Binding Proteins.” https://doi.org/10.1210/endrev/bnad008 (baxter2023signalingpathwaysof pages 1-2, baxter2023signalingpathwaysof pages 3-4, baxter2023signalingpathwaysof pages 9-9)
+- Coleman K-l et al. *Cells* (Jan 2023). “Phosphorylation of IGFBP-3 by Casein Kinase 2 Blocks Its Interaction with Hyaluronan…” https://doi.org/10.3390/cells12030405 (coleman2023phosphorylationofigfbp3 pages 1-2, coleman2023phosphorylationofigfbp3 pages 5-7, coleman2023phosphorylationofigfbp3 media 0143ad9b, coleman2023phosphorylationofigfbp3 media 21878636)
+- Ding T-Y et al. *Discover Oncology* (Nov 2022). “Serum IGFBP3 as a diagnostic and prognostic biomarker in esophagogastric junction adenocarcinoma.” https://doi.org/10.1007/s12672-022-00591-1 (ding2022seruminsulinlikegrowth pages 1-3)
+- Shrivastav SV et al. *Frontiers in Cell and Developmental Biology* (May 2020). “IGFBP-3: IGF-independent effects within the cell.” https://doi.org/10.3389/fcell.2020.00286 (shrivastav2020insulinlikegrowthfactor pages 7-8)
+- Lee K-W, Cohen P. *Journal of Endocrinology* (Oct 2002). “Nuclear effects: unexpected intracellular actions of IGFBP-3.” https://doi.org/10.1677/joe.0.1750033 (lee2002nucleareffectsunexpected pages 3-4)
+- Mofid MR et al. *Research in Pharmaceutical Sciences* (Jul 2018). “In silico interaction of IGFBP-3 with IGF-1.” https://doi.org/10.4103/1735-5362.235160 (mofid2018insilicointeraction pages 1-3)
+
+
+References
+
+1. (mofid2018insilicointeraction pages 1-3): MohammadReza Mofid, Elham Jafari, Ali Gheysarzadeh, Karim Mahnam, Rezvan Shahmohammadi, Amir Ansari, and Hadi Bakhtyari. In silico interaction of insulin-like growth factor binding protein 3 with insulin-like growth factor 1. Research in Pharmaceutical Sciences, 13:332-342, Jul 2018. URL: https://doi.org/10.4103/1735-5362.235160, doi:10.4103/1735-5362.235160. This article has 17 citations.
+
+2. (price2020humaninblocksaggregation pages 1-2): Deanna Price, Sadaf Dorandish, Asana Williams, Brandon Iwaniec, Alexis Stephens, Keyan Marshall, Jeffrey Guthrie, Deborah Heyl, and Hedeel Guy Evans. Humanin blocks aggregation of amyloid beta induced by acetylcholinesterase, an effect abolished in the presence of igfbp-3. Biochemistry, 59:1981-2002, May 2020. URL: https://doi.org/10.1021/acs.biochem.0c00274, doi:10.1021/acs.biochem.0c00274. This article has 26 citations and is from a peer-reviewed journal.
+
+3. (baxter2023signalingpathwaysof pages 1-2): Robert C Baxter. Signaling pathways of the insulin-like growth factor binding proteins. Endocrine Reviews, 44:753-778, Mar 2023. URL: https://doi.org/10.1210/endrev/bnad008, doi:10.1210/endrev/bnad008. This article has 144 citations and is from a domain leading peer-reviewed journal.
+
+4. (baxter2023signalingpathwaysof pages 2-2): Robert C Baxter. Signaling pathways of the insulin-like growth factor binding proteins. Endocrine Reviews, 44:753-778, Mar 2023. URL: https://doi.org/10.1210/endrev/bnad008, doi:10.1210/endrev/bnad008. This article has 144 citations and is from a domain leading peer-reviewed journal.
+
+5. (mofid2018insilicointeraction pages 8-10): MohammadReza Mofid, Elham Jafari, Ali Gheysarzadeh, Karim Mahnam, Rezvan Shahmohammadi, Amir Ansari, and Hadi Bakhtyari. In silico interaction of insulin-like growth factor binding protein 3 with insulin-like growth factor 1. Research in Pharmaceutical Sciences, 13:332-342, Jul 2018. URL: https://doi.org/10.4103/1735-5362.235160, doi:10.4103/1735-5362.235160. This article has 17 citations.
+
+6. (mofid2018insilicointeraction pages 11-11): MohammadReza Mofid, Elham Jafari, Ali Gheysarzadeh, Karim Mahnam, Rezvan Shahmohammadi, Amir Ansari, and Hadi Bakhtyari. In silico interaction of insulin-like growth factor binding protein 3 with insulin-like growth factor 1. Research in Pharmaceutical Sciences, 13:332-342, Jul 2018. URL: https://doi.org/10.4103/1735-5362.235160, doi:10.4103/1735-5362.235160. This article has 17 citations.
+
+7. (sechrist2025pathologicsignalingand pages 2-4): Zachary R. Sechrist, Jaeden S. Cortés, Nidhi R. Patel, Zoe J. Pittman, Gayathri Guru Murthy, Guangzhen Zhu, Calvin L. Cole, and Benjamin D. Korman. Pathologic signaling and disease implications of insulin-like growth factor binding proteins in cancer, cardiovascular disease, and fibrosis. International Journal of Molecular Sciences, 26:10248, Oct 2025. URL: https://doi.org/10.3390/ijms262110248, doi:10.3390/ijms262110248. This article has 7 citations.
+
+8. (coleman2023phosphorylationofigfbp3 pages 5-7): Kai-ling Coleman, Michael Chiaramonti, Ben Haddad, Robert Ranzenberger, Heather Henning, Hind Al Khashali, Ravel Ray, Ban Darweesh, Jeffrey Guthrie, Deborah Heyl, and Hedeel Guy Evans. Phosphorylation of igfbp-3 by casein kinase 2 blocks its interaction with hyaluronan, enabling ha-cd44 signaling leading to increased nsclc cell survival and cisplatin resistance. Cells, 12:405, Jan 2023. URL: https://doi.org/10.3390/cells12030405, doi:10.3390/cells12030405. This article has 18 citations.
+
+9. (lee2002nucleareffectsunexpected pages 3-4): KW Lee and P Cohen. Nuclear effects: unexpected intracellular actions of insulin-like growth factor binding protein-3. Journal of Endocrinology, 175:33-40, Oct 2002. URL: https://doi.org/10.1677/joe.0.1750033, doi:10.1677/joe.0.1750033. This article has 127 citations and is from a peer-reviewed journal.
+
+10. (shrivastav2020insulinlikegrowthfactor pages 7-8): Shailly Varma Shrivastav, Apurva Bhardwaj, Kumar Alok Pathak, and Anuraag Shrivastav. Insulin-like growth factor binding protein-3 (igfbp-3): unraveling the role in mediating igf-independent effects within the cell. Frontiers in Cell and Developmental Biology, May 2020. URL: https://doi.org/10.3389/fcell.2020.00286, doi:10.3389/fcell.2020.00286. This article has 175 citations.
+
+11. (baxter2023signalingpathwaysof pages 3-4): Robert C Baxter. Signaling pathways of the insulin-like growth factor binding proteins. Endocrine Reviews, 44:753-778, Mar 2023. URL: https://doi.org/10.1210/endrev/bnad008, doi:10.1210/endrev/bnad008. This article has 144 citations and is from a domain leading peer-reviewed journal.
+
+12. (baxter2023signalingpathwaysof pages 4-5): Robert C Baxter. Signaling pathways of the insulin-like growth factor binding proteins. Endocrine Reviews, 44:753-778, Mar 2023. URL: https://doi.org/10.1210/endrev/bnad008, doi:10.1210/endrev/bnad008. This article has 144 citations and is from a domain leading peer-reviewed journal.
+
+13. (coleman2023phosphorylationofigfbp3 pages 2-4): Kai-ling Coleman, Michael Chiaramonti, Ben Haddad, Robert Ranzenberger, Heather Henning, Hind Al Khashali, Ravel Ray, Ban Darweesh, Jeffrey Guthrie, Deborah Heyl, and Hedeel Guy Evans. Phosphorylation of igfbp-3 by casein kinase 2 blocks its interaction with hyaluronan, enabling ha-cd44 signaling leading to increased nsclc cell survival and cisplatin resistance. Cells, 12:405, Jan 2023. URL: https://doi.org/10.3390/cells12030405, doi:10.3390/cells12030405. This article has 18 citations.
+
+14. (coleman2023phosphorylationofigfbp3 pages 1-2): Kai-ling Coleman, Michael Chiaramonti, Ben Haddad, Robert Ranzenberger, Heather Henning, Hind Al Khashali, Ravel Ray, Ban Darweesh, Jeffrey Guthrie, Deborah Heyl, and Hedeel Guy Evans. Phosphorylation of igfbp-3 by casein kinase 2 blocks its interaction with hyaluronan, enabling ha-cd44 signaling leading to increased nsclc cell survival and cisplatin resistance. Cells, 12:405, Jan 2023. URL: https://doi.org/10.3390/cells12030405, doi:10.3390/cells12030405. This article has 18 citations.
+
+15. (coleman2023phosphorylationofigfbp3 pages 19-21): Kai-ling Coleman, Michael Chiaramonti, Ben Haddad, Robert Ranzenberger, Heather Henning, Hind Al Khashali, Ravel Ray, Ban Darweesh, Jeffrey Guthrie, Deborah Heyl, and Hedeel Guy Evans. Phosphorylation of igfbp-3 by casein kinase 2 blocks its interaction with hyaluronan, enabling ha-cd44 signaling leading to increased nsclc cell survival and cisplatin resistance. Cells, 12:405, Jan 2023. URL: https://doi.org/10.3390/cells12030405, doi:10.3390/cells12030405. This article has 18 citations.
+
+16. (coleman2023phosphorylationofigfbp3 media 0143ad9b): Kai-ling Coleman, Michael Chiaramonti, Ben Haddad, Robert Ranzenberger, Heather Henning, Hind Al Khashali, Ravel Ray, Ban Darweesh, Jeffrey Guthrie, Deborah Heyl, and Hedeel Guy Evans. Phosphorylation of igfbp-3 by casein kinase 2 blocks its interaction with hyaluronan, enabling ha-cd44 signaling leading to increased nsclc cell survival and cisplatin resistance. Cells, 12:405, Jan 2023. URL: https://doi.org/10.3390/cells12030405, doi:10.3390/cells12030405. This article has 18 citations.
+
+17. (coleman2023phosphorylationofigfbp3 media 21878636): Kai-ling Coleman, Michael Chiaramonti, Ben Haddad, Robert Ranzenberger, Heather Henning, Hind Al Khashali, Ravel Ray, Ban Darweesh, Jeffrey Guthrie, Deborah Heyl, and Hedeel Guy Evans. Phosphorylation of igfbp-3 by casein kinase 2 blocks its interaction with hyaluronan, enabling ha-cd44 signaling leading to increased nsclc cell survival and cisplatin resistance. Cells, 12:405, Jan 2023. URL: https://doi.org/10.3390/cells12030405, doi:10.3390/cells12030405. This article has 18 citations.
+
+18. (baxter2023signalingpathwaysof pages 9-9): Robert C Baxter. Signaling pathways of the insulin-like growth factor binding proteins. Endocrine Reviews, 44:753-778, Mar 2023. URL: https://doi.org/10.1210/endrev/bnad008, doi:10.1210/endrev/bnad008. This article has 144 citations and is from a domain leading peer-reviewed journal.
+
+19. (ding2022seruminsulinlikegrowth pages 1-3): Tian-Yan Ding, Yu-Hui Peng, Chao-Qun Hong, Bin-Liang Huang, Can-Tong Liu, Yun Luo, Ling-Yu Chu, Biao Zhang, Xin-Hao Li, Qi-Qi Qu, Yi-Wei Xu, and Fang-Cai Wu. Serum insulin-like growth factor binding protein 3 as a promising diagnostic and prognostic biomarker in esophagogastric junction adenocarcinoma. Discover. Oncology, Nov 2022. URL: https://doi.org/10.1007/s12672-022-00591-1, doi:10.1007/s12672-022-00591-1. This article has 5 citations.
+
+20. (sechrist2025pathologicsignalingand pages 1-2): Zachary R. Sechrist, Jaeden S. Cortés, Nidhi R. Patel, Zoe J. Pittman, Gayathri Guru Murthy, Guangzhen Zhu, Calvin L. Cole, and Benjamin D. Korman. Pathologic signaling and disease implications of insulin-like growth factor binding proteins in cancer, cardiovascular disease, and fibrosis. International Journal of Molecular Sciences, 26:10248, Oct 2025. URL: https://doi.org/10.3390/ijms262110248, doi:10.3390/ijms262110248. This article has 7 citations.
+
+21. (shrivastav2020insulinlikegrowthfactor pages 2-4): Shailly Varma Shrivastav, Apurva Bhardwaj, Kumar Alok Pathak, and Anuraag Shrivastav. Insulin-like growth factor binding protein-3 (igfbp-3): unraveling the role in mediating igf-independent effects within the cell. Frontiers in Cell and Developmental Biology, May 2020. URL: https://doi.org/10.3389/fcell.2020.00286, doi:10.3389/fcell.2020.00286. This article has 175 citations.
+
+22. (lee2002nucleareffectsunexpected pages 1-3): KW Lee and P Cohen. Nuclear effects: unexpected intracellular actions of insulin-like growth factor binding protein-3. Journal of Endocrinology, 175:33-40, Oct 2002. URL: https://doi.org/10.1677/joe.0.1750033, doi:10.1677/joe.0.1750033. This article has 127 citations and is from a peer-reviewed journal.
+
+23. (skorupa2018igfbp3inducedby pages 19-23): Jennifer A. Skorupa. Igfbp-3 induced by ribotoxic stress is not secreted prior to nuclear localization in mammary epithelial cells. ArXiv, Jan 2018. URL: https://doi.org/10.7282/t3d50r5w, doi:10.7282/t3d50r5w. This article has 0 citations.
+
+24. (ding2022seruminsulinlikegrowth pages 3-5): Tian-Yan Ding, Yu-Hui Peng, Chao-Qun Hong, Bin-Liang Huang, Can-Tong Liu, Yun Luo, Ling-Yu Chu, Biao Zhang, Xin-Hao Li, Qi-Qi Qu, Yi-Wei Xu, and Fang-Cai Wu. Serum insulin-like growth factor binding protein 3 as a promising diagnostic and prognostic biomarker in esophagogastric junction adenocarcinoma. Discover. Oncology, Nov 2022. URL: https://doi.org/10.1007/s12672-022-00591-1, doi:10.1007/s12672-022-00591-1. This article has 5 citations.
+
+25. (watts2023circulatinginsulinlikegrowth pages 13-14): Eleanor L Watts, Aurora Perez-Cornago, Georgina K Fensom, Karl Smith-Byrne, Urwah Noor, Colm D Andrews, Marc J Gunter, Michael V Holmes, Richard M Martin, Konstantinos K Tsilidis, Demetrius Albanes, Aurelio Barricarte, H Bas Bueno-de-Mesquita, Barbara A Cohn, Melanie Deschasaux-Tanguy, Niki L Dimou, Luigi Ferrucci, Leon Flicker, Neal D Freedman, Graham G Giles, Edward L Giovannucci, Christopher A Haiman, Graham J Hankey, Jeffrey M P Holly, Jiaqi Huang, Wen-Yi Huang, Lauren M Hurwitz, Rudolf Kaaks, Tatsuhiko Kubo, Loic Le Marchand, Robert J MacInnis, Satu Männistö, E Jeffrey Metter, Kazuya Mikami, Lorelei A Mucci, Anja Olsen, Kotaro Ozasa, Domenico Palli, Kathryn L Penney, Elizabeth A Platz, Michael N Pollak, Monique J Roobol, Catherine A Schaefer, Jeannette M Schenk, Pär Stattin, Akiko Tamakoshi, Elin Thysell, Chiaojung Jillian Tsai, Mathilde Touvier, Stephen K Van Den Eeden, Elisabete Weiderpass, Stephanie J Weinstein, Lynne R Wilkens, Bu B Yeap, Rosalind A Eeles, Christopher A Haiman, Zsofia Kote-Jarai, Fredrick R Schumacher, Sara Benlloch, Ali Amin Al Olama, Kenneth R Muir, Sonja I Berndt, David V Conti, Fredrik Wiklund, Stephen Chanock, Ying Wang, Catherine M Tangen, Jyotsna Batra, Judith A Clements, Naomi E Allen, Timothy J Key, and Ruth C Travis. Circulating insulin-like growth factors and risks of overall, aggressive and early-onset prostate cancer: a collaborative analysis of 20 prospective studies and mendelian randomization analysis. International Journal of Epidemiology, 52:71-86, Jun 2023. URL: https://doi.org/10.1093/ije/dyac124, doi:10.1093/ije/dyac124. This article has 60 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. sechrist2025pathologicsignalingand pages 2-4
+2. mofid2018insilicointeraction pages 1-3
+3. lee2002nucleareffectsunexpected pages 3-4
+4. shrivastav2020insulinlikegrowthfactor pages 7-8
+5. baxter2023signalingpathwaysof pages 9-9
+6. ding2022seruminsulinlikegrowth pages 1-3
+7. baxter2023signalingpathwaysof pages 1-2
+8. ding2022seruminsulinlikegrowth pages 3-5
+9. watts2023circulatinginsulinlikegrowth pages 13-14
+10. price2020humaninblocksaggregation pages 1-2
+11. baxter2023signalingpathwaysof pages 2-2
+12. mofid2018insilicointeraction pages 8-10
+13. mofid2018insilicointeraction pages 11-11
+14. baxter2023signalingpathwaysof pages 3-4
+15. baxter2023signalingpathwaysof pages 4-5
+16. sechrist2025pathologicsignalingand pages 1-2
+17. shrivastav2020insulinlikegrowthfactor pages 2-4
+18. lee2002nucleareffectsunexpected pages 1-3
+19. https://doi.org/10.4103/1735-5362.235160;
+20. https://doi.org/10.1021/acs.biochem.0c00274
+21. https://doi.org/10.4103/1735-5362.235160
+22. https://doi.org/10.1210/endrev/bnad008;
+23. https://doi.org/10.3390/ijms262110248
+24. https://doi.org/10.3390/cells12030405;
+25. https://doi.org/10.3390/ijms22010407
+26. https://doi.org/10.1210/endrev/bnad008
+27. https://doi.org/10.3390/cells12030405
+28. https://doi.org/10.3389/fcell.2020.00286;
+29. https://doi.org/10.1677/joe.0.1750033
+30. https://doi.org/10.1677/joe.0.1750033;
+31. https://doi.org/10.1038/s41598-023-35291-5
+32. https://doi.org/10.1007/s12672-022-00591-1
+33. https://doi.org/10.1093/ije/dyac124
+34. https://doi.org/10.3389/fcell.2020.00286
+35. https://doi.org/10.4103/1735-5362.235160,
+36. https://doi.org/10.1021/acs.biochem.0c00274,
+37. https://doi.org/10.1210/endrev/bnad008,
+38. https://doi.org/10.3390/ijms262110248,
+39. https://doi.org/10.3390/cells12030405,
+40. https://doi.org/10.1677/joe.0.1750033,
+41. https://doi.org/10.3389/fcell.2020.00286,
+42. https://doi.org/10.1007/s12672-022-00591-1,
+43. https://doi.org/10.7282/t3d50r5w,
+44. https://doi.org/10.1093/ije/dyac124,

--- a/genes/human/LIMD1/LIMD1-ai-review.html
+++ b/genes/human/LIMD1/LIMD1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>LIMD1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q9UGP4" target="_blank" class="term-link">
                         Q9UGP4
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-initialized">
-                    INITIALIZED
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="Q9UGP4" data-a="DESCRIPTION: TODO: Add description for LIMD1..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="Q9UGP4" data-a="DESCRIPTION: LIMD1 encodes a multi-domain LIM zinc-binding adap..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for LIMD1</p>
+        <p>LIMD1 encodes a multi-domain LIM zinc-binding adaptor/scaffold protein that assembles regulatory complexes at adherens junctions, P-bodies, cytoplasmic HIF degradation machinery, and the nucleus. Its best-supported functions include mechanosensitive Hippo/LATS-YAP regulation, miRISC-mediated translational repression, PHD2-VHL-dependent HIF-alpha degradation, and pRB/E2F transcriptional corepression.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,2705 +758,3861 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003714" target="_blank" class="term-link">
                                     GO:0003714
                                 </a>
                             </span>
                             <span class="term-label">transcription corepressor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0003714" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0003714" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Transcription corepressor activity is supported by pRB/E2F repression and related corepressor interactions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven transcription**, coupling LIMD1 to cell-cycle control.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005912" target="_blank" class="term-link">
                                     GO:0005912
                                 </a>
                             </span>
                             <span class="term-label">adherens junction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005912" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005912" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> adherens junction localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleus localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006355" target="_blank" class="term-link">
                                     GO:0006355
                                 </a>
                             </span>
                             <span class="term-label">regulation of DNA-templated transcription</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0006355" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0006355" data-r="GO_REF:0000033" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Regulation of DNA-templated transcription is correct but too broad; LIMD1 evidence supports negative transcriptional regulation/corepression.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Use the directionally specific transcriptional repression term.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045892" target="_blank" class="term-link">
+                                    negative regulation of DNA-templated transcription
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven transcription**, coupling LIMD1 to cell-cycle control.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007010" target="_blank" class="term-link">
                                     GO:0007010
                                 </a>
                             </span>
                             <span class="term-label">cytoskeleton organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0007010" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0007010" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytoskeleton organization is a broad downstream description; the mechanistic evidence is more specifically adherens-junction/F-actin tension sensing for Hippo signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035331" target="_blank" class="term-link">
                                     GO:0035331
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of hippo signaling</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0035331" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0035331" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Negative regulation of Hippo signaling is supported by LIMD1-mediated LATS1/2 recruitment/localization at adherens junctions and consequent YAP/TAZ regulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000932" target="_blank" class="term-link">
                                     GO:0000932
                                 </a>
                             </span>
                             <span class="term-label">P-body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0000932" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0000932" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> P-body localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001666" target="_blank" class="term-link">
                                     GO:0001666
                                 </a>
                             </span>
                             <span class="term-label">response to hypoxia</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0001666" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0001666" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Response to hypoxia is supported by LIMD1 induction and by LIMD1 scaffolding of PHD2/VHL complexes for HIF-alpha degradation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback loop limiting pro-tumorigenic hypoxia signaling.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005667" target="_blank" class="term-link">
                                     GO:0005667
                                 </a>
                             </span>
                             <span class="term-label">transcription regulator complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005667" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005667" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Transcription regulator complex is retained as a non-core complex context for pRB/E2F and SNAI-associated repression, but the more informative annotation is transcription corepressor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven transcription**, coupling LIMD1 to cell-cycle control.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000932" target="_blank" class="term-link">
                                     GO:0000932
                                 </a>
                             </span>
                             <span class="term-label">P-body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0000932" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0000932" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> P-body localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001666" target="_blank" class="term-link">
                                     GO:0001666
                                 </a>
                             </span>
                             <span class="term-label">response to hypoxia</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0001666" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0001666" data-r="GO_REF:0000117" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Response to hypoxia is supported by LIMD1 induction and by LIMD1 scaffolding of PHD2/VHL complexes for HIF-alpha degradation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback loop limiting pro-tumorigenic hypoxia signaling.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005634" data-r="GO_REF:0000044" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleus localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005737" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005737" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytoplasm localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005912" target="_blank" class="term-link">
                                     GO:0005912
                                 </a>
                             </span>
                             <span class="term-label">adherens junction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005912" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005912" data-r="GO_REF:0000044" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> adherens junction localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005925" target="_blank" class="term-link">
                                     GO:0005925
                                 </a>
                             </span>
                             <span class="term-label">focal adhesion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005925" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005925" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Focal adhesion localization is supported by UniProt/subcellular evidence, but the strongest mechanistic Hippo evidence centers on adherens junctions under tension.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031047" target="_blank" class="term-link">
                                     GO:0031047
                                 </a>
                             </span>
                             <span class="term-label">regulatory ncRNA-mediated gene silencing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0031047" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0031047" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Regulatory ncRNA-mediated gene silencing is supported but should be represented more specifically as miRNA-mediated post-transcriptional silencing.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The evidence is specifically miRISC/miRNA-mediated silencing.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035195" target="_blank" class="term-link">
+                                    miRNA-mediated post-transcriptional gene silencing
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6 and downstream effector complexes, and by linking silencing to translation initiation control at the 5′ cap.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035278" target="_blank" class="term-link">
                                     GO:0035278
                                 </a>
                             </span>
                             <span class="term-label">miRNA-mediated gene silencing by inhibition of translation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0035278" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0035278" data-r="GO_REF:0000117" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> miRNA-mediated gene silencing by inhibition of translation is supported by LIMD1 function as a miRISC/P-body scaffold linking AGO proteins, GW182/TNRC6, DDX6, and cap-associated translation repression.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6 and downstream effector complexes, and by linking silencing to translation initiation control at the 5′ cap.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035331" target="_blank" class="term-link">
                                     GO:0035331
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of hippo signaling</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0035331" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0035331" data-r="GO_REF:0000117" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Negative regulation of Hippo signaling is supported by LIMD1-mediated LATS1/2 recruitment/localization at adherens junctions and consequent YAP/TAZ regulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The metal-binding evidence is specifically zinc binding by LIM domains, so this broad metal ion binding term should be replaced by zinc ion binding.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> LIM domains are zinc-binding modules; use the specific zinc ion binding term.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
+                                    zinc ion binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**LIMD1 is a multi-domain adaptor/scaffold protein**, not an enzyme. Its biological roles derive from assembling protein complexes and controlling where/when those complexes form—particularly at **cell junctions**, **P-bodies**, and in **oxygen-sensing (HIF) degradation complexes**. LIM domains are zinc-binding modules (~55–65 aa) that act as protein-interaction interfaces; LIMD1 contains **three tandem LIM domains** at its C‑terminus.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22190034" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22190034
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global landscape of HIV-human protein complexes.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:22190034" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:22190034" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for LIMD1. Specific adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Avoid generic protein binding when specific complex/adaptor mechanisms are known.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22190034" target="_blank" class="term-link">
                                         PMID:22190034
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Global landscape of HIV-human protein complexes.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">LIMD1 (Q9UGP4) is best understood as a **multi-compartment scaffold** that (i) couples **mechanical tension** at adherens junctions to **Hippo pathway kinase (LATS) localization**, (ii) enables efficient **miRNA-mediated translational repression** by scaffolding Argonaute and GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α degradation** by scaffolding PHD2–VHL complexes and participating in a HIF-driven negative feedback loop, and (iv) exerts tumor suppressor functions via **pRB/E2F repression** and via maintaining homeostatic control over hypoxia and mechanotransduction outputs.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28683311" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28683311
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Argonaute Utilization for miRNA Silencing Is Determined by P...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:28683311" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:28683311" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for LIMD1. Specific adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Avoid generic protein binding when specific complex/adaptor mechanisms are known.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/28683311" target="_blank" class="term-link">
                                         PMID:28683311
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Argonaute Utilization for miRNA Silencing Is Determined by Phosphorylation-Dependent Recruitment of LIM-Domain-Containing Proteins.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">LIMD1 (Q9UGP4) is best understood as a **multi-compartment scaffold** that (i) couples **mechanical tension** at adherens junctions to **Hippo pathway kinase (LATS) localization**, (ii) enables efficient **miRNA-mediated translational repression** by scaffolding Argonaute and GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α degradation** by scaffolding PHD2–VHL complexes and participating in a HIF-driven negative feedback loop, and (iv) exerts tumor suppressor functions via **pRB/E2F repression** and via maintaining homeostatic control over hypoxia and mechanotransduction outputs.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:33961781" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for LIMD1. Specific adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Avoid generic protein binding when specific complex/adaptor mechanisms are known.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                                         PMID:33961781
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2021 May 6. Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">LIMD1 (Q9UGP4) is best understood as a **multi-compartment scaffold** that (i) couples **mechanical tension** at adherens junctions to **Hippo pathway kinase (LATS) localization**, (ii) enables efficient **miRNA-mediated translational repression** by scaffolding Argonaute and GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α degradation** by scaffolding PHD2–VHL complexes and participating in a HIF-driven negative feedback loop, and (iv) exerts tumor suppressor functions via **pRB/E2F repression** and via maintaining homeostatic control over hypoxia and mechanotransduction outputs.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002076" target="_blank" class="term-link">
                                     GO:0002076
                                 </a>
                             </span>
                             <span class="term-label">osteoblast development</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0002076" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0002076" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> osteoblast development is retained as a non-core osteoblast/Wnt-related role supported by UniProt-curated literature, but it is peripheral to the main LIMD1 scaffold functions synthesized here.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Regulates osteoblast development, function, differentiation and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt receptor signaling pathway in osteoblasts.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003714" target="_blank" class="term-link">
                                     GO:0003714
                                 </a>
                             </span>
                             <span class="term-label">transcription corepressor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0003714" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0003714" data-r="GO_REF:0000107" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Transcription corepressor activity is supported by pRB/E2F repression and related corepressor interactions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven transcription**, coupling LIMD1 to cell-cycle control.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045668" target="_blank" class="term-link">
                                     GO:0045668
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of osteoblast differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0045668" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0045668" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> negative regulation of osteoblast differentiation is retained as a non-core osteoblast/Wnt-related role supported by UniProt-curated literature, but it is peripheral to the main LIMD1 scaffold functions synthesized here.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Regulates osteoblast development, function, differentiation and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt receptor signaling pathway in osteoblasts.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090090" target="_blank" class="term-link">
                                     GO:0090090
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of canonical Wnt signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0090090" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0090090" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> negative regulation of canonical Wnt signaling pathway is retained as a non-core osteoblast/Wnt-related role supported by UniProt-curated literature, but it is peripheral to the main LIMD1 scaffold functions synthesized here.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Regulates osteoblast development, function, differentiation and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt receptor signaling pathway in osteoblasts.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005654" data-r="GO_REF:0000052" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005654" data-r="GO_REF:0000052" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005925" target="_blank" class="term-link">
                                     GO:0005925
                                 </a>
                             </span>
                             <span class="term-label">focal adhesion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005925" data-r="GO_REF:0000052" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005925" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Focal adhesion localization is supported by UniProt/subcellular evidence, but the strongest mechanistic Hippo evidence centers on adherens junctions under tension.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035278" target="_blank" class="term-link">
                                     GO:0035278
                                 </a>
                             </span>
                             <span class="term-label">miRNA-mediated gene silencing by inhibition of translation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20616046" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20616046
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0035278" data-r="PMID:20616046" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0035278" data-r="PMID:20616046" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> miRNA-mediated gene silencing by inhibition of translation is supported by LIMD1 function as a miRISC/P-body scaffold linking AGO proteins, GW182/TNRC6, DDX6, and cap-associated translation repression.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20616046" target="_blank" class="term-link">
                                         PMID:20616046
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for microRNA-mediated gene silencing.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6 and downstream effector complexes, and by linking silencing to translation initiation control at the 5′ cap.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1234159
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005829" data-r="Reactome:R-HSA-1234159" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005829" data-r="Reactome:R-HSA-1234159" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1234163
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005829" data-r="Reactome:R-HSA-1234163" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005829" data-r="Reactome:R-HSA-1234163" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1234173
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005829" data-r="Reactome:R-HSA-1234173" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005829" data-r="Reactome:R-HSA-1234173" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1234177
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005829" data-r="Reactome:R-HSA-1234177" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005829" data-r="Reactome:R-HSA-1234177" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1234183
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005829" data-r="Reactome:R-HSA-1234183" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005829" data-r="Reactome:R-HSA-1234183" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003714" target="_blank" class="term-link">
                                     GO:0003714
                                 </a>
                             </span>
                             <span class="term-label">transcription corepressor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0003714" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0003714" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Transcription corepressor activity is supported by pRB/E2F repression and related corepressor interactions.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven transcription**, coupling LIMD1 to cell-cycle control.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002076" target="_blank" class="term-link">
                                     GO:0002076
                                 </a>
                             </span>
                             <span class="term-label">osteoblast development</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0002076" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0002076" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> osteoblast development is retained as a non-core osteoblast/Wnt-related role supported by UniProt-curated literature, but it is peripheral to the main LIMD1 scaffold functions synthesized here.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Regulates osteoblast development, function, differentiation and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt receptor signaling pathway in osteoblasts.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045668" target="_blank" class="term-link">
                                     GO:0045668
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of osteoblast differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0045668" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0045668" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> negative regulation of osteoblast differentiation is retained as a non-core osteoblast/Wnt-related role supported by UniProt-curated literature, but it is peripheral to the main LIMD1 scaffold functions synthesized here.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Regulates osteoblast development, function, differentiation and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt receptor signaling pathway in osteoblasts.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090090" target="_blank" class="term-link">
                                     GO:0090090
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of canonical Wnt signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0090090" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0090090" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> negative regulation of canonical Wnt signaling pathway is retained as a non-core osteoblast/Wnt-related role supported by UniProt-curated literature, but it is peripheral to the main LIMD1 scaffold functions synthesized here.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Regulates osteoblast development, function, differentiation and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt receptor signaling pathway in osteoblasts.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001666" target="_blank" class="term-link">
                                     GO:0001666
                                 </a>
                             </span>
                             <span class="term-label">response to hypoxia</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22286099" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22286099
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The LIMD1 protein bridges an association between the prolyl ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0001666" data-r="PMID:22286099" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0001666" data-r="PMID:22286099" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Response to hypoxia is supported by LIMD1 induction and by LIMD1 scaffolding of PHD2/VHL complexes for HIF-alpha degradation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22286099" target="_blank" class="term-link">
                                         PMID:22286099
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The LIMD1 protein bridges an association between the prolyl hydroxylases and VHL to repress HIF-1 activity.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback loop limiting pro-tumorigenic hypoxia signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18331720" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18331720
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Ajuba LIM proteins are snail/slug corepressors required for ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:18331720" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:18331720" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for LIMD1. Specific adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Avoid generic protein binding when specific complex/adaptor mechanisms are known.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18331720" target="_blank" class="term-link">
                                         PMID:18331720
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Ajuba LIM proteins are snail/slug corepressors required for neural crest development in Xenopus.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">LIMD1 (Q9UGP4) is best understood as a **multi-compartment scaffold** that (i) couples **mechanical tension** at adherens junctions to **Hippo pathway kinase (LATS) localization**, (ii) enables efficient **miRNA-mediated translational repression** by scaffolding Argonaute and GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α degradation** by scaffolding PHD2–VHL complexes and participating in a HIF-driven negative feedback loop, and (iv) exerts tumor suppressor functions via **pRB/E2F repression** and via maintaining homeostatic control over hypoxia and mechanotransduction outputs.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20616046" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20616046
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:20616046" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:20616046" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for LIMD1. Specific adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Avoid generic protein binding when specific complex/adaptor mechanisms are known.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20616046" target="_blank" class="term-link">
                                         PMID:20616046
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for microRNA-mediated gene silencing.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">LIMD1 (Q9UGP4) is best understood as a **multi-compartment scaffold** that (i) couples **mechanical tension** at adherens junctions to **Hippo pathway kinase (LATS) localization**, (ii) enables efficient **miRNA-mediated translational repression** by scaffolding Argonaute and GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α degradation** by scaffolding PHD2–VHL complexes and participating in a HIF-driven negative feedback loop, and (iv) exerts tumor suppressor functions via **pRB/E2F repression** and via maintaining homeostatic control over hypoxia and mechanotransduction outputs.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22286099" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22286099
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The LIMD1 protein bridges an association between the prolyl ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:22286099" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:22286099" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for LIMD1. Specific adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Avoid generic protein binding when specific complex/adaptor mechanisms are known.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22286099" target="_blank" class="term-link">
                                         PMID:22286099
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The LIMD1 protein bridges an association between the prolyl hydroxylases and VHL to repress HIF-1 activity.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">LIMD1 (Q9UGP4) is best understood as a **multi-compartment scaffold** that (i) couples **mechanical tension** at adherens junctions to **Hippo pathway kinase (LATS) localization**, (ii) enables efficient **miRNA-mediated translational repression** by scaffolding Argonaute and GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α degradation** by scaffolding PHD2–VHL complexes and participating in a HIF-driven negative feedback loop, and (iv) exerts tumor suppressor functions via **pRB/E2F repression** and via maintaining homeostatic control over hypoxia and mechanotransduction outputs.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045892" target="_blank" class="term-link">
                                     GO:0045892
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of DNA-templated transcription</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22286099" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22286099
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The LIMD1 protein bridges an association between the prolyl ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0045892" data-r="PMID:22286099" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0045892" data-r="PMID:22286099" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Negative regulation of DNA-templated transcription is supported by both pRB/E2F repression and HIF pathway repression through enhanced HIF-alpha degradation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22286099" target="_blank" class="term-link">
                                         PMID:22286099
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The LIMD1 protein bridges an association between the prolyl hydroxylases and VHL to repress HIF-1 activity.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven transcription**, coupling LIMD1 to cell-cycle control.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback loop limiting pro-tumorigenic hypoxia signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20303269" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20303269
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Ajuba LIM proteins are negative regulators of the Hippo sign...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:20303269" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:20303269" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for LIMD1. Specific adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Avoid generic protein binding when specific complex/adaptor mechanisms are known.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20303269" target="_blank" class="term-link">
                                         PMID:20303269
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mar 18. Ajuba LIM proteins are negative regulators of the Hippo signaling pathway.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">LIMD1 (Q9UGP4) is best understood as a **multi-compartment scaffold** that (i) couples **mechanical tension** at adherens junctions to **Hippo pathway kinase (LATS) localization**, (ii) enables efficient **miRNA-mediated translational repression** by scaffolding Argonaute and GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α degradation** by scaffolding PHD2–VHL complexes and participating in a HIF-driven negative feedback loop, and (iv) exerts tumor suppressor functions via **pRB/E2F repression** and via maintaining homeostatic control over hypoxia and mechanotransduction outputs.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18439753" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18439753
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cell cycle regulated phosphorylation of LIMD1 in cell lines ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005634" data-r="PMID:18439753" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005634" data-r="PMID:18439753" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleus localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18439753" target="_blank" class="term-link">
                                         PMID:18439753
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2008 Apr 24. Cell cycle regulated phosphorylation of LIMD1 in cell lines and expression in human breast cancers.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18439753" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18439753
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cell cycle regulated phosphorylation of LIMD1 in cell lines ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005737" data-r="PMID:18439753" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005737" data-r="PMID:18439753" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytoplasm localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18439753" target="_blank" class="term-link">
                                         PMID:18439753
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2008 Apr 24. Cell cycle regulated phosphorylation of LIMD1 in cell lines and expression in human breast cancers.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005912" target="_blank" class="term-link">
                                     GO:0005912
                                 </a>
                             </span>
                             <span class="term-label">adherens junction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20303269" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20303269
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Ajuba LIM proteins are negative regulators of the Hippo sign...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005912" data-r="PMID:20303269" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005912" data-r="PMID:20303269" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> adherens junction localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20303269" target="_blank" class="term-link">
                                         PMID:20303269
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mar 18. Ajuba LIM proteins are negative regulators of the Hippo signaling pathway.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005925" target="_blank" class="term-link">
                                     GO:0005925
                                 </a>
                             </span>
                             <span class="term-label">focal adhesion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18439753" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18439753
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cell cycle regulated phosphorylation of LIMD1 in cell lines ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005925" data-r="PMID:18439753" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005925" data-r="PMID:18439753" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Focal adhesion localization is supported by UniProt/subcellular evidence, but the strongest mechanistic Hippo evidence centers on adherens junctions under tension.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18439753" target="_blank" class="term-link">
                                         PMID:18439753
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2008 Apr 24. Cell cycle regulated phosphorylation of LIMD1 in cell lines and expression in human breast cancers.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016310" target="_blank" class="term-link">
                                     GO:0016310
                                 </a>
                             </span>
                             <span class="term-label">phosphorylation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18439753" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18439753
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cell cycle regulated phosphorylation of LIMD1 in cell lines ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -3468,1089 +4624,2132 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> MISANNOTATION: LIMD1 is a LIM domain scaffold protein, NOT a kinase. PMID:18439753 title is &#34;Cell cycle regulated phosphorylation OF LIMD1&#34; - LIMD1 is the SUBSTRATE being phosphorylated. Paper explicitly states &#34;LIMD1 is phosphorylated during mitosis in HeLa cells&#34;. UniProt shows LIMD1 is phosphorylated at Ser-272, Ser-277, Ser-304, Ser-421, Ser-424. This is a substrate-as-enzyme misannotation.
+                            <strong>Summary:</strong> LIMD1 is a scaffold protein and not a kinase; the cited paper concerns phosphorylation of LIMD1 rather than LIMD1 catalyzing phosphorylation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Substrate-as-enzyme misannotation.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18439753" target="_blank" class="term-link">
                                         PMID:18439753
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2008 Apr 24. Cell cycle regulated phosphorylation of LIMD1 in cell lines and expression in human breast cancers.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035331" target="_blank" class="term-link">
                                     GO:0035331
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of hippo signaling</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20303269" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20303269
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Ajuba LIM proteins are negative regulators of the Hippo sign...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0035331" data-r="PMID:20303269" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0035331" data-r="PMID:20303269" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Negative regulation of Hippo signaling is supported by LIMD1-mediated LATS1/2 recruitment/localization at adherens junctions and consequent YAP/TAZ regulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20303269" target="_blank" class="term-link">
                                         PMID:20303269
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Mar 18. Ajuba LIM proteins are negative regulators of the Hippo signaling pathway.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000932" target="_blank" class="term-link">
                                     GO:0000932
                                 </a>
                             </span>
                             <span class="term-label">P-body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20616046" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20616046
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0000932" data-r="PMID:20616046" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0000932" data-r="PMID:20616046" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> P-body localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20616046" target="_blank" class="term-link">
                                         PMID:20616046
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for microRNA-mediated gene silencing.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016442" target="_blank" class="term-link">
                                     GO:0016442
                                 </a>
                             </span>
                             <span class="term-label">RISC complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20616046" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20616046
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0016442" data-r="PMID:20616046" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0016442" data-r="PMID:20616046" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> RISC complex is supported by LIMD1 function as a miRISC/P-body scaffold linking AGO proteins, GW182/TNRC6, DDX6, and cap-associated translation repression.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20616046" target="_blank" class="term-link">
                                         PMID:20616046
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for microRNA-mediated gene silencing.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6 and downstream effector complexes, and by linking silencing to translation initiation control at the 5′ cap.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033962" target="_blank" class="term-link">
                                     GO:0033962
                                 </a>
                             </span>
                             <span class="term-label">P-body assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20616046" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20616046
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0033962" data-r="PMID:20616046" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0033962" data-r="PMID:20616046" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> P-body assembly is supported by LIMD1 function as a miRISC/P-body scaffold linking AGO proteins, GW182/TNRC6, DDX6, and cap-associated translation repression.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20616046" target="_blank" class="term-link">
                                         PMID:20616046
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for microRNA-mediated gene silencing.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6 and downstream effector complexes, and by linking silencing to translation initiation control at the 5′ cap.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035195" target="_blank" class="term-link">
                                     GO:0035195
                                 </a>
                             </span>
                             <span class="term-label">miRNA-mediated post-transcriptional gene silencing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20616046" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20616046
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0035195" data-r="PMID:20616046" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0035195" data-r="PMID:20616046" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> miRNA-mediated post-transcriptional gene silencing is supported by LIMD1 function as a miRISC/P-body scaffold linking AGO proteins, GW182/TNRC6, DDX6, and cap-associated translation repression.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20616046" target="_blank" class="term-link">
                                         PMID:20616046
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for microRNA-mediated gene silencing.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6 and downstream effector complexes, and by linking silencing to translation initiation control at the 5′ cap.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15542589" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15542589
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LIM domains-containing protein 1 (LIMD1), a tumor suppressor...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:15542589" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005515" data-r="PMID:15542589" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic protein binding is over-broad for LIMD1. Specific adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Avoid generic protein binding when specific complex/adaptor mechanisms are known.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15542589" target="_blank" class="term-link">
                                         PMID:15542589
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">LIM domains-containing protein 1 (LIMD1), a tumor suppressor encoded at chromosome 3p21.3, binds pRB and represses E2F-driven transcription.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">LIMD1 (Q9UGP4) is best understood as a **multi-compartment scaffold** that (i) couples **mechanical tension** at adherens junctions to **Hippo pathway kinase (LATS) localization**, (ii) enables efficient **miRNA-mediated translational repression** by scaffolding Argonaute and GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α degradation** by scaffolding PHD2–VHL complexes and participating in a HIF-driven negative feedback loop, and (iv) exerts tumor suppressor functions via **pRB/E2F repression** and via maintaining homeostatic control over hypoxia and mechanotransduction outputs.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15542589" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15542589
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LIM domains-containing protein 1 (LIMD1), a tumor suppressor...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005634" data-r="PMID:15542589" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005634" data-r="PMID:15542589" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleus localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15542589" target="_blank" class="term-link">
                                         PMID:15542589
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">LIM domains-containing protein 1 (LIMD1), a tumor suppressor encoded at chromosome 3p21.3, binds pRB and represses E2F-driven transcription.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15542589" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15542589
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LIM domains-containing protein 1 (LIMD1), a tumor suppressor...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005737" data-r="PMID:15542589" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0005737" data-r="PMID:15542589" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytoplasm localization is supported for LIMD1 scaffold function across junctional, cytoplasmic/P-body, and nuclear compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15542589" target="_blank" class="term-link">
                                         PMID:15542589
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">LIM domains-containing protein 1 (LIMD1), a tumor suppressor encoded at chromosome 3p21.3, binds pRB and represses E2F-driven transcription.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction, adherens junction. Cell junction, focal adhesion.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045892" target="_blank" class="term-link">
                                     GO:0045892
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of DNA-templated transcription</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15542589" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15542589
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LIM domains-containing protein 1 (LIMD1), a tumor suppressor...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0045892" data-r="PMID:15542589" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0045892" data-r="PMID:15542589" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Negative regulation of DNA-templated transcription is supported by both pRB/E2F repression and HIF pathway repression through enhanced HIF-alpha degradation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15542589" target="_blank" class="term-link">
                                         PMID:15542589
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">LIM domains-containing protein 1 (LIMD1), a tumor suppressor encoded at chromosome 3p21.3, binds pRB and represses E2F-driven transcription.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven transcription**, coupling LIMD1 to cell-cycle control.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback loop limiting pro-tumorigenic hypoxia signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
+                <tr>
+                    <td>
+                        <div class="term-info">
+
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060090" target="_blank" class="term-link">
+                                    GO:0060090
+                                </a>
+                            </span>
+                            <span class="term-label">molecular adaptor activity</span>
+
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IC</span>
+
+
+
+                        <br>
+                        <span style="font-size: 0.75rem;">
+
+                            file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                        </span>
+
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0060090" data-r="file:human/LIMD1/LIMD1-deep-research-falcon.md" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> LIMD1 is a non-enzymatic molecular adaptor/scaffold that assembles context-specific regulatory complexes.
+                        </div>
+
+
+                        <div>
+                            <strong>Reason:</strong> This directly captures the dominant molecular role synthesized from the Falcon report.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**LIMD1 is a multi-domain adaptor/scaffold protein**, not an enzyme. Its biological roles derive from assembling protein complexes and controlling where/when those complexes form—particularly at **cell junctions**, **P-bodies**, and in **oxygen-sensing (HIF) degradation complexes**. LIM domains are zinc-binding modules (~55–65 aa) that act as protein-interaction interfaces; LIMD1 contains **three tandem LIM domains** at its C‑terminus.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">LIMD1 (Q9UGP4) is best understood as a **multi-compartment scaffold** that (i) couples **mechanical tension** at adherens junctions to **Hippo pathway kinase (LATS) localization**, (ii) enables efficient **miRNA-mediated translational repression** by scaffolding Argonaute and GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α degradation** by scaffolding PHD2–VHL complexes and participating in a HIF-driven negative feedback loop, and (iv) exerts tumor suppressor functions via **pRB/E2F repression** and via maintaining homeostatic control over hypoxia and mechanotransduction outputs.</div>
+
+                            </div>
+
+                        </div>
+
+                    </td>
+                </tr>
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Mechanosensitive adaptor activity at adherens junctions that recruits/localizes LATS1/2 and negatively regulates Hippo signaling output.</h3>
+                <span class="vote-buttons" data-g="Q9UGP4" data-a="FUNCTION: Mechanosensitive adaptor activity at adherens junc..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060090" target="_blank" class="term-link">
+                            molecular adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035331" target="_blank" class="term-link">
+                                negative regulation of hippo signaling
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005912" target="_blank" class="term-link">
+                                adherens junction
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**LIMD1 is a multi-domain adaptor/scaffold protein**, not an enzyme. Its biological roles derive from assembling protein complexes and controlling where/when those complexes form—particularly at **cell junctions**, **P-bodies**, and in **oxygen-sensing (HIF) degradation complexes**. LIM domains are zinc-binding modules (~55–65 aa) that act as protein-interaction interfaces; LIMD1 contains **three tandem LIM domains** at its C‑terminus.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>miRISC/P-body adaptor activity that promotes miRNA-mediated translational repression by coupling Argonaute, TNRC6/GW182, DDX6, and cap-associated machinery.</h3>
+                <span class="vote-buttons" data-g="Q9UGP4" data-a="FUNCTION: miRISC/P-body adaptor activity that promotes miRNA..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060090" target="_blank" class="term-link">
+                            molecular adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035195" target="_blank" class="term-link">
+                                miRNA-mediated post-transcriptional gene silencing
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033962" target="_blank" class="term-link">
+                                P-body assembly
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000932" target="_blank" class="term-link">
+                                P-body
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016442" target="_blank" class="term-link">
+                            RISC complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6 and downstream effector complexes, and by linking silencing to translation initiation control at the 5′ cap.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Adaptor activity in hypoxia signaling that bridges PHD2/VHL machinery to promote HIF-alpha degradation and limit hypoxic transcriptional responses.</h3>
+                <span class="vote-buttons" data-g="Q9UGP4" data-a="FUNCTION: Adaptor activity in hypoxia signaling that bridges..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060090" target="_blank" class="term-link">
+                            molecular adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001666" target="_blank" class="term-link">
+                                response to hypoxia
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045892" target="_blank" class="term-link">
+                                negative regulation of DNA-templated transcription
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback loop limiting pro-tumorigenic hypoxia signaling.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">LIMD1 (Q9UGP4) is best understood as a **multi-compartment scaffold** that (i) couples **mechanical tension** at adherens junctions to **Hippo pathway kinase (LATS) localization**, (ii) enables efficient **miRNA-mediated translational repression** by scaffolding Argonaute and GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α degradation** by scaffolding PHD2–VHL complexes and participating in a HIF-driven negative feedback loop, and (iv) exerts tumor suppressor functions via **pRB/E2F repression** and via maintaining homeostatic control over hypoxia and mechanotransduction outputs.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Nuclear transcription corepressor activity through pRB/E2F repression.</h3>
+                <span class="vote-buttons" data-g="Q9UGP4" data-a="FUNCTION: Nuclear transcription corepressor activity through..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003714" target="_blank" class="term-link">
+                            transcription corepressor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045892" target="_blank" class="term-link">
+                                negative regulation of DNA-templated transcription
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven transcription**, coupling LIMD1 to cell-cycle control.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
                             GO_REF:0000024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15542589" target="_blank" class="term-link">
                             PMID:15542589
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">LIM domains-containing protein 1 (LIMD1), a tumor suppressor encoded at chromosome 3p21.3, binds pRB and represses E2F-driven transcription.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18331720" target="_blank" class="term-link">
                             PMID:18331720
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Ajuba LIM proteins are snail/slug corepressors required for neural crest development in Xenopus.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18439753" target="_blank" class="term-link">
                             PMID:18439753
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cell cycle regulated phosphorylation of LIMD1 in cell lines and expression in human breast cancers.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20303269" target="_blank" class="term-link">
                             PMID:20303269
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Ajuba LIM proteins are negative regulators of the Hippo signaling pathway.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20616046" target="_blank" class="term-link">
                             PMID:20616046
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for microRNA-mediated gene silencing.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22190034" target="_blank" class="term-link">
                             PMID:22190034
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global landscape of HIV-human protein complexes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22286099" target="_blank" class="term-link">
                             PMID:22286099
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The LIMD1 protein bridges an association between the prolyl hydroxylases and VHL to repress HIF-1 activity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28683311" target="_blank" class="term-link">
                             PMID:28683311
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Argonaute Utilization for miRNA Silencing Is Determined by Phosphorylation-Dependent Recruitment of LIM-Domain-Containing Proteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1234159
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteasome proteolyzes ub-HIF-alpha</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1234163
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cytosolic VBC complex ubiquitinylates hydroxyprolyl-HIF-alpha</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1234173
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cytosolic PHD2,3 hydroxylates proline residues on HIF3A</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1234177
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cytosolic PHD2,3 hydroxylates proline residues on HIF1A</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1234183
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cytosolic VHL:EloB,C:CUL2:RBX1 binds hydroxyprolyl-HIF-alpha</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/LIMD1/LIMD1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research synthesis for LIMD1</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/LIMD1/LIMD1-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt record for LIMD1</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(LIMD1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9UGP4" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-11T21:17:56.304846'<br />
+end_time: '2026-05-11T21:28:54.920198'<br />
+duration_seconds: 658.62<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: LIMD1<br />
+  gene_symbol: LIMD1<br />
+  uniprot_accession: Q9UGP4<br />
+  protein_description: 'RecName: Full=LIM domain-containing protein 1;'<br />
+  gene_info: Name=LIMD1;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the zyxin/ajuba family. .<br />
+  protein_domains: Ajuba-like. (IPR047172); Ajuba-like_LIM1. (IPR047245); Ajuba-like_LIM2.<br />
+    (IPR047247); Ajuba-like_LIM3. (IPR047248); Znf_LIM. (IPR001781)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 32</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9UGP4</li>
+<li><strong>Protein Description:</strong> RecName: Full=LIM domain-containing protein 1;</li>
+<li><strong>Gene Information:</strong> Name=LIMD1;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the zyxin/ajuba family. .</li>
+<li><strong>Key Domains:</strong> Ajuba-like. (IPR047172); Ajuba-like_LIM1. (IPR047245); Ajuba-like_LIM2. (IPR047247); Ajuba-like_LIM3. (IPR047248); Znf_LIM. (IPR001781)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "LIMD1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'LIMD1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>LIMD1</strong> (gene ID: LIMD1, UniProt: Q9UGP4) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9UGP4</li>
+<li><strong>Protein Description:</strong> RecName: Full=LIM domain-containing protein 1;</li>
+<li><strong>Gene Information:</strong> Name=LIMD1;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the zyxin/ajuba family. .</li>
+<li><strong>Key Domains:</strong> Ajuba-like. (IPR047172); Ajuba-like_LIM1. (IPR047245); Ajuba-like_LIM2. (IPR047247); Ajuba-like_LIM3. (IPR047248); Znf_LIM. (IPR001781)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "LIMD1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'LIMD1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>LIMD1</strong> (gene ID: LIMD1, UniProt: Q9UGP4) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-functional-annotation-report-limd1-human-uniprot-q9ugp4">Comprehensive functional-annotation report: <strong>LIMD1</strong> (human; UniProt <strong>Q9UGP4</strong>)</h2>
+<h3 id="0-target-verification-mandatory">0) Target verification (mandatory)</h3>
+<p>The literature and database-derived sources retrieved here consistently match the requested target: <strong>human LIMD1 (UniProt Q9UGP4)</strong>, annotated as <strong>LIM domain-containing protein 1</strong> and a member of the <strong>Ajuba-like/zyxin (LAW) family</strong> with <strong>three C‑terminal LIM zinc-binding domains</strong> and an N‑terminal low-complexity/proline-rich region that supports protein–protein interactions and nucleo-cytoplasmic shuttling. (siddiqui2021bioinformaticanalysisof pages 2-4, siddiqui2021bioinformaticanalysisof pages 1-2, rolo2025investigatingtherole pages 35-40)</p>
+<h3 id="1-key-concepts-definitions-and-current-understanding">1) Key concepts, definitions, and current understanding</h3>
+<h4 id="11-what-limd1-is-conceptual-definition">1.1 What LIMD1 is (conceptual definition)</h4>
+<p><strong>LIMD1 is a multi-domain adaptor/scaffold protein</strong>, not an enzyme. Its biological roles derive from assembling protein complexes and controlling where/when those complexes form—particularly at <strong>cell junctions</strong>, <strong>P-bodies</strong>, and in <strong>oxygen-sensing (HIF) degradation complexes</strong>. LIM domains are zinc-binding modules (~55–65 aa) that act as protein-interaction interfaces; LIMD1 contains <strong>three tandem LIM domains</strong> at its C‑terminus. (siddiqui2021bioinformaticanalysisof pages 2-4, siddiqui2021bioinformaticanalysisof pages 1-2)</p>
+<h4 id="12-core-mechanistic-functions-high-confidence">1.2 Core mechanistic functions (high-confidence)</h4>
+<p>Across primary literature, LIMD1 has four repeatedly supported mechanistic “axes”:</p>
+<ol>
+<li><strong>Hippo pathway mechanotransduction (LATS–YAP control):</strong> LIMD1 localizes to <strong>adherens junctions in a tension-dependent manner</strong>, engages <strong>strained F‑actin</strong>, and binds/recruits <strong>LATS1/2</strong>, thereby regulating downstream YAP/TAZ activity. (silva2026regulationoftensiondependent pages 4-7, silva2026regulationoftensiondependent pages 7-9)</li>
+<li><strong>miRNA-induced silencing complex (miRISC) scaffolding:</strong> LIMD1 scaffolds <strong>AGO2</strong> with <strong>GW182/TNRC6A</strong> and effectors (e.g., <strong>DDX6</strong>), and links silencing to the <strong>cap-binding translation machinery (eIF4E)</strong>; LIMD1 localizes with miRISC components in <strong>P-bodies</strong>. (james2010limdomainproteinslimd1 pages 4-5, bridge2017argonauteutilizationfor pages 3-4)</li>
+<li><strong>Hypoxia signaling (HIF degradation):</strong> LIMD1 scaffolds <strong>PHD2 (EGLN1)</strong> and <strong>VHL</strong> to promote proteasomal degradation of <strong>HIF‑α</strong>; additionally, LIMD1 can be induced by HIF‑1 to form a negative-feedback loop that restrains prolonged hypoxic signaling. (foxler2018ahif–limd1negative pages 1-2, foxler2018ahif–limd1negative pages 10-12)</li>
+<li><strong>Tumor suppressor cell-cycle control (pRB/E2F):</strong> LIMD1 binds <strong>pRB</strong> and represses <strong>E2F-driven transcription</strong>, consistent with growth suppression and tumor suppressor activity, especially in lung cancer contexts where the 3p21.3 locus is frequently deleted. (sharp2004limdomainscontainingprotein pages 5-6, sharp2008thechromosome3p21.3encoded pages 1-2)</li>
+</ol>
+<h3 id="2-recent-developments-and-latest-research-prioritizing-20232024">2) Recent developments and latest research (prioritizing 2023–2024)</h3>
+<h4 id="21-2024-limd1-as-a-strain-sensing-hippo-scaffold-via-lim-domain-binding-to-strained-actin">2.1 2024: LIMD1 as a strain-sensing Hippo scaffold via LIM-domain binding to strained actin</h4>
+<p>A 2024 peer-reviewed mechanistic study in <em>Cytoskeleton</em> reports that the <strong>three LIM domains of LIMD1 are necessary and sufficient</strong> for <strong>tension-dependent</strong> localization to adherens junctions and association with the Hippo kinase <strong>LATS1</strong>, and supports a model in which LIM domains can bind <strong>F-actin under strain</strong> to achieve mechanosensitive targeting. (silva2026regulationoftensiondependent pages 12-16)</p>
+<h4 id="22-2023-limd1-positioned-among-hippo-components-that-integrate-mechanical-cues-and-growth-control">2.2 2023: LIMD1 positioned among Hippo components that integrate mechanical cues and growth control</h4>
+<p>In 2023 Hippo-focused mechanistic work on cell-density sensing and Hippo pathway regulation, LIMD1 is cited among key components coupling upstream physical cues to the Hippo pathway output (YAP control), reflecting ongoing consolidation of LIMD1’s role in mechanoregulation. (silva2026regulationoftensiondependent pages 12-16)</p>
+<h4 id="23-20232024-continued-expansion-of-limd1-context-beyond-cancerimmunitymetabolism-and-tissue-models">2.3 2023–2024: continued expansion of LIMD1 context beyond cancer—immunity/metabolism and tissue models</h4>
+<p>A 2024 in vivo study of NASH progression reports <strong>LIMD1 and LATS1 colocalization/interaction</strong> associated with YAP nuclear translocation in hepatic macrophage settings, placing LIMD1 within emerging YAP/TAZ–immunity interfaces (though not a LIMD1-focused mechanistic dissection). (silva2026regulationoftensiondependent pages 12-16)</p>
+<h3 id="3-pathways-molecular-interactions-and-cellular-localization">3) Pathways, molecular interactions, and cellular localization</h3>
+<h3 id="31-hippo-pathway-mechanotransduction-adherens-junctions-lats-yap">3.1 Hippo pathway / mechanotransduction (adherens junctions, LATS, YAP)</h3>
+<p><strong>Primary function:</strong> LIMD1 acts as a <strong>mechanosensitive scaffold</strong> controlling the <strong>subcellular localization</strong> (and functional availability) of <strong>LATS1/2</strong> kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization. (silva2026regulationoftensiondependent pages 4-7, silva2026regulationoftensiondependent pages 7-9)</p>
+<p><strong>Localization:</strong> adherens junctions (tension-dependent), F‑actin strain sites; broader family annotation supports nuclear/cytoplasmic shuttling. (silva2026regulationoftensiondependent pages 4-7, siddiqui2021bioinformaticanalysisof pages 2-4)</p>
+<p><strong>Mechanistic details with residue/domain-level mapping:</strong> LIMD1 contains an N‑terminal intrinsically disordered region and a C‑terminal LIM region; LIM1+LIM2 are required for efficient recruitment of LATS1, and LIM-domain point mutants can disrupt strain-site targeting and LATS recruitment. (silva2026regulationoftensiondependent pages 4-7)</p>
+<h3 id="32-mirna-mediated-gene-silencing-mirisc-p-bodies-phosphorylation-dependent-ago-usage">3.2 miRNA-mediated gene silencing (miRISC; P-bodies; phosphorylation-dependent AGO usage)</h3>
+<p><strong>Primary function:</strong> LIMD1 is a <strong>miRISC adaptor/scaffold</strong> that promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6 and downstream effector complexes, and by linking silencing to translation initiation control at the 5′ cap. (bridge2017argonauteutilizationfor pages 3-4, james2010limdomainproteinslimd1 pages 4-5)</p>
+<p><strong>Key interactions:</strong> AGO2, GW182/TNRC6A, DDX6, and eIF4E/cap complex. (james2010limdomainproteinslimd1 pages 4-5, bridge2017argonauteutilizationfor pages 4-6)</p>
+<p><strong>Regulatory logic (phosphorylation switch):</strong> AGO2 Ser387 phosphorylation (via Akt3) promotes LIMD1 recruitment, enabling AGO2–TNRC6A–DDX6 assembly; LIMD1 loss can shift functional dependence from AGO2 to AGO3/WTIP. (bridge2017argonauteutilizationfor pages 3-4, bridge2017argonauteutilizationfor pages 10-13)</p>
+<p><strong>Localization:</strong> LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in <strong>P-bodies</strong>. (james2010limdomainproteinslimd1 pages 2-3, james2010limdomainproteinslimd1 pages 1-2)</p>
+<h3 id="33-hypoxia-hif-degradation-phd2vhl-scaffold-negative-feedback">3.3 Hypoxia / HIF-α degradation (PHD2–VHL scaffold; negative feedback)</h3>
+<p><strong>Primary function:</strong> LIMD1 acts as a scaffold for the oxygen-sensing degradation machinery by bridging <strong>PHD2</strong> and <strong>VHL</strong> to promote efficient <strong>HIF‑α degradation</strong>, and is itself <strong>HIF-1 inducible</strong>, creating a negative-feedback loop limiting pro-tumorigenic hypoxia signaling. (foxler2018ahif–limd1negative pages 1-2, foxler2018ahif–limd1negative pages 10-12)</p>
+<h3 id="34-prbe2f-repression-and-tumor-suppressor-activity">3.4 pRB/E2F repression and tumor suppressor activity</h3>
+<p><strong>Primary function:</strong> LIMD1 binds <strong>pRB</strong> and represses <strong>E2F-driven transcription</strong>, coupling LIMD1 to cell-cycle control. (sharp2004limdomainscontainingprotein pages 5-6)</p>
+<p><strong>Cancer genetics context:</strong> LIMD1 lies in the <strong>3p21.3</strong> region with very high LOH in lung cancer; one study reports LOH exceeding <strong>90%</strong> in the mapped region and no coding mutations detected in <strong>188</strong> lung adenocarcinoma samples, supporting deletion/epigenetic silencing as common modes of LIMD1 loss. (sharp2008thechromosome3p21.3encoded pages 1-2)</p>
+<h3 id="4-relevant-statistics-and-quantitative-findings-from-primary-studies">4) Relevant statistics and quantitative findings (from primary studies)</h3>
+<ul>
+<li><strong>80% reduction in colony formation</strong> after LIMD1 transfection in two tested cell types (growth-suppressive phenotype consistent with tumor suppressor function). (sharp2004limdomainscontainingprotein pages 5-6)</li>
+<li><strong>83% (5/6) lung cancer cell lines</strong> showed reduced LIMD1 protein in one study, and <strong>all 14 paired lung tumor/normal samples</strong> tested had reduced LIMD1 expression by qRT-PCR. (sharp2004limdomainscontainingprotein pages 5-6)</li>
+<li><strong>47.1% copy-number variation</strong> at the LIMD1 locus in TCGA lung adenocarcinoma reported in an EMBO Molecular Medicine study, with association to HIF target-gene signatures and poor prognosis. (foxler2018ahif–limd1negative pages 1-2)</li>
+<li>In a <strong>276-patient tissue microarray</strong>, low LIMD1 by IHC correlated with poorer overall survival; the cohort had <strong>80% high VEGF</strong> expression reported. (foxler2018ahif–limd1negative pages 10-12)</li>
+<li>LIMD1−/− MEFs show <strong>~40% increased protein synthesis</strong> by [35S]-methionine incorporation, consistent with LIMD1’s role in translational repression in miRNA silencing. (james2010limdomainproteinslimd1 pages 3-4)</li>
+</ul>
+<h3 id="5-current-applications-and-real-world-implementations">5) Current applications and real-world implementations</h3>
+<h4 id="51-prognosticbiomarker-use-cases-in-oncology">5.1 Prognostic/biomarker use cases in oncology</h4>
+<p>Multiple lines of evidence support LIMD1 as a clinically relevant biomarker candidate in lung cancer contexts: frequent deletion/LOH at 3p21.3 and reduced expression in tumors, and the association of LIMD1 copy-number variation with hypoxia transcriptional signatures and prognosis. (sharp2008thechromosome3p21.3encoded pages 1-2, foxler2018ahif–limd1negative pages 1-2)</p>
+<h4 id="52-therapeutic-implications-pathway-level-targeting">5.2 Therapeutic implications: pathway-level targeting</h4>
+<p>Because LIMD1 is a scaffold (not an enzyme), direct druggability is challenging; practical translational leverage is more likely via <strong>targeting nodes in LIMD1-regulated pathways</strong>, such as:<br />
+* Hippo/YAP mechanotransduction modules that control LATS localization/activity at junctions (conceptually relevant to tissue growth and cancer). (silva2026regulationoftensiondependent pages 4-7)<br />
+* Hypoxia pathway interventions that modulate PHD/VHL/HIF axis output, where LIMD1 participates in complex assembly. (foxler2018ahif–limd1negative pages 1-2)<br />
+* miRNA silencing machinery and signaling inputs (e.g., Akt-dependent AGO2 phosphorylation) that determine Argonaute utilization and repression efficiency. (bridge2017argonauteutilizationfor pages 3-4)</p>
+<h4 id="53-disease-association-landscape-database-evidence">5.3 Disease association landscape (database evidence)</h4>
+<p>Open Targets lists multiple disease associations for LIMD1 (each with small evidence counts), indicating ongoing but relatively limited curated disease-target evidence outside major cancer/hypoxia contexts. These associations are best treated as hypothesis-generating. (OpenTargets Search: -LIMD1)</p>
+<h3 id="6-expert-opinions-and-authoritative-synthesis">6) Expert opinions and authoritative synthesis</h3>
+<p>A mechanistic review on miRNA-mediated gene silencing discusses LIMD1-family proteins as effectors/adaptors bridging miRISC and translation control, reflecting expert consensus that non-enzymatic scaffolds can be essential determinants of silencing architecture and mechanism. (bridge2017argonauteutilizationfor pages 3-4)</p>
+<p>A zyxin-family structural/bioinformatic analysis supports that LIMD1-family proteins may have both nuclear and cytoplasmic roles (NES/NLS features) and emphasizes the LIM domains as modular interaction hubs. (siddiqui2021bioinformaticanalysisof pages 2-4)</p>
+<h3 id="7-consolidated-functional-summary">7) Consolidated functional summary</h3>
+<p>LIMD1 (Q9UGP4) is best understood as a <strong>multi-compartment scaffold</strong> that (i) couples <strong>mechanical tension</strong> at adherens junctions to <strong>Hippo pathway kinase (LATS) localization</strong>, (ii) enables efficient <strong>miRNA-mediated translational repression</strong> by scaffolding Argonaute and GW182/TNRC6 and engaging the cap complex, (iii) promotes <strong>HIF‑α degradation</strong> by scaffolding PHD2–VHL complexes and participating in a HIF-driven negative feedback loop, and (iv) exerts tumor suppressor functions via <strong>pRB/E2F repression</strong> and via maintaining homeostatic control over hypoxia and mechanotransduction outputs. (silva2026regulationoftensiondependent pages 4-7, bridge2017argonauteutilizationfor pages 3-4, foxler2018ahif–limd1negative pages 1-2, sharp2004limdomainscontainingprotein pages 5-6)</p>
+<h3 id="8-structured-evidence-map">8) Structured evidence map</h3>
+<p>The table below provides a compact cross-walk from functional axis → mechanism → key evidence → localization → reference URLs.</p>
+<table>
+<thead>
+<tr>
+<th>Functional area</th>
+<th>Core mechanism / interactions</th>
+<th>Key experimental evidence / findings</th>
+<th>Subcellular localization</th>
+<th>Key references (year; URL)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Hippo mechanotransduction</td>
+<td>LIMD1 is an Ajuba/zyxin-family scaffold with an N-terminal intrinsically disordered/proline-rich region and three C-terminal LIM domains. It localizes to adherens junctions in a tension-dependent manner, binds strained F-actin, and recruits/inhibits LATS1/2; LIM1 and LIM2 are especially important. A conserved LATS “LATCH” motif mediates LIMD1-LATS binding. AJUBA and WTIP can compete with LIMD1 for junctional localization and reduce LIMD1-dependent LATS recruitment. (silva2026regulationoftensiondependent pages 4-7, silva2026regulationoftensiondependent pages 7-9)</td>
+<td>Tension inhibition with 25 µM blebbistatin for 2 h disrupts LIMD1/LATS1 junctional recruitment; LIMD1 C-terminus aa468-676 binds LATS2, but full LATS1 recruitment requires both LIM domains and the N-terminal IDR; point mutants F512A (LIM1), F575A (LIM2), Y646A (LIM3) impair strain-site/adherens-junction localization and LATS recruitment; LATS-LATCH mutant residues L441G/V444A/K445D/R448D abolish LIMD1 binding and AJ localization; AJUBA/WTIP overexpression increases YAP1 phosphorylation and decreases YAP1 nuclear localization by displacing LIMD1. (silva2026regulationoftensiondependent pages 7-9, silva2026regulationoftensiondependent pages 4-7, bridge2017argonauteutilizationfor pages 4-6)</td>
+<td>Predominantly adherens junctions under tension; also F-actin strain sites; family-level evidence supports nuclear/cytoplasmic shuttling. (silva2026regulationoftensiondependent pages 4-7, siddiqui2021bioinformaticanalysisof pages 2-4, siddiqui2021bioinformaticanalysisof pages 1-2)</td>
+<td>Ray et al., 2024: https://doi.org/10.1002/cm.21847 ; Ibar et al., 2018: https://doi.org/10.1242/jcs.214700 ; Kirichenko &amp; Irvine, 2022: https://doi.org/10.17912/micropub.biology.000666 ; De Silva et al., 2026 preprint: https://doi.org/10.1101/2025.08.26.672419</td>
+</tr>
+<tr>
+<td>miRISC / miRNA-mediated gene silencing</td>
+<td>LIMD1 acts as a scaffold in miRISC, binding AGO2 (via pre-LIM/AB motif) and TNRC6A/GW182 (via LIM domains), promoting recruitment of DDX6 and linking miRISC to eIF4E/m7GTP cap complexes. AGO2 Ser387 phosphorylation by Akt3 promotes LIMD1 recruitment; in LIMD1 loss, silencing can switch from AGO2 dependence to AGO3/WTIP. LIMD1 also localizes with GW182/TNRC6A in P-bodies. (bridge2017argonauteutilizationfor pages 3-4, james2010limdomainproteinslimd1 pages 4-5, bridge2017argonauteutilizationfor pages 4-6, bridge2017argonauteutilizationfor pages 1-3, bridge2017argonauteutilizationfor pages 10-13)</td>
+<td>LIMD1 depletion derepresses miRNA-mediated but not siRNA-mediated silencing; LIMD1−/− MEFs show ~40% increased protein synthesis by [35S]-methionine incorporation; HMGA2 protein increases after LIMD1 depletion while HMGA2 mRNA is unchanged; LIMD1 coexpression increases Ago2-eIF4E co-immunoprecipitation; reporter assays show significant de-repression after LIMD1, AGO2, or TNRC6A loss while reporter mRNA remains unchanged; AGO2 is ~60% of total AGO protein in HeLa, yet LIMD1 loss shifts functional dependence toward AGO3; PLA/co-IP show LIMD1 loss reduces AGO2:TNRC6A and AGO2:DDX6 interactions. (bridge2017argonauteutilizationfor pages 3-4, james2010limdomainproteinslimd1 pages 4-5, bridge2017argonauteutilizationfor pages 4-6, james2010limdomainproteinslimd1 pages 2-3, james2010limdomainproteinslimd1 pages 3-4, james2010limdomainproteinslimd1 pages 1-2)</td>
+<td>P-bodies / GW-bodies; cytoplasmic cap-associated translation complexes; also reported nuclear/P-body localization in family annotation. (siddiqui2021bioinformaticanalysisof pages 1-2, james2010limdomainproteinslimd1 pages 4-5, james2010limdomainproteinslimd1 pages 2-3, james2010limdomainproteinslimd1 pages 1-2)</td>
+<td>James et al., 2010: https://doi.org/10.1073/pnas.0914987107 ; Bridge et al., 2017: https://doi.org/10.1016/j.celrep.2017.06.027 ; James et al., 2012 review: https://doi.org/10.1515/bmc.2011.047</td>
+</tr>
+<tr>
+<td>Hypoxia / HIF regulation</td>
+<td>LIMD1 scaffolds PHD2 and VHL to promote proteasomal degradation of HIF-α. LIMD1 is itself a HIF-1 target gene, creating a negative-feedback loop in hypoxia that enhances formation of a hypoxic PHD2-LIMD1-VHL degradation complex and restrains HIF signaling. RHOBTB3 can cooperate with LIMD1 in HIFα degradation complexes. (rowlinson2022isotopiclabellingtools pages 1-5, foxler2018ahif–limd1negative pages 1-2, foxler2018ahif–limd1negative pages 10-12)</td>
+<td>Hypoxia (1% O2) increases LIMD1 mRNA/protein; LIMD1 promoter reporters show ~3-fold induction in hypoxia; disrupting LIMD1 hypoxic induction increases tumor growth and vasculature in xenografts; TCGA LUAD analysis found LIMD1 copy-number variation in 47.1% of patients, associated with higher HIF-target signatures and poorer prognosis; low LIMD1 expression on a 276-patient TMA associated with worse overall survival; 80% of that cohort had high VEGF expression. (foxler2018ahif–limd1negative pages 1-2, foxler2018ahif–limd1negative pages 10-12)</td>
+<td>Cytoplasmic scaffold for PHD2/VHL/HIF complex; also nucleo-cytoplasmic shuttling reported for family members. (siddiqui2021bioinformaticanalysisof pages 2-4, rowlinson2022isotopiclabellingtools pages 1-5)</td>
+<td>Foxler et al., 2018: https://doi.org/10.15252/emmm.201708304 ; Zhang et al., 2015: https://doi.org/10.1038/cr.2015.90</td>
+</tr>
+<tr>
+<td>pRB / E2F tumor-suppressor function</td>
+<td>LIMD1 binds pRB and functions as an RB corepressor that represses E2F-driven transcription, linking LIMD1 to cell-cycle control and tumor suppression. It is encoded at chromosome 3p21.3, a region frequently deleted in lung cancer. (sharp2008thechromosome3p21.3encoded pages 1-2, sharp2004limdomainscontainingprotein pages 5-6)</td>
+<td>LIMD1 transfection reduced Zeocin-resistant colony formation by 80% in two tested cell types; LIMD1 significantly reduced xenograft tumor size and lung metastasis incidence in nude mice; 5/6 lung cancer cell lines (83%) showed reduced LIMD1 protein; qRT-PCR on 14 paired lung tumor/normal samples found reduced LIMD1 expression in all cancers tested; LOH in the mapped C3CER1 region exceeds 90%; Limd1−/− mice are predisposed to chemical-induced lung adenocarcinoma, and Limd1 loss in KrasG12D mice markedly increases tumor initiation, promotion, and mortality; no coding mutations detected in 188 lung adenocarcinomas in one screen. (sharp2008thechromosome3p21.3encoded pages 1-2, sharp2004limdomainscontainingprotein pages 5-6)</td>
+<td>Nucleus for pRB/E2F repression; also observed at E-cadherin junctions with translocation to nucleus. (sharp2008thechromosome3p21.3encoded pages 1-2)</td>
+<td>Sharp et al., 2004: https://doi.org/10.1073/pnas.0407123101 ; Sharp et al., 2008: https://doi.org/10.1073/pnas.0805003105 ; Zabarovsky et al., 2002: https://doi.org/10.1038/sj.onc.1205835</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the best-supported functional roles of human LIMD1 (UniProt Q9UGP4) across four major pathways, highlighting mechanism, localization, and quantitative evidence from primary studies. It is useful as a compact functional-annotation reference anchored to the cited context evidence.</em></p>
+<p>References</p>
+<ol>
+<li>
+<p>(siddiqui2021bioinformaticanalysisof pages 2-4): Mohammad Quadir Siddiqui, Maulik D. Badmalia, and Trushar R. Patel. Bioinformatic analysis of structure and function of lim domains of human zyxin family proteins. International Journal of Molecular Sciences, Mar 2021. URL: https://doi.org/10.3390/ijms22052647, doi:10.3390/ijms22052647. This article has 31 citations.</p>
+</li>
+<li>
+<p>(siddiqui2021bioinformaticanalysisof pages 1-2): Mohammad Quadir Siddiqui, Maulik D. Badmalia, and Trushar R. Patel. Bioinformatic analysis of structure and function of lim domains of human zyxin family proteins. International Journal of Molecular Sciences, Mar 2021. URL: https://doi.org/10.3390/ijms22052647, doi:10.3390/ijms22052647. This article has 31 citations.</p>
+</li>
+<li>
+<p>(rolo2025investigatingtherole pages 35-40): S Rolo. Investigating the role of ajuba lim domain protein in pancreatic ductal adenocarcinoma. Unknown journal, 2025.</p>
+</li>
+<li>
+<p>(silva2026regulationoftensiondependent pages 4-7): Chamika De Silva, Brian A. Kelch, and Dannel McCollum. Regulation of tension-dependent localization of lats1 and lats2 to adherens junctions. BioRxiv, Aug 2026. URL: https://doi.org/10.1101/2025.08.26.672419, doi:10.1101/2025.08.26.672419. This article has 1 citations.</p>
+</li>
+<li>
+<p>(silva2026regulationoftensiondependent pages 7-9): Chamika De Silva, Brian A. Kelch, and Dannel McCollum. Regulation of tension-dependent localization of lats1 and lats2 to adherens junctions. BioRxiv, Aug 2026. URL: https://doi.org/10.1101/2025.08.26.672419, doi:10.1101/2025.08.26.672419. This article has 1 citations.</p>
+</li>
+<li>
+<p>(james2010limdomainproteinslimd1 pages 4-5): Victoria James, Yining Zhang, Daniel E. Foxler, Cornelia H. de Moor, Yi Wen Kong, Thomas M. Webb, Tim J. Self, Yungfeng Feng, Dimitrios Lagos, Chia-Ying Chu, Tariq M. Rana, Simon J. Morley, Gregory D. Longmore, Martin Bushell, and Tyson V. Sharp. Lim-domain proteins, limd1, ajuba, and wtip are required for microrna-mediated gene silencing. Proceedings of the National Academy of Sciences, 107:12499-12504, Jun 2010. URL: https://doi.org/10.1073/pnas.0914987107, doi:10.1073/pnas.0914987107. This article has 86 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bridge2017argonauteutilizationfor pages 3-4): Katherine S. Bridge, Kunal M. Shah, Yigen Li, Daniel E. Foxler, Sybil C.K. Wong, Duncan C. Miller, Kathryn M. Davidson, John G. Foster, Ruth Rose, Michael R. Hodgkinson, Paulo S. Ribeiro, A. Aziz Aboobaker, Kenta Yashiro, Xiaozhong Wang, Paul R. Graves, Michael J. Plevin, Dimitris Lagos, and Tyson V. Sharp. Argonaute utilization for mirna silencing is determined by phosphorylation-dependent recruitment of lim-domain-containing proteins. Cell Reports, 20:173-187, Jul 2017. URL: https://doi.org/10.1016/j.celrep.2017.06.027, doi:10.1016/j.celrep.2017.06.027. This article has 89 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(foxler2018ahif–limd1negative pages 1-2): Daniel E Foxler, Katherine S Bridge, John G Foster, Paul Grevitt, Sean Curry, Kunal M Shah, Kathryn M Davidson, Ai Nagano, Emanuela Gadaleta, Hefin I Rhys, Paul T Kennedy, Miguel A Hermida, Ting‐Yu Chang, Peter E Shaw, Louise E Reynolds, Tristan R McKay, Hsei‐Wei Wang, Paulo S Ribeiro, Michael J Plevin, Dimitris Lagos, Nicholas R Lemoine, Prabhakar Rajan, Trevor A Graham, Claude Chelala, Kairbaan M Hodivala‐Dilke, Ian Spendlove, and Tyson V Sharp. A hif–limd1 negative feedback mechanism mitigates the pro‐tumorigenic effects of hypoxia. EMBO Molecular Medicine, Jun 2018. URL: https://doi.org/10.15252/emmm.201708304, doi:10.15252/emmm.201708304. This article has 34 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(foxler2018ahif–limd1negative pages 10-12): Daniel E Foxler, Katherine S Bridge, John G Foster, Paul Grevitt, Sean Curry, Kunal M Shah, Kathryn M Davidson, Ai Nagano, Emanuela Gadaleta, Hefin I Rhys, Paul T Kennedy, Miguel A Hermida, Ting‐Yu Chang, Peter E Shaw, Louise E Reynolds, Tristan R McKay, Hsei‐Wei Wang, Paulo S Ribeiro, Michael J Plevin, Dimitris Lagos, Nicholas R Lemoine, Prabhakar Rajan, Trevor A Graham, Claude Chelala, Kairbaan M Hodivala‐Dilke, Ian Spendlove, and Tyson V Sharp. A hif–limd1 negative feedback mechanism mitigates the pro‐tumorigenic effects of hypoxia. EMBO Molecular Medicine, Jun 2018. URL: https://doi.org/10.15252/emmm.201708304, doi:10.15252/emmm.201708304. This article has 34 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sharp2004limdomainscontainingprotein pages 5-6): Tyson V. Sharp, Fernando Munoz, Dimitra Bourboulia, Nadege Presneau, Eva Darai, Hsei-Wei Wang, Mark Cannon, David N. Butcher, Andrew G. Nicholson, George Klein, Stephan Imreh, and Chris Boshoff. Lim domains-containing protein 1 (limd1), a tumor suppressor encoded at chromosome 3p21.3, binds prb and represses e2f-driven transcription. Proceedings of the National Academy of Sciences of the United States of America, 101 47:16531-6, Nov 2004. URL: https://doi.org/10.1073/pnas.0407123101, doi:10.1073/pnas.0407123101. This article has 117 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(sharp2008thechromosome3p21.3encoded pages 1-2): Tyson V. Sharp, Ahmad Al-Attar, Daniel E. Foxler, Li Ding, Thomas Q. de A. Vallim, Yining Zhang, Hala S. Nijmeh, Thomas M. Webb, Andrew G. Nicholson, Qunyuan Zhang, Aldi Kraja, Ian Spendlove, John Osborne, Elaine Mardis, and Gregory D. Longmore. The chromosome 3p21.3-encoded gene, limd1, is a critical tumor suppressor involved in human lung cancer development. Proceedings of the National Academy of Sciences, 105:19932-19937, Dec 2008. URL: https://doi.org/10.1073/pnas.0805003105, doi:10.1073/pnas.0805003105. This article has 85 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(silva2026regulationoftensiondependent pages 12-16): Chamika De Silva, Brian A. Kelch, and Dannel McCollum. Regulation of tension-dependent localization of lats1 and lats2 to adherens junctions. BioRxiv, Aug 2026. URL: https://doi.org/10.1101/2025.08.26.672419, doi:10.1101/2025.08.26.672419. This article has 1 citations.</p>
+</li>
+<li>
+<p>(bridge2017argonauteutilizationfor pages 4-6): Katherine S. Bridge, Kunal M. Shah, Yigen Li, Daniel E. Foxler, Sybil C.K. Wong, Duncan C. Miller, Kathryn M. Davidson, John G. Foster, Ruth Rose, Michael R. Hodgkinson, Paulo S. Ribeiro, A. Aziz Aboobaker, Kenta Yashiro, Xiaozhong Wang, Paul R. Graves, Michael J. Plevin, Dimitris Lagos, and Tyson V. Sharp. Argonaute utilization for mirna silencing is determined by phosphorylation-dependent recruitment of lim-domain-containing proteins. Cell Reports, 20:173-187, Jul 2017. URL: https://doi.org/10.1016/j.celrep.2017.06.027, doi:10.1016/j.celrep.2017.06.027. This article has 89 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bridge2017argonauteutilizationfor pages 10-13): Katherine S. Bridge, Kunal M. Shah, Yigen Li, Daniel E. Foxler, Sybil C.K. Wong, Duncan C. Miller, Kathryn M. Davidson, John G. Foster, Ruth Rose, Michael R. Hodgkinson, Paulo S. Ribeiro, A. Aziz Aboobaker, Kenta Yashiro, Xiaozhong Wang, Paul R. Graves, Michael J. Plevin, Dimitris Lagos, and Tyson V. Sharp. Argonaute utilization for mirna silencing is determined by phosphorylation-dependent recruitment of lim-domain-containing proteins. Cell Reports, 20:173-187, Jul 2017. URL: https://doi.org/10.1016/j.celrep.2017.06.027, doi:10.1016/j.celrep.2017.06.027. This article has 89 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(james2010limdomainproteinslimd1 pages 2-3): Victoria James, Yining Zhang, Daniel E. Foxler, Cornelia H. de Moor, Yi Wen Kong, Thomas M. Webb, Tim J. Self, Yungfeng Feng, Dimitrios Lagos, Chia-Ying Chu, Tariq M. Rana, Simon J. Morley, Gregory D. Longmore, Martin Bushell, and Tyson V. Sharp. Lim-domain proteins, limd1, ajuba, and wtip are required for microrna-mediated gene silencing. Proceedings of the National Academy of Sciences, 107:12499-12504, Jun 2010. URL: https://doi.org/10.1073/pnas.0914987107, doi:10.1073/pnas.0914987107. This article has 86 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(james2010limdomainproteinslimd1 pages 1-2): Victoria James, Yining Zhang, Daniel E. Foxler, Cornelia H. de Moor, Yi Wen Kong, Thomas M. Webb, Tim J. Self, Yungfeng Feng, Dimitrios Lagos, Chia-Ying Chu, Tariq M. Rana, Simon J. Morley, Gregory D. Longmore, Martin Bushell, and Tyson V. Sharp. Lim-domain proteins, limd1, ajuba, and wtip are required for microrna-mediated gene silencing. Proceedings of the National Academy of Sciences, 107:12499-12504, Jun 2010. URL: https://doi.org/10.1073/pnas.0914987107, doi:10.1073/pnas.0914987107. This article has 86 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(james2010limdomainproteinslimd1 pages 3-4): Victoria James, Yining Zhang, Daniel E. Foxler, Cornelia H. de Moor, Yi Wen Kong, Thomas M. Webb, Tim J. Self, Yungfeng Feng, Dimitrios Lagos, Chia-Ying Chu, Tariq M. Rana, Simon J. Morley, Gregory D. Longmore, Martin Bushell, and Tyson V. Sharp. Lim-domain proteins, limd1, ajuba, and wtip are required for microrna-mediated gene silencing. Proceedings of the National Academy of Sciences, 107:12499-12504, Jun 2010. URL: https://doi.org/10.1073/pnas.0914987107, doi:10.1073/pnas.0914987107. This article has 86 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -LIMD1): Open Targets Query (-LIMD1, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(bridge2017argonauteutilizationfor pages 1-3): Katherine S. Bridge, Kunal M. Shah, Yigen Li, Daniel E. Foxler, Sybil C.K. Wong, Duncan C. Miller, Kathryn M. Davidson, John G. Foster, Ruth Rose, Michael R. Hodgkinson, Paulo S. Ribeiro, A. Aziz Aboobaker, Kenta Yashiro, Xiaozhong Wang, Paul R. Graves, Michael J. Plevin, Dimitris Lagos, and Tyson V. Sharp. Argonaute utilization for mirna silencing is determined by phosphorylation-dependent recruitment of lim-domain-containing proteins. Cell Reports, 20:173-187, Jul 2017. URL: https://doi.org/10.1016/j.celrep.2017.06.027, doi:10.1016/j.celrep.2017.06.027. This article has 89 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rowlinson2022isotopiclabellingtools pages 1-5): B Rowlinson. Isotopic labelling tools to aid nmr studies of protein structure and interactions: applications to the limd1 scaffold protein. Unknown journal, 2022.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>silva2026regulationoftensiondependent pages 12-16</li>
+<li>silva2026regulationoftensiondependent pages 4-7</li>
+<li>sharp2004limdomainscontainingprotein pages 5-6</li>
+<li>bridge2017argonauteutilizationfor pages 3-4</li>
+<li>siddiqui2021bioinformaticanalysisof pages 2-4</li>
+<li>siddiqui2021bioinformaticanalysisof pages 1-2</li>
+<li>rolo2025investigatingtherole pages 35-40</li>
+<li>silva2026regulationoftensiondependent pages 7-9</li>
+<li>bridge2017argonauteutilizationfor pages 4-6</li>
+<li>bridge2017argonauteutilizationfor pages 10-13</li>
+<li>bridge2017argonauteutilizationfor pages 1-3</li>
+<li>rowlinson2022isotopiclabellingtools pages 1-5</li>
+<li>35S</li>
+<li>https://doi.org/10.1002/cm.21847</li>
+<li>https://doi.org/10.1242/jcs.214700</li>
+<li>https://doi.org/10.17912/micropub.biology.000666</li>
+<li>https://doi.org/10.1101/2025.08.26.672419</li>
+<li>https://doi.org/10.1073/pnas.0914987107</li>
+<li>https://doi.org/10.1016/j.celrep.2017.06.027</li>
+<li>https://doi.org/10.1515/bmc.2011.047</li>
+<li>https://doi.org/10.15252/emmm.201708304</li>
+<li>https://doi.org/10.1038/cr.2015.90</li>
+<li>https://doi.org/10.1073/pnas.0407123101</li>
+<li>https://doi.org/10.1073/pnas.0805003105</li>
+<li>https://doi.org/10.1038/sj.onc.1205835</li>
+<li>https://doi.org/10.3390/ijms22052647,</li>
+<li>https://doi.org/10.1101/2025.08.26.672419,</li>
+<li>https://doi.org/10.1073/pnas.0914987107,</li>
+<li>https://doi.org/10.1016/j.celrep.2017.06.027,</li>
+<li>https://doi.org/10.15252/emmm.201708304,</li>
+<li>https://doi.org/10.1073/pnas.0407123101,</li>
+<li>https://doi.org/10.1073/pnas.0805003105,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -4562,11 +6761,15 @@
                 <pre><code>id: Q9UGP4
 gene_symbol: LIMD1
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: &#39;TODO: Add description for LIMD1&#39;
+description: &#39;LIMD1 encodes a multi-domain LIM zinc-binding adaptor/scaffold protein that
+  assembles regulatory complexes at adherens junctions, P-bodies, cytoplasmic HIF degradation
+  machinery, and the nucleus. Its best-supported functions include mechanosensitive Hippo/LATS-YAP
+  regulation, miRISC-mediated translational repression, PHD2-VHL-dependent HIF-alpha degradation,
+  and pRB/E2F transcriptional corepression.&#39;
 existing_annotations:
   - term:
       id: GO:0003714
@@ -4574,635 +6777,1251 @@ existing_annotations:
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Transcription corepressor activity is supported by pRB/E2F repression and
+        related corepressor interactions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+            transcription**, coupling LIMD1 to cell-cycle control.&#39;
   - term:
       id: GO:0005912
       label: adherens junction
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: adherens junction localization is supported for LIMD1 scaffold function
+        across junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: nucleus localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0006355
       label: regulation of DNA-templated transcription
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Regulation of DNA-templated transcription is correct but too broad; LIMD1
+        evidence supports negative transcriptional regulation/corepression.
+      action: MODIFY
+      reason: Use the directionally specific transcriptional repression term.
+      proposed_replacement_terms:
+        - id: GO:0045892
+          label: negative regulation of DNA-templated transcription
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+            transcription**, coupling LIMD1 to cell-cycle control.&#39;
   - term:
       id: GO:0007010
       label: cytoskeleton organization
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Cytoskeleton organization is a broad downstream description; the
+        mechanistic evidence is more specifically adherens-junction/F-actin tension
+        sensing for Hippo signaling.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
   - term:
       id: GO:0035331
       label: negative regulation of hippo signaling
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Negative regulation of Hippo signaling is supported by LIMD1-mediated
+        LATS1/2 recruitment/localization at adherens junctions and consequent YAP/TAZ
+        regulation.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
   - term:
       id: GO:0000932
       label: P-body
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: P-body localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0001666
       label: response to hypoxia
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Response to hypoxia is supported by LIMD1 induction and by LIMD1
+        scaffolding of PHD2/VHL complexes for HIF-alpha degradation.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing
+            degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α
+            degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback
+            loop limiting pro-tumorigenic hypoxia signaling.&#39;
   - term:
       id: GO:0005667
       label: transcription regulator complex
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Transcription regulator complex is retained as a non-core complex context
+        for pRB/E2F and SNAI-associated repression, but the more informative annotation
+        is transcription corepressor activity.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+            transcription**, coupling LIMD1 to cell-cycle control.&#39;
   - term:
       id: GO:0000932
       label: P-body
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: P-body localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0001666
       label: response to hypoxia
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Response to hypoxia is supported by LIMD1 induction and by LIMD1
+        scaffolding of PHD2/VHL complexes for HIF-alpha degradation.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing
+            degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α
+            degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback
+            loop limiting pro-tumorigenic hypoxia signaling.&#39;
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: nucleus localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005737
       label: cytoplasm
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: cytoplasm localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005912
       label: adherens junction
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: adherens junction localization is supported for LIMD1 scaffold function
+        across junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005925
       label: focal adhesion
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Focal adhesion localization is supported by UniProt/subcellular evidence,
+        but the strongest mechanistic Hippo evidence centers on adherens junctions under
+        tension.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0031047
       label: regulatory ncRNA-mediated gene silencing
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Regulatory ncRNA-mediated gene silencing is supported but should be
+        represented more specifically as miRNA-mediated post-transcriptional silencing.
+      action: MODIFY
+      reason: The evidence is specifically miRISC/miRNA-mediated silencing.
+      proposed_replacement_terms:
+        - id: GO:0035195
+          label: miRNA-mediated post-transcriptional gene silencing
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that
+            promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6
+            and downstream effector complexes, and by linking silencing to translation initiation
+            control at the 5′ cap.&#39;
   - term:
       id: GO:0035278
       label: miRNA-mediated gene silencing by inhibition of translation
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: miRNA-mediated gene silencing by inhibition of translation is supported
+        by LIMD1 function as a miRISC/P-body scaffold linking AGO proteins, GW182/TNRC6,
+        DDX6, and cap-associated translation repression.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that
+            promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6
+            and downstream effector complexes, and by linking silencing to translation initiation
+            control at the 5′ cap.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
   - term:
       id: GO:0035331
       label: negative regulation of hippo signaling
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Negative regulation of Hippo signaling is supported by LIMD1-mediated
+        LATS1/2 recruitment/localization at adherens junctions and consequent YAP/TAZ
+        regulation.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
   - term:
       id: GO:0046872
       label: metal ion binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: The metal-binding evidence is specifically zinc binding by LIM domains,
+        so this broad metal ion binding term should be replaced by zinc ion binding.
+      action: MODIFY
+      reason: LIM domains are zinc-binding modules; use the specific zinc ion binding
+        term.
+      proposed_replacement_terms:
+        - id: GO:0008270
+          label: zinc ion binding
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**LIMD1 is a multi-domain adaptor/scaffold protein**, not an enzyme.
+            Its biological roles derive from assembling protein complexes and controlling
+            where/when those complexes form—particularly at **cell junctions**, **P-bodies**,
+            and in **oxygen-sensing (HIF) degradation complexes**. LIM domains are zinc-binding
+            modules (~55–65 aa) that act as protein-interaction interfaces; LIMD1 contains
+            **three tandem LIM domains** at its C‑terminus.&#39;
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:22190034
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:22190034
           supporting_text: Global landscape of HIV-human protein complexes.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:28683311
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:28683311
-          supporting_text: Argonaute Utilization for miRNA Silencing Is 
-            Determined by Phosphorylation-Dependent Recruitment of 
-            LIM-Domain-Containing Proteins.
+          supporting_text: Argonaute Utilization for miRNA Silencing Is Determined by
+            Phosphorylation-Dependent Recruitment of LIM-Domain-Containing Proteins.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:33961781
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:33961781
-          supporting_text: 2021 May 6. Dual proteome-scale networks reveal 
-            cell-specific remodeling of the human interactome.
+          supporting_text: 2021 May 6. Dual proteome-scale networks reveal cell-specific
+            remodeling of the human interactome.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0002076
       label: osteoblast development
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: osteoblast development is retained as a non-core osteoblast/Wnt-related
+        role supported by UniProt-curated literature, but it is peripheral to the main
+        LIMD1 scaffold functions synthesized here.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Regulates osteoblast development, function, differentiation
+            and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate
+            adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt
+            receptor signaling pathway in osteoblasts.
   - term:
       id: GO:0003714
       label: transcription corepressor activity
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Transcription corepressor activity is supported by pRB/E2F repression and
+        related corepressor interactions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+            transcription**, coupling LIMD1 to cell-cycle control.&#39;
   - term:
       id: GO:0045668
       label: negative regulation of osteoblast differentiation
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: negative regulation of osteoblast differentiation is retained as a
+        non-core osteoblast/Wnt-related role supported by UniProt-curated literature,
+        but it is peripheral to the main LIMD1 scaffold functions synthesized here.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Regulates osteoblast development, function, differentiation
+            and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate
+            adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt
+            receptor signaling pathway in osteoblasts.
   - term:
       id: GO:0090090
       label: negative regulation of canonical Wnt signaling pathway
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: negative regulation of canonical Wnt signaling pathway is retained as a
+        non-core osteoblast/Wnt-related role supported by UniProt-curated literature,
+        but it is peripheral to the main LIMD1 scaffold functions synthesized here.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Regulates osteoblast development, function, differentiation
+            and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate
+            adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt
+            receptor signaling pathway in osteoblasts.
   - term:
       id: GO:0005654
       label: nucleoplasm
     evidence_type: IDA
     original_reference_id: GO_REF:0000052
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: nucleoplasm localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005925
       label: focal adhesion
     evidence_type: IDA
     original_reference_id: GO_REF:0000052
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Focal adhesion localization is supported by UniProt/subcellular evidence,
+        but the strongest mechanistic Hippo evidence centers on adherens junctions under
+        tension.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0035278
       label: miRNA-mediated gene silencing by inhibition of translation
     evidence_type: IMP
     original_reference_id: PMID:20616046
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: miRNA-mediated gene silencing by inhibition of translation is supported
+        by LIMD1 function as a miRISC/P-body scaffold linking AGO proteins, GW182/TNRC6,
+        DDX6, and cap-associated translation repression.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:20616046
-          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are 
-            required for microRNA-mediated gene silencing.
+          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for
+            microRNA-mediated gene silencing.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that
+            promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6
+            and downstream effector complexes, and by linking silencing to translation initiation
+            control at the 5′ cap.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
   - term:
       id: GO:0005829
       label: cytosol
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1234159
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: cytosol localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005829
       label: cytosol
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1234163
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: cytosol localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005829
       label: cytosol
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1234173
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: cytosol localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005829
       label: cytosol
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1234177
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: cytosol localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005829
       label: cytosol
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1234183
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: cytosol localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0003714
       label: transcription corepressor activity
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Transcription corepressor activity is supported by pRB/E2F repression and
+        related corepressor interactions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+            transcription**, coupling LIMD1 to cell-cycle control.&#39;
   - term:
       id: GO:0002076
       label: osteoblast development
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: osteoblast development is retained as a non-core osteoblast/Wnt-related
+        role supported by UniProt-curated literature, but it is peripheral to the main
+        LIMD1 scaffold functions synthesized here.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Regulates osteoblast development, function, differentiation
+            and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate
+            adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt
+            receptor signaling pathway in osteoblasts.
   - term:
       id: GO:0045668
       label: negative regulation of osteoblast differentiation
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: negative regulation of osteoblast differentiation is retained as a
+        non-core osteoblast/Wnt-related role supported by UniProt-curated literature,
+        but it is peripheral to the main LIMD1 scaffold functions synthesized here.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Regulates osteoblast development, function, differentiation
+            and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate
+            adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt
+            receptor signaling pathway in osteoblasts.
   - term:
       id: GO:0090090
       label: negative regulation of canonical Wnt signaling pathway
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: negative regulation of canonical Wnt signaling pathway is retained as a
+        non-core osteoblast/Wnt-related role supported by UniProt-curated literature,
+        but it is peripheral to the main LIMD1 scaffold functions synthesized here.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Regulates osteoblast development, function, differentiation
+            and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate
+            adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt
+            receptor signaling pathway in osteoblasts.
   - term:
       id: GO:0001666
       label: response to hypoxia
     evidence_type: IDA
     original_reference_id: PMID:22286099
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Response to hypoxia is supported by LIMD1 induction and by LIMD1
+        scaffolding of PHD2/VHL complexes for HIF-alpha degradation.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:22286099
-          supporting_text: The LIMD1 protein bridges an association between the 
-            prolyl hydroxylases and VHL to repress HIF-1 activity.
+          supporting_text: The LIMD1 protein bridges an association between the prolyl
+            hydroxylases and VHL to repress HIF-1 activity.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing
+            degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α
+            degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback
+            loop limiting pro-tumorigenic hypoxia signaling.&#39;
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:18331720
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:18331720
-          supporting_text: Ajuba LIM proteins are snail/slug corepressors 
-            required for neural crest development in Xenopus.
+          supporting_text: Ajuba LIM proteins are snail/slug corepressors required for
+            neural crest development in Xenopus.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:20616046
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:20616046
-          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are 
-            required for microRNA-mediated gene silencing.
+          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for
+            microRNA-mediated gene silencing.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:22286099
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:22286099
-          supporting_text: The LIMD1 protein bridges an association between the 
-            prolyl hydroxylases and VHL to repress HIF-1 activity.
+          supporting_text: The LIMD1 protein bridges an association between the prolyl
+            hydroxylases and VHL to repress HIF-1 activity.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0045892
       label: negative regulation of DNA-templated transcription
     evidence_type: IMP
     original_reference_id: PMID:22286099
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Negative regulation of DNA-templated transcription is supported by both
+        pRB/E2F repression and HIF pathway repression through enhanced HIF-alpha
+        degradation.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:22286099
-          supporting_text: The LIMD1 protein bridges an association between the 
-            prolyl hydroxylases and VHL to repress HIF-1 activity.
+          supporting_text: The LIMD1 protein bridges an association between the prolyl
+            hydroxylases and VHL to repress HIF-1 activity.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+            transcription**, coupling LIMD1 to cell-cycle control.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing
+            degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α
+            degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback
+            loop limiting pro-tumorigenic hypoxia signaling.&#39;
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:20303269
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:20303269
-          supporting_text: Mar 18. Ajuba LIM proteins are negative regulators of
-            the Hippo signaling pathway.
+          supporting_text: Mar 18. Ajuba LIM proteins are negative regulators of the
+            Hippo signaling pathway.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IDA
     original_reference_id: PMID:18439753
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: nucleus localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:18439753
-          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of 
-            LIMD1 in cell lines and expression in human breast cancers.
+          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of LIMD1 in
+            cell lines and expression in human breast cancers.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005737
       label: cytoplasm
     evidence_type: IDA
     original_reference_id: PMID:18439753
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: cytoplasm localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:18439753
-          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of 
-            LIMD1 in cell lines and expression in human breast cancers.
+          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of LIMD1 in
+            cell lines and expression in human breast cancers.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005912
       label: adherens junction
     evidence_type: IDA
     original_reference_id: PMID:20303269
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: adherens junction localization is supported for LIMD1 scaffold function
+        across junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:20303269
-          supporting_text: Mar 18. Ajuba LIM proteins are negative regulators of
-            the Hippo signaling pathway.
+          supporting_text: Mar 18. Ajuba LIM proteins are negative regulators of the
+            Hippo signaling pathway.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005925
       label: focal adhesion
     evidence_type: IDA
     original_reference_id: PMID:18439753
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Focal adhesion localization is supported by UniProt/subcellular evidence,
+        but the strongest mechanistic Hippo evidence centers on adherens junctions under
+        tension.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:18439753
-          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of 
-            LIMD1 in cell lines and expression in human breast cancers.
+          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of LIMD1 in
+            cell lines and expression in human breast cancers.
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0016310
       label: phosphorylation
     evidence_type: IDA
     original_reference_id: PMID:18439753
     review:
-      summary: &gt;-
-        MISANNOTATION: LIMD1 is a LIM domain scaffold protein, NOT a kinase. PMID:18439753
-        title is &#34;Cell cycle regulated phosphorylation OF LIMD1&#34; - LIMD1 is the SUBSTRATE
-        being phosphorylated. Paper explicitly states &#34;LIMD1 is phosphorylated during
-        mitosis in HeLa cells&#34;. UniProt shows LIMD1 is phosphorylated at Ser-272,
-        Ser-277,
-        Ser-304, Ser-421, Ser-424. This is a substrate-as-enzyme misannotation.
+      summary: LIMD1 is a scaffold protein and not a kinase; the cited paper concerns
+        phosphorylation of LIMD1 rather than LIMD1 catalyzing phosphorylation.
       action: REMOVE
+      reason: Substrate-as-enzyme misannotation.
       supported_by:
         - reference_id: PMID:18439753
-          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of 
-            LIMD1 in cell lines and expression in human breast cancers.
+          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of LIMD1 in
+            cell lines and expression in human breast cancers.
   - term:
       id: GO:0035331
       label: negative regulation of hippo signaling
     evidence_type: IDA
     original_reference_id: PMID:20303269
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Negative regulation of Hippo signaling is supported by LIMD1-mediated
+        LATS1/2 recruitment/localization at adherens junctions and consequent YAP/TAZ
+        regulation.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:20303269
-          supporting_text: Mar 18. Ajuba LIM proteins are negative regulators of
-            the Hippo signaling pathway.
+          supporting_text: Mar 18. Ajuba LIM proteins are negative regulators of the
+            Hippo signaling pathway.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
   - term:
       id: GO:0000932
       label: P-body
     evidence_type: IDA
     original_reference_id: PMID:20616046
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: P-body localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:20616046
-          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are 
-            required for microRNA-mediated gene silencing.
+          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for
+            microRNA-mediated gene silencing.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0016442
       label: RISC complex
     evidence_type: IDA
     original_reference_id: PMID:20616046
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: RISC complex is supported by LIMD1 function as a miRISC/P-body scaffold
+        linking AGO proteins, GW182/TNRC6, DDX6, and cap-associated translation
+        repression.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:20616046
-          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are 
-            required for microRNA-mediated gene silencing.
+          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for
+            microRNA-mediated gene silencing.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that
+            promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6
+            and downstream effector complexes, and by linking silencing to translation initiation
+            control at the 5′ cap.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
   - term:
       id: GO:0033962
       label: P-body assembly
     evidence_type: IMP
     original_reference_id: PMID:20616046
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: P-body assembly is supported by LIMD1 function as a miRISC/P-body
+        scaffold linking AGO proteins, GW182/TNRC6, DDX6, and cap-associated translation
+        repression.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:20616046
-          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are 
-            required for microRNA-mediated gene silencing.
+          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for
+            microRNA-mediated gene silencing.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that
+            promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6
+            and downstream effector complexes, and by linking silencing to translation initiation
+            control at the 5′ cap.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
   - term:
       id: GO:0035195
       label: miRNA-mediated post-transcriptional gene silencing
     evidence_type: IMP
     original_reference_id: PMID:20616046
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: miRNA-mediated post-transcriptional gene silencing is supported by LIMD1
+        function as a miRISC/P-body scaffold linking AGO proteins, GW182/TNRC6, DDX6,
+        and cap-associated translation repression.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:20616046
-          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are 
-            required for microRNA-mediated gene silencing.
+          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for
+            microRNA-mediated gene silencing.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that
+            promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6
+            and downstream effector complexes, and by linking silencing to translation initiation
+            control at the 5′ cap.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:15542589
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:15542589
-          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor 
-            suppressor encoded at chromosome 3p21.3, binds pRB and represses 
-            E2F-driven transcription.
+          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor suppressor
+            encoded at chromosome 3p21.3, binds pRB and represses E2F-driven
+            transcription.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IDA
     original_reference_id: PMID:15542589
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: nucleus localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:15542589
-          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor 
-            suppressor encoded at chromosome 3p21.3, binds pRB and represses 
-            E2F-driven transcription.
+          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor suppressor
+            encoded at chromosome 3p21.3, binds pRB and represses E2F-driven
+            transcription.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005737
       label: cytoplasm
     evidence_type: IDA
     original_reference_id: PMID:15542589
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: cytoplasm localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:15542589
-          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor 
-            suppressor encoded at chromosome 3p21.3, binds pRB and represses 
-            E2F-driven transcription.
+          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor suppressor
+            encoded at chromosome 3p21.3, binds pRB and represses E2F-driven
+            transcription.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0045892
       label: negative regulation of DNA-templated transcription
     evidence_type: IDA
     original_reference_id: PMID:15542589
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Negative regulation of DNA-templated transcription is supported by both
+        pRB/E2F repression and HIF pathway repression through enhanced HIF-alpha
+        degradation.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:15542589
-          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor 
-            suppressor encoded at chromosome 3p21.3, binds pRB and represses 
-            E2F-driven transcription.
+          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor suppressor
+            encoded at chromosome 3p21.3, binds pRB and represses E2F-driven
+            transcription.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+            transcription**, coupling LIMD1 to cell-cycle control.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing
+            degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α
+            degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback
+            loop limiting pro-tumorigenic hypoxia signaling.&#39;
+  - term:
+      id: GO:0060090
+      label: molecular adaptor activity
+    evidence_type: IC
+    original_reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+    review:
+      summary: LIMD1 is a non-enzymatic molecular adaptor/scaffold that assembles
+        context-specific regulatory complexes.
+      action: NEW
+      reason: This directly captures the dominant molecular role synthesized from the
+        Falcon report.
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: &#39;**LIMD1 is a multi-domain adaptor/scaffold protein**, not an enzyme.
+            Its biological roles derive from assembling protein complexes and controlling
+            where/when those complexes form—particularly at **cell junctions**, **P-bodies**,
+            and in **oxygen-sensing (HIF) degradation complexes**. LIM domains are zinc-binding
+            modules (~55–65 aa) that act as protein-interaction interfaces; LIMD1 contains
+            **three tandem LIM domains** at its C‑terminus.&#39;
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
 references:
   - id: GO_REF:0000024
-    title: Manual transfer of experimentally-verified manual GO annotation data 
-      to orthologs by curator judgment of sequence similarity
+    title: Manual transfer of experimentally-verified manual GO annotation data to
+      orthologs by curator judgment of sequence similarity
     findings: []
   - id: GO_REF:0000033
     title: Annotation inferences using phylogenetic trees
     findings: []
   - id: GO_REF:0000043
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword 
-      mapping
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
     findings: []
   - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
     findings: []
   - id: GO_REF:0000052
     title: Gene Ontology annotation based on curation of immunofluorescence data
     findings: []
   - id: GO_REF:0000107
-    title: Automatic transfer of experimentally verified manual GO annotation 
-      data to orthologs using Ensembl Compara
+    title: Automatic transfer of experimentally verified manual GO annotation data to
+      orthologs using Ensembl Compara
     findings: []
   - id: GO_REF:0000117
-    title: Electronic Gene Ontology annotations created by ARBA machine learning
-      models
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
     findings: []
   - id: GO_REF:0000120
     title: Combined Automated Annotation using Multiple IEA Methods
     findings: []
   - id: PMID:15542589
-    title: LIM domains-containing protein 1 (LIMD1), a tumor suppressor encoded 
-      at chromosome 3p21.3, binds pRB and represses E2F-driven transcription.
+    title: LIM domains-containing protein 1 (LIMD1), a tumor suppressor encoded at
+      chromosome 3p21.3, binds pRB and represses E2F-driven transcription.
     findings: []
   - id: PMID:18331720
-    title: Ajuba LIM proteins are snail/slug corepressors required for neural 
-      crest development in Xenopus.
+    title: Ajuba LIM proteins are snail/slug corepressors required for neural crest
+      development in Xenopus.
     findings: []
   - id: PMID:18439753
-    title: Cell cycle regulated phosphorylation of LIMD1 in cell lines and 
-      expression in human breast cancers.
+    title: Cell cycle regulated phosphorylation of LIMD1 in cell lines and expression in
+      human breast cancers.
     findings: []
   - id: PMID:20303269
-    title: Ajuba LIM proteins are negative regulators of the Hippo signaling 
-      pathway.
+    title: Ajuba LIM proteins are negative regulators of the Hippo signaling pathway.
     findings: []
   - id: PMID:20616046
-    title: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for 
+    title: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for
       microRNA-mediated gene silencing.
     findings: []
   - id: PMID:22190034
     title: Global landscape of HIV-human protein complexes.
     findings: []
   - id: PMID:22286099
-    title: The LIMD1 protein bridges an association between the prolyl 
-      hydroxylases and VHL to repress HIF-1 activity.
+    title: The LIMD1 protein bridges an association between the prolyl hydroxylases and
+      VHL to repress HIF-1 activity.
     findings: []
   - id: PMID:28683311
-    title: Argonaute Utilization for miRNA Silencing Is Determined by 
+    title: Argonaute Utilization for miRNA Silencing Is Determined by
       Phosphorylation-Dependent Recruitment of LIM-Domain-Containing Proteins.
     findings: []
   - id: PMID:33961781
-    title: Dual proteome-scale networks reveal cell-specific remodeling of the 
-      human interactome.
+    title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+      interactome.
     findings: []
   - id: Reactome:R-HSA-1234159
     title: Proteasome proteolyzes ub-HIF-alpha
@@ -5219,13 +8038,122 @@ references:
   - id: Reactome:R-HSA-1234183
     title: Cytosolic VHL:EloB,C:CUL2:RBX1 binds hydroxyprolyl-HIF-alpha
     findings: []
+  - id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+    title: Falcon deep research synthesis for LIMD1
+    findings: []
+  - id: file:human/LIMD1/LIMD1-uniprot.txt
+    title: UniProt record for LIMD1
+    findings: []
+core_functions:
+  - description: Mechanosensitive adaptor activity at adherens junctions that
+      recruits/localizes LATS1/2 and negatively regulates Hippo signaling output.
+    molecular_function:
+      id: GO:0060090
+      label: molecular adaptor activity
+    directly_involved_in:
+      - id: GO:0035331
+        label: negative regulation of hippo signaling
+    locations:
+      - id: GO:0005912
+        label: adherens junction
+      - id: GO:0005737
+        label: cytoplasm
+    supported_by:
+      - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+        supporting_text: &#39;**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+          controlling the **subcellular localization** (and functional availability) of **LATS1/2**
+          kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state
+          and nuclear localization.&#39;
+      - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+        supporting_text: &#39;**LIMD1 is a multi-domain adaptor/scaffold protein**, not an enzyme.
+          Its biological roles derive from assembling protein complexes and controlling where/when
+          those complexes form—particularly at **cell junctions**, **P-bodies**, and in **oxygen-sensing
+          (HIF) degradation complexes**. LIM domains are zinc-binding modules (~55–65 aa)
+          that act as protein-interaction interfaces; LIMD1 contains **three tandem LIM domains**
+          at its C‑terminus.&#39;
+  - description: miRISC/P-body adaptor activity that promotes miRNA-mediated
+      translational repression by coupling Argonaute, TNRC6/GW182, DDX6, and
+      cap-associated machinery.
+    molecular_function:
+      id: GO:0060090
+      label: molecular adaptor activity
+    directly_involved_in:
+      - id: GO:0035195
+        label: miRNA-mediated post-transcriptional gene silencing
+      - id: GO:0033962
+        label: P-body assembly
+    locations:
+      - id: GO:0000932
+        label: P-body
+      - id: GO:0005737
+        label: cytoplasm
+    in_complex:
+      id: GO:0016442
+      label: RISC complex
+    supported_by:
+      - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+        supporting_text: &#39;**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that
+          promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6
+          and downstream effector complexes, and by linking silencing to translation initiation
+          control at the 5′ cap.&#39;
+      - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+        supporting_text: &#39;**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC
+          components in **P-bodies**.&#39;
+  - description: Adaptor activity in hypoxia signaling that bridges PHD2/VHL machinery
+      to promote HIF-alpha degradation and limit hypoxic transcriptional responses.
+    molecular_function:
+      id: GO:0060090
+      label: molecular adaptor activity
+    directly_involved_in:
+      - id: GO:0001666
+        label: response to hypoxia
+      - id: GO:0045892
+        label: negative regulation of DNA-templated transcription
+    locations:
+      - id: GO:0005829
+        label: cytosol
+      - id: GO:0005737
+        label: cytoplasm
+    supported_by:
+      - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+        supporting_text: &#39;**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing
+          degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α
+          degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback loop
+          limiting pro-tumorigenic hypoxia signaling.&#39;
+      - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+        supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+          scaffold** that (i) couples **mechanical tension** at adherens junctions to
+          **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+          **miRNA-mediated translational repression** by scaffolding Argonaute and
+          GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α degradation**
+          by scaffolding PHD2–VHL complexes and participating in a HIF-driven negative
+          feedback loop, and (iv) exerts tumor suppressor functions via **pRB/E2F
+          repression** and via maintaining homeostatic control over hypoxia and
+          mechanotransduction outputs.
+  - description: Nuclear transcription corepressor activity through pRB/E2F repression.
+    molecular_function:
+      id: GO:0003714
+      label: transcription corepressor activity
+    directly_involved_in:
+      - id: GO:0045892
+        label: negative regulation of DNA-templated transcription
+    locations:
+      - id: GO:0005634
+        label: nucleus
+    supported_by:
+      - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+        supporting_text: &#39;**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+          transcription**, coupling LIMD1 to cell-cycle control.&#39;
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/LIMD1/LIMD1-ai-review.html
+++ b/genes/human/LIMD1/LIMD1-ai-review.html
@@ -5568,14 +5568,25 @@
                         </div>
                     </td>
                     <td>
-                        <span class="evidence-code">IC</span>
+                        <span class="evidence-code">IDA</span>
 
 
 
                         <br>
                         <span style="font-size: 0.75rem;">
 
-                            file:human/LIMD1/LIMD1-deep-research-falcon.md
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/20616046" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:20616046
+                            </a>
+
+
+
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for...
+                                </span>
+
+
 
                         </span>
 
@@ -5584,7 +5595,7 @@
                         <span class="action-badge action-new">
                             NEW
                         </span>
-                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0060090" data-r="file:human/LIMD1/LIMD1-deep-research-falcon.md" data-act="NEW">
+                        <span class="vote-buttons" data-g="Q9UGP4" data-a="GO:0060090" data-r="PMID:20616046" data-act="NEW">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -5592,12 +5603,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> LIMD1 is a non-enzymatic molecular adaptor/scaffold that assembles context-specific regulatory complexes.
+                            <strong>Summary:</strong> LIMD1 molecular adaptor activity is directly supported by PMID:20616046, which shows LIMD1/Ajuba/WTIP linking Ago1/2, eIF4E-cap complexes, and miRNA-mediated silencing machinery; this captures the broader scaffold/adaptor role synthesized across LIMD1 pathways.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> This directly captures the dominant molecular role synthesized from the Falcon report.
+                            <strong>Reason:</strong> The existing GOA annotations capture downstream processes but lack the core molecular adaptor/scaffold activity demonstrated by primary mechanistic literature.
                         </div>
 
 
@@ -5608,11 +5619,13 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    file:human/LIMD1/LIMD1-deep-research-falcon.md
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20616046" target="_blank" class="term-link">
+                                        PMID:20616046
+                                    </a>
 
                                 </span>
 
-                                <div class="support-text">**LIMD1 is a multi-domain adaptor/scaffold protein**, not an enzyme. Its biological roles derive from assembling protein complexes and controlling where/when those complexes form—particularly at **cell junctions**, **P-bodies**, and in **oxygen-sensing (HIF) degradation complexes**. LIM domains are zinc-binding modules (~55–65 aa) that act as protein-interaction interfaces; LIMD1 contains **three tandem LIM domains** at its C‑terminus.</div>
+                                <div class="support-text">these LIM-domain proteins facilitate miRNA-mediated gene silencing by acting as an essential molecular link between the translationally inhibited eIF4E-m(7)GTP-5(&#39;)cap and Ago1/2 within the miRISC complex attached to the 3&#39;-UTR of mRNA, creating an inhibitory closed-loop complex.</div>
 
                             </div>
 
@@ -5623,7 +5636,7 @@
 
                                 </span>
 
-                                <div class="support-text">LIMD1 (Q9UGP4) is best understood as a **multi-compartment scaffold** that (i) couples **mechanical tension** at adherens junctions to **Hippo pathway kinase (LATS) localization**, (ii) enables efficient **miRNA-mediated translational repression** by scaffolding Argonaute and GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α degradation** by scaffolding PHD2–VHL complexes and participating in a HIF-driven negative feedback loop, and (iv) exerts tumor suppressor functions via **pRB/E2F repression** and via maintaining homeostatic control over hypoxia and mechanotransduction outputs.</div>
+                                <div class="support-text">**LIMD1 is a multi-domain adaptor/scaffold protein**, not an enzyme. Its biological roles derive from assembling protein complexes and controlling where/when those complexes form—particularly at **cell junctions**, **P-bodies**, and in **oxygen-sensing (HIF) degradation complexes**. LIM domains are zinc-binding modules (~55–65 aa) that act as protein-interaction interfaces; LIMD1 contains **three tandem LIM domains** at its C‑terminus.</div>
 
                             </div>
 
@@ -7934,15 +7947,24 @@ existing_annotations:
   - term:
       id: GO:0060090
       label: molecular adaptor activity
-    evidence_type: IC
-    original_reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+    evidence_type: IDA
+    original_reference_id: PMID:20616046
     review:
-      summary: LIMD1 is a non-enzymatic molecular adaptor/scaffold that assembles
-        context-specific regulatory complexes.
+      summary: LIMD1 molecular adaptor activity is directly supported by PMID:20616046,
+        which shows LIMD1/Ajuba/WTIP linking Ago1/2, eIF4E-cap complexes, and
+        miRNA-mediated silencing machinery; this captures the broader scaffold/adaptor
+        role synthesized across LIMD1 pathways.
       action: NEW
-      reason: This directly captures the dominant molecular role synthesized from the
-        Falcon report.
+      reason: The existing GOA annotations capture downstream processes but lack the
+        core molecular adaptor/scaffold activity demonstrated by primary mechanistic
+        literature.
       supported_by:
+        - reference_id: PMID:20616046
+          supporting_text: these LIM-domain proteins facilitate miRNA-mediated gene
+            silencing by acting as an essential molecular link between the
+            translationally inhibited eIF4E-m(7)GTP-5(&#39;)cap and Ago1/2 within the miRISC
+            complex attached to the 3&#39;-UTR of mRNA, creating an inhibitory closed-loop
+            complex.
         - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
           supporting_text: &#39;**LIMD1 is a multi-domain adaptor/scaffold protein**, not an enzyme.
             Its biological roles derive from assembling protein complexes and controlling
@@ -7950,16 +7972,6 @@ existing_annotations:
             and in **oxygen-sensing (HIF) degradation complexes**. LIM domains are zinc-binding
             modules (~55–65 aa) that act as protein-interaction interfaces; LIMD1 contains
             **three tandem LIM domains** at its C‑terminus.&#39;
-        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
-          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
-            scaffold** that (i) couples **mechanical tension** at adherens junctions to
-            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
-            **miRNA-mediated translational repression** by scaffolding Argonaute and
-            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
-            degradation** by scaffolding PHD2–VHL complexes and participating in a
-            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
-            functions via **pRB/E2F repression** and via maintaining homeostatic control
-            over hypoxia and mechanotransduction outputs.
 references:
   - id: GO_REF:0000024
     title: Manual transfer of experimentally-verified manual GO annotation data to

--- a/genes/human/LIMD1/LIMD1-ai-review.yaml
+++ b/genes/human/LIMD1/LIMD1-ai-review.yaml
@@ -1174,15 +1174,24 @@ existing_annotations:
   - term:
       id: GO:0060090
       label: molecular adaptor activity
-    evidence_type: IC
-    original_reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+    evidence_type: IDA
+    original_reference_id: PMID:20616046
     review:
-      summary: LIMD1 is a non-enzymatic molecular adaptor/scaffold that assembles
-        context-specific regulatory complexes.
+      summary: LIMD1 molecular adaptor activity is directly supported by PMID:20616046,
+        which shows LIMD1/Ajuba/WTIP linking Ago1/2, eIF4E-cap complexes, and
+        miRNA-mediated silencing machinery; this captures the broader scaffold/adaptor
+        role synthesized across LIMD1 pathways.
       action: NEW
-      reason: This directly captures the dominant molecular role synthesized from the
-        Falcon report.
+      reason: The existing GOA annotations capture downstream processes but lack the
+        core molecular adaptor/scaffold activity demonstrated by primary mechanistic
+        literature.
       supported_by:
+        - reference_id: PMID:20616046
+          supporting_text: these LIM-domain proteins facilitate miRNA-mediated gene
+            silencing by acting as an essential molecular link between the
+            translationally inhibited eIF4E-m(7)GTP-5(')cap and Ago1/2 within the miRISC
+            complex attached to the 3'-UTR of mRNA, creating an inhibitory closed-loop
+            complex.
         - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
           supporting_text: '**LIMD1 is a multi-domain adaptor/scaffold protein**, not an enzyme.
             Its biological roles derive from assembling protein complexes and controlling
@@ -1190,16 +1199,6 @@ existing_annotations:
             and in **oxygen-sensing (HIF) degradation complexes**. LIM domains are zinc-binding
             modules (~55–65 aa) that act as protein-interaction interfaces; LIMD1 contains
             **three tandem LIM domains** at its C‑terminus.'
-        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
-          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
-            scaffold** that (i) couples **mechanical tension** at adherens junctions to
-            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
-            **miRNA-mediated translational repression** by scaffolding Argonaute and
-            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
-            degradation** by scaffolding PHD2–VHL complexes and participating in a
-            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
-            functions via **pRB/E2F repression** and via maintaining homeostatic control
-            over hypoxia and mechanotransduction outputs.
 references:
   - id: GO_REF:0000024
     title: Manual transfer of experimentally-verified manual GO annotation data to

--- a/genes/human/LIMD1/LIMD1-ai-review.yaml
+++ b/genes/human/LIMD1/LIMD1-ai-review.yaml
@@ -1,11 +1,15 @@
 id: Q9UGP4
 gene_symbol: LIMD1
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for LIMD1'
+description: 'LIMD1 encodes a multi-domain LIM zinc-binding adaptor/scaffold protein that
+  assembles regulatory complexes at adherens junctions, P-bodies, cytoplasmic HIF degradation
+  machinery, and the nucleus. Its best-supported functions include mechanosensitive Hippo/LATS-YAP
+  regulation, miRISC-mediated translational repression, PHD2-VHL-dependent HIF-alpha degradation,
+  and pRB/E2F transcriptional corepression.'
 existing_annotations:
   - term:
       id: GO:0003714
@@ -13,635 +17,1251 @@ existing_annotations:
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Transcription corepressor activity is supported by pRB/E2F repression and
+        related corepressor interactions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+            transcription**, coupling LIMD1 to cell-cycle control.'
   - term:
       id: GO:0005912
       label: adherens junction
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: adherens junction localization is supported for LIMD1 scaffold function
+        across junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: nucleus localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0006355
       label: regulation of DNA-templated transcription
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Regulation of DNA-templated transcription is correct but too broad; LIMD1
+        evidence supports negative transcriptional regulation/corepression.
+      action: MODIFY
+      reason: Use the directionally specific transcriptional repression term.
+      proposed_replacement_terms:
+        - id: GO:0045892
+          label: negative regulation of DNA-templated transcription
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+            transcription**, coupling LIMD1 to cell-cycle control.'
   - term:
       id: GO:0007010
       label: cytoskeleton organization
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Cytoskeleton organization is a broad downstream description; the
+        mechanistic evidence is more specifically adherens-junction/F-actin tension
+        sensing for Hippo signaling.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
   - term:
       id: GO:0035331
       label: negative regulation of hippo signaling
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Negative regulation of Hippo signaling is supported by LIMD1-mediated
+        LATS1/2 recruitment/localization at adherens junctions and consequent YAP/TAZ
+        regulation.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
   - term:
       id: GO:0000932
       label: P-body
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: P-body localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0001666
       label: response to hypoxia
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Response to hypoxia is supported by LIMD1 induction and by LIMD1
+        scaffolding of PHD2/VHL complexes for HIF-alpha degradation.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing
+            degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α
+            degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback
+            loop limiting pro-tumorigenic hypoxia signaling.'
   - term:
       id: GO:0005667
       label: transcription regulator complex
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Transcription regulator complex is retained as a non-core complex context
+        for pRB/E2F and SNAI-associated repression, but the more informative annotation
+        is transcription corepressor activity.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+            transcription**, coupling LIMD1 to cell-cycle control.'
   - term:
       id: GO:0000932
       label: P-body
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: P-body localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0001666
       label: response to hypoxia
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Response to hypoxia is supported by LIMD1 induction and by LIMD1
+        scaffolding of PHD2/VHL complexes for HIF-alpha degradation.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing
+            degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α
+            degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback
+            loop limiting pro-tumorigenic hypoxia signaling.'
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: nucleus localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005737
       label: cytoplasm
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: cytoplasm localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005912
       label: adherens junction
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: adherens junction localization is supported for LIMD1 scaffold function
+        across junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005925
       label: focal adhesion
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Focal adhesion localization is supported by UniProt/subcellular evidence,
+        but the strongest mechanistic Hippo evidence centers on adherens junctions under
+        tension.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0031047
       label: regulatory ncRNA-mediated gene silencing
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Regulatory ncRNA-mediated gene silencing is supported but should be
+        represented more specifically as miRNA-mediated post-transcriptional silencing.
+      action: MODIFY
+      reason: The evidence is specifically miRISC/miRNA-mediated silencing.
+      proposed_replacement_terms:
+        - id: GO:0035195
+          label: miRNA-mediated post-transcriptional gene silencing
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that
+            promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6
+            and downstream effector complexes, and by linking silencing to translation initiation
+            control at the 5′ cap.'
   - term:
       id: GO:0035278
       label: miRNA-mediated gene silencing by inhibition of translation
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: miRNA-mediated gene silencing by inhibition of translation is supported
+        by LIMD1 function as a miRISC/P-body scaffold linking AGO proteins, GW182/TNRC6,
+        DDX6, and cap-associated translation repression.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that
+            promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6
+            and downstream effector complexes, and by linking silencing to translation initiation
+            control at the 5′ cap.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
   - term:
       id: GO:0035331
       label: negative regulation of hippo signaling
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Negative regulation of Hippo signaling is supported by LIMD1-mediated
+        LATS1/2 recruitment/localization at adherens junctions and consequent YAP/TAZ
+        regulation.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
   - term:
       id: GO:0046872
       label: metal ion binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: The metal-binding evidence is specifically zinc binding by LIM domains,
+        so this broad metal ion binding term should be replaced by zinc ion binding.
+      action: MODIFY
+      reason: LIM domains are zinc-binding modules; use the specific zinc ion binding
+        term.
+      proposed_replacement_terms:
+        - id: GO:0008270
+          label: zinc ion binding
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**LIMD1 is a multi-domain adaptor/scaffold protein**, not an enzyme.
+            Its biological roles derive from assembling protein complexes and controlling
+            where/when those complexes form—particularly at **cell junctions**, **P-bodies**,
+            and in **oxygen-sensing (HIF) degradation complexes**. LIM domains are zinc-binding
+            modules (~55–65 aa) that act as protein-interaction interfaces; LIMD1 contains
+            **three tandem LIM domains** at its C‑terminus.'
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:22190034
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:22190034
           supporting_text: Global landscape of HIV-human protein complexes.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:28683311
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:28683311
-          supporting_text: Argonaute Utilization for miRNA Silencing Is 
-            Determined by Phosphorylation-Dependent Recruitment of 
-            LIM-Domain-Containing Proteins.
+          supporting_text: Argonaute Utilization for miRNA Silencing Is Determined by
+            Phosphorylation-Dependent Recruitment of LIM-Domain-Containing Proteins.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:33961781
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:33961781
-          supporting_text: 2021 May 6. Dual proteome-scale networks reveal 
-            cell-specific remodeling of the human interactome.
+          supporting_text: 2021 May 6. Dual proteome-scale networks reveal cell-specific
+            remodeling of the human interactome.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0002076
       label: osteoblast development
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: osteoblast development is retained as a non-core osteoblast/Wnt-related
+        role supported by UniProt-curated literature, but it is peripheral to the main
+        LIMD1 scaffold functions synthesized here.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Regulates osteoblast development, function, differentiation
+            and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate
+            adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt
+            receptor signaling pathway in osteoblasts.
   - term:
       id: GO:0003714
       label: transcription corepressor activity
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Transcription corepressor activity is supported by pRB/E2F repression and
+        related corepressor interactions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+            transcription**, coupling LIMD1 to cell-cycle control.'
   - term:
       id: GO:0045668
       label: negative regulation of osteoblast differentiation
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: negative regulation of osteoblast differentiation is retained as a
+        non-core osteoblast/Wnt-related role supported by UniProt-curated literature,
+        but it is peripheral to the main LIMD1 scaffold functions synthesized here.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Regulates osteoblast development, function, differentiation
+            and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate
+            adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt
+            receptor signaling pathway in osteoblasts.
   - term:
       id: GO:0090090
       label: negative regulation of canonical Wnt signaling pathway
     evidence_type: IEA
     original_reference_id: GO_REF:0000107
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: negative regulation of canonical Wnt signaling pathway is retained as a
+        non-core osteoblast/Wnt-related role supported by UniProt-curated literature,
+        but it is peripheral to the main LIMD1 scaffold functions synthesized here.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Regulates osteoblast development, function, differentiation
+            and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate
+            adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt
+            receptor signaling pathway in osteoblasts.
   - term:
       id: GO:0005654
       label: nucleoplasm
     evidence_type: IDA
     original_reference_id: GO_REF:0000052
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: nucleoplasm localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005925
       label: focal adhesion
     evidence_type: IDA
     original_reference_id: GO_REF:0000052
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Focal adhesion localization is supported by UniProt/subcellular evidence,
+        but the strongest mechanistic Hippo evidence centers on adherens junctions under
+        tension.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0035278
       label: miRNA-mediated gene silencing by inhibition of translation
     evidence_type: IMP
     original_reference_id: PMID:20616046
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: miRNA-mediated gene silencing by inhibition of translation is supported
+        by LIMD1 function as a miRISC/P-body scaffold linking AGO proteins, GW182/TNRC6,
+        DDX6, and cap-associated translation repression.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:20616046
-          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are 
-            required for microRNA-mediated gene silencing.
+          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for
+            microRNA-mediated gene silencing.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that
+            promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6
+            and downstream effector complexes, and by linking silencing to translation initiation
+            control at the 5′ cap.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
   - term:
       id: GO:0005829
       label: cytosol
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1234159
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: cytosol localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005829
       label: cytosol
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1234163
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: cytosol localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005829
       label: cytosol
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1234173
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: cytosol localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005829
       label: cytosol
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1234177
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: cytosol localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005829
       label: cytosol
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-1234183
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: cytosol localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0003714
       label: transcription corepressor activity
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Transcription corepressor activity is supported by pRB/E2F repression and
+        related corepressor interactions.
+      action: ACCEPT
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+            transcription**, coupling LIMD1 to cell-cycle control.'
   - term:
       id: GO:0002076
       label: osteoblast development
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: osteoblast development is retained as a non-core osteoblast/Wnt-related
+        role supported by UniProt-curated literature, but it is peripheral to the main
+        LIMD1 scaffold functions synthesized here.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Regulates osteoblast development, function, differentiation
+            and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate
+            adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt
+            receptor signaling pathway in osteoblasts.
   - term:
       id: GO:0045668
       label: negative regulation of osteoblast differentiation
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: negative regulation of osteoblast differentiation is retained as a
+        non-core osteoblast/Wnt-related role supported by UniProt-curated literature,
+        but it is peripheral to the main LIMD1 scaffold functions synthesized here.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Regulates osteoblast development, function, differentiation
+            and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate
+            adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt
+            receptor signaling pathway in osteoblasts.
   - term:
       id: GO:0090090
       label: negative regulation of canonical Wnt signaling pathway
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: negative regulation of canonical Wnt signaling pathway is retained as a
+        non-core osteoblast/Wnt-related role supported by UniProt-curated literature,
+        but it is peripheral to the main LIMD1 scaffold functions synthesized here.
+      action: KEEP_AS_NON_CORE
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Regulates osteoblast development, function, differentiation
+            and stress osteoclastogenesis. Enhances the ability of TRAF6 to activate
+            adapter protein complex 1 (AP-1) and negatively regulates the canonical Wnt
+            receptor signaling pathway in osteoblasts.
   - term:
       id: GO:0001666
       label: response to hypoxia
     evidence_type: IDA
     original_reference_id: PMID:22286099
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Response to hypoxia is supported by LIMD1 induction and by LIMD1
+        scaffolding of PHD2/VHL complexes for HIF-alpha degradation.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:22286099
-          supporting_text: The LIMD1 protein bridges an association between the 
-            prolyl hydroxylases and VHL to repress HIF-1 activity.
+          supporting_text: The LIMD1 protein bridges an association between the prolyl
+            hydroxylases and VHL to repress HIF-1 activity.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing
+            degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α
+            degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback
+            loop limiting pro-tumorigenic hypoxia signaling.'
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:18331720
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:18331720
-          supporting_text: Ajuba LIM proteins are snail/slug corepressors 
-            required for neural crest development in Xenopus.
+          supporting_text: Ajuba LIM proteins are snail/slug corepressors required for
+            neural crest development in Xenopus.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:20616046
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:20616046
-          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are 
-            required for microRNA-mediated gene silencing.
+          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for
+            microRNA-mediated gene silencing.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:22286099
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:22286099
-          supporting_text: The LIMD1 protein bridges an association between the 
-            prolyl hydroxylases and VHL to repress HIF-1 activity.
+          supporting_text: The LIMD1 protein bridges an association between the prolyl
+            hydroxylases and VHL to repress HIF-1 activity.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0045892
       label: negative regulation of DNA-templated transcription
     evidence_type: IMP
     original_reference_id: PMID:22286099
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Negative regulation of DNA-templated transcription is supported by both
+        pRB/E2F repression and HIF pathway repression through enhanced HIF-alpha
+        degradation.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:22286099
-          supporting_text: The LIMD1 protein bridges an association between the 
-            prolyl hydroxylases and VHL to repress HIF-1 activity.
+          supporting_text: The LIMD1 protein bridges an association between the prolyl
+            hydroxylases and VHL to repress HIF-1 activity.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+            transcription**, coupling LIMD1 to cell-cycle control.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing
+            degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α
+            degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback
+            loop limiting pro-tumorigenic hypoxia signaling.'
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:20303269
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:20303269
-          supporting_text: Mar 18. Ajuba LIM proteins are negative regulators of
-            the Hippo signaling pathway.
+          supporting_text: Mar 18. Ajuba LIM proteins are negative regulators of the
+            Hippo signaling pathway.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IDA
     original_reference_id: PMID:18439753
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: nucleus localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:18439753
-          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of 
-            LIMD1 in cell lines and expression in human breast cancers.
+          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of LIMD1 in
+            cell lines and expression in human breast cancers.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005737
       label: cytoplasm
     evidence_type: IDA
     original_reference_id: PMID:18439753
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: cytoplasm localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:18439753
-          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of 
-            LIMD1 in cell lines and expression in human breast cancers.
+          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of LIMD1 in
+            cell lines and expression in human breast cancers.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005912
       label: adherens junction
     evidence_type: IDA
     original_reference_id: PMID:20303269
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: adherens junction localization is supported for LIMD1 scaffold function
+        across junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:20303269
-          supporting_text: Mar 18. Ajuba LIM proteins are negative regulators of
-            the Hippo signaling pathway.
+          supporting_text: Mar 18. Ajuba LIM proteins are negative regulators of the
+            Hippo signaling pathway.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005925
       label: focal adhesion
     evidence_type: IDA
     original_reference_id: PMID:18439753
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Focal adhesion localization is supported by UniProt/subcellular evidence,
+        but the strongest mechanistic Hippo evidence centers on adherens junctions under
+        tension.
+      action: KEEP_AS_NON_CORE
       supported_by:
         - reference_id: PMID:18439753
-          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of 
-            LIMD1 in cell lines and expression in human breast cancers.
+          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of LIMD1 in
+            cell lines and expression in human breast cancers.
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0016310
       label: phosphorylation
     evidence_type: IDA
     original_reference_id: PMID:18439753
     review:
-      summary: >-
-        MISANNOTATION: LIMD1 is a LIM domain scaffold protein, NOT a kinase. PMID:18439753
-        title is "Cell cycle regulated phosphorylation OF LIMD1" - LIMD1 is the SUBSTRATE
-        being phosphorylated. Paper explicitly states "LIMD1 is phosphorylated during
-        mitosis in HeLa cells". UniProt shows LIMD1 is phosphorylated at Ser-272,
-        Ser-277,
-        Ser-304, Ser-421, Ser-424. This is a substrate-as-enzyme misannotation.
+      summary: LIMD1 is a scaffold protein and not a kinase; the cited paper concerns
+        phosphorylation of LIMD1 rather than LIMD1 catalyzing phosphorylation.
       action: REMOVE
+      reason: Substrate-as-enzyme misannotation.
       supported_by:
         - reference_id: PMID:18439753
-          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of 
-            LIMD1 in cell lines and expression in human breast cancers.
+          supporting_text: 2008 Apr 24. Cell cycle regulated phosphorylation of LIMD1 in
+            cell lines and expression in human breast cancers.
   - term:
       id: GO:0035331
       label: negative regulation of hippo signaling
     evidence_type: IDA
     original_reference_id: PMID:20303269
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Negative regulation of Hippo signaling is supported by LIMD1-mediated
+        LATS1/2 recruitment/localization at adherens junctions and consequent YAP/TAZ
+        regulation.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:20303269
-          supporting_text: Mar 18. Ajuba LIM proteins are negative regulators of
-            the Hippo signaling pathway.
+          supporting_text: Mar 18. Ajuba LIM proteins are negative regulators of the
+            Hippo signaling pathway.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
   - term:
       id: GO:0000932
       label: P-body
     evidence_type: IDA
     original_reference_id: PMID:20616046
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: P-body localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:20616046
-          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are 
-            required for microRNA-mediated gene silencing.
+          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for
+            microRNA-mediated gene silencing.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0016442
       label: RISC complex
     evidence_type: IDA
     original_reference_id: PMID:20616046
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: RISC complex is supported by LIMD1 function as a miRISC/P-body scaffold
+        linking AGO proteins, GW182/TNRC6, DDX6, and cap-associated translation
+        repression.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:20616046
-          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are 
-            required for microRNA-mediated gene silencing.
+          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for
+            microRNA-mediated gene silencing.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that
+            promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6
+            and downstream effector complexes, and by linking silencing to translation initiation
+            control at the 5′ cap.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
   - term:
       id: GO:0033962
       label: P-body assembly
     evidence_type: IMP
     original_reference_id: PMID:20616046
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: P-body assembly is supported by LIMD1 function as a miRISC/P-body
+        scaffold linking AGO proteins, GW182/TNRC6, DDX6, and cap-associated translation
+        repression.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:20616046
-          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are 
-            required for microRNA-mediated gene silencing.
+          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for
+            microRNA-mediated gene silencing.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that
+            promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6
+            and downstream effector complexes, and by linking silencing to translation initiation
+            control at the 5′ cap.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
   - term:
       id: GO:0035195
       label: miRNA-mediated post-transcriptional gene silencing
     evidence_type: IMP
     original_reference_id: PMID:20616046
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: miRNA-mediated post-transcriptional gene silencing is supported by LIMD1
+        function as a miRISC/P-body scaffold linking AGO proteins, GW182/TNRC6, DDX6,
+        and cap-associated translation repression.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:20616046
-          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are 
-            required for microRNA-mediated gene silencing.
+          supporting_text: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for
+            microRNA-mediated gene silencing.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that
+            promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6
+            and downstream effector complexes, and by linking silencing to translation initiation
+            control at the 5′ cap.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:15542589
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Generic protein binding is over-broad for LIMD1. Specific
+        adaptor/scaffold roles with AGO/TNRC6/DDX6, LATS1/2, PHD/VHL, and pRB are more
+        informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: Avoid generic protein binding when specific complex/adaptor mechanisms are
+        known.
       supported_by:
         - reference_id: PMID:15542589
-          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor 
-            suppressor encoded at chromosome 3p21.3, binds pRB and represses 
-            E2F-driven transcription.
+          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor suppressor
+            encoded at chromosome 3p21.3, binds pRB and represses E2F-driven
+            transcription.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IDA
     original_reference_id: PMID:15542589
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: nucleus localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:15542589
-          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor 
-            suppressor encoded at chromosome 3p21.3, binds pRB and represses 
-            E2F-driven transcription.
+          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor suppressor
+            encoded at chromosome 3p21.3, binds pRB and represses E2F-driven
+            transcription.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0005737
       label: cytoplasm
     evidence_type: IDA
     original_reference_id: PMID:15542589
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: cytoplasm localization is supported for LIMD1 scaffold function across
+        junctional, cytoplasmic/P-body, and nuclear compartments.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:15542589
-          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor 
-            suppressor encoded at chromosome 3p21.3, binds pRB and represses 
-            E2F-driven transcription.
+          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor suppressor
+            encoded at chromosome 3p21.3, binds pRB and represses E2F-driven
+            transcription.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+            controlling the **subcellular localization** (and functional availability) of
+            **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation
+            state and nuclear localization.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other
+            miRISC components in **P-bodies**.'
+        - reference_id: file:human/LIMD1/LIMD1-uniprot.txt
+          supporting_text: Cytoplasm. Nucleus. Cytoplasm, P-body. Cell junction,
+            adherens junction. Cell junction, focal adhesion.
   - term:
       id: GO:0045892
       label: negative regulation of DNA-templated transcription
     evidence_type: IDA
     original_reference_id: PMID:15542589
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Negative regulation of DNA-templated transcription is supported by both
+        pRB/E2F repression and HIF pathway repression through enhanced HIF-alpha
+        degradation.
+      action: ACCEPT
       supported_by:
         - reference_id: PMID:15542589
-          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor 
-            suppressor encoded at chromosome 3p21.3, binds pRB and represses 
-            E2F-driven transcription.
+          supporting_text: LIM domains-containing protein 1 (LIMD1), a tumor suppressor
+            encoded at chromosome 3p21.3, binds pRB and represses E2F-driven
+            transcription.
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+            transcription**, coupling LIMD1 to cell-cycle control.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing
+            degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α
+            degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback
+            loop limiting pro-tumorigenic hypoxia signaling.'
+  - term:
+      id: GO:0060090
+      label: molecular adaptor activity
+    evidence_type: IC
+    original_reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+    review:
+      summary: LIMD1 is a non-enzymatic molecular adaptor/scaffold that assembles
+        context-specific regulatory complexes.
+      action: NEW
+      reason: This directly captures the dominant molecular role synthesized from the
+        Falcon report.
+      supported_by:
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: '**LIMD1 is a multi-domain adaptor/scaffold protein**, not an enzyme.
+            Its biological roles derive from assembling protein complexes and controlling
+            where/when those complexes form—particularly at **cell junctions**, **P-bodies**,
+            and in **oxygen-sensing (HIF) degradation complexes**. LIM domains are zinc-binding
+            modules (~55–65 aa) that act as protein-interaction interfaces; LIMD1 contains
+            **three tandem LIM domains** at its C‑terminus.'
+        - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+          supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+            scaffold** that (i) couples **mechanical tension** at adherens junctions to
+            **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+            **miRNA-mediated translational repression** by scaffolding Argonaute and
+            GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α
+            degradation** by scaffolding PHD2–VHL complexes and participating in a
+            HIF-driven negative feedback loop, and (iv) exerts tumor suppressor
+            functions via **pRB/E2F repression** and via maintaining homeostatic control
+            over hypoxia and mechanotransduction outputs.
 references:
   - id: GO_REF:0000024
-    title: Manual transfer of experimentally-verified manual GO annotation data 
-      to orthologs by curator judgment of sequence similarity
+    title: Manual transfer of experimentally-verified manual GO annotation data to
+      orthologs by curator judgment of sequence similarity
     findings: []
   - id: GO_REF:0000033
     title: Annotation inferences using phylogenetic trees
     findings: []
   - id: GO_REF:0000043
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword 
-      mapping
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
     findings: []
   - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+      vocabulary mapping, accompanied by conservative changes to GO terms applied by
+      UniProt
     findings: []
   - id: GO_REF:0000052
     title: Gene Ontology annotation based on curation of immunofluorescence data
     findings: []
   - id: GO_REF:0000107
-    title: Automatic transfer of experimentally verified manual GO annotation 
-      data to orthologs using Ensembl Compara
+    title: Automatic transfer of experimentally verified manual GO annotation data to
+      orthologs using Ensembl Compara
     findings: []
   - id: GO_REF:0000117
-    title: Electronic Gene Ontology annotations created by ARBA machine learning
-      models
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
     findings: []
   - id: GO_REF:0000120
     title: Combined Automated Annotation using Multiple IEA Methods
     findings: []
   - id: PMID:15542589
-    title: LIM domains-containing protein 1 (LIMD1), a tumor suppressor encoded 
-      at chromosome 3p21.3, binds pRB and represses E2F-driven transcription.
+    title: LIM domains-containing protein 1 (LIMD1), a tumor suppressor encoded at
+      chromosome 3p21.3, binds pRB and represses E2F-driven transcription.
     findings: []
   - id: PMID:18331720
-    title: Ajuba LIM proteins are snail/slug corepressors required for neural 
-      crest development in Xenopus.
+    title: Ajuba LIM proteins are snail/slug corepressors required for neural crest
+      development in Xenopus.
     findings: []
   - id: PMID:18439753
-    title: Cell cycle regulated phosphorylation of LIMD1 in cell lines and 
-      expression in human breast cancers.
+    title: Cell cycle regulated phosphorylation of LIMD1 in cell lines and expression in
+      human breast cancers.
     findings: []
   - id: PMID:20303269
-    title: Ajuba LIM proteins are negative regulators of the Hippo signaling 
-      pathway.
+    title: Ajuba LIM proteins are negative regulators of the Hippo signaling pathway.
     findings: []
   - id: PMID:20616046
-    title: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for 
+    title: LIM-domain proteins, LIMD1, Ajuba, and WTIP are required for
       microRNA-mediated gene silencing.
     findings: []
   - id: PMID:22190034
     title: Global landscape of HIV-human protein complexes.
     findings: []
   - id: PMID:22286099
-    title: The LIMD1 protein bridges an association between the prolyl 
-      hydroxylases and VHL to repress HIF-1 activity.
+    title: The LIMD1 protein bridges an association between the prolyl hydroxylases and
+      VHL to repress HIF-1 activity.
     findings: []
   - id: PMID:28683311
-    title: Argonaute Utilization for miRNA Silencing Is Determined by 
+    title: Argonaute Utilization for miRNA Silencing Is Determined by
       Phosphorylation-Dependent Recruitment of LIM-Domain-Containing Proteins.
     findings: []
   - id: PMID:33961781
-    title: Dual proteome-scale networks reveal cell-specific remodeling of the 
-      human interactome.
+    title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+      interactome.
     findings: []
   - id: Reactome:R-HSA-1234159
     title: Proteasome proteolyzes ub-HIF-alpha
@@ -658,3 +1278,112 @@ references:
   - id: Reactome:R-HSA-1234183
     title: Cytosolic VHL:EloB,C:CUL2:RBX1 binds hydroxyprolyl-HIF-alpha
     findings: []
+  - id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+    title: Falcon deep research synthesis for LIMD1
+    findings: []
+  - id: file:human/LIMD1/LIMD1-uniprot.txt
+    title: UniProt record for LIMD1
+    findings: []
+core_functions:
+  - description: Mechanosensitive adaptor activity at adherens junctions that
+      recruits/localizes LATS1/2 and negatively regulates Hippo signaling output.
+    molecular_function:
+      id: GO:0060090
+      label: molecular adaptor activity
+    directly_involved_in:
+      - id: GO:0035331
+        label: negative regulation of hippo signaling
+    locations:
+      - id: GO:0005912
+        label: adherens junction
+      - id: GO:0005737
+        label: cytoplasm
+    supported_by:
+      - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+        supporting_text: '**Primary function:** LIMD1 acts as a **mechanosensitive scaffold**
+          controlling the **subcellular localization** (and functional availability) of **LATS1/2**
+          kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state
+          and nuclear localization.'
+      - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+        supporting_text: '**LIMD1 is a multi-domain adaptor/scaffold protein**, not an enzyme.
+          Its biological roles derive from assembling protein complexes and controlling where/when
+          those complexes form—particularly at **cell junctions**, **P-bodies**, and in **oxygen-sensing
+          (HIF) degradation complexes**. LIM domains are zinc-binding modules (~55–65 aa)
+          that act as protein-interaction interfaces; LIMD1 contains **three tandem LIM domains**
+          at its C‑terminus.'
+  - description: miRISC/P-body adaptor activity that promotes miRNA-mediated
+      translational repression by coupling Argonaute, TNRC6/GW182, DDX6, and
+      cap-associated machinery.
+    molecular_function:
+      id: GO:0060090
+      label: molecular adaptor activity
+    directly_involved_in:
+      - id: GO:0035195
+        label: miRNA-mediated post-transcriptional gene silencing
+      - id: GO:0033962
+        label: P-body assembly
+    locations:
+      - id: GO:0000932
+        label: P-body
+      - id: GO:0005737
+        label: cytoplasm
+    in_complex:
+      id: GO:0016442
+      label: RISC complex
+    supported_by:
+      - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+        supporting_text: '**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that
+          promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6
+          and downstream effector complexes, and by linking silencing to translation initiation
+          control at the 5′ cap.'
+      - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+        supporting_text: '**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC
+          components in **P-bodies**.'
+  - description: Adaptor activity in hypoxia signaling that bridges PHD2/VHL machinery
+      to promote HIF-alpha degradation and limit hypoxic transcriptional responses.
+    molecular_function:
+      id: GO:0060090
+      label: molecular adaptor activity
+    directly_involved_in:
+      - id: GO:0001666
+        label: response to hypoxia
+      - id: GO:0045892
+        label: negative regulation of DNA-templated transcription
+    locations:
+      - id: GO:0005829
+        label: cytosol
+      - id: GO:0005737
+        label: cytoplasm
+    supported_by:
+      - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+        supporting_text: '**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing
+          degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α
+          degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback loop
+          limiting pro-tumorigenic hypoxia signaling.'
+      - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+        supporting_text: LIMD1 (Q9UGP4) is best understood as a **multi-compartment
+          scaffold** that (i) couples **mechanical tension** at adherens junctions to
+          **Hippo pathway kinase (LATS) localization**, (ii) enables efficient
+          **miRNA-mediated translational repression** by scaffolding Argonaute and
+          GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α degradation**
+          by scaffolding PHD2–VHL complexes and participating in a HIF-driven negative
+          feedback loop, and (iv) exerts tumor suppressor functions via **pRB/E2F
+          repression** and via maintaining homeostatic control over hypoxia and
+          mechanotransduction outputs.
+  - description: Nuclear transcription corepressor activity through pRB/E2F repression.
+    molecular_function:
+      id: GO:0003714
+      label: transcription corepressor activity
+    directly_involved_in:
+      - id: GO:0045892
+        label: negative regulation of DNA-templated transcription
+    locations:
+      - id: GO:0005634
+        label: nucleus
+    supported_by:
+      - reference_id: file:human/LIMD1/LIMD1-deep-research-falcon.md
+        supporting_text: '**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven
+          transcription**, coupling LIMD1 to cell-cycle control.'
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []

--- a/genes/human/LIMD1/LIMD1-deep-research-falcon.md
+++ b/genes/human/LIMD1/LIMD1-deep-research-falcon.md
@@ -1,0 +1,311 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T21:17:56.304846'
+end_time: '2026-05-11T21:28:54.920198'
+duration_seconds: 658.62
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: LIMD1
+  gene_symbol: LIMD1
+  uniprot_accession: Q9UGP4
+  protein_description: 'RecName: Full=LIM domain-containing protein 1;'
+  gene_info: Name=LIMD1;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the zyxin/ajuba family. .
+  protein_domains: Ajuba-like. (IPR047172); Ajuba-like_LIM1. (IPR047245); Ajuba-like_LIM2.
+    (IPR047247); Ajuba-like_LIM3. (IPR047248); Znf_LIM. (IPR001781)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 32
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9UGP4
+- **Protein Description:** RecName: Full=LIM domain-containing protein 1;
+- **Gene Information:** Name=LIMD1;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the zyxin/ajuba family. .
+- **Key Domains:** Ajuba-like. (IPR047172); Ajuba-like_LIM1. (IPR047245); Ajuba-like_LIM2. (IPR047247); Ajuba-like_LIM3. (IPR047248); Znf_LIM. (IPR001781)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "LIMD1" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'LIMD1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **LIMD1** (gene ID: LIMD1, UniProt: Q9UGP4) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9UGP4
+- **Protein Description:** RecName: Full=LIM domain-containing protein 1;
+- **Gene Information:** Name=LIMD1;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the zyxin/ajuba family. .
+- **Key Domains:** Ajuba-like. (IPR047172); Ajuba-like_LIM1. (IPR047245); Ajuba-like_LIM2. (IPR047247); Ajuba-like_LIM3. (IPR047248); Znf_LIM. (IPR001781)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "LIMD1" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'LIMD1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **LIMD1** (gene ID: LIMD1, UniProt: Q9UGP4) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Comprehensive functional-annotation report: **LIMD1** (human; UniProt **Q9UGP4**)
+
+### 0) Target verification (mandatory)
+The literature and database-derived sources retrieved here consistently match the requested target: **human LIMD1 (UniProt Q9UGP4)**, annotated as **LIM domain-containing protein 1** and a member of the **Ajuba-like/zyxin (LAW) family** with **three C‑terminal LIM zinc-binding domains** and an N‑terminal low-complexity/proline-rich region that supports protein–protein interactions and nucleo-cytoplasmic shuttling. (siddiqui2021bioinformaticanalysisof pages 2-4, siddiqui2021bioinformaticanalysisof pages 1-2, rolo2025investigatingtherole pages 35-40)
+
+### 1) Key concepts, definitions, and current understanding
+
+#### 1.1 What LIMD1 is (conceptual definition)
+**LIMD1 is a multi-domain adaptor/scaffold protein**, not an enzyme. Its biological roles derive from assembling protein complexes and controlling where/when those complexes form—particularly at **cell junctions**, **P-bodies**, and in **oxygen-sensing (HIF) degradation complexes**. LIM domains are zinc-binding modules (~55–65 aa) that act as protein-interaction interfaces; LIMD1 contains **three tandem LIM domains** at its C‑terminus. (siddiqui2021bioinformaticanalysisof pages 2-4, siddiqui2021bioinformaticanalysisof pages 1-2)
+
+#### 1.2 Core mechanistic functions (high-confidence)
+Across primary literature, LIMD1 has four repeatedly supported mechanistic “axes”:
+
+1. **Hippo pathway mechanotransduction (LATS–YAP control):** LIMD1 localizes to **adherens junctions in a tension-dependent manner**, engages **strained F‑actin**, and binds/recruits **LATS1/2**, thereby regulating downstream YAP/TAZ activity. (silva2026regulationoftensiondependent pages 4-7, silva2026regulationoftensiondependent pages 7-9)
+2. **miRNA-induced silencing complex (miRISC) scaffolding:** LIMD1 scaffolds **AGO2** with **GW182/TNRC6A** and effectors (e.g., **DDX6**), and links silencing to the **cap-binding translation machinery (eIF4E)**; LIMD1 localizes with miRISC components in **P-bodies**. (james2010limdomainproteinslimd1 pages 4-5, bridge2017argonauteutilizationfor pages 3-4)
+3. **Hypoxia signaling (HIF degradation):** LIMD1 scaffolds **PHD2 (EGLN1)** and **VHL** to promote proteasomal degradation of **HIF‑α**; additionally, LIMD1 can be induced by HIF‑1 to form a negative-feedback loop that restrains prolonged hypoxic signaling. (foxler2018ahif–limd1negative pages 1-2, foxler2018ahif–limd1negative pages 10-12)
+4. **Tumor suppressor cell-cycle control (pRB/E2F):** LIMD1 binds **pRB** and represses **E2F-driven transcription**, consistent with growth suppression and tumor suppressor activity, especially in lung cancer contexts where the 3p21.3 locus is frequently deleted. (sharp2004limdomainscontainingprotein pages 5-6, sharp2008thechromosome3p21.3encoded pages 1-2)
+
+### 2) Recent developments and latest research (prioritizing 2023–2024)
+
+#### 2.1 2024: LIMD1 as a strain-sensing Hippo scaffold via LIM-domain binding to strained actin
+A 2024 peer-reviewed mechanistic study in *Cytoskeleton* reports that the **three LIM domains of LIMD1 are necessary and sufficient** for **tension-dependent** localization to adherens junctions and association with the Hippo kinase **LATS1**, and supports a model in which LIM domains can bind **F-actin under strain** to achieve mechanosensitive targeting. (silva2026regulationoftensiondependent pages 12-16)
+
+#### 2.2 2023: LIMD1 positioned among Hippo components that integrate mechanical cues and growth control
+In 2023 Hippo-focused mechanistic work on cell-density sensing and Hippo pathway regulation, LIMD1 is cited among key components coupling upstream physical cues to the Hippo pathway output (YAP control), reflecting ongoing consolidation of LIMD1’s role in mechanoregulation. (silva2026regulationoftensiondependent pages 12-16)
+
+#### 2.3 2023–2024: continued expansion of LIMD1 context beyond cancer—immunity/metabolism and tissue models
+A 2024 in vivo study of NASH progression reports **LIMD1 and LATS1 colocalization/interaction** associated with YAP nuclear translocation in hepatic macrophage settings, placing LIMD1 within emerging YAP/TAZ–immunity interfaces (though not a LIMD1-focused mechanistic dissection). (silva2026regulationoftensiondependent pages 12-16)
+
+### 3) Pathways, molecular interactions, and cellular localization
+
+### 3.1 Hippo pathway / mechanotransduction (adherens junctions, LATS, YAP)
+**Primary function:** LIMD1 acts as a **mechanosensitive scaffold** controlling the **subcellular localization** (and functional availability) of **LATS1/2** kinases at adherens junctions, thereby influencing YAP/TAZ phosphorylation state and nuclear localization. (silva2026regulationoftensiondependent pages 4-7, silva2026regulationoftensiondependent pages 7-9)
+
+**Localization:** adherens junctions (tension-dependent), F‑actin strain sites; broader family annotation supports nuclear/cytoplasmic shuttling. (silva2026regulationoftensiondependent pages 4-7, siddiqui2021bioinformaticanalysisof pages 2-4)
+
+**Mechanistic details with residue/domain-level mapping:** LIMD1 contains an N‑terminal intrinsically disordered region and a C‑terminal LIM region; LIM1+LIM2 are required for efficient recruitment of LATS1, and LIM-domain point mutants can disrupt strain-site targeting and LATS recruitment. (silva2026regulationoftensiondependent pages 4-7)
+
+### 3.2 miRNA-mediated gene silencing (miRISC; P-bodies; phosphorylation-dependent AGO usage)
+**Primary function:** LIMD1 is a **miRISC adaptor/scaffold** that promotes productive AGO-dependent silencing by coupling Argonaute to GW182/TNRC6 and downstream effector complexes, and by linking silencing to translation initiation control at the 5′ cap. (bridge2017argonauteutilizationfor pages 3-4, james2010limdomainproteinslimd1 pages 4-5)
+
+**Key interactions:** AGO2, GW182/TNRC6A, DDX6, and eIF4E/cap complex. (james2010limdomainproteinslimd1 pages 4-5, bridge2017argonauteutilizationfor pages 4-6)
+
+**Regulatory logic (phosphorylation switch):** AGO2 Ser387 phosphorylation (via Akt3) promotes LIMD1 recruitment, enabling AGO2–TNRC6A–DDX6 assembly; LIMD1 loss can shift functional dependence from AGO2 to AGO3/WTIP. (bridge2017argonauteutilizationfor pages 3-4, bridge2017argonauteutilizationfor pages 10-13)
+
+**Localization:** LIMD1 colocalizes with GW182/TNRC6 and other miRISC components in **P-bodies**. (james2010limdomainproteinslimd1 pages 2-3, james2010limdomainproteinslimd1 pages 1-2)
+
+### 3.3 Hypoxia / HIF-α degradation (PHD2–VHL scaffold; negative feedback)
+**Primary function:** LIMD1 acts as a scaffold for the oxygen-sensing degradation machinery by bridging **PHD2** and **VHL** to promote efficient **HIF‑α degradation**, and is itself **HIF-1 inducible**, creating a negative-feedback loop limiting pro-tumorigenic hypoxia signaling. (foxler2018ahif–limd1negative pages 1-2, foxler2018ahif–limd1negative pages 10-12)
+
+### 3.4 pRB/E2F repression and tumor suppressor activity
+**Primary function:** LIMD1 binds **pRB** and represses **E2F-driven transcription**, coupling LIMD1 to cell-cycle control. (sharp2004limdomainscontainingprotein pages 5-6)
+
+**Cancer genetics context:** LIMD1 lies in the **3p21.3** region with very high LOH in lung cancer; one study reports LOH exceeding **90%** in the mapped region and no coding mutations detected in **188** lung adenocarcinoma samples, supporting deletion/epigenetic silencing as common modes of LIMD1 loss. (sharp2008thechromosome3p21.3encoded pages 1-2)
+
+### 4) Relevant statistics and quantitative findings (from primary studies)
+
+* **80% reduction in colony formation** after LIMD1 transfection in two tested cell types (growth-suppressive phenotype consistent with tumor suppressor function). (sharp2004limdomainscontainingprotein pages 5-6)
+* **83% (5/6) lung cancer cell lines** showed reduced LIMD1 protein in one study, and **all 14 paired lung tumor/normal samples** tested had reduced LIMD1 expression by qRT-PCR. (sharp2004limdomainscontainingprotein pages 5-6)
+* **47.1% copy-number variation** at the LIMD1 locus in TCGA lung adenocarcinoma reported in an EMBO Molecular Medicine study, with association to HIF target-gene signatures and poor prognosis. (foxler2018ahif–limd1negative pages 1-2)
+* In a **276-patient tissue microarray**, low LIMD1 by IHC correlated with poorer overall survival; the cohort had **80% high VEGF** expression reported. (foxler2018ahif–limd1negative pages 10-12)
+* LIMD1−/− MEFs show **~40% increased protein synthesis** by [35S]-methionine incorporation, consistent with LIMD1’s role in translational repression in miRNA silencing. (james2010limdomainproteinslimd1 pages 3-4)
+
+### 5) Current applications and real-world implementations
+
+#### 5.1 Prognostic/biomarker use cases in oncology
+Multiple lines of evidence support LIMD1 as a clinically relevant biomarker candidate in lung cancer contexts: frequent deletion/LOH at 3p21.3 and reduced expression in tumors, and the association of LIMD1 copy-number variation with hypoxia transcriptional signatures and prognosis. (sharp2008thechromosome3p21.3encoded pages 1-2, foxler2018ahif–limd1negative pages 1-2)
+
+#### 5.2 Therapeutic implications: pathway-level targeting
+Because LIMD1 is a scaffold (not an enzyme), direct druggability is challenging; practical translational leverage is more likely via **targeting nodes in LIMD1-regulated pathways**, such as:
+* Hippo/YAP mechanotransduction modules that control LATS localization/activity at junctions (conceptually relevant to tissue growth and cancer). (silva2026regulationoftensiondependent pages 4-7)
+* Hypoxia pathway interventions that modulate PHD/VHL/HIF axis output, where LIMD1 participates in complex assembly. (foxler2018ahif–limd1negative pages 1-2)
+* miRNA silencing machinery and signaling inputs (e.g., Akt-dependent AGO2 phosphorylation) that determine Argonaute utilization and repression efficiency. (bridge2017argonauteutilizationfor pages 3-4)
+
+#### 5.3 Disease association landscape (database evidence)
+Open Targets lists multiple disease associations for LIMD1 (each with small evidence counts), indicating ongoing but relatively limited curated disease-target evidence outside major cancer/hypoxia contexts. These associations are best treated as hypothesis-generating. (OpenTargets Search: -LIMD1)
+
+### 6) Expert opinions and authoritative synthesis
+A mechanistic review on miRNA-mediated gene silencing discusses LIMD1-family proteins as effectors/adaptors bridging miRISC and translation control, reflecting expert consensus that non-enzymatic scaffolds can be essential determinants of silencing architecture and mechanism. (bridge2017argonauteutilizationfor pages 3-4)
+
+A zyxin-family structural/bioinformatic analysis supports that LIMD1-family proteins may have both nuclear and cytoplasmic roles (NES/NLS features) and emphasizes the LIM domains as modular interaction hubs. (siddiqui2021bioinformaticanalysisof pages 2-4)
+
+### 7) Consolidated functional summary
+LIMD1 (Q9UGP4) is best understood as a **multi-compartment scaffold** that (i) couples **mechanical tension** at adherens junctions to **Hippo pathway kinase (LATS) localization**, (ii) enables efficient **miRNA-mediated translational repression** by scaffolding Argonaute and GW182/TNRC6 and engaging the cap complex, (iii) promotes **HIF‑α degradation** by scaffolding PHD2–VHL complexes and participating in a HIF-driven negative feedback loop, and (iv) exerts tumor suppressor functions via **pRB/E2F repression** and via maintaining homeostatic control over hypoxia and mechanotransduction outputs. (silva2026regulationoftensiondependent pages 4-7, bridge2017argonauteutilizationfor pages 3-4, foxler2018ahif–limd1negative pages 1-2, sharp2004limdomainscontainingprotein pages 5-6)
+
+### 8) Structured evidence map
+The table below provides a compact cross-walk from functional axis → mechanism → key evidence → localization → reference URLs.
+
+| Functional area | Core mechanism / interactions | Key experimental evidence / findings | Subcellular localization | Key references (year; URL) |
+|---|---|---|---|---|
+| Hippo mechanotransduction | LIMD1 is an Ajuba/zyxin-family scaffold with an N-terminal intrinsically disordered/proline-rich region and three C-terminal LIM domains. It localizes to adherens junctions in a tension-dependent manner, binds strained F-actin, and recruits/inhibits LATS1/2; LIM1 and LIM2 are especially important. A conserved LATS “LATCH” motif mediates LIMD1-LATS binding. AJUBA and WTIP can compete with LIMD1 for junctional localization and reduce LIMD1-dependent LATS recruitment. (silva2026regulationoftensiondependent pages 4-7, silva2026regulationoftensiondependent pages 7-9) | Tension inhibition with 25 µM blebbistatin for 2 h disrupts LIMD1/LATS1 junctional recruitment; LIMD1 C-terminus aa468-676 binds LATS2, but full LATS1 recruitment requires both LIM domains and the N-terminal IDR; point mutants F512A (LIM1), F575A (LIM2), Y646A (LIM3) impair strain-site/adherens-junction localization and LATS recruitment; LATS-LATCH mutant residues L441G/V444A/K445D/R448D abolish LIMD1 binding and AJ localization; AJUBA/WTIP overexpression increases YAP1 phosphorylation and decreases YAP1 nuclear localization by displacing LIMD1. (silva2026regulationoftensiondependent pages 7-9, silva2026regulationoftensiondependent pages 4-7, bridge2017argonauteutilizationfor pages 4-6) | Predominantly adherens junctions under tension; also F-actin strain sites; family-level evidence supports nuclear/cytoplasmic shuttling. (silva2026regulationoftensiondependent pages 4-7, siddiqui2021bioinformaticanalysisof pages 2-4, siddiqui2021bioinformaticanalysisof pages 1-2) | Ray et al., 2024: https://doi.org/10.1002/cm.21847 ; Ibar et al., 2018: https://doi.org/10.1242/jcs.214700 ; Kirichenko & Irvine, 2022: https://doi.org/10.17912/micropub.biology.000666 ; De Silva et al., 2026 preprint: https://doi.org/10.1101/2025.08.26.672419 |
+| miRISC / miRNA-mediated gene silencing | LIMD1 acts as a scaffold in miRISC, binding AGO2 (via pre-LIM/AB motif) and TNRC6A/GW182 (via LIM domains), promoting recruitment of DDX6 and linking miRISC to eIF4E/m7GTP cap complexes. AGO2 Ser387 phosphorylation by Akt3 promotes LIMD1 recruitment; in LIMD1 loss, silencing can switch from AGO2 dependence to AGO3/WTIP. LIMD1 also localizes with GW182/TNRC6A in P-bodies. (bridge2017argonauteutilizationfor pages 3-4, james2010limdomainproteinslimd1 pages 4-5, bridge2017argonauteutilizationfor pages 4-6, bridge2017argonauteutilizationfor pages 1-3, bridge2017argonauteutilizationfor pages 10-13) | LIMD1 depletion derepresses miRNA-mediated but not siRNA-mediated silencing; LIMD1−/− MEFs show ~40% increased protein synthesis by [35S]-methionine incorporation; HMGA2 protein increases after LIMD1 depletion while HMGA2 mRNA is unchanged; LIMD1 coexpression increases Ago2-eIF4E co-immunoprecipitation; reporter assays show significant de-repression after LIMD1, AGO2, or TNRC6A loss while reporter mRNA remains unchanged; AGO2 is ~60% of total AGO protein in HeLa, yet LIMD1 loss shifts functional dependence toward AGO3; PLA/co-IP show LIMD1 loss reduces AGO2:TNRC6A and AGO2:DDX6 interactions. (bridge2017argonauteutilizationfor pages 3-4, james2010limdomainproteinslimd1 pages 4-5, bridge2017argonauteutilizationfor pages 4-6, james2010limdomainproteinslimd1 pages 2-3, james2010limdomainproteinslimd1 pages 3-4, james2010limdomainproteinslimd1 pages 1-2) | P-bodies / GW-bodies; cytoplasmic cap-associated translation complexes; also reported nuclear/P-body localization in family annotation. (siddiqui2021bioinformaticanalysisof pages 1-2, james2010limdomainproteinslimd1 pages 4-5, james2010limdomainproteinslimd1 pages 2-3, james2010limdomainproteinslimd1 pages 1-2) | James et al., 2010: https://doi.org/10.1073/pnas.0914987107 ; Bridge et al., 2017: https://doi.org/10.1016/j.celrep.2017.06.027 ; James et al., 2012 review: https://doi.org/10.1515/bmc.2011.047 |
+| Hypoxia / HIF regulation | LIMD1 scaffolds PHD2 and VHL to promote proteasomal degradation of HIF-α. LIMD1 is itself a HIF-1 target gene, creating a negative-feedback loop in hypoxia that enhances formation of a hypoxic PHD2-LIMD1-VHL degradation complex and restrains HIF signaling. RHOBTB3 can cooperate with LIMD1 in HIFα degradation complexes. (rowlinson2022isotopiclabellingtools pages 1-5, foxler2018ahif–limd1negative pages 1-2, foxler2018ahif–limd1negative pages 10-12) | Hypoxia (1% O2) increases LIMD1 mRNA/protein; LIMD1 promoter reporters show ~3-fold induction in hypoxia; disrupting LIMD1 hypoxic induction increases tumor growth and vasculature in xenografts; TCGA LUAD analysis found LIMD1 copy-number variation in 47.1% of patients, associated with higher HIF-target signatures and poorer prognosis; low LIMD1 expression on a 276-patient TMA associated with worse overall survival; 80% of that cohort had high VEGF expression. (foxler2018ahif–limd1negative pages 1-2, foxler2018ahif–limd1negative pages 10-12) | Cytoplasmic scaffold for PHD2/VHL/HIF complex; also nucleo-cytoplasmic shuttling reported for family members. (siddiqui2021bioinformaticanalysisof pages 2-4, rowlinson2022isotopiclabellingtools pages 1-5) | Foxler et al., 2018: https://doi.org/10.15252/emmm.201708304 ; Zhang et al., 2015: https://doi.org/10.1038/cr.2015.90 |
+| pRB / E2F tumor-suppressor function | LIMD1 binds pRB and functions as an RB corepressor that represses E2F-driven transcription, linking LIMD1 to cell-cycle control and tumor suppression. It is encoded at chromosome 3p21.3, a region frequently deleted in lung cancer. (sharp2008thechromosome3p21.3encoded pages 1-2, sharp2004limdomainscontainingprotein pages 5-6) | LIMD1 transfection reduced Zeocin-resistant colony formation by 80% in two tested cell types; LIMD1 significantly reduced xenograft tumor size and lung metastasis incidence in nude mice; 5/6 lung cancer cell lines (83%) showed reduced LIMD1 protein; qRT-PCR on 14 paired lung tumor/normal samples found reduced LIMD1 expression in all cancers tested; LOH in the mapped C3CER1 region exceeds 90%; Limd1−/− mice are predisposed to chemical-induced lung adenocarcinoma, and Limd1 loss in KrasG12D mice markedly increases tumor initiation, promotion, and mortality; no coding mutations detected in 188 lung adenocarcinomas in one screen. (sharp2008thechromosome3p21.3encoded pages 1-2, sharp2004limdomainscontainingprotein pages 5-6) | Nucleus for pRB/E2F repression; also observed at E-cadherin junctions with translocation to nucleus. (sharp2008thechromosome3p21.3encoded pages 1-2) | Sharp et al., 2004: https://doi.org/10.1073/pnas.0407123101 ; Sharp et al., 2008: https://doi.org/10.1073/pnas.0805003105 ; Zabarovsky et al., 2002: https://doi.org/10.1038/sj.onc.1205835 |
+
+
+*Table: This table summarizes the best-supported functional roles of human LIMD1 (UniProt Q9UGP4) across four major pathways, highlighting mechanism, localization, and quantitative evidence from primary studies. It is useful as a compact functional-annotation reference anchored to the cited context evidence.*
+
+
+References
+
+1. (siddiqui2021bioinformaticanalysisof pages 2-4): Mohammad Quadir Siddiqui, Maulik D. Badmalia, and Trushar R. Patel. Bioinformatic analysis of structure and function of lim domains of human zyxin family proteins. International Journal of Molecular Sciences, Mar 2021. URL: https://doi.org/10.3390/ijms22052647, doi:10.3390/ijms22052647. This article has 31 citations.
+
+2. (siddiqui2021bioinformaticanalysisof pages 1-2): Mohammad Quadir Siddiqui, Maulik D. Badmalia, and Trushar R. Patel. Bioinformatic analysis of structure and function of lim domains of human zyxin family proteins. International Journal of Molecular Sciences, Mar 2021. URL: https://doi.org/10.3390/ijms22052647, doi:10.3390/ijms22052647. This article has 31 citations.
+
+3. (rolo2025investigatingtherole pages 35-40): S Rolo. Investigating the role of ajuba lim domain protein in pancreatic ductal adenocarcinoma. Unknown journal, 2025.
+
+4. (silva2026regulationoftensiondependent pages 4-7): Chamika De Silva, Brian A. Kelch, and Dannel McCollum. Regulation of tension-dependent localization of lats1 and lats2 to adherens junctions. BioRxiv, Aug 2026. URL: https://doi.org/10.1101/2025.08.26.672419, doi:10.1101/2025.08.26.672419. This article has 1 citations.
+
+5. (silva2026regulationoftensiondependent pages 7-9): Chamika De Silva, Brian A. Kelch, and Dannel McCollum. Regulation of tension-dependent localization of lats1 and lats2 to adherens junctions. BioRxiv, Aug 2026. URL: https://doi.org/10.1101/2025.08.26.672419, doi:10.1101/2025.08.26.672419. This article has 1 citations.
+
+6. (james2010limdomainproteinslimd1 pages 4-5): Victoria James, Yining Zhang, Daniel E. Foxler, Cornelia H. de Moor, Yi Wen Kong, Thomas M. Webb, Tim J. Self, Yungfeng Feng, Dimitrios Lagos, Chia-Ying Chu, Tariq M. Rana, Simon J. Morley, Gregory D. Longmore, Martin Bushell, and Tyson V. Sharp. Lim-domain proteins, limd1, ajuba, and wtip are required for microrna-mediated gene silencing. Proceedings of the National Academy of Sciences, 107:12499-12504, Jun 2010. URL: https://doi.org/10.1073/pnas.0914987107, doi:10.1073/pnas.0914987107. This article has 86 citations and is from a highest quality peer-reviewed journal.
+
+7. (bridge2017argonauteutilizationfor pages 3-4): Katherine S. Bridge, Kunal M. Shah, Yigen Li, Daniel E. Foxler, Sybil C.K. Wong, Duncan C. Miller, Kathryn M. Davidson, John G. Foster, Ruth Rose, Michael R. Hodgkinson, Paulo S. Ribeiro, A. Aziz Aboobaker, Kenta Yashiro, Xiaozhong Wang, Paul R. Graves, Michael J. Plevin, Dimitris Lagos, and Tyson V. Sharp. Argonaute utilization for mirna silencing is determined by phosphorylation-dependent recruitment of lim-domain-containing proteins. Cell Reports, 20:173-187, Jul 2017. URL: https://doi.org/10.1016/j.celrep.2017.06.027, doi:10.1016/j.celrep.2017.06.027. This article has 89 citations and is from a highest quality peer-reviewed journal.
+
+8. (foxler2018ahif–limd1negative pages 1-2): Daniel E Foxler, Katherine S Bridge, John G Foster, Paul Grevitt, Sean Curry, Kunal M Shah, Kathryn M Davidson, Ai Nagano, Emanuela Gadaleta, Hefin I Rhys, Paul T Kennedy, Miguel A Hermida, Ting‐Yu Chang, Peter E Shaw, Louise E Reynolds, Tristan R McKay, Hsei‐Wei Wang, Paulo S Ribeiro, Michael J Plevin, Dimitris Lagos, Nicholas R Lemoine, Prabhakar Rajan, Trevor A Graham, Claude Chelala, Kairbaan M Hodivala‐Dilke, Ian Spendlove, and Tyson V Sharp. A hif–limd1 negative feedback mechanism mitigates the pro‐tumorigenic effects of hypoxia. EMBO Molecular Medicine, Jun 2018. URL: https://doi.org/10.15252/emmm.201708304, doi:10.15252/emmm.201708304. This article has 34 citations and is from a highest quality peer-reviewed journal.
+
+9. (foxler2018ahif–limd1negative pages 10-12): Daniel E Foxler, Katherine S Bridge, John G Foster, Paul Grevitt, Sean Curry, Kunal M Shah, Kathryn M Davidson, Ai Nagano, Emanuela Gadaleta, Hefin I Rhys, Paul T Kennedy, Miguel A Hermida, Ting‐Yu Chang, Peter E Shaw, Louise E Reynolds, Tristan R McKay, Hsei‐Wei Wang, Paulo S Ribeiro, Michael J Plevin, Dimitris Lagos, Nicholas R Lemoine, Prabhakar Rajan, Trevor A Graham, Claude Chelala, Kairbaan M Hodivala‐Dilke, Ian Spendlove, and Tyson V Sharp. A hif–limd1 negative feedback mechanism mitigates the pro‐tumorigenic effects of hypoxia. EMBO Molecular Medicine, Jun 2018. URL: https://doi.org/10.15252/emmm.201708304, doi:10.15252/emmm.201708304. This article has 34 citations and is from a highest quality peer-reviewed journal.
+
+10. (sharp2004limdomainscontainingprotein pages 5-6): Tyson V. Sharp, Fernando Munoz, Dimitra Bourboulia, Nadege Presneau, Eva Darai, Hsei-Wei Wang, Mark Cannon, David N. Butcher, Andrew G. Nicholson, George Klein, Stephan Imreh, and Chris Boshoff. Lim domains-containing protein 1 (limd1), a tumor suppressor encoded at chromosome 3p21.3, binds prb and represses e2f-driven transcription. Proceedings of the National Academy of Sciences of the United States of America, 101 47:16531-6, Nov 2004. URL: https://doi.org/10.1073/pnas.0407123101, doi:10.1073/pnas.0407123101. This article has 117 citations and is from a highest quality peer-reviewed journal.
+
+11. (sharp2008thechromosome3p21.3encoded pages 1-2): Tyson V. Sharp, Ahmad Al-Attar, Daniel E. Foxler, Li Ding, Thomas Q. de A. Vallim, Yining Zhang, Hala S. Nijmeh, Thomas M. Webb, Andrew G. Nicholson, Qunyuan Zhang, Aldi Kraja, Ian Spendlove, John Osborne, Elaine Mardis, and Gregory D. Longmore. The chromosome 3p21.3-encoded gene, limd1, is a critical tumor suppressor involved in human lung cancer development. Proceedings of the National Academy of Sciences, 105:19932-19937, Dec 2008. URL: https://doi.org/10.1073/pnas.0805003105, doi:10.1073/pnas.0805003105. This article has 85 citations and is from a highest quality peer-reviewed journal.
+
+12. (silva2026regulationoftensiondependent pages 12-16): Chamika De Silva, Brian A. Kelch, and Dannel McCollum. Regulation of tension-dependent localization of lats1 and lats2 to adherens junctions. BioRxiv, Aug 2026. URL: https://doi.org/10.1101/2025.08.26.672419, doi:10.1101/2025.08.26.672419. This article has 1 citations.
+
+13. (bridge2017argonauteutilizationfor pages 4-6): Katherine S. Bridge, Kunal M. Shah, Yigen Li, Daniel E. Foxler, Sybil C.K. Wong, Duncan C. Miller, Kathryn M. Davidson, John G. Foster, Ruth Rose, Michael R. Hodgkinson, Paulo S. Ribeiro, A. Aziz Aboobaker, Kenta Yashiro, Xiaozhong Wang, Paul R. Graves, Michael J. Plevin, Dimitris Lagos, and Tyson V. Sharp. Argonaute utilization for mirna silencing is determined by phosphorylation-dependent recruitment of lim-domain-containing proteins. Cell Reports, 20:173-187, Jul 2017. URL: https://doi.org/10.1016/j.celrep.2017.06.027, doi:10.1016/j.celrep.2017.06.027. This article has 89 citations and is from a highest quality peer-reviewed journal.
+
+14. (bridge2017argonauteutilizationfor pages 10-13): Katherine S. Bridge, Kunal M. Shah, Yigen Li, Daniel E. Foxler, Sybil C.K. Wong, Duncan C. Miller, Kathryn M. Davidson, John G. Foster, Ruth Rose, Michael R. Hodgkinson, Paulo S. Ribeiro, A. Aziz Aboobaker, Kenta Yashiro, Xiaozhong Wang, Paul R. Graves, Michael J. Plevin, Dimitris Lagos, and Tyson V. Sharp. Argonaute utilization for mirna silencing is determined by phosphorylation-dependent recruitment of lim-domain-containing proteins. Cell Reports, 20:173-187, Jul 2017. URL: https://doi.org/10.1016/j.celrep.2017.06.027, doi:10.1016/j.celrep.2017.06.027. This article has 89 citations and is from a highest quality peer-reviewed journal.
+
+15. (james2010limdomainproteinslimd1 pages 2-3): Victoria James, Yining Zhang, Daniel E. Foxler, Cornelia H. de Moor, Yi Wen Kong, Thomas M. Webb, Tim J. Self, Yungfeng Feng, Dimitrios Lagos, Chia-Ying Chu, Tariq M. Rana, Simon J. Morley, Gregory D. Longmore, Martin Bushell, and Tyson V. Sharp. Lim-domain proteins, limd1, ajuba, and wtip are required for microrna-mediated gene silencing. Proceedings of the National Academy of Sciences, 107:12499-12504, Jun 2010. URL: https://doi.org/10.1073/pnas.0914987107, doi:10.1073/pnas.0914987107. This article has 86 citations and is from a highest quality peer-reviewed journal.
+
+16. (james2010limdomainproteinslimd1 pages 1-2): Victoria James, Yining Zhang, Daniel E. Foxler, Cornelia H. de Moor, Yi Wen Kong, Thomas M. Webb, Tim J. Self, Yungfeng Feng, Dimitrios Lagos, Chia-Ying Chu, Tariq M. Rana, Simon J. Morley, Gregory D. Longmore, Martin Bushell, and Tyson V. Sharp. Lim-domain proteins, limd1, ajuba, and wtip are required for microrna-mediated gene silencing. Proceedings of the National Academy of Sciences, 107:12499-12504, Jun 2010. URL: https://doi.org/10.1073/pnas.0914987107, doi:10.1073/pnas.0914987107. This article has 86 citations and is from a highest quality peer-reviewed journal.
+
+17. (james2010limdomainproteinslimd1 pages 3-4): Victoria James, Yining Zhang, Daniel E. Foxler, Cornelia H. de Moor, Yi Wen Kong, Thomas M. Webb, Tim J. Self, Yungfeng Feng, Dimitrios Lagos, Chia-Ying Chu, Tariq M. Rana, Simon J. Morley, Gregory D. Longmore, Martin Bushell, and Tyson V. Sharp. Lim-domain proteins, limd1, ajuba, and wtip are required for microrna-mediated gene silencing. Proceedings of the National Academy of Sciences, 107:12499-12504, Jun 2010. URL: https://doi.org/10.1073/pnas.0914987107, doi:10.1073/pnas.0914987107. This article has 86 citations and is from a highest quality peer-reviewed journal.
+
+18. (OpenTargets Search: -LIMD1): Open Targets Query (-LIMD1, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+19. (bridge2017argonauteutilizationfor pages 1-3): Katherine S. Bridge, Kunal M. Shah, Yigen Li, Daniel E. Foxler, Sybil C.K. Wong, Duncan C. Miller, Kathryn M. Davidson, John G. Foster, Ruth Rose, Michael R. Hodgkinson, Paulo S. Ribeiro, A. Aziz Aboobaker, Kenta Yashiro, Xiaozhong Wang, Paul R. Graves, Michael J. Plevin, Dimitris Lagos, and Tyson V. Sharp. Argonaute utilization for mirna silencing is determined by phosphorylation-dependent recruitment of lim-domain-containing proteins. Cell Reports, 20:173-187, Jul 2017. URL: https://doi.org/10.1016/j.celrep.2017.06.027, doi:10.1016/j.celrep.2017.06.027. This article has 89 citations and is from a highest quality peer-reviewed journal.
+
+20. (rowlinson2022isotopiclabellingtools pages 1-5): B Rowlinson. Isotopic labelling tools to aid nmr studies of protein structure and interactions: applications to the limd1 scaffold protein. Unknown journal, 2022.
+
+## Citations
+
+1. silva2026regulationoftensiondependent pages 12-16
+2. silva2026regulationoftensiondependent pages 4-7
+3. sharp2004limdomainscontainingprotein pages 5-6
+4. bridge2017argonauteutilizationfor pages 3-4
+5. siddiqui2021bioinformaticanalysisof pages 2-4
+6. siddiqui2021bioinformaticanalysisof pages 1-2
+7. rolo2025investigatingtherole pages 35-40
+8. silva2026regulationoftensiondependent pages 7-9
+9. bridge2017argonauteutilizationfor pages 4-6
+10. bridge2017argonauteutilizationfor pages 10-13
+11. bridge2017argonauteutilizationfor pages 1-3
+12. rowlinson2022isotopiclabellingtools pages 1-5
+13. 35S
+14. https://doi.org/10.1002/cm.21847
+15. https://doi.org/10.1242/jcs.214700
+16. https://doi.org/10.17912/micropub.biology.000666
+17. https://doi.org/10.1101/2025.08.26.672419
+18. https://doi.org/10.1073/pnas.0914987107
+19. https://doi.org/10.1016/j.celrep.2017.06.027
+20. https://doi.org/10.1515/bmc.2011.047
+21. https://doi.org/10.15252/emmm.201708304
+22. https://doi.org/10.1038/cr.2015.90
+23. https://doi.org/10.1073/pnas.0407123101
+24. https://doi.org/10.1073/pnas.0805003105
+25. https://doi.org/10.1038/sj.onc.1205835
+26. https://doi.org/10.3390/ijms22052647,
+27. https://doi.org/10.1101/2025.08.26.672419,
+28. https://doi.org/10.1073/pnas.0914987107,
+29. https://doi.org/10.1016/j.celrep.2017.06.027,
+30. https://doi.org/10.15252/emmm.201708304,
+31. https://doi.org/10.1073/pnas.0407123101,
+32. https://doi.org/10.1073/pnas.0805003105,


### PR DESCRIPTION
## Summary
- add Falcon deep research reports for ARIH1, IGFBP3, and LIMD1
- curate existing GO annotations, add core functions, and add conservative NEW annotations for IGFBP3 hyaluronic acid binding and LIMD1 molecular adaptor activity
- regenerate the gene review HTML pages

## Validation
- uv run python scripts/validate_deep_research.py genes/human/ARIH1/ARIH1-deep-research-falcon.md genes/human/IGFBP3/IGFBP3-deep-research-falcon.md genes/human/LIMD1/LIMD1-deep-research-falcon.md
- just validate human ARIH1
- just validate human IGFBP3
- just validate human LIMD1
- just render human ARIH1
- just render human IGFBP3
- just render human LIMD1
- custom audit: checked 326 file-backed supporting_text snippets
- git diff --check