### PR TITLE
[codex] Add Falcon reviews for TOLLIP PICK1 RUNX3

### DIFF
--- a/genes/human/PICK1/PICK1-ai-review.html
+++ b/genes/human/PICK1/PICK1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>PICK1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q9NRD5" target="_blank" class="term-link">
                         Q9NRD5
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-initialized">
-                    INITIALIZED
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="Q9NRD5" data-a="DESCRIPTION: TODO: Add description for PICK1..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="Q9NRD5" data-a="DESCRIPTION: PICK1 encodes Protein interacting with C kinase 1,..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for PICK1</p>
+        <p>PICK1 encodes Protein interacting with C kinase 1, a PDZ/BAR-domain scaffold that couples cargo-protein binding to membrane binding and curvature-dependent trafficking. Its best-supported core role is regulation of membrane protein trafficking, especially AMPA receptor GluA2/GluA3 internalization/recycling and synaptic receptor organization, through PDZ-mediated partner selection, PKC-associated signaling, and BAR-domain membrane remodeling.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,3533 +758,5002 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043113" target="_blank" class="term-link">
                                     GO:0043113
                                 </a>
                             </span>
                             <span class="term-label">receptor clustering</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0043113" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0043113" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Receptor clustering is supported by PICK1 PDZ/BAR-dependent organization of synaptic receptor complexes.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> receptor clustering is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006886" target="_blank" class="term-link">
                                     GO:0006886
                                 </a>
                             </span>
                             <span class="term-label">intracellular protein transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0006886" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0006886" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Intracellular protein transport is central to PICK1 regulation of AMPAR and other membrane-protein trafficking.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> intracellular protein transport is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043005" target="_blank" class="term-link">
                                     GO:0043005
                                 </a>
                             </span>
                             <span class="term-label">neuron projection</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0043005" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0043005" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Neuron projection localization is consistent with PICK1 function in pre- and postsynaptic neuronal compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> neuron projection is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PICK1 is described as enriched in brain and localized to **pre- and postsynaptic compartments**, consistent with its role in regulating synaptic receptor trafficking</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005543" target="_blank" class="term-link">
                                     GO:0005543
                                 </a>
                             </span>
                             <span class="term-label">phospholipid binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005543" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005543" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Phospholipid binding is supported by the BAR/N-BAR membrane-binding module.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> phospholipid binding is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008021" target="_blank" class="term-link">
                                     GO:0008021
                                 </a>
                             </span>
                             <span class="term-label">synaptic vesicle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0008021" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0008021" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Synaptic vesicle localization is consistent with synaptic trafficking functions of PICK1.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> synaptic vesicle is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PICK1 is described as enriched in brain and localized to **pre- and postsynaptic compartments**, consistent with its role in regulating synaptic receptor trafficking</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0014069" target="_blank" class="term-link">
                                     GO:0014069
                                 </a>
                             </span>
                             <span class="term-label">postsynaptic density</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0014069" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0014069" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Postsynaptic density localization is supported by PICK1 action at postsynaptic AMPAR complexes.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> postsynaptic density is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PICK1 is described as enriched in brain and localized to **pre- and postsynaptic compartments**, consistent with its role in regulating synaptic receptor trafficking</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032588" target="_blank" class="term-link">
                                     GO:0032588
                                 </a>
                             </span>
                             <span class="term-label">trans-Golgi network membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0032588" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0032588" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> trans-Golgi network membrane is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> trans-Golgi network membrane is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097062" target="_blank" class="term-link">
                                     GO:0097062
                                 </a>
                             </span>
                             <span class="term-label">dendritic spine maintenance</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0097062" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0097062" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Dendritic spine maintenance is supported by PICK1 roles in AMPAR trafficking and synaptic plasticity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> dendritic spine maintenance is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PICK1 is described as enriched in brain and localized to **pre- and postsynaptic compartments**, consistent with its role in regulating synaptic receptor trafficking</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002092" target="_blank" class="term-link">
                                     GO:0002092
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of receptor internalization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0002092" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0002092" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Positive regulation of receptor internalization is a core PICK1-supported process for AMPAR GluA2 trafficking.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> positive regulation of receptor internalization is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In vivo evidence from mouse hippocampus (kainic acid model) supports a mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization; PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005080" target="_blank" class="term-link">
                                     GO:0005080
                                 </a>
                             </span>
                             <span class="term-label">protein kinase C binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005080" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005080" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein kinase C binding is supported by PICK1 identity as a PKC-alpha-binding protein.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein kinase C binding is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PICK1 was originally cloned/recognized as a **PKCα-binding protein**, a point reiterated in 2023 work on synaptic receptor regulation</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034315" target="_blank" class="term-link">
                                     GO:0034315
                                 </a>
                             </span>
                             <span class="term-label">regulation of Arp2/3 complex-mediated actin nucleation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0034315" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0034315" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> regulation of Arp2/3 complex-mediated actin nucleation is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> regulation of Arp2/3 complex-mediated actin nucleation is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003779" target="_blank" class="term-link">
                                     GO:0003779
                                 </a>
                             </span>
                             <span class="term-label">actin binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0003779" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0003779" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> actin binding is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> actin binding is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005737" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005737" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytoplasm is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytoplasm is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2024 Molecular Biology of the Cell study reports that in nonpolarized cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive organizer of protein sequestration/aggregation compartments</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005856" target="_blank" class="term-link">
                                     GO:0005856
                                 </a>
                             </span>
                             <span class="term-label">cytoskeleton</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005856" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005856" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytoskeleton is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytoskeleton is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0014069" target="_blank" class="term-link">
                                     GO:0014069
                                 </a>
                             </span>
                             <span class="term-label">postsynaptic density</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0014069" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0014069" data-r="GO_REF:0000044" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Postsynaptic density localization is supported by PICK1 action at postsynaptic AMPAR complexes.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> postsynaptic density is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PICK1 is described as enriched in brain and localized to **pre- and postsynaptic compartments**, consistent with its role in regulating synaptic receptor trafficking</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0016020" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> membrane is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> membrane is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019904" target="_blank" class="term-link">
                                     GO:0019904
                                 </a>
                             </span>
                             <span class="term-label">protein domain specific binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0019904" data-r="GO_REF:0000002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0019904" data-r="GO_REF:0000002" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein domain specific binding is supported by PICK1 PDZ-domain recognition of receptor/cargo C-terminal motifs.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein domain specific binding is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043005" target="_blank" class="term-link">
                                     GO:0043005
                                 </a>
                             </span>
                             <span class="term-label">neuron projection</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0043005" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0043005" data-r="GO_REF:0000043" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Neuron projection localization is consistent with PICK1 function in pre- and postsynaptic neuronal compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> neuron projection is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PICK1 is described as enriched in brain and localized to **pre- and postsynaptic compartments**, consistent with its role in regulating synaptic receptor trafficking</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045202" target="_blank" class="term-link">
                                     GO:0045202
                                 </a>
                             </span>
                             <span class="term-label">synapse</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0045202" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0045202" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Synapse localization is supported by PICK1 enrichment in pre- and postsynaptic compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> synapse is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PICK1 is described as enriched in brain and localized to **pre- and postsynaptic compartments**, consistent with its role in regulating synaptic receptor trafficking</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0046872" data-r="GO_REF:0000043" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Metal ion binding is not the functionally informative annotation for PICK1 compared with PDZ/BAR scaffold and membrane-remodeling activities.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> metal ion binding is less informative than the specific PICK1 scaffold mechanism.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
                                     GO:0048471
                                 </a>
                             </span>
                             <span class="term-label">perinuclear region of cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0048471" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0048471" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> perinuclear region of cytoplasm is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> perinuclear region of cytoplasm is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2024 Molecular Biology of the Cell study reports that in nonpolarized cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive organizer of protein sequestration/aggregation compartments</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11343649" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11343649
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional interaction between monoamine plasma membrane tra...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:11343649" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:11343649" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor binding, and identical protein binding are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding is less informative than the specific PICK1 scaffold mechanism.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11343649" target="_blank" class="term-link">
-                                        PMID:11343649
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Functional interaction between monoamine plasma membrane transporters and the synaptic PDZ domain-containing protein PICK1.</div>
-                                
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11802773" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11802773
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interaction of the synaptic protein PICK1 (protein interacti...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:11802773" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:11802773" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor binding, and identical protein binding are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding is less informative than the specific PICK1 scaffold mechanism.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11802773" target="_blank" class="term-link">
-                                        PMID:11802773
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Interaction of the synaptic protein PICK1 (protein interacting with C kinase 1) with the non-voltage gated sodium channels BNC1 (brain Na+ channel 1) and ASIC (acid-sensing ion channel).</div>
-                                
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16713569" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16713569
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A protein-protein interaction network for human inherited at...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:16713569" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:16713569" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor binding, and identical protein binding are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding is less informative than the specific PICK1 scaffold mechanism.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16713569" target="_blank" class="term-link">
-                                        PMID:16713569
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">A protein-protein interaction network for human inherited ataxias and disorders of Purkinje cell degeneration.</div>
-                                
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21653829" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21653829
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protein interactome reveals converging molecular pathways am...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:21653829" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:21653829" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor binding, and identical protein binding are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding is less informative than the specific PICK1 scaffold mechanism.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21653829" target="_blank" class="term-link">
-                                        PMID:21653829
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Protein interactome reveals converging molecular pathways among autism disorders.</div>
-                                
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26787460" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26787460
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteomic peptide phage display uncovers novel interactions ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:26787460" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:26787460" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor binding, and identical protein binding are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding is less informative than the specific PICK1 scaffold mechanism.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26787460" target="_blank" class="term-link">
-                                        PMID:26787460
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Proteomic peptide phage display uncovers novel interactions of the PDZ1-2 supramodule of syntenin.</div>
-                                
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the human interactome defines protein commun...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:28514442" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor binding, and identical protein binding are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding is less informative than the specific PICK1 scaffold mechanism.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
-                                        PMID:28514442
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Architecture of the human interactome defines protein communities and disease networks.</div>
-                                
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31413325" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31413325
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     HENA, heterogeneous network-based data set for Alzheimer&#39;s d...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:31413325" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:31413325" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor binding, and identical protein binding are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding is less informative than the specific PICK1 scaffold mechanism.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31413325" target="_blank" class="term-link">
-                                        PMID:31413325
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">HENA, heterogeneous network-based data set for Alzheimer&#39;s disease.</div>
-                                
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:32296183" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor binding, and identical protein binding are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding is less informative than the specific PICK1 scaffold mechanism.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
-                                        PMID:32296183
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Apr 8. A reference map of the human binary protein interactome.</div>
-                                
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:32814053" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:32814053" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor binding, and identical protein binding are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding is less informative than the specific PICK1 scaffold mechanism.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
-                                        PMID:32814053
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                                
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:33961781" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor binding, and identical protein binding are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding is less informative than the specific PICK1 scaffold mechanism.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
-                                        PMID:33961781
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2021 May 6. Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                                
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/36115835" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:36115835
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Quantitative fragmentomics allow affinity mapping of interac...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:36115835" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:36115835" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor binding, and identical protein binding are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding is less informative than the specific PICK1 scaffold mechanism.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/36115835" target="_blank" class="term-link">
-                                        PMID:36115835
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Quantitative fragmentomics allow affinity mapping of interactomes.</div>
-                                
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/37207277" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:37207277
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Using brain cell-type-specific protein interactomes to inter...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:37207277" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:37207277" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor binding, and identical protein binding are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding is less informative than the specific PICK1 scaffold mechanism.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/37207277" target="_blank" class="term-link">
-                                        PMID:37207277
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">eCollection 2023 May 19.</div>
-                                
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0042802" data-r="PMID:32296183" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0042802" data-r="PMID:32296183" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Identical protein binding is supported by BAR-domain homodimerization and higher-order PICK1 assembly.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> identical protein binding is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
-                                        PMID:32296183
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Apr 8. A reference map of the human binary protein interactome.</div>
-                                
+
+                                <div class="support-text">**BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytosol is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2024 Molecular Biology of the Cell study reports that in nonpolarized cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive organizer of protein sequestration/aggregation compartments</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16314870" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16314870
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Serine racemase binds to PICK1: potential relevance to schiz...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:16314870" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005515" data-r="PMID:16314870" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor binding, and identical protein binding are more informative.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding is less informative than the specific PICK1 scaffold mechanism.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16314870" target="_blank" class="term-link">
-                                        PMID:16314870
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Serine racemase binds to PICK1: potential relevance to schizophrenia.</div>
-                                
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050796" target="_blank" class="term-link">
                                     GO:0050796
                                 </a>
                             </span>
                             <span class="term-label">regulation of insulin secretion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29768204" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29768204
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An Amphipathic Helix Directs Cellular Membrane Curvature Sen...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0050796" data-r="PMID:29768204" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0050796" data-r="PMID:29768204" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> regulation of insulin secretion is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> regulation of insulin secretion is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29768204" target="_blank" class="term-link">
-                                        PMID:29768204
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">An Amphipathic Helix Directs Cellular Membrane Curvature Sensing and Function of the BAR Domain Protein PICK1.</div>
-                                
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140090" target="_blank" class="term-link">
                                     GO:0140090
                                 </a>
                             </span>
                             <span class="term-label">membrane curvature sensor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29768204" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29768204
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An Amphipathic Helix Directs Cellular Membrane Curvature Sen...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0140090" data-r="PMID:29768204" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0140090" data-r="PMID:29768204" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Membrane curvature sensor activity is supported by PICK1 BAR/N-BAR membrane-remodeling function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> membrane curvature sensor activity is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/29768204" target="_blank" class="term-link">
-                                        PMID:29768204
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">An Amphipathic Helix Directs Cellular Membrane Curvature Sensing and Function of the BAR Domain Protein PICK1.</div>
-                                
+
+                                <div class="support-text">**BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001664" target="_blank" class="term-link">
                                     GO:0001664
                                 </a>
                             </span>
                             <span class="term-label">G protein-coupled receptor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0001664" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0001664" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> G protein-coupled receptor binding is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> G protein-coupled receptor binding is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019904" target="_blank" class="term-link">
                                     GO:0019904
                                 </a>
                             </span>
                             <span class="term-label">protein domain specific binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0019904" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0019904" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein domain specific binding is supported by PICK1 PDZ-domain recognition of receptor/cargo C-terminal motifs.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein domain specific binding is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0042802" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0042802" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Identical protein binding is supported by BAR-domain homodimerization and higher-order PICK1 assembly.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> identical protein binding is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002092" target="_blank" class="term-link">
                                     GO:0002092
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of receptor internalization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0002092" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0002092" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Positive regulation of receptor internalization is a core PICK1-supported process for AMPAR GluA2 trafficking.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> positive regulation of receptor internalization is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In vivo evidence from mouse hippocampus (kainic acid model) supports a mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization; PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0021782" target="_blank" class="term-link">
                                     GO:0021782
                                 </a>
                             </span>
                             <span class="term-label">glial cell development</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0021782" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0021782" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> glial cell development is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> glial cell development is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034316" target="_blank" class="term-link">
                                     GO:0034316
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of Arp2/3 complex-mediated actin nucleation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0034316" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0034316" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> negative regulation of Arp2/3 complex-mediated actin nucleation is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> negative regulation of Arp2/3 complex-mediated actin nucleation is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036294" target="_blank" class="term-link">
                                     GO:0036294
                                 </a>
                             </span>
                             <span class="term-label">cellular response to decreased oxygen levels</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0036294" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0036294" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cellular response to decreased oxygen levels is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cellular response to decreased oxygen levels is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042149" target="_blank" class="term-link">
                                     GO:0042149
                                 </a>
                             </span>
                             <span class="term-label">cellular response to glucose starvation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0042149" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0042149" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cellular response to glucose starvation is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cellular response to glucose starvation is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043005" target="_blank" class="term-link">
                                     GO:0043005
                                 </a>
                             </span>
                             <span class="term-label">neuron projection</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0043005" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0043005" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Neuron projection localization is consistent with PICK1 function in pre- and postsynaptic neuronal compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> neuron projection is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PICK1 is described as enriched in brain and localized to **pre- and postsynaptic compartments**, consistent with its role in regulating synaptic receptor trafficking</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051015" target="_blank" class="term-link">
                                     GO:0051015
                                 </a>
                             </span>
                             <span class="term-label">actin filament binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0051015" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0051015" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> actin filament binding is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> actin filament binding is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060292" target="_blank" class="term-link">
                                     GO:0060292
                                 </a>
                             </span>
                             <span class="term-label">long-term synaptic depression</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0060292" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0060292" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Long-term synaptic depression is supported as a synaptic plasticity context for PICK1-mediated AMPAR internalization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> long-term synaptic depression is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In vivo evidence from mouse hippocampus (kainic acid model) supports a mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization; PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071933" target="_blank" class="term-link">
                                     GO:0071933
                                 </a>
                             </span>
                             <span class="term-label">Arp2/3 complex binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0071933" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0071933" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Arp2/3 complex binding is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Arp2/3 complex binding is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097061" target="_blank" class="term-link">
                                     GO:0097061
                                 </a>
                             </span>
                             <span class="term-label">dendritic spine organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0097061" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0097061" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Dendritic spine organization is supported through PICK1-dependent AMPAR trafficking and synaptic plasticity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> dendritic spine organization is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PICK1 is described as enriched in brain and localized to **pre- and postsynaptic compartments**, consistent with its role in regulating synaptic receptor trafficking</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097062" target="_blank" class="term-link">
                                     GO:0097062
                                 </a>
                             </span>
                             <span class="term-label">dendritic spine maintenance</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0097062" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0097062" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Dendritic spine maintenance is supported by PICK1 roles in AMPAR trafficking and synaptic plasticity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> dendritic spine maintenance is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PICK1 is described as enriched in brain and localized to **pre- and postsynaptic compartments**, consistent with its role in regulating synaptic receptor trafficking</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-416639
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005886" data-r="Reactome:R-HSA-416639" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005886" data-r="Reactome:R-HSA-416639" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Plasma membrane localization is supported by PICK1 roles in surface receptor internalization and trafficking.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> plasma membrane is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In vivo evidence from mouse hippocampus (kainic acid model) supports a mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization; PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-416985
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005886" data-r="Reactome:R-HSA-416985" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005886" data-r="Reactome:R-HSA-416985" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Plasma membrane localization is supported by PICK1 roles in surface receptor internalization and trafficking.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> plasma membrane is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In vivo evidence from mouse hippocampus (kainic acid model) supports a mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization; PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-421007
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005886" data-r="Reactome:R-HSA-421007" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005886" data-r="Reactome:R-HSA-421007" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Plasma membrane localization is supported by PICK1 roles in surface receptor internalization and trafficking.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> plasma membrane is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In vivo evidence from mouse hippocampus (kainic acid model) supports a mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization; PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030666" target="_blank" class="term-link">
                                     GO:0030666
                                 </a>
                             </span>
                             <span class="term-label">endocytic vesicle membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-416639
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0030666" data-r="Reactome:R-HSA-416639" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0030666" data-r="Reactome:R-HSA-416639" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Endocytic vesicle membrane localization is consistent with PICK1-mediated receptor internalization/recycling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> endocytic vesicle membrane is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In vivo evidence from mouse hippocampus (kainic acid model) supports a mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization; PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030666" target="_blank" class="term-link">
                                     GO:0030666
                                 </a>
                             </span>
                             <span class="term-label">endocytic vesicle membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-421007
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0030666" data-r="Reactome:R-HSA-421007" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0030666" data-r="Reactome:R-HSA-421007" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Endocytic vesicle membrane localization is consistent with PICK1-mediated receptor internalization/recycling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> endocytic vesicle membrane is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In vivo evidence from mouse hippocampus (kainic acid model) supports a mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization; PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16314870" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16314870
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Serine racemase binds to PICK1: potential relevance to schiz...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005737" data-r="PMID:16314870" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005737" data-r="PMID:16314870" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytoplasm is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytoplasm is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16314870" target="_blank" class="term-link">
-                                        PMID:16314870
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Serine racemase binds to PICK1: potential relevance to schizophrenia.</div>
-                                
+
+                                <div class="support-text">A 2024 Molecular Biology of the Cell study reports that in nonpolarized cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive organizer of protein sequestration/aggregation compartments</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005102" target="_blank" class="term-link">
                                     GO:0005102
                                 </a>
                             </span>
                             <span class="term-label">signaling receptor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005102" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005102" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Signaling receptor binding is supported by PICK1 PDZ-domain interactions with receptor cargo such as AMPAR subunits.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> signaling receptor binding is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043113" target="_blank" class="term-link">
                                     GO:0043113
                                 </a>
                             </span>
                             <span class="term-label">receptor clustering</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0043113" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0043113" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Receptor clustering is supported by PICK1 PDZ/BAR-dependent organization of synaptic receptor complexes.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> receptor clustering is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045202" target="_blank" class="term-link">
                                     GO:0045202
                                 </a>
                             </span>
                             <span class="term-label">synapse</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0045202" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0045202" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Synapse localization is supported by PICK1 enrichment in pre- and postsynaptic compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> synapse is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PICK1 is described as enriched in brain and localized to **pre- and postsynaptic compartments**, consistent with its role in regulating synaptic receptor trafficking</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005080" target="_blank" class="term-link">
                                     GO:0005080
                                 </a>
                             </span>
                             <span class="term-label">protein kinase C binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005080" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005080" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein kinase C binding is supported by PICK1 identity as a PKC-alpha-binding protein.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein kinase C binding is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PICK1 was originally cloned/recognized as a **PKCα-binding protein**, a point reiterated in 2023 work on synaptic receptor regulation</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
                                     GO:0048471
                                 </a>
                             </span>
                             <span class="term-label">perinuclear region of cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0048471" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0048471" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> perinuclear region of cytoplasm is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> perinuclear region of cytoplasm is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2024 Molecular Biology of the Cell study reports that in nonpolarized cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive organizer of protein sequestration/aggregation compartments</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005794" target="_blank" class="term-link">
                                     GO:0005794
                                 </a>
                             </span>
                             <span class="term-label">Golgi apparatus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005794" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005794" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Golgi apparatus is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Golgi apparatus is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006468" target="_blank" class="term-link">
                                     GO:0006468
                                 </a>
                             </span>
                             <span class="term-label">protein phosphorylation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4296,819 +5765,1608 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> MISANNOTATION: PICK1 (Protein interacting with C kinase 1) is NOT a kinase. It is a PDZ domain scaffold/adapter protein that BINDS protein kinase C (has GO:0005080 &#34;protein kinase C binding&#34;). UniProt describes it as a &#34;Probable adapter protein that bind to and organize&#34; signaling complexes. PICK1 is also a phosphorylation SUBSTRATE - &#34;Phosphorylation at Thr-82 appears to inhibit the interaction&#34; with GluR2. The ISS evidence is invalid as PICK1 has no kinase domain and doesn&#39;t catalyze phosphorylation.
+                            <strong>Summary:</strong> PICK1 controls phosphorylation-dependent receptor partner switching as a scaffold, but it does not catalyze protein phosphorylation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PICK1 is a phosphorylation-dependent scaffold/trafficking regulator, not a kinase.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In vivo evidence from mouse hippocampus (kainic acid model) supports a mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization; PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11343649" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11343649
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional interaction between monoamine plasma membrane tra...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005737" data-r="PMID:11343649" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005737" data-r="PMID:11343649" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytoplasm is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytoplasm is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11343649" target="_blank" class="term-link">
-                                        PMID:11343649
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Functional interaction between monoamine plasma membrane transporters and the synaptic PDZ domain-containing protein PICK1.</div>
-                                
+
+                                <div class="support-text">A 2024 Molecular Biology of the Cell study reports that in nonpolarized cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive organizer of protein sequestration/aggregation compartments</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11343649" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11343649
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional interaction between monoamine plasma membrane tra...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005886" data-r="PMID:11343649" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0005886" data-r="PMID:11343649" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Plasma membrane localization is supported by PICK1 roles in surface receptor internalization and trafficking.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> plasma membrane is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11343649" target="_blank" class="term-link">
-                                        PMID:11343649
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Functional interaction between monoamine plasma membrane transporters and the synaptic PDZ domain-containing protein PICK1.</div>
-                                
+
+                                <div class="support-text">In vivo evidence from mouse hippocampus (kainic acid model) supports a mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization; PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0015844" target="_blank" class="term-link">
                                     GO:0015844
                                 </a>
                             </span>
                             <span class="term-label">monoamine transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11343649" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11343649
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional interaction between monoamine plasma membrane tra...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0015844" data-r="PMID:11343649" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0015844" data-r="PMID:11343649" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> monoamine transport is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> monoamine transport is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11343649" target="_blank" class="term-link">
-                                        PMID:11343649
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Functional interaction between monoamine plasma membrane transporters and the synaptic PDZ domain-containing protein PICK1.</div>
-                                
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042734" target="_blank" class="term-link">
                                     GO:0042734
                                 </a>
                             </span>
                             <span class="term-label">presynaptic membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11343649" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11343649
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional interaction between monoamine plasma membrane tra...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0042734" data-r="PMID:11343649" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0042734" data-r="PMID:11343649" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> presynaptic membrane is plausible as a context-specific PICK1 localization, binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> presynaptic membrane is secondary to PICK1 membrane protein trafficking and synaptic receptor organization.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11343649" target="_blank" class="term-link">
-                                        PMID:11343649
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Functional interaction between monoamine plasma membrane transporters and the synaptic PDZ domain-containing protein PICK1.</div>
-                                
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045161" target="_blank" class="term-link">
                                     GO:0045161
                                 </a>
                             </span>
                             <span class="term-label">neuronal ion channel clustering</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11343649" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11343649
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Functional interaction between monoamine plasma membrane tra...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0045161" data-r="PMID:11343649" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9NRD5" data-a="GO:0045161" data-r="PMID:11343649" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Neuronal ion channel clustering is consistent with PICK1 synaptic receptor clustering and trafficking roles.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> neuronal ion channel clustering is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11343649" target="_blank" class="term-link">
-                                        PMID:11343649
-                                    </a>
-                                    
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Functional interaction between monoamine plasma membrane transporters and the synaptic PDZ domain-containing protein PICK1.</div>
-                                
+
+                                <div class="support-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PICK1/PICK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">PICK1 is described as enriched in brain and localized to **pre- and postsynaptic compartments**, consistent with its role in regulating synaptic receptor trafficking</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>PDZ-domain scaffold activity that selects receptor/cargo partners such as AMPAR GluA2/GluA3 and regulates receptor internalization, clustering, and synaptic trafficking.</h3>
+                <span class="vote-buttons" data-g="Q9NRD5" data-a="FUNCTION: PDZ-domain scaffold activity that selects receptor..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019904" target="_blank" class="term-link">
+                            protein domain specific binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002092" target="_blank" class="term-link">
+                                positive regulation of receptor internalization
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043113" target="_blank" class="term-link">
+                                receptor clustering
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006886" target="_blank" class="term-link">
+                                intracellular protein transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060292" target="_blank" class="term-link">
+                                long-term synaptic depression
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0014069" target="_blank" class="term-link">
+                                postsynaptic density
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045202" target="_blank" class="term-link">
+                                synapse
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                plasma membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PICK1/PICK1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PICK1/PICK1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">In vivo evidence from mouse hippocampus (kainic acid model) supports a mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization; PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PICK1/PICK1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>BAR/N-BAR membrane binding and curvature-sensing activity that couples PICK1 cargo complexes to membrane remodeling and compartmentalized trafficking.</h3>
+                <span class="vote-buttons" data-g="Q9NRD5" data-a="FUNCTION: BAR/N-BAR membrane binding and curvature-sensing a..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140090" target="_blank" class="term-link">
+                            membrane curvature sensor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006886" target="_blank" class="term-link">
+                                intracellular protein transport
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002092" target="_blank" class="term-link">
+                                positive regulation of receptor internalization
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030666" target="_blank" class="term-link">
+                                endocytic vesicle membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PICK1/PICK1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PICK1/PICK1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PICK1/PICK1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes**</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
                             GO_REF:0000024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11343649" target="_blank" class="term-link">
                             PMID:11343649
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Functional interaction between monoamine plasma membrane transporters and the synaptic PDZ domain-containing protein PICK1.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11802773" target="_blank" class="term-link">
                             PMID:11802773
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interaction of the synaptic protein PICK1 (protein interacting with C kinase 1) with the non-voltage gated sodium channels BNC1 (brain Na+ channel 1) and ASIC (acid-sensing ion channel).</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16314870" target="_blank" class="term-link">
                             PMID:16314870
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Serine racemase binds to PICK1: potential relevance to schizophrenia.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16713569" target="_blank" class="term-link">
                             PMID:16713569
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A protein-protein interaction network for human inherited ataxias and disorders of Purkinje cell degeneration.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21653829" target="_blank" class="term-link">
                             PMID:21653829
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Protein interactome reveals converging molecular pathways among autism disorders.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26787460" target="_blank" class="term-link">
                             PMID:26787460
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteomic peptide phage display uncovers novel interactions of the PDZ1-2 supramodule of syntenin.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/29768204" target="_blank" class="term-link">
                             PMID:29768204
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An Amphipathic Helix Directs Cellular Membrane Curvature Sensing and Function of the BAR Domain Protein PICK1.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31413325" target="_blank" class="term-link">
                             PMID:31413325
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HENA, heterogeneous network-based data set for Alzheimer&#39;s disease.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/36115835" target="_blank" class="term-link">
                             PMID:36115835
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Quantitative fragmentomics allow affinity mapping of interactomes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/37207277" target="_blank" class="term-link">
                             PMID:37207277
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Using brain cell-type-specific protein interactomes to interpret neurodevelopmental genetic signals in schizophrenia.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-416639
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Trafficking of GluR2-containing AMPA receptors to extrasynaptic sites</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-416985
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Trafficking of GluR2-containing AMPA receptors to synapse</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-421007
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Endocytosis of Ca impermeable AMPA receptors</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PICK1/PICK1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research synthesis for PICK1</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PICK1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9NRD5" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-12T00:13:27.954226'<br />
+end_time: '2026-05-12T00:25:00.312279'<br />
+duration_seconds: 692.36<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: PICK1<br />
+  gene_symbol: PICK1<br />
+  uniprot_accession: Q9NRD5<br />
+  protein_description: 'RecName: Full=PRKCA-binding protein; AltName: Full=Protein<br />
+    interacting with C kinase 1; AltName: Full=Protein kinase C-alpha-binding protein;'<br />
+  gene_info: Name=PICK1; Synonyms=PRKCABP;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Not specified in UniProt<br />
+  protein_domains: AH/BAR_dom_sf. (IPR027267); AH_dom. (IPR010504); Arfaptin_fam.<br />
+    (IPR030798); PDZ. (IPR001478); PDZ_sf. (IPR036034)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 24</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9NRD5</li>
+<li><strong>Protein Description:</strong> RecName: Full=PRKCA-binding protein; AltName: Full=Protein interacting with C kinase 1; AltName: Full=Protein kinase C-alpha-binding protein;</li>
+<li><strong>Gene Information:</strong> Name=PICK1; Synonyms=PRKCABP;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> AH/BAR_dom_sf. (IPR027267); AH_dom. (IPR010504); Arfaptin_fam. (IPR030798); PDZ. (IPR001478); PDZ_sf. (IPR036034)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "PICK1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'PICK1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>PICK1</strong> (gene ID: PICK1, UniProt: Q9NRD5) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9NRD5</li>
+<li><strong>Protein Description:</strong> RecName: Full=PRKCA-binding protein; AltName: Full=Protein interacting with C kinase 1; AltName: Full=Protein kinase C-alpha-binding protein;</li>
+<li><strong>Gene Information:</strong> Name=PICK1; Synonyms=PRKCABP;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> AH/BAR_dom_sf. (IPR027267); AH_dom. (IPR010504); Arfaptin_fam. (IPR030798); PDZ. (IPR001478); PDZ_sf. (IPR036034)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "PICK1" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'PICK1' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>PICK1</strong> (gene ID: PICK1, UniProt: Q9NRD5) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-human-pick1-uniprot-q9nrd5-functional-annotation-and-recent-research-20232024">Research Report: Human <strong>PICK1</strong> (UniProt Q9NRD5) — Functional Annotation and Recent Research (2023–2024)</h2>
+<h3 id="0-target-verification-mandatory">0. Target verification (mandatory)</h3>
+<p>The gene symbol <strong>PICK1</strong> in the retrieved literature corresponds to <strong>Protein interacting with C kinase 1 / PRKCA-binding protein</strong> in <strong>Homo sapiens</strong>, matching the UniProt entry <strong>Q9NRD5</strong>. Multiple 2023–2024 sources explicitly describe PICK1 as a <strong>PKCα-binding</strong> protein containing <strong>both a PDZ domain and a BAR (N‑BAR) domain</strong>, consistent with the UniProt-provided domain architecture and synonyms (zhu2023them1muscarinic pages 1-4, song2023investigatingthemechanical pages 1-2).</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1. Key concepts and definitions (current understanding)</h3>
+<h4 id="11-what-pick1-is">1.1. What PICK1 is</h4>
+<p><strong>PICK1 is a dual-domain scaffolding/adaptor protein</strong> that couples (i) <strong>PDZ-domain–mediated binding</strong> to C-terminal motifs on cargo proteins with (ii) <strong>BAR/N‑BAR–mediated lipid/membrane binding and remodeling</strong>, enabling regulation of membrane protein trafficking and compartmentalization (rathod2023ampaglua2subunit pages 1-4, cao2023molecularmechanismsof pages 1-2, song2023investigatingthemechanical pages 1-2).</p>
+<h4 id="12-core-domains-and-what-they-imply-functionally">1.2. Core domains and what they imply functionally</h4>
+<ul>
+<li><strong>PDZ domain (protein interaction module):</strong> In AMPAR biology, authoritative review evidence states that the <strong>GluA2 C-terminus</strong> contains a PDZ ligand that binds directly to <strong>PICK1</strong> (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain (cao2023molecularmechanismsof pages 1-2). A high-quality 2024 translational study similarly states that the <strong>PICK1 PDZ domain interacts with GluA2/GluA3 C termini to regulate receptor trafficking</strong> (fadahunsi2024targetingpostsynapticglutamate pages 2-4).</li>
+<li><strong>BAR / N‑BAR domain (membrane remodeling module):</strong> BAR domains are classically crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking. A 2023 molecular-dynamics study positions PICK1’s N‑BAR dimer as a mechanically specialized membrane-remodeling unit, whose inter-monomer interaction networks and flexibility are proposed to facilitate membrane binding and curvature-related function (song2023investigatingthemechanical pages 1-2, song2023investigatingthemechanical pages 6-7).</li>
+</ul>
+<h4 id="13-primary-molecular-function-functional-annotation-statement">1.3. Primary molecular function (functional annotation statement)</h4>
+<p>Across the recent literature, PICK1’s primary molecular role is best described as a <strong>PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes</strong> (cao2023molecularmechanismsof pages 1-2, rathod2023ampaglua2subunit pages 1-4, zhu2023them1muscarinic pages 1-4).</p>
+<h3 id="2-biological-processes-pathways-and-binding-partners">2. Biological processes, pathways, and binding partners</h3>
+<h4 id="21-ampa-receptor-ampar-trafficking-and-synaptic-plasticity-central-pathway">2.1. AMPA receptor (AMPAR) trafficking and synaptic plasticity (central pathway)</h4>
+<p><strong>AMPAR trafficking is the dominant experimentally supported pathway for PICK1 in the retrieved 2023–2024 corpus.</strong></p>
+<p><strong>(a) PICK1–GluA2/3 binding and ER-to-synapse trafficking logic</strong><br />
+A 2023 AMPAR trafficking review states that PICK1 binds the <strong>GluA2 C-terminal domain</strong> via its PDZ domain and reports that PICK1 can <strong>“stimulate the transportation of GluA2 to the ER membrane”</strong>, placing PICK1 activity in early AMPAR biogenesis/trafficking steps (cao2023molecularmechanismsof pages 1-2).</p>
+<p><strong>(b) Phosphorylation-dependent switching: GRIP1 ↔ PICK1 on GluA2</strong><br />
+In vivo evidence from mouse hippocampus (kainic acid model) supports a mechanistic switch in which <strong>GluA2 Ser880 phosphorylation</strong> promotes dissociation from GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization; PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association (lee2023pdiaugmentskainic pages 9-11).</p>
+<p><strong>(c) Quantitative evidence: increasing GluA2:PICK1 binding promotes internalization</strong><br />
+Lee et al. (2023) directly tested whether PICK1-mediated internalization is enhanced when upstream redox regulation perturbs PP2A. In mouse hippocampus, <strong>PDI knockdown increased GluA2:PICK1 binding to 1.27-fold of control</strong> (p &lt; 0.001), and kainic acid (KA) further enhanced binding under PDI knockdown (lee2023pdiaugmentskainic pages 9-11). The authors interpret this as a mechanism facilitating <strong>PICK1-mediated AMPAR internalization via increased GluA2 S880 phosphorylation</strong> (lee2023pdiaugmentskainic pages 9-11).</p>
+<p><strong>(d) Cholinergic regulation: M1 muscarinic receptor → PICK1 → GluA2 endocytosis</strong><br />
+Zhu et al. (2023) report that activation of the <strong>M1 muscarinic acetylcholine receptor</strong> (77-LH-28-1; 5 µL of 5 µM i.c.v.) promoted <strong>surface endocytosis of GluA2</strong>, reduced its postsynaptic colocalization with PSD-95, and increased GluA2 Ser880 phosphorylation, with the <strong>PICK1–GluA2 interaction required</strong> for M1-mediated postsynaptic GluA2 regulation (zhu2023them1muscarinic pages 1-4).</p>
+<h4 id="22-pkc-prkca-linkage">2.2. PKCα (PRKCA) linkage</h4>
+<p>PICK1 was originally cloned/recognized as a <strong>PKCα-binding protein</strong>, a point reiterated in 2023 work on synaptic receptor regulation (zhu2023them1muscarinic pages 1-4). In a broader mechanistic synthesis of PICK1 biology, PICK1 is described as targeting activated PKC to AMPAR-associated complexes and thereby influencing receptor surface levels (hendrix2025utilizingafdesignfor pages 8-9).</p>
+<h4 id="23-camkii-linkage">2.3. CaMKII linkage</h4>
+<p>In an authoritative 2023 review of AMPAR trafficking, Ca2+-dependent CaMKII activation is reported to promote formation of a <strong>CaMKII–PICK1 complex</strong> (cao2023molecularmechanismsof pages 1-2). This supports a model in which PICK1 participates in activity-dependent receptor trafficking regulated by Ca2+-linked kinases.</p>
+<h3 id="3-subcellular-localization-where-pick1-acts">3. Subcellular localization (where PICK1 acts)</h3>
+<h4 id="31-neuronal-compartments-pre-postsynaptic-regions">3.1. Neuronal compartments: pre-/postsynaptic regions</h4>
+<p>PICK1 is described as enriched in brain and localized to <strong>pre- and postsynaptic compartments</strong>, consistent with its role in regulating synaptic receptor trafficking (rathod2023ampaglua2subunit pages 1-4, zhu2023them1muscarinic pages 1-4).</p>
+<h4 id="32-er-membrane-trafficking-context">3.2. ER membrane trafficking context</h4>
+<p>The 2023 AMPAR trafficking review explicitly situates PICK1 in early trafficking steps by stating that PICK1 binds GluA2 and can stimulate its transport to the <strong>ER membrane</strong>, implying a role beyond the plasma membrane/PSD alone (cao2023molecularmechanismsof pages 1-2).</p>
+<h4 id="33-cytosolperinuclear-localization-and-stress-induced-aggresome-recruitment">3.3. Cytosol/perinuclear localization and stress-induced aggresome recruitment</h4>
+<p>A 2024 Molecular Biology of the Cell study reports that in nonpolarized cells PICK1 is typically <strong>cytosolic</strong>, but under <strong>sodium arsenite</strong> stress it relocalizes to <strong>perinuclear aggresomes</strong>, identifying PICK1 as a stress-responsive organizer of protein sequestration/aggregation compartments (lai2024sodiumarseniteinduces pages 1-2, lai2024sodiumarseniteinduces pages 6-8).</p>
+<p>Mechanistically, arsenite:<br />
+- <strong>Abolished</strong> a PDZ-mediated interaction (reported as the PICK1–GluR2 interaction being “completely abolished”) and<br />
+- Strongly promoted PICK1 BAR-dependent homodimerization (<strong>+544.3 ± 19.52%, P &lt; 0.0001</strong>) (lai2024sodiumarseniteinduces pages 6-8).</p>
+<p>This connects PICK1’s BAR domain to conditional relocalization and higher-order assembly at perinuclear quality-control organelles (lai2024sodiumarseniteinduces pages 6-8).</p>
+<h3 id="4-recent-developments-and-latest-research-prioritizing-20232024">4. Recent developments and latest research (prioritizing 2023–2024)</h3>
+<table>
+<thead>
+<tr>
+<th>Section</th>
+<th>Item</th>
+<th>System/Context</th>
+<th>Function / Key Result</th>
+<th>Quantitative detail</th>
+<th>Citation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Domain</td>
+<td>PDZ domain</td>
+<td>Human PICK1 scaffold</td>
+<td>Recognizes C-terminal PDZ ligands on partner proteins; mediates protein-protein interactions central to AMPAR/GluA2 trafficking and synaptic targeting; originally identified in a PKCα-binding protein context</td>
+<td>No single universal value reported in the cited excerpts</td>
+<td>(rathod2023ampaglua2subunit pages 1-4, zhu2023them1muscarinic pages 1-4, cao2023molecularmechanismsof pages 1-2)</td>
+</tr>
+<tr>
+<td>Domain</td>
+<td>BAR / N-BAR domain</td>
+<td>Human PICK1 scaffold</td>
+<td>Lipid-binding, membrane-remodeling, curvature-sensing/inducing module; supports synaptic targeting, membrane association, receptor trafficking, and stress-induced higher-order assembly</td>
+<td>MD simulations found directional asymmetry: during downward steering all 67 native inter-monomer residue pairs broke and 17 new pairs formed, whereas upward steering retained 35/67 native pairs and formed 23 new pairs</td>
+<td>(zhu2023them1muscarinic pages 1-4, song2023investigatingthemechanical pages 6-7)</td>
+</tr>
+<tr>
+<td>Partner / pathway</td>
+<td>PRKCA / PKCα</td>
+<td>Original PICK1 identification; synaptic signaling</td>
+<td>PICK1 is described as a PKCα-binding protein and can target activated PKC to AMPAR-associated complexes, linking phosphorylation to receptor trafficking/plasticity</td>
+<td>Qualitative mechanism in cited excerpts</td>
+<td>(hendrix2025utilizingafdesignfor pages 8-9, zhu2023them1muscarinic pages 1-4)</td>
+</tr>
+<tr>
+<td>Partner / pathway</td>
+<td>AMPAR GluA2</td>
+<td>Postsynaptic receptor trafficking</td>
+<td>Best-established PICK1 cargo/partner in the cited literature; PICK1 binds the GluA2 C-terminus via its PDZ domain and promotes internalization / intracellular retention during LTD-related processes</td>
+<td>GluA2:PICK1 binding increased to 1.27-fold after PDI knockdown in mouse hippocampus</td>
+<td>(rathod2023ampaglua2subunit pages 1-4, zhu2023them1muscarinic pages 1-4, cao2023molecularmechanismsof pages 1-2, lee2023pdiaugmentskainic pages 9-11)</td>
+</tr>
+<tr>
+<td>Partner / pathway</td>
+<td>GRIP1</td>
+<td>AMPAR trafficking switch</td>
+<td>GRIP1 opposes PICK1 on GluA2 trafficking: GRIP1 favors surface expression, while GluA2 S880 phosphorylation promotes GRIP1 dissociation and PICK1 association, driving AMPAR endocytosis</td>
+<td>Mechanistic switch centered on GluA2 Ser880 dephosphorylation/phosphorylation; no single effect size in excerpt</td>
+<td>(lee2023pdiaugmentskainic pages 9-11)</td>
+</tr>
+<tr>
+<td>Partner / pathway</td>
+<td>PP2A</td>
+<td>GluA2 phosphorylation control</td>
+<td>PP2A dephosphorylates GluA2 Ser880, weakening PICK1 association and favoring GRIP1 rebinding; inhibition of PP2A facilitates PICK1-mediated AMPAR internalization</td>
+<td>In Lee 2023, oxidation-linked PP2A inhibition was proposed to increase PICK1-mediated internalization; GluA2:PICK1 binding rose 1.27-fold</td>
+<td>(lee2023pdiaugmentskainic pages 9-11)</td>
+</tr>
+<tr>
+<td>Partner / pathway</td>
+<td>CaMKII</td>
+<td>Activity-dependent AMPAR regulation</td>
+<td>Ca2+-dependent CaMKII activation forms a CaMKII-PICK1 complex in AMPAR trafficking models; both CaMKII and PKC impinge on AMPAR phosphosites relevant to PICK1 function</td>
+<td>No standalone numeric value in cited excerpt</td>
+<td>(cao2023molecularmechanismsof pages 1-2, lee2023pdiaugmentskainic pages 9-11)</td>
+</tr>
+<tr>
+<td>Partner / pathway</td>
+<td>M1 muscarinic acetylcholine receptor pathway</td>
+<td>Cholinergic control of postsynaptic AMPARs</td>
+<td>M1 receptor activation regulates postsynaptic GluA2 surface expression through PICK1-dependent mechanisms, coupling cholinergic signaling to AMPAR endocytosis</td>
+<td>77-LH-28-1 delivered i.c.v. at 5 µL of 5 µM; Fsc231 used at 5 µL of 50 µM in the study</td>
+<td>(zhu2023them1muscarinic pages 1-4)</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>Synapse / postsynaptic density</td>
+<td>Neurons</td>
+<td>PICK1 is enriched in pre/postsynaptic neural compartments and acts at postsynaptic AMPAR complexes to regulate receptor localization and plasticity</td>
+<td>Qualitative localization in cited excerpts</td>
+<td>(rathod2023ampaglua2subunit pages 1-4, zhu2023them1muscarinic pages 1-4)</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>ER / early secretory pathway</td>
+<td>AMPAR trafficking pathway</td>
+<td>Review evidence states PICK1 binds GluA2 and stimulates trafficking toward the ER membrane / early secretory pathway steps in AMPAR biogenesis and movement</td>
+<td>Qualitative localization in cited excerpt</td>
+<td>(cao2023molecularmechanismsof pages 1-2)</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>Cytosol / perinuclear region</td>
+<td>Nonpolarized cells, heterologous cells</td>
+<td>PICK1 is generally cytosolic with occasional perinuclear structures under basal conditions</td>
+<td>Qualitative basal localization</td>
+<td>(rathod2023ampaglua2subunit pages 1-4, lai2024sodiumarseniteinduces pages 1-2)</td>
+</tr>
+<tr>
+<td>Localization</td>
+<td>Perinuclear aggresome</td>
+<td>Stress response in HEK293T cells</td>
+<td>Under arsenite stress, PICK1 relocalizes from diffuse cytosol to perinuclear aggresomes in a BAR-domain-dependent manner</td>
+<td>Detergent-insoluble PICK1 increased by ~191.2 ± 20.79 (P = 0.008); soluble fraction decreased by 32.77 ± 3.28% (P = 0.006)</td>
+<td>(lai2024sodiumarseniteinduces pages 6-8)</td>
+</tr>
+<tr>
+<td>Recent study (2023)</td>
+<td>Cao 2023 review</td>
+<td>Nervous system / AMPAR trafficking review</td>
+<td>Summarizes that GluA2 C-terminal PDZ ligands bind PICK1 and GRIP1; PICK1 binds GluA2 via its PDZ domain and participates in ER-to-synapse trafficking logic and CaMKII-linked regulation</td>
+<td>Review, no primary effect size</td>
+<td>(cao2023molecularmechanismsof pages 1-2)</td>
+</tr>
+<tr>
+<td>Recent study (2023)</td>
+<td>Zhu 2023</td>
+<td>Mouse brain, M1 mAChR activation</td>
+<td>M1 receptor activation promoted postsynaptic GluA2 endocytosis, reduced GluA2-PSD95 colocalization, and increased GluA2 Ser880 phosphorylation in a PICK1-dependent pathway</td>
+<td>77-LH-28-1: 5 µL of 5 µM i.c.v.; surface biotinylation used 1 mg/mL sulfo-NHS-LC-biotin; Fsc231: 5 µL of 50 µM; n = 3 replicates</td>
+<td>(zhu2023them1muscarinic pages 1-4)</td>
+</tr>
+<tr>
+<td>Recent study (2023)</td>
+<td>Lee 2023</td>
+<td>Mouse hippocampus / kainic acid model</td>
+<td>PDI knockdown facilitated PICK1-mediated AMPAR internalization by increasing GluA2 Ser880 phosphorylation and strengthening GluA2:PICK1 interaction</td>
+<td>GluA2:PICK1 binding increased to 1.27-fold of control (p &lt; 0.001); KA further enhanced binding in PDI-siRNA animals; n = 7</td>
+<td>(lee2023pdiaugmentskainic pages 9-11)</td>
+</tr>
+<tr>
+<td>Recent study (2023)</td>
+<td>Rathod 2023</td>
+<td>In silico PDZ inhibitor discovery</td>
+<td>Pharmacophore/docking/MD campaign identified candidate competitive and allosteric PICK1 PDZ inhibitors as potential neurological leads</td>
+<td>10 libraries; 340,731,400 molecules and 1,603,779,177 conformers screened; docking scores: Hit_I -9.0, Hit_III -8.9, Hit_IV -9.2, control BQA -8.6 kcal/mol; Hit_II ESOL LogS -3.47</td>
+<td>(rathod2023ampaglua2subunit pages 22-26)</td>
+</tr>
+<tr>
+<td>Recent study (2023)</td>
+<td>Song 2023</td>
+<td>Molecular dynamics of PICK1 N-BAR dimer</td>
+<td>Mechanical simulations support that helix kinks and interaction networks confer flexibility needed for membrane engagement and asymmetric responses to force</td>
+<td>Downward steering broke all 67 native residue pairs and formed 17 new ones; upward steering retained 35/67 and formed 23 new ones</td>
+<td>(song2023investigatingthemechanical pages 6-7)</td>
+</tr>
+<tr>
+<td>Recent study (2024)</td>
+<td>Fadahunsi 2024</td>
+<td>Human genetics + obese mouse intervention</td>
+<td>GWAS linked PICK1 locus to adiposity; pharmacologic PDZ inhibition with mPD5 produced sustained anti-obesity effects in mice, supporting translational targeting of PICK1</td>
+<td>Lead SNP rs4821764 P = 4.9 × 10−12; rs17752670 blood eQTL P = 3.3 × 10−106; 56 mg/kg tolerated; 14-day daily s.c. mPD5 caused 9.8% vehicle-corrected weight loss</td>
+<td>(fadahunsi2024targetingpostsynapticglutamate pages 1-2, fadahunsi2024targetingpostsynapticglutamate pages 2-4)</td>
+</tr>
+<tr>
+<td>Recent study (2024)</td>
+<td>Lai 2024</td>
+<td>HEK293T arsenite stress / aggresome biology</td>
+<td>Arsenite drove PICK1 BAR-dependent homodimerization, abolished PICK1-GluR2 interaction, shifted PICK1 to aggresomes, and promoted insoluble aggregate formation</td>
+<td>PICK1 homodimerization +544.3 ± 19.52% (P &lt; 0.0001); competitive coIP favored PICK1-PICK1 +397.7 ± 4.27% vs PICK1-ICA1 +59.8 ± 3.31%; insoluble pellet +191.2 ± 20.79 (P = 0.008)</td>
+<td>(lai2024sodiumarseniteinduces pages 6-8)</td>
+</tr>
+<tr>
+<td>Recent study (2024)</td>
+<td>Ou 2024</td>
+<td>Nasopharyngeal carcinoma cells and xenografts</td>
+<td>PICK1 acted as a tumor suppressor in NPC by inhibiting migration, invasion, proliferation, tumor growth, metastasis, and Wnt/β-catenin pathway output</td>
+<td>Tail-vein metastasis experiments used n = 5 mice/group; in vitro and in vivo differences were reported as significant with <strong>p &lt; 0.01 / </strong>*p &lt; 0.001, but effect sizes were not numerically tabulated in the excerpt</td>
+<td>(ou2024pick1inhibitsthe pages 2-7)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table consolidates the core functional annotation of human PICK1, including its PDZ and BAR domains, key partners and pathways, subcellular localization, and major 2023–2024 findings. It is designed to support a narrative research report with quick access to mechanisms, applications, and quantitative study results.</em></p>
+<h4 id="41-2024-translational-advance-pdz-domain-targeting-for-obesity-treatment-real-world-implementation-trend">4.1. 2024 translational advance: PDZ-domain targeting for obesity treatment (real-world implementation trend)</h4>
+<p>Fadahunsi et al. (Science Advances, <strong>March 2024</strong>, https://doi.org/10.1126/sciadv.adg2636) integrated human genetics and mouse pharmacology:<br />
+- <strong>Human genetics:</strong> loci in/near <strong>PICK1</strong> reached genome-wide significance for adiposity traits; the paper reports a lead SNP <strong>rs4821764 (P = 4.9 × 10−12)</strong> and a blood eQTL for PICK1 <strong>rs17752670 (P = 3.3 × 10−106)</strong> (fadahunsi2024targetingpostsynapticglutamate pages 1-2, fadahunsi2024targetingpostsynapticglutamate pages 2-4).<br />
+- <strong>In vivo intervention:</strong> a lipidated dimeric PICK1 PDZ-targeting peptide inhibitor (<strong>mPD5</strong>) produced <strong>9.8% vehicle-corrected weight loss</strong> over <strong>14 days</strong> (once-daily s.c.), with <strong>56 mg/kg</strong> identified as a tolerated dose for chronic studies (fadahunsi2024targetingpostsynapticglutamate pages 2-4).</p>
+<p>This is among the strongest recent in vivo demonstrations that PICK1 PDZ targeting can drive a durable physiological phenotype with therapeutic framing (fadahunsi2024targetingpostsynapticglutamate pages 2-4).</p>
+<h4 id="42-2024-mechanistic-advance-arsenite-stress-bar-domain-homodimerization-and-aggresomes">4.2. 2024 mechanistic advance: arsenite stress, BAR-domain homodimerization, and aggresomes</h4>
+<p>Lai et al. (Molecular Biology of the Cell, <strong>October 2024</strong>, https://doi.org/10.1091/mbc.e24-05-0201) provide quantitative evidence that arsenite selectively promotes PICK1–PICK1 assembly and insolubility:<br />
+- PICK1 homodimerization increased <strong>+544.3 ± 19.52% (P &lt; 0.0001)</strong>.<br />
+- PICK1 shifted toward detergent-insoluble fractions (pellet <strong>~+191.2 ± 20.79</strong>, P = 0.008) with decreased soluble fraction (−32.77 ± 3.28%, P = 0.006) (lai2024sodiumarseniteinduces pages 6-8).</p>
+<p>This work expands PICK1 biology beyond synapses, tying it to proteostasis-related compartmentalization relevant to neurodegeneration hypotheses (lai2024sodiumarseniteinduces pages 6-8).</p>
+<h4 id="43-2023-mechanistic-evidence-pp2aglua2-s880pick1-axis-in-vivo">4.3. 2023 mechanistic evidence: PP2A–GluA2 S880–PICK1 axis in vivo</h4>
+<p>Lee et al. (Scientific Reports, <strong>August 2023</strong>, https://doi.org/10.1038/s41598-023-41014-7) support a model in which upstream redox state (via PDI) can enhance <strong>PICK1-mediated AMPAR internalization</strong> by promoting GluA2 S880 phosphorylation and increasing PICK1 binding (lee2023pdiaugmentskainic pages 9-11). The directly quantified increase in <strong>GluA2:PICK1 binding (1.27-fold, p &lt; 0.001)</strong> provides an experimentally anchored statistic linking PICK1 complex formation to trafficking outcomes (lee2023pdiaugmentskainic pages 9-11).</p>
+<h4 id="44-20232024-receptor-signaling-linkage-m1-machr-pick1-glua2-trafficking">4.4. 2023–2024 receptor-signaling linkage: M1 mAChR → PICK1 → GluA2 trafficking</h4>
+<p>Zhu et al. (Psychopharmacology, <strong>December 2023</strong>, https://doi.org/10.1007/s00213-022-06304-4) provide a pathway-level example of how a GPCR (M1 mAChR) can modulate postsynaptic receptor composition through PICK1-dependent GluA2 trafficking (zhu2023them1muscarinic pages 1-4).</p>
+<h4 id="45-2023-structuralbiophysical-developments-bar-domain-mechanics">4.5. 2023 structural/biophysical developments: BAR-domain mechanics</h4>
+<p>Song et al. (Current Protein &amp; Peptide Science, <strong>December 2023</strong>, https://doi.org/10.2174/1389203724666230522093842) used steered molecular dynamics to infer anisotropic mechanical responses of the PICK1 BAR dimer and detailed inter-monomer contact changes under force (e.g., <strong>downward steering broke all 67 native residue pairs</strong>; <strong>upward steering retained 35/67 and formed 23 new pairs</strong>) (song2023investigatingthemechanical pages 6-7, song2023investigatingthemechanical pages 1-2). While computational, this supports current mechanistic thinking that BAR-domain flexibility and interaction networks underlie membrane engagement and curvature-related function (song2023investigatingthemechanical pages 1-2).</p>
+<h3 id="5-current-applications-and-real-world-implementations">5. Current applications and real-world implementations</h3>
+<h4 id="51-therapeutic-targeting-of-pick1-pdz-interactions">5.1. Therapeutic targeting of PICK1 PDZ interactions</h4>
+<p>Three convergent application streams appear in 2023–2024 evidence:<br />
+1. <strong>Anti-obesity intervention:</strong> pharmacological PDZ targeting with mPD5 produces sustained weight loss in obese mice (9.8% vehicle-corrected) (fadahunsi2024targetingpostsynapticglutamate pages 2-4).<br />
+2. <strong>Neurological disease targeting rationale:</strong> PDZ-mediated PICK1–GluA2 interactions are widely framed as druggable points for conditions involving synaptic plasticity dysregulation; 2023 inhibitor-design work positions the PDZ domain as a therapeutic target (rathod2023ampaglua2subunit pages 1-4, rathod2023ampaglua2subunit pages 22-26).<br />
+3. <strong>Neurodegeneration/proteostasis hypothesis:</strong> arsenite-triggered aggresome localization and insolubility suggest PICK1 could participate in stress-linked aggregation pathways, relevant to neurodegenerative disease models (lai2024sodiumarseniteinduces pages 6-8).</p>
+<h4 id="52-cancer-biology-and-biomarker-potential">5.2. Cancer biology and biomarker potential</h4>
+<p>Ou et al. (Cell Death &amp; Disease, <strong>April 2024</strong>, https://doi.org/10.1038/s41419-024-06687-6) report that PICK1 suppresses migration/invasion and inhibits tumor growth and lung metastasis in nasopharyngeal carcinoma models; in tail-vein metastasis experiments they report <strong>n = 5 mice per group</strong>, and mechanistically find that PICK1 inhibits classical <strong>Wnt/β-catenin signaling</strong> (β-catenin, c-Myc, CyclinD1) (ou2024pick1inhibitsthe pages 2-7). This positions PICK1 as a potential <strong>tumor suppressor/prognostic marker</strong> in NPC, although generalization beyond this cancer context requires caution (ou2024pick1inhibitsthe pages 2-7).</p>
+<h3 id="6-expert-opinions-and-authoritative-synthesis-with-analysis">6. Expert opinions and authoritative synthesis (with analysis)</h3>
+<h4 id="61-consensus-model">6.1. Consensus model</h4>
+<p>Across authoritative 2023–2024 review/primary sources, the consensus is:<br />
+- <strong>PICK1 is a PDZ/BAR scaffold</strong> whose PDZ interactions with receptor C-termini (especially AMPAR GluA2/3) place it at the center of activity-dependent receptor trafficking and plasticity mechanisms (cao2023molecularmechanismsof pages 1-2, fadahunsi2024targetingpostsynapticglutamate pages 2-4, zhu2023them1muscarinic pages 1-4).<br />
+- <strong>Phosphorylation state controls partner switching</strong> (GRIP1 ↔ PICK1) on GluA2, providing a biochemical mechanism for directional trafficking (surface retention versus internalization) (lee2023pdiaugmentskainic pages 9-11).<br />
+- <strong>BAR-domain–dependent membrane/proteostasis behaviors</strong> extend PICK1’s functions beyond synapses, enabling stress-induced relocalization and assembly (lai2024sodiumarseniteinduces pages 6-8, song2023investigatingthemechanical pages 1-2).</p>
+<h4 id="62-reconciling-apparent-pleiotropy">6.2. Reconciling apparent “pleiotropy”</h4>
+<p>The recent evidence supports a unifying interpretation: PICK1’s apparent pleiotropy (synaptic plasticity, obesity, cancer, aggresomes) is consistent with a <strong>core mechanistic toolkit—PDZ-based cargo selection + BAR-based membrane/assembly control</strong>—deployed in different cellular contexts (fadahunsi2024targetingpostsynapticglutamate pages 2-4, lai2024sodiumarseniteinduces pages 6-8, ou2024pick1inhibitsthe pages 2-7).</p>
+<h3 id="7-relevant-statistics-and-data-points-from-recent-studies">7. Relevant statistics and data points (from recent studies)</h3>
+<ul>
+<li><strong>Obesity genetics:</strong> rs4821764 associated with adiposity traits (<strong>P = 4.9 × 10−12</strong>); rs17752670 as blood eQTL for PICK1 (<strong>P = 3.3 × 10−106</strong>) (Science Advances, Mar 2024) (fadahunsi2024targetingpostsynapticglutamate pages 2-4).</li>
+<li><strong>Anti-obesity pharmacology:</strong> mPD5 caused <strong>9.8% vehicle-corrected weight loss in 14 days</strong>; <strong>56 mg/kg</strong> tolerated (fadahunsi2024targetingpostsynapticglutamate pages 2-4).</li>
+<li><strong>Synaptic trafficking biochemistry:</strong> GluA2:PICK1 binding increased to <strong>1.27-fold</strong> after PDI knockdown (<strong>p &lt; 0.001</strong>, n = 7) (Scientific Reports, Aug 2023) (lee2023pdiaugmentskainic pages 9-11).</li>
+<li><strong>Stress/aggresome biology:</strong> arsenite increased PICK1 homodimerization <strong>+544.3 ± 19.52% (P &lt; 0.0001)</strong> and increased detergent-insoluble pellet signal <strong>~+191.2 ± 20.79 (P = 0.008)</strong> (MBoC, Oct 2024) (lai2024sodiumarseniteinduces pages 6-8).</li>
+<li><strong>In silico inhibitor discovery scale:</strong> virtual screen of <strong>340,731,400 molecules</strong> and <strong>1,603,779,177 conformers</strong>; docking scores down to <strong>−9.2 kcal/mol</strong> for reported hits (Journal of Biomolecular Structure and Dynamics, Nov 2023) (rathod2023ampaglua2subunit pages 22-26).</li>
+</ul>
+<h3 id="8-disease-associations-database-level-context">8. Disease associations (database-level context)</h3>
+<p>OpenTargets reports PICK1 disease-target associations including <strong>Alzheimer disease</strong>, <strong>Parkinson disease</strong>, broader <strong>neurodegenerative disease</strong>, <strong>lysosomal storage disease</strong>, and <strong>male infertility due to globozoospermia</strong> (OpenTargets context) (OpenTargets Search: -PICK1). These associations are useful for hypothesis generation but should be interpreted alongside direct mechanistic evidence from primary studies.</p>
+<h3 id="9-summary-functional-annotation-statement">9. Summary (functional annotation statement)</h3>
+<p>Human <strong>PICK1 (Q9NRD5)</strong> is best annotated as a <strong>PDZ/BAR scaffolding and membrane-remodeling protein</strong> that controls <strong>membrane protein trafficking</strong>, with the strongest 2023–2024 evidence supporting roles in <strong>AMPAR (GluA2/3) internalization/recycling and synaptic plasticity</strong> through phosphorylation-dependent partner switching and regulated complex formation. Recent work extends PICK1 relevance to <strong>system-level phenotypes (obesity via PDZ targeting)</strong>, <strong>stress-driven aggresome biology</strong>, and <strong>context-specific tumor suppressor signaling via Wnt/β-catenin</strong>, motivating ongoing therapeutic and mechanistic studies (fadahunsi2024targetingpostsynapticglutamate pages 2-4, lee2023pdiaugmentskainic pages 9-11, lai2024sodiumarseniteinduces pages 6-8, ou2024pick1inhibitsthe pages 2-7).</p>
+<p>References</p>
+<ol>
+<li>
+<p>(zhu2023them1muscarinic pages 1-4): Zengyan Zhu, Wenjuan Wang, Chao Gu, Mei Wang, and Yinghui Yan. The m1 muscarinic acetylcholine receptor regulates the surface expression of the ampa receptor subunit glua2 via pick1. Psychopharmacology, 240:239-248, Dec 2023. URL: https://doi.org/10.1007/s00213-022-06304-4, doi:10.1007/s00213-022-06304-4. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(song2023investigatingthemechanical pages 1-2): Shenghan Song, Tongtong Li, Amy O. Stevens, Taha Raad, and Yi He. Investigating the mechanical properties and flexibility of n-bar domains in pick1 by molecular dynamics simulations. Current Protein &amp; Peptide Science, 24:865-877, Dec 2023. URL: https://doi.org/10.2174/1389203724666230522093842, doi:10.2174/1389203724666230522093842. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rathod2023ampaglua2subunit pages 1-4): Shravan B. Rathod, Pravin B. Prajapati, Ranjana Pal, and Mohmedyasin F. Mansuri. Ampa glua2 subunit competitive inhibitors for pick1 pdz domain: pharmacophore-based virtual screening, molecular docking, molecular dynamics simulation, and adme studies. Journal of Biomolecular Structure and Dynamics, 41:336-351, Nov 2023. URL: https://doi.org/10.1080/07391102.2021.2006086, doi:10.1080/07391102.2021.2006086. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(cao2023molecularmechanismsof pages 1-2): Yi-Yang Cao, Ling-Ling Wu, Xiao-Nan Li, Yu-Lian Yuan, Wan-Wei Zhao, Jing-Xuan Qi, Xu-Yu Zhao, Natalie Ward, and Jiao Wang. Molecular mechanisms of ampa receptor trafficking in the nervous system. International Journal of Molecular Sciences, 25:111, Dec 2023. URL: https://doi.org/10.3390/ijms25010111, doi:10.3390/ijms25010111. This article has 30 citations.</p>
+</li>
+<li>
+<p>(fadahunsi2024targetingpostsynapticglutamate pages 2-4): Nicole Fadahunsi, Jonas Petersen, Sophia Metz, Alexander Jakobsen, Cecilie Vad Mathiesen, Alberte Silke Buch-Rasmussen, Nigel Kurgan, Jeppe Kjærgaard Larsen, Rita C. Andersen, Thomas Topilko, Charlotte Svendsen, Mia Apuschkin, Grethe Skovbjerg, Jan Hendrik Schmidt, Grace Houser, Sara Elgaard Jager, Anders Bach, Atul S. Deshmukh, Tuomas O. Kilpeläinen, Kristian Strømgaard, Kenneth L. Madsen, and Christoffer Clemmensen. Targeting postsynaptic glutamate receptor scaffolding proteins psd-95 and pick1 for obesity treatment. Science Advances, Mar 2024. URL: https://doi.org/10.1126/sciadv.adg2636, doi:10.1126/sciadv.adg2636. This article has 17 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(song2023investigatingthemechanical pages 6-7): Shenghan Song, Tongtong Li, Amy O. Stevens, Taha Raad, and Yi He. Investigating the mechanical properties and flexibility of n-bar domains in pick1 by molecular dynamics simulations. Current Protein &amp; Peptide Science, 24:865-877, Dec 2023. URL: https://doi.org/10.2174/1389203724666230522093842, doi:10.2174/1389203724666230522093842. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lee2023pdiaugmentskainic pages 9-11): Duk-shin Lee, Tae-Hyun Kim, Hana Park, and Ji-eun Kim. Pdi augments kainic acid-induced seizure activity and neuronal death by inhibiting pp2a-glua2-pick1-mediated ampa receptor internalization in the mouse hippocampus. Scientific Reports, Aug 2023. URL: https://doi.org/10.1038/s41598-023-41014-7, doi:10.1038/s41598-023-41014-7. This article has 6 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hendrix2025utilizingafdesignfor pages 8-9): Emily Hendrix, Xinyu Xia, Amy O. Stevens, and Yi He. Utilizing afdesign for developing a small molecule inhibitor of pick 1-pdz. Current protein &amp; peptide science, Aug 2025. URL: https://doi.org/10.2174/0113892037316932240806102854, doi:10.2174/0113892037316932240806102854. This article has 2 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lai2024sodiumarseniteinduces pages 1-2): John Ho Chun Lai, Marianthi Tsogka, and Jun Xia. Sodium arsenite induces aggresome formation by promoting pick1 bar domain homodimer formation. Molecular Biology of the Cell, Oct 2024. URL: https://doi.org/10.1091/mbc.e24-05-0201, doi:10.1091/mbc.e24-05-0201. This article has 0 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lai2024sodiumarseniteinduces pages 6-8): John Ho Chun Lai, Marianthi Tsogka, and Jun Xia. Sodium arsenite induces aggresome formation by promoting pick1 bar domain homodimer formation. Molecular Biology of the Cell, Oct 2024. URL: https://doi.org/10.1091/mbc.e24-05-0201, doi:10.1091/mbc.e24-05-0201. This article has 0 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rathod2023ampaglua2subunit pages 22-26): Shravan B. Rathod, Pravin B. Prajapati, Ranjana Pal, and Mohmedyasin F. Mansuri. Ampa glua2 subunit competitive inhibitors for pick1 pdz domain: pharmacophore-based virtual screening, molecular docking, molecular dynamics simulation, and adme studies. Journal of Biomolecular Structure and Dynamics, 41:336-351, Nov 2023. URL: https://doi.org/10.1080/07391102.2021.2006086, doi:10.1080/07391102.2021.2006086. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fadahunsi2024targetingpostsynapticglutamate pages 1-2): Nicole Fadahunsi, Jonas Petersen, Sophia Metz, Alexander Jakobsen, Cecilie Vad Mathiesen, Alberte Silke Buch-Rasmussen, Nigel Kurgan, Jeppe Kjærgaard Larsen, Rita C. Andersen, Thomas Topilko, Charlotte Svendsen, Mia Apuschkin, Grethe Skovbjerg, Jan Hendrik Schmidt, Grace Houser, Sara Elgaard Jager, Anders Bach, Atul S. Deshmukh, Tuomas O. Kilpeläinen, Kristian Strømgaard, Kenneth L. Madsen, and Christoffer Clemmensen. Targeting postsynaptic glutamate receptor scaffolding proteins psd-95 and pick1 for obesity treatment. Science Advances, Mar 2024. URL: https://doi.org/10.1126/sciadv.adg2636, doi:10.1126/sciadv.adg2636. This article has 17 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ou2024pick1inhibitsthe pages 2-7): Xiaomin Ou, Yingzi Zhang, Yiqing Xu, Yi Liu, Wenzhi Tu, Chaosu Hu, and Yong Liu. Pick1 inhibits the malignancy of nasopharyngeal carcinoma and serves as a novel prognostic marker. Cell Death &amp; Disease, Apr 2024. URL: https://doi.org/10.1038/s41419-024-06687-6, doi:10.1038/s41419-024-06687-6. This article has 3 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -PICK1): Open Targets Query (-PICK1, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>cao2023molecularmechanismsof pages 1-2</li>
+<li>fadahunsi2024targetingpostsynapticglutamate pages 2-4</li>
+<li>lee2023pdiaugmentskainic pages 9-11</li>
+<li>hendrix2025utilizingafdesignfor pages 8-9</li>
+<li>lai2024sodiumarseniteinduces pages 6-8</li>
+<li>song2023investigatingthemechanical pages 6-7</li>
+<li>song2023investigatingthemechanical pages 1-2</li>
+<li>lai2024sodiumarseniteinduces pages 1-2</li>
+<li>fadahunsi2024targetingpostsynapticglutamate pages 1-2</li>
+<li>https://doi.org/10.1126/sciadv.adg2636</li>
+<li>https://doi.org/10.1091/mbc.e24-05-0201</li>
+<li>https://doi.org/10.1038/s41598-023-41014-7</li>
+<li>https://doi.org/10.1007/s00213-022-06304-4</li>
+<li>https://doi.org/10.2174/1389203724666230522093842</li>
+<li>https://doi.org/10.1038/s41419-024-06687-6</li>
+<li>https://doi.org/10.1007/s00213-022-06304-4,</li>
+<li>https://doi.org/10.2174/1389203724666230522093842,</li>
+<li>https://doi.org/10.1080/07391102.2021.2006086,</li>
+<li>https://doi.org/10.3390/ijms25010111,</li>
+<li>https://doi.org/10.1126/sciadv.adg2636,</li>
+<li>https://doi.org/10.1038/s41598-023-41014-7,</li>
+<li>https://doi.org/10.2174/0113892037316932240806102854,</li>
+<li>https://doi.org/10.1091/mbc.e24-05-0201,</li>
+<li>https://doi.org/10.1038/s41419-024-06687-6,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -5120,11 +7378,15 @@
                 <pre><code>id: Q9NRD5
 gene_symbol: PICK1
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: &#39;TODO: Add description for PICK1&#39;
+description: &#39;PICK1 encodes Protein interacting with C kinase 1, a PDZ/BAR-domain scaffold that couples
+  cargo-protein binding to membrane binding and curvature-dependent trafficking. Its best-supported core
+  role is regulation of membrane protein trafficking, especially AMPA receptor GluA2/GluA3 internalization/recycling
+  and synaptic receptor organization, through PDZ-mediated partner selection, PKC-associated signaling,
+  and BAR-domain membrane remodeling.&#39;
 alternative_products:
   - name: &#39;1&#39;
     id: Q9NRD5-1
@@ -5138,725 +7400,1482 @@ existing_annotations:
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Receptor clustering is supported by PICK1 PDZ/BAR-dependent organization of synaptic
+        receptor complexes.
+      action: ACCEPT
+      reason: receptor clustering is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0006886
       label: intracellular protein transport
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Intracellular protein transport is central to PICK1 regulation of AMPAR and other
+        membrane-protein trafficking.
+      action: ACCEPT
+      reason: intracellular protein transport is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0043005
       label: neuron projection
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Neuron projection localization is consistent with PICK1 function in pre- and
+        postsynaptic neuronal compartments.
+      action: ACCEPT
+      reason: neuron projection is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0005543
       label: phospholipid binding
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Phospholipid binding is supported by the BAR/N-BAR membrane-binding module.
+      action: ACCEPT
+      reason: phospholipid binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically
+            crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking.&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
   - term:
       id: GO:0008021
       label: synaptic vesicle
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Synaptic vesicle localization is consistent with synaptic trafficking functions of
+        PICK1.
+      action: ACCEPT
+      reason: synaptic vesicle is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0014069
       label: postsynaptic density
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Postsynaptic density localization is supported by PICK1 action at postsynaptic AMPAR
+        complexes.
+      action: ACCEPT
+      reason: postsynaptic density is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0032588
       label: trans-Golgi network membrane
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: trans-Golgi network membrane is plausible as a context-specific PICK1 localization,
+        binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking
+        function.
+      action: KEEP_AS_NON_CORE
+      reason: trans-Golgi network membrane is secondary to PICK1 membrane protein trafficking and
+        synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0097062
       label: dendritic spine maintenance
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Dendritic spine maintenance is supported by PICK1 roles in AMPAR trafficking and
+        synaptic plasticity.
+      action: ACCEPT
+      reason: dendritic spine maintenance is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0002092
       label: positive regulation of receptor internalization
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Positive regulation of receptor internalization is a core PICK1-supported process for
+        AMPAR GluA2 trafficking.
+      action: ACCEPT
+      reason: positive regulation of receptor internalization is supported as part of PICK1 PDZ/BAR
+        scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0005080
       label: protein kinase C binding
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein kinase C binding is supported by PICK1 identity as a PKC-alpha-binding
+        protein.
+      action: ACCEPT
+      reason: protein kinase C binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 was originally cloned/recognized as a **PKCα-binding protein**, a
+            point reiterated in 2023 work on synaptic receptor regulation
   - term:
       id: GO:0034315
       label: regulation of Arp2/3 complex-mediated actin nucleation
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: regulation of Arp2/3 complex-mediated actin nucleation is plausible as a
+        context-specific PICK1 localization, binding, or downstream process, but it is secondary to
+        the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: regulation of Arp2/3 complex-mediated actin nucleation is secondary to PICK1 membrane
+        protein trafficking and synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0003779
       label: actin binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: actin binding is plausible as a context-specific PICK1 localization, binding, or
+        downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: actin binding is secondary to PICK1 membrane protein trafficking and synaptic receptor
+        organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0005737
       label: cytoplasm
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: cytoplasm is plausible as a context-specific PICK1 localization, binding, or
+        downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: cytoplasm is secondary to PICK1 membrane protein trafficking and synaptic receptor
+        organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: A 2024 Molecular Biology of the Cell study reports that in nonpolarized
+            cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it
+            relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive
+            organizer of protein sequestration/aggregation compartments
   - term:
       id: GO:0005856
       label: cytoskeleton
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: cytoskeleton is plausible as a context-specific PICK1 localization, binding, or
+        downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: cytoskeleton is secondary to PICK1 membrane protein trafficking and synaptic receptor
+        organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0014069
       label: postsynaptic density
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Postsynaptic density localization is supported by PICK1 action at postsynaptic AMPAR
+        complexes.
+      action: ACCEPT
+      reason: postsynaptic density is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0016020
       label: membrane
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: membrane is plausible as a context-specific PICK1 localization, binding, or
+        downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: membrane is secondary to PICK1 membrane protein trafficking and synaptic receptor
+        organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0019904
       label: protein domain specific binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000002
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein domain specific binding is supported by PICK1 PDZ-domain recognition of
+        receptor/cargo C-terminal motifs.
+      action: ACCEPT
+      reason: protein domain specific binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0043005
       label: neuron projection
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Neuron projection localization is consistent with PICK1 function in pre- and
+        postsynaptic neuronal compartments.
+      action: ACCEPT
+      reason: neuron projection is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0045202
       label: synapse
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Synapse localization is supported by PICK1 enrichment in pre- and postsynaptic
+        compartments.
+      action: ACCEPT
+      reason: synapse is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or
+        synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0046872
       label: metal ion binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Metal ion binding is not the functionally informative annotation for PICK1 compared
+        with PDZ/BAR scaffold and membrane-remodeling activities.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: metal ion binding is less informative than the specific PICK1 scaffold mechanism.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
   - term:
       id: GO:0048471
       label: perinuclear region of cytoplasm
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: perinuclear region of cytoplasm is plausible as a context-specific PICK1
+        localization, binding, or downstream process, but it is secondary to the core PDZ/BAR
+        receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: perinuclear region of cytoplasm is secondary to PICK1 membrane protein trafficking and
+        synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: A 2024 Molecular Biology of the Cell study reports that in nonpolarized
+            cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it
+            relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive
+            organizer of protein sequestration/aggregation compartments
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:11343649
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:11343649
-          supporting_text: Functional interaction between monoamine plasma 
-            membrane transporters and the synaptic PDZ domain-containing protein
-            PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:11802773
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:11802773
-          supporting_text: Interaction of the synaptic protein PICK1 (protein 
-            interacting with C kinase 1) with the non-voltage gated sodium 
-            channels BNC1 (brain Na+ channel 1) and ASIC (acid-sensing ion 
-            channel).
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:16713569
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:16713569
-          supporting_text: A protein-protein interaction network for human 
-            inherited ataxias and disorders of Purkinje cell degeneration.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:21653829
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:21653829
-          supporting_text: Protein interactome reveals converging molecular 
-            pathways among autism disorders.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:26787460
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:26787460
-          supporting_text: Proteomic peptide phage display uncovers novel 
-            interactions of the PDZ1-2 supramodule of syntenin.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:28514442
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:28514442
-          supporting_text: Architecture of the human interactome defines protein
-            communities and disease networks.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:31413325
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:31413325
-          supporting_text: HENA, heterogeneous network-based data set for 
-            Alzheimer&#39;s disease.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:32296183
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:32296183
-          supporting_text: Apr 8. A reference map of the human binary protein 
-            interactome.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:32814053
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:32814053
-          supporting_text: Interactome Mapping Provides a Network of 
-            Neurodegenerative Disease Proteins and Uncovers Widespread Protein 
-            Aggregation in Affected Brains.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:33961781
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:33961781
-          supporting_text: 2021 May 6. Dual proteome-scale networks reveal 
-            cell-specific remodeling of the human interactome.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:36115835
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:36115835
-          supporting_text: Quantitative fragmentomics allow affinity mapping of 
-            interactomes.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:37207277
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:37207277
-          supporting_text: eCollection 2023 May 19.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0042802
       label: identical protein binding
     evidence_type: IPI
     original_reference_id: PMID:32296183
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Identical protein binding is supported by BAR-domain homodimerization and
+        higher-order PICK1 assembly.
+      action: ACCEPT
+      reason: identical protein binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
       supported_by:
-        - reference_id: PMID:32296183
-          supporting_text: Apr 8. A reference map of the human binary protein 
-            interactome.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically
+            crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking.&#39;
   - term:
       id: GO:0005829
       label: cytosol
     evidence_type: IDA
     original_reference_id: GO_REF:0000052
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: cytosol is plausible as a context-specific PICK1 localization, binding, or downstream
+        process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: cytosol is secondary to PICK1 membrane protein trafficking and synaptic receptor
+        organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: A 2024 Molecular Biology of the Cell study reports that in nonpolarized
+            cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it
+            relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive
+            organizer of protein sequestration/aggregation compartments
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:16314870
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:16314870
-          supporting_text: &#39;Serine racemase binds to PICK1: potential relevance to
-            schizophrenia.&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0050796
       label: regulation of insulin secretion
     evidence_type: IMP
     original_reference_id: PMID:29768204
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: regulation of insulin secretion is plausible as a context-specific PICK1
+        localization, binding, or downstream process, but it is secondary to the core PDZ/BAR
+        receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: regulation of insulin secretion is secondary to PICK1 membrane protein trafficking and
+        synaptic receptor organization.
       supported_by:
-        - reference_id: PMID:29768204
-          supporting_text: An Amphipathic Helix Directs Cellular Membrane 
-            Curvature Sensing and Function of the BAR Domain Protein PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0140090
       label: membrane curvature sensor activity
     evidence_type: IDA
     original_reference_id: PMID:29768204
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Membrane curvature sensor activity is supported by PICK1 BAR/N-BAR
+        membrane-remodeling function.
+      action: ACCEPT
+      reason: membrane curvature sensor activity is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
       supported_by:
-        - reference_id: PMID:29768204
-          supporting_text: An Amphipathic Helix Directs Cellular Membrane 
-            Curvature Sensing and Function of the BAR Domain Protein PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically
+            crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking.&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
   - term:
       id: GO:0001664
       label: G protein-coupled receptor binding
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: G protein-coupled receptor binding is plausible as a context-specific PICK1
+        localization, binding, or downstream process, but it is secondary to the core PDZ/BAR
+        receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: G protein-coupled receptor binding is secondary to PICK1 membrane protein trafficking
+        and synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0019904
       label: protein domain specific binding
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein domain specific binding is supported by PICK1 PDZ-domain recognition of
+        receptor/cargo C-terminal motifs.
+      action: ACCEPT
+      reason: protein domain specific binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0042802
       label: identical protein binding
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Identical protein binding is supported by BAR-domain homodimerization and
+        higher-order PICK1 assembly.
+      action: ACCEPT
+      reason: identical protein binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically
+            crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking.&#39;
   - term:
       id: GO:0002092
       label: positive regulation of receptor internalization
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Positive regulation of receptor internalization is a core PICK1-supported process for
+        AMPAR GluA2 trafficking.
+      action: ACCEPT
+      reason: positive regulation of receptor internalization is supported as part of PICK1 PDZ/BAR
+        scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0021782
       label: glial cell development
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: glial cell development is plausible as a context-specific PICK1 localization,
+        binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking
+        function.
+      action: KEEP_AS_NON_CORE
+      reason: glial cell development is secondary to PICK1 membrane protein trafficking and synaptic
+        receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0034316
       label: negative regulation of Arp2/3 complex-mediated actin nucleation
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: negative regulation of Arp2/3 complex-mediated actin nucleation is plausible as a
+        context-specific PICK1 localization, binding, or downstream process, but it is secondary to
+        the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: negative regulation of Arp2/3 complex-mediated actin nucleation is secondary to PICK1
+        membrane protein trafficking and synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0036294
       label: cellular response to decreased oxygen levels
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: cellular response to decreased oxygen levels is plausible as a context-specific PICK1
+        localization, binding, or downstream process, but it is secondary to the core PDZ/BAR
+        receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: cellular response to decreased oxygen levels is secondary to PICK1 membrane protein
+        trafficking and synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0042149
       label: cellular response to glucose starvation
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: cellular response to glucose starvation is plausible as a context-specific PICK1
+        localization, binding, or downstream process, but it is secondary to the core PDZ/BAR
+        receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: cellular response to glucose starvation is secondary to PICK1 membrane protein
+        trafficking and synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0043005
       label: neuron projection
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Neuron projection localization is consistent with PICK1 function in pre- and
+        postsynaptic neuronal compartments.
+      action: ACCEPT
+      reason: neuron projection is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0051015
       label: actin filament binding
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: actin filament binding is plausible as a context-specific PICK1 localization,
+        binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking
+        function.
+      action: KEEP_AS_NON_CORE
+      reason: actin filament binding is secondary to PICK1 membrane protein trafficking and synaptic
+        receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0060292
       label: long-term synaptic depression
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Long-term synaptic depression is supported as a synaptic plasticity context for
+        PICK1-mediated AMPAR internalization.
+      action: ACCEPT
+      reason: long-term synaptic depression is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0071933
       label: Arp2/3 complex binding
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Arp2/3 complex binding is plausible as a context-specific PICK1 localization,
+        binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking
+        function.
+      action: KEEP_AS_NON_CORE
+      reason: Arp2/3 complex binding is secondary to PICK1 membrane protein trafficking and synaptic
+        receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0097061
       label: dendritic spine organization
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Dendritic spine organization is supported through PICK1-dependent AMPAR trafficking
+        and synaptic plasticity.
+      action: ACCEPT
+      reason: dendritic spine organization is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0097062
       label: dendritic spine maintenance
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Dendritic spine maintenance is supported by PICK1 roles in AMPAR trafficking and
+        synaptic plasticity.
+      action: ACCEPT
+      reason: dendritic spine maintenance is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0005886
       label: plasma membrane
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-416639
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Plasma membrane localization is supported by PICK1 roles in surface receptor
+        internalization and trafficking.
+      action: ACCEPT
+      reason: plasma membrane is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0005886
       label: plasma membrane
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-416985
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Plasma membrane localization is supported by PICK1 roles in surface receptor
+        internalization and trafficking.
+      action: ACCEPT
+      reason: plasma membrane is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0005886
       label: plasma membrane
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-421007
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Plasma membrane localization is supported by PICK1 roles in surface receptor
+        internalization and trafficking.
+      action: ACCEPT
+      reason: plasma membrane is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0030666
       label: endocytic vesicle membrane
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-416639
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Endocytic vesicle membrane localization is consistent with PICK1-mediated receptor
+        internalization/recycling.
+      action: ACCEPT
+      reason: endocytic vesicle membrane is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0030666
       label: endocytic vesicle membrane
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-421007
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Endocytic vesicle membrane localization is consistent with PICK1-mediated receptor
+        internalization/recycling.
+      action: ACCEPT
+      reason: endocytic vesicle membrane is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0005737
       label: cytoplasm
     evidence_type: IDA
     original_reference_id: PMID:16314870
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: cytoplasm is plausible as a context-specific PICK1 localization, binding, or
+        downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: cytoplasm is secondary to PICK1 membrane protein trafficking and synaptic receptor
+        organization.
       supported_by:
-        - reference_id: PMID:16314870
-          supporting_text: &#39;Serine racemase binds to PICK1: potential relevance to
-            schizophrenia.&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: A 2024 Molecular Biology of the Cell study reports that in nonpolarized
+            cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it
+            relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive
+            organizer of protein sequestration/aggregation compartments
   - term:
       id: GO:0005102
       label: signaling receptor binding
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Signaling receptor binding is supported by PICK1 PDZ-domain interactions with
+        receptor cargo such as AMPAR subunits.
+      action: ACCEPT
+      reason: signaling receptor binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0043113
       label: receptor clustering
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Receptor clustering is supported by PICK1 PDZ/BAR-dependent organization of synaptic
+        receptor complexes.
+      action: ACCEPT
+      reason: receptor clustering is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
   - term:
       id: GO:0045202
       label: synapse
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Synapse localization is supported by PICK1 enrichment in pre- and postsynaptic
+        compartments.
+      action: ACCEPT
+      reason: synapse is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or
+        synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0005080
       label: protein kinase C binding
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Protein kinase C binding is supported by PICK1 identity as a PKC-alpha-binding
+        protein.
+      action: ACCEPT
+      reason: protein kinase C binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 was originally cloned/recognized as a **PKCα-binding protein**, a
+            point reiterated in 2023 work on synaptic receptor regulation
   - term:
       id: GO:0048471
       label: perinuclear region of cytoplasm
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: perinuclear region of cytoplasm is plausible as a context-specific PICK1
+        localization, binding, or downstream process, but it is secondary to the core PDZ/BAR
+        receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: perinuclear region of cytoplasm is secondary to PICK1 membrane protein trafficking and
+        synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: A 2024 Molecular Biology of the Cell study reports that in nonpolarized
+            cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it
+            relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive
+            organizer of protein sequestration/aggregation compartments
   - term:
       id: GO:0005794
       label: Golgi apparatus
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Golgi apparatus is plausible as a context-specific PICK1 localization, binding, or
+        downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: Golgi apparatus is secondary to PICK1 membrane protein trafficking and synaptic
+        receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0006468
       label: protein phosphorylation
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: &gt;-
-        MISANNOTATION: PICK1 (Protein interacting with C kinase 1) is NOT a kinase.
-        It is a PDZ domain scaffold/adapter protein that BINDS protein kinase C
-        (has GO:0005080 &#34;protein kinase C binding&#34;). UniProt describes it as a
-        &#34;Probable adapter protein that bind to and organize&#34; signaling complexes.
-        PICK1 is also a phosphorylation SUBSTRATE - &#34;Phosphorylation at Thr-82
-        appears to inhibit the interaction&#34; with GluR2. The ISS evidence is invalid
-        as PICK1 has no kinase domain and doesn&#39;t catalyze phosphorylation.
+      summary: PICK1 controls phosphorylation-dependent receptor partner switching as a scaffold,
+        but it does not catalyze protein phosphorylation.
       action: REMOVE
+      reason: PICK1 is a phosphorylation-dependent scaffold/trafficking regulator, not a kinase.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
   - term:
       id: GO:0005737
       label: cytoplasm
     evidence_type: IDA
     original_reference_id: PMID:11343649
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: cytoplasm is plausible as a context-specific PICK1 localization, binding, or
+        downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: cytoplasm is secondary to PICK1 membrane protein trafficking and synaptic receptor
+        organization.
       supported_by:
-        - reference_id: PMID:11343649
-          supporting_text: Functional interaction between monoamine plasma 
-            membrane transporters and the synaptic PDZ domain-containing protein
-            PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: A 2024 Molecular Biology of the Cell study reports that in nonpolarized
+            cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it
+            relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive
+            organizer of protein sequestration/aggregation compartments
   - term:
       id: GO:0005886
       label: plasma membrane
     evidence_type: IDA
     original_reference_id: PMID:11343649
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Plasma membrane localization is supported by PICK1 roles in surface receptor
+        internalization and trafficking.
+      action: ACCEPT
+      reason: plasma membrane is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
       supported_by:
-        - reference_id: PMID:11343649
-          supporting_text: Functional interaction between monoamine plasma 
-            membrane transporters and the synaptic PDZ domain-containing protein
-            PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0015844
       label: monoamine transport
     evidence_type: IDA
     original_reference_id: PMID:11343649
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: monoamine transport is plausible as a context-specific PICK1 localization, binding,
+        or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking
+        function.
+      action: KEEP_AS_NON_CORE
+      reason: monoamine transport is secondary to PICK1 membrane protein trafficking and synaptic
+        receptor organization.
       supported_by:
-        - reference_id: PMID:11343649
-          supporting_text: Functional interaction between monoamine plasma 
-            membrane transporters and the synaptic PDZ domain-containing protein
-            PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0042734
       label: presynaptic membrane
     evidence_type: IDA
     original_reference_id: PMID:11343649
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: presynaptic membrane is plausible as a context-specific PICK1 localization, binding,
+        or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking
+        function.
+      action: KEEP_AS_NON_CORE
+      reason: presynaptic membrane is secondary to PICK1 membrane protein trafficking and synaptic
+        receptor organization.
       supported_by:
-        - reference_id: PMID:11343649
-          supporting_text: Functional interaction between monoamine plasma 
-            membrane transporters and the synaptic PDZ domain-containing protein
-            PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0045161
       label: neuronal ion channel clustering
     evidence_type: TAS
     original_reference_id: PMID:11343649
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: Neuronal ion channel clustering is consistent with PICK1 synaptic receptor clustering
+        and trafficking roles.
+      action: ACCEPT
+      reason: neuronal ion channel clustering is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
       supported_by:
-        - reference_id: PMID:11343649
-          supporting_text: Functional interaction between monoamine plasma 
-            membrane transporters and the synaptic PDZ domain-containing protein
-            PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
 references:
   - id: GO_REF:0000002
-    title: Gene Ontology annotation through association of InterPro records with
-      GO terms
+    title: Gene Ontology annotation through association of InterPro records with GO terms
     findings: []
   - id: GO_REF:0000024
-    title: Manual transfer of experimentally-verified manual GO annotation data 
-      to orthologs by curator judgment of sequence similarity
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by
+      curator judgment of sequence similarity
     findings: []
   - id: GO_REF:0000033
     title: Annotation inferences using phylogenetic trees
     findings: []
   - id: GO_REF:0000043
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword 
-      mapping
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
     findings: []
   - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+      mapping, accompanied by conservative changes to GO terms applied by UniProt
     findings: []
   - id: GO_REF:0000052
     title: Gene Ontology annotation based on curation of immunofluorescence data
     findings: []
   - id: GO_REF:0000117
-    title: Electronic Gene Ontology annotations created by ARBA machine learning
-      models
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
     findings: []
   - id: GO_REF:0000120
     title: Combined Automated Annotation using Multiple IEA Methods
     findings: []
   - id: PMID:11343649
-    title: Functional interaction between monoamine plasma membrane transporters
-      and the synaptic PDZ domain-containing protein PICK1.
+    title: Functional interaction between monoamine plasma membrane transporters and the synaptic
+      PDZ domain-containing protein PICK1.
     findings: []
   - id: PMID:11802773
-    title: Interaction of the synaptic protein PICK1 (protein interacting with C
-      kinase 1) with the non-voltage gated sodium channels BNC1 (brain Na+ 
-      channel 1) and ASIC (acid-sensing ion channel).
+    title: Interaction of the synaptic protein PICK1 (protein interacting with C kinase 1) with the
+      non-voltage gated sodium channels BNC1 (brain Na+ channel 1) and ASIC (acid-sensing ion
+      channel).
     findings: []
   - id: PMID:16314870
     title: &#39;Serine racemase binds to PICK1: potential relevance to schizophrenia.&#39;
     findings: []
   - id: PMID:16713569
-    title: A protein-protein interaction network for human inherited ataxias and
-      disorders of Purkinje cell degeneration.
+    title: A protein-protein interaction network for human inherited ataxias and disorders of
+      Purkinje cell degeneration.
     findings: []
   - id: PMID:21653829
-    title: Protein interactome reveals converging molecular pathways among 
-      autism disorders.
+    title: Protein interactome reveals converging molecular pathways among autism disorders.
     findings: []
   - id: PMID:26787460
-    title: Proteomic peptide phage display uncovers novel interactions of the 
-      PDZ1-2 supramodule of syntenin.
+    title: Proteomic peptide phage display uncovers novel interactions of the PDZ1-2 supramodule of
+      syntenin.
     findings: []
   - id: PMID:28514442
-    title: Architecture of the human interactome defines protein communities and
-      disease networks.
+    title: Architecture of the human interactome defines protein communities and disease networks.
     findings: []
   - id: PMID:29768204
-    title: An Amphipathic Helix Directs Cellular Membrane Curvature Sensing and 
-      Function of the BAR Domain Protein PICK1.
+    title: An Amphipathic Helix Directs Cellular Membrane Curvature Sensing and Function of the BAR
+      Domain Protein PICK1.
     findings: []
   - id: PMID:31413325
     title: HENA, heterogeneous network-based data set for Alzheimer&#39;s disease.
@@ -5865,19 +8884,18 @@ references:
     title: A reference map of the human binary protein interactome.
     findings: []
   - id: PMID:32814053
-    title: Interactome Mapping Provides a Network of Neurodegenerative Disease 
-      Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.
+    title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers
+      Widespread Protein Aggregation in Affected Brains.
     findings: []
   - id: PMID:33961781
-    title: Dual proteome-scale networks reveal cell-specific remodeling of the 
-      human interactome.
+    title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
     findings: []
   - id: PMID:36115835
     title: Quantitative fragmentomics allow affinity mapping of interactomes.
     findings: []
   - id: PMID:37207277
-    title: Using brain cell-type-specific protein interactomes to interpret 
-      neurodevelopmental genetic signals in schizophrenia.
+    title: Using brain cell-type-specific protein interactomes to interpret neurodevelopmental
+      genetic signals in schizophrenia.
     findings: []
   - id: Reactome:R-HSA-416639
     title: Trafficking of GluR2-containing AMPA receptors to extrasynaptic sites
@@ -5888,13 +8906,83 @@ references:
   - id: Reactome:R-HSA-421007
     title: Endocytosis of Ca impermeable AMPA receptors
     findings: []
+  - id: file:human/PICK1/PICK1-deep-research-falcon.md
+    title: Falcon deep research synthesis for PICK1
+    findings: []
+core_functions:
+  - description: PDZ-domain scaffold activity that selects receptor/cargo partners such as AMPAR
+      GluA2/GluA3 and regulates receptor internalization, clustering, and synaptic trafficking.
+    molecular_function:
+      id: GO:0019904
+      label: protein domain specific binding
+    directly_involved_in:
+      - id: GO:0002092
+        label: positive regulation of receptor internalization
+      - id: GO:0043113
+        label: receptor clustering
+      - id: GO:0006886
+        label: intracellular protein transport
+      - id: GO:0060292
+        label: long-term synaptic depression
+    locations:
+      - id: GO:0014069
+        label: postsynaptic density
+      - id: GO:0045202
+        label: synapse
+      - id: GO:0005886
+        label: plasma membrane
+    supported_by:
+      - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+        supporting_text: &#39;**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+          review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+          to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain&#39;
+      - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+        supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+          mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+          GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization; PP2A-mediated
+          dephosphorylation reverses this and disfavors PICK1 association
+      - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+        supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+          membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+          strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+          internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+          partner switching and regulated complex formation.
+  - description: BAR/N-BAR membrane binding and curvature-sensing activity that couples PICK1 cargo
+      complexes to membrane remodeling and compartmentalized trafficking.
+    molecular_function:
+      id: GO:0140090
+      label: membrane curvature sensor activity
+    directly_involved_in:
+      - id: GO:0006886
+        label: intracellular protein transport
+      - id: GO:0002092
+        label: positive regulation of receptor internalization
+    locations:
+      - id: GO:0030666
+        label: endocytic vesicle membrane
+    supported_by:
+      - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+        supporting_text: &#39;**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+          binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+          binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization&#39;
+      - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+        supporting_text: &#39;**BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically
+          crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking.&#39;
+      - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+        supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+          described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability
+          of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein
+          complex assembly with membrane remodeling and endocytic/recycling processes**
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/PICK1/PICK1-ai-review.yaml
+++ b/genes/human/PICK1/PICK1-ai-review.yaml
@@ -1,11 +1,15 @@
 id: Q9NRD5
 gene_symbol: PICK1
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for PICK1'
+description: 'PICK1 encodes Protein interacting with C kinase 1, a PDZ/BAR-domain scaffold that couples
+  cargo-protein binding to membrane binding and curvature-dependent trafficking. Its best-supported core
+  role is regulation of membrane protein trafficking, especially AMPA receptor GluA2/GluA3 internalization/recycling
+  and synaptic receptor organization, through PDZ-mediated partner selection, PKC-associated signaling,
+  and BAR-domain membrane remodeling.'
 alternative_products:
   - name: '1'
     id: Q9NRD5-1
@@ -19,725 +23,1482 @@ existing_annotations:
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Receptor clustering is supported by PICK1 PDZ/BAR-dependent organization of synaptic
+        receptor complexes.
+      action: ACCEPT
+      reason: receptor clustering is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0006886
       label: intracellular protein transport
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Intracellular protein transport is central to PICK1 regulation of AMPAR and other
+        membrane-protein trafficking.
+      action: ACCEPT
+      reason: intracellular protein transport is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0043005
       label: neuron projection
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Neuron projection localization is consistent with PICK1 function in pre- and
+        postsynaptic neuronal compartments.
+      action: ACCEPT
+      reason: neuron projection is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0005543
       label: phospholipid binding
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Phospholipid binding is supported by the BAR/N-BAR membrane-binding module.
+      action: ACCEPT
+      reason: phospholipid binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically
+            crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking.'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
   - term:
       id: GO:0008021
       label: synaptic vesicle
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Synaptic vesicle localization is consistent with synaptic trafficking functions of
+        PICK1.
+      action: ACCEPT
+      reason: synaptic vesicle is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0014069
       label: postsynaptic density
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Postsynaptic density localization is supported by PICK1 action at postsynaptic AMPAR
+        complexes.
+      action: ACCEPT
+      reason: postsynaptic density is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0032588
       label: trans-Golgi network membrane
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: trans-Golgi network membrane is plausible as a context-specific PICK1 localization,
+        binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking
+        function.
+      action: KEEP_AS_NON_CORE
+      reason: trans-Golgi network membrane is secondary to PICK1 membrane protein trafficking and
+        synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0097062
       label: dendritic spine maintenance
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Dendritic spine maintenance is supported by PICK1 roles in AMPAR trafficking and
+        synaptic plasticity.
+      action: ACCEPT
+      reason: dendritic spine maintenance is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0002092
       label: positive regulation of receptor internalization
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Positive regulation of receptor internalization is a core PICK1-supported process for
+        AMPAR GluA2 trafficking.
+      action: ACCEPT
+      reason: positive regulation of receptor internalization is supported as part of PICK1 PDZ/BAR
+        scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0005080
       label: protein kinase C binding
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein kinase C binding is supported by PICK1 identity as a PKC-alpha-binding
+        protein.
+      action: ACCEPT
+      reason: protein kinase C binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 was originally cloned/recognized as a **PKCα-binding protein**, a
+            point reiterated in 2023 work on synaptic receptor regulation
   - term:
       id: GO:0034315
       label: regulation of Arp2/3 complex-mediated actin nucleation
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: regulation of Arp2/3 complex-mediated actin nucleation is plausible as a
+        context-specific PICK1 localization, binding, or downstream process, but it is secondary to
+        the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: regulation of Arp2/3 complex-mediated actin nucleation is secondary to PICK1 membrane
+        protein trafficking and synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0003779
       label: actin binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: actin binding is plausible as a context-specific PICK1 localization, binding, or
+        downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: actin binding is secondary to PICK1 membrane protein trafficking and synaptic receptor
+        organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0005737
       label: cytoplasm
     evidence_type: IEA
     original_reference_id: GO_REF:0000117
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: cytoplasm is plausible as a context-specific PICK1 localization, binding, or
+        downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: cytoplasm is secondary to PICK1 membrane protein trafficking and synaptic receptor
+        organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: A 2024 Molecular Biology of the Cell study reports that in nonpolarized
+            cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it
+            relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive
+            organizer of protein sequestration/aggregation compartments
   - term:
       id: GO:0005856
       label: cytoskeleton
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: cytoskeleton is plausible as a context-specific PICK1 localization, binding, or
+        downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: cytoskeleton is secondary to PICK1 membrane protein trafficking and synaptic receptor
+        organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0014069
       label: postsynaptic density
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Postsynaptic density localization is supported by PICK1 action at postsynaptic AMPAR
+        complexes.
+      action: ACCEPT
+      reason: postsynaptic density is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0016020
       label: membrane
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: membrane is plausible as a context-specific PICK1 localization, binding, or
+        downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: membrane is secondary to PICK1 membrane protein trafficking and synaptic receptor
+        organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0019904
       label: protein domain specific binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000002
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein domain specific binding is supported by PICK1 PDZ-domain recognition of
+        receptor/cargo C-terminal motifs.
+      action: ACCEPT
+      reason: protein domain specific binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0043005
       label: neuron projection
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Neuron projection localization is consistent with PICK1 function in pre- and
+        postsynaptic neuronal compartments.
+      action: ACCEPT
+      reason: neuron projection is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0045202
       label: synapse
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Synapse localization is supported by PICK1 enrichment in pre- and postsynaptic
+        compartments.
+      action: ACCEPT
+      reason: synapse is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or
+        synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0046872
       label: metal ion binding
     evidence_type: IEA
     original_reference_id: GO_REF:0000043
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Metal ion binding is not the functionally informative annotation for PICK1 compared
+        with PDZ/BAR scaffold and membrane-remodeling activities.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: metal ion binding is less informative than the specific PICK1 scaffold mechanism.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
   - term:
       id: GO:0048471
       label: perinuclear region of cytoplasm
     evidence_type: IEA
     original_reference_id: GO_REF:0000044
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: perinuclear region of cytoplasm is plausible as a context-specific PICK1
+        localization, binding, or downstream process, but it is secondary to the core PDZ/BAR
+        receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: perinuclear region of cytoplasm is secondary to PICK1 membrane protein trafficking and
+        synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: A 2024 Molecular Biology of the Cell study reports that in nonpolarized
+            cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it
+            relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive
+            organizer of protein sequestration/aggregation compartments
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:11343649
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:11343649
-          supporting_text: Functional interaction between monoamine plasma 
-            membrane transporters and the synaptic PDZ domain-containing protein
-            PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:11802773
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:11802773
-          supporting_text: Interaction of the synaptic protein PICK1 (protein 
-            interacting with C kinase 1) with the non-voltage gated sodium 
-            channels BNC1 (brain Na+ channel 1) and ASIC (acid-sensing ion 
-            channel).
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:16713569
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:16713569
-          supporting_text: A protein-protein interaction network for human 
-            inherited ataxias and disorders of Purkinje cell degeneration.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:21653829
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:21653829
-          supporting_text: Protein interactome reveals converging molecular 
-            pathways among autism disorders.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:26787460
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:26787460
-          supporting_text: Proteomic peptide phage display uncovers novel 
-            interactions of the PDZ1-2 supramodule of syntenin.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:28514442
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:28514442
-          supporting_text: Architecture of the human interactome defines protein
-            communities and disease networks.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:31413325
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:31413325
-          supporting_text: HENA, heterogeneous network-based data set for 
-            Alzheimer's disease.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:32296183
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:32296183
-          supporting_text: Apr 8. A reference map of the human binary protein 
-            interactome.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:32814053
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:32814053
-          supporting_text: Interactome Mapping Provides a Network of 
-            Neurodegenerative Disease Proteins and Uncovers Widespread Protein 
-            Aggregation in Affected Brains.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:33961781
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:33961781
-          supporting_text: 2021 May 6. Dual proteome-scale networks reveal 
-            cell-specific remodeling of the human interactome.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:36115835
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:36115835
-          supporting_text: Quantitative fragmentomics allow affinity mapping of 
-            interactomes.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:37207277
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:37207277
-          supporting_text: eCollection 2023 May 19.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0042802
       label: identical protein binding
     evidence_type: IPI
     original_reference_id: PMID:32296183
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Identical protein binding is supported by BAR-domain homodimerization and
+        higher-order PICK1 assembly.
+      action: ACCEPT
+      reason: identical protein binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
       supported_by:
-        - reference_id: PMID:32296183
-          supporting_text: Apr 8. A reference map of the human binary protein 
-            interactome.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically
+            crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking.'
   - term:
       id: GO:0005829
       label: cytosol
     evidence_type: IDA
     original_reference_id: GO_REF:0000052
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: cytosol is plausible as a context-specific PICK1 localization, binding, or downstream
+        process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: cytosol is secondary to PICK1 membrane protein trafficking and synaptic receptor
+        organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: A 2024 Molecular Biology of the Cell study reports that in nonpolarized
+            cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it
+            relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive
+            organizer of protein sequestration/aggregation compartments
   - term:
       id: GO:0005515
       label: protein binding
     evidence_type: IPI
     original_reference_id: PMID:16314870
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein binding is too generic for PICK1; PDZ-domain binding, PKC binding, receptor
+        binding, and identical protein binding are more informative.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: protein binding is less informative than the specific PICK1 scaffold mechanism.
       supported_by:
-        - reference_id: PMID:16314870
-          supporting_text: 'Serine racemase binds to PICK1: potential relevance to
-            schizophrenia.'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0050796
       label: regulation of insulin secretion
     evidence_type: IMP
     original_reference_id: PMID:29768204
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: regulation of insulin secretion is plausible as a context-specific PICK1
+        localization, binding, or downstream process, but it is secondary to the core PDZ/BAR
+        receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: regulation of insulin secretion is secondary to PICK1 membrane protein trafficking and
+        synaptic receptor organization.
       supported_by:
-        - reference_id: PMID:29768204
-          supporting_text: An Amphipathic Helix Directs Cellular Membrane 
-            Curvature Sensing and Function of the BAR Domain Protein PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0140090
       label: membrane curvature sensor activity
     evidence_type: IDA
     original_reference_id: PMID:29768204
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Membrane curvature sensor activity is supported by PICK1 BAR/N-BAR
+        membrane-remodeling function.
+      action: ACCEPT
+      reason: membrane curvature sensor activity is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
       supported_by:
-        - reference_id: PMID:29768204
-          supporting_text: An Amphipathic Helix Directs Cellular Membrane 
-            Curvature Sensing and Function of the BAR Domain Protein PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically
+            crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking.'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+            binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+            binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
   - term:
       id: GO:0001664
       label: G protein-coupled receptor binding
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: G protein-coupled receptor binding is plausible as a context-specific PICK1
+        localization, binding, or downstream process, but it is secondary to the core PDZ/BAR
+        receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: G protein-coupled receptor binding is secondary to PICK1 membrane protein trafficking
+        and synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0019904
       label: protein domain specific binding
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein domain specific binding is supported by PICK1 PDZ-domain recognition of
+        receptor/cargo C-terminal motifs.
+      action: ACCEPT
+      reason: protein domain specific binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0042802
       label: identical protein binding
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Identical protein binding is supported by BAR-domain homodimerization and
+        higher-order PICK1 assembly.
+      action: ACCEPT
+      reason: identical protein binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically
+            crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking.'
   - term:
       id: GO:0002092
       label: positive regulation of receptor internalization
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Positive regulation of receptor internalization is a core PICK1-supported process for
+        AMPAR GluA2 trafficking.
+      action: ACCEPT
+      reason: positive regulation of receptor internalization is supported as part of PICK1 PDZ/BAR
+        scaffold, membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0021782
       label: glial cell development
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: glial cell development is plausible as a context-specific PICK1 localization,
+        binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking
+        function.
+      action: KEEP_AS_NON_CORE
+      reason: glial cell development is secondary to PICK1 membrane protein trafficking and synaptic
+        receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0034316
       label: negative regulation of Arp2/3 complex-mediated actin nucleation
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: negative regulation of Arp2/3 complex-mediated actin nucleation is plausible as a
+        context-specific PICK1 localization, binding, or downstream process, but it is secondary to
+        the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: negative regulation of Arp2/3 complex-mediated actin nucleation is secondary to PICK1
+        membrane protein trafficking and synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0036294
       label: cellular response to decreased oxygen levels
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: cellular response to decreased oxygen levels is plausible as a context-specific PICK1
+        localization, binding, or downstream process, but it is secondary to the core PDZ/BAR
+        receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: cellular response to decreased oxygen levels is secondary to PICK1 membrane protein
+        trafficking and synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0042149
       label: cellular response to glucose starvation
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: cellular response to glucose starvation is plausible as a context-specific PICK1
+        localization, binding, or downstream process, but it is secondary to the core PDZ/BAR
+        receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: cellular response to glucose starvation is secondary to PICK1 membrane protein
+        trafficking and synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0043005
       label: neuron projection
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Neuron projection localization is consistent with PICK1 function in pre- and
+        postsynaptic neuronal compartments.
+      action: ACCEPT
+      reason: neuron projection is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0051015
       label: actin filament binding
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: actin filament binding is plausible as a context-specific PICK1 localization,
+        binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking
+        function.
+      action: KEEP_AS_NON_CORE
+      reason: actin filament binding is secondary to PICK1 membrane protein trafficking and synaptic
+        receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0060292
       label: long-term synaptic depression
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Long-term synaptic depression is supported as a synaptic plasticity context for
+        PICK1-mediated AMPAR internalization.
+      action: ACCEPT
+      reason: long-term synaptic depression is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0071933
       label: Arp2/3 complex binding
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Arp2/3 complex binding is plausible as a context-specific PICK1 localization,
+        binding, or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking
+        function.
+      action: KEEP_AS_NON_CORE
+      reason: Arp2/3 complex binding is secondary to PICK1 membrane protein trafficking and synaptic
+        receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0097061
       label: dendritic spine organization
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Dendritic spine organization is supported through PICK1-dependent AMPAR trafficking
+        and synaptic plasticity.
+      action: ACCEPT
+      reason: dendritic spine organization is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0097062
       label: dendritic spine maintenance
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Dendritic spine maintenance is supported by PICK1 roles in AMPAR trafficking and
+        synaptic plasticity.
+      action: ACCEPT
+      reason: dendritic spine maintenance is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0005886
       label: plasma membrane
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-416639
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Plasma membrane localization is supported by PICK1 roles in surface receptor
+        internalization and trafficking.
+      action: ACCEPT
+      reason: plasma membrane is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0005886
       label: plasma membrane
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-416985
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Plasma membrane localization is supported by PICK1 roles in surface receptor
+        internalization and trafficking.
+      action: ACCEPT
+      reason: plasma membrane is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0005886
       label: plasma membrane
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-421007
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Plasma membrane localization is supported by PICK1 roles in surface receptor
+        internalization and trafficking.
+      action: ACCEPT
+      reason: plasma membrane is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0030666
       label: endocytic vesicle membrane
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-416639
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Endocytic vesicle membrane localization is consistent with PICK1-mediated receptor
+        internalization/recycling.
+      action: ACCEPT
+      reason: endocytic vesicle membrane is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0030666
       label: endocytic vesicle membrane
     evidence_type: TAS
     original_reference_id: Reactome:R-HSA-421007
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Endocytic vesicle membrane localization is consistent with PICK1-mediated receptor
+        internalization/recycling.
+      action: ACCEPT
+      reason: endocytic vesicle membrane is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0005737
       label: cytoplasm
     evidence_type: IDA
     original_reference_id: PMID:16314870
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: cytoplasm is plausible as a context-specific PICK1 localization, binding, or
+        downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: cytoplasm is secondary to PICK1 membrane protein trafficking and synaptic receptor
+        organization.
       supported_by:
-        - reference_id: PMID:16314870
-          supporting_text: 'Serine racemase binds to PICK1: potential relevance to
-            schizophrenia.'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: A 2024 Molecular Biology of the Cell study reports that in nonpolarized
+            cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it
+            relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive
+            organizer of protein sequestration/aggregation compartments
   - term:
       id: GO:0005102
       label: signaling receptor binding
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Signaling receptor binding is supported by PICK1 PDZ-domain interactions with
+        receptor cargo such as AMPAR subunits.
+      action: ACCEPT
+      reason: signaling receptor binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0043113
       label: receptor clustering
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Receptor clustering is supported by PICK1 PDZ/BAR-dependent organization of synaptic
+        receptor complexes.
+      action: ACCEPT
+      reason: receptor clustering is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+            review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+            to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
   - term:
       id: GO:0045202
       label: synapse
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Synapse localization is supported by PICK1 enrichment in pre- and postsynaptic
+        compartments.
+      action: ACCEPT
+      reason: synapse is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling, or
+        synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
   - term:
       id: GO:0005080
       label: protein kinase C binding
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Protein kinase C binding is supported by PICK1 identity as a PKC-alpha-binding
+        protein.
+      action: ACCEPT
+      reason: protein kinase C binding is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 was originally cloned/recognized as a **PKCα-binding protein**, a
+            point reiterated in 2023 work on synaptic receptor regulation
   - term:
       id: GO:0048471
       label: perinuclear region of cytoplasm
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: perinuclear region of cytoplasm is plausible as a context-specific PICK1
+        localization, binding, or downstream process, but it is secondary to the core PDZ/BAR
+        receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: perinuclear region of cytoplasm is secondary to PICK1 membrane protein trafficking and
+        synaptic receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: A 2024 Molecular Biology of the Cell study reports that in nonpolarized
+            cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it
+            relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive
+            organizer of protein sequestration/aggregation compartments
   - term:
       id: GO:0005794
       label: Golgi apparatus
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Golgi apparatus is plausible as a context-specific PICK1 localization, binding, or
+        downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: Golgi apparatus is secondary to PICK1 membrane protein trafficking and synaptic
+        receptor organization.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0006468
       label: protein phosphorylation
     evidence_type: ISS
     original_reference_id: GO_REF:0000024
     review:
-      summary: >-
-        MISANNOTATION: PICK1 (Protein interacting with C kinase 1) is NOT a kinase.
-        It is a PDZ domain scaffold/adapter protein that BINDS protein kinase C
-        (has GO:0005080 "protein kinase C binding"). UniProt describes it as a
-        "Probable adapter protein that bind to and organize" signaling complexes.
-        PICK1 is also a phosphorylation SUBSTRATE - "Phosphorylation at Thr-82
-        appears to inhibit the interaction" with GluR2. The ISS evidence is invalid
-        as PICK1 has no kinase domain and doesn't catalyze phosphorylation.
+      summary: PICK1 controls phosphorylation-dependent receptor partner switching as a scaffold,
+        but it does not catalyze protein phosphorylation.
       action: REMOVE
+      reason: PICK1 is a phosphorylation-dependent scaffold/trafficking regulator, not a kinase.
+      supported_by:
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
   - term:
       id: GO:0005737
       label: cytoplasm
     evidence_type: IDA
     original_reference_id: PMID:11343649
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: cytoplasm is plausible as a context-specific PICK1 localization, binding, or
+        downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking function.
+      action: KEEP_AS_NON_CORE
+      reason: cytoplasm is secondary to PICK1 membrane protein trafficking and synaptic receptor
+        organization.
       supported_by:
-        - reference_id: PMID:11343649
-          supporting_text: Functional interaction between monoamine plasma 
-            membrane transporters and the synaptic PDZ domain-containing protein
-            PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: A 2024 Molecular Biology of the Cell study reports that in nonpolarized
+            cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it
+            relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive
+            organizer of protein sequestration/aggregation compartments
   - term:
       id: GO:0005886
       label: plasma membrane
     evidence_type: IDA
     original_reference_id: PMID:11343649
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Plasma membrane localization is supported by PICK1 roles in surface receptor
+        internalization and trafficking.
+      action: ACCEPT
+      reason: plasma membrane is supported as part of PICK1 PDZ/BAR scaffold, membrane-remodeling,
+        or synaptic receptor-trafficking function.
       supported_by:
-        - reference_id: PMID:11343649
-          supporting_text: Functional interaction between monoamine plasma 
-            membrane transporters and the synaptic PDZ domain-containing protein
-            PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+            mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+            GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization;
+            PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
   - term:
       id: GO:0015844
       label: monoamine transport
     evidence_type: IDA
     original_reference_id: PMID:11343649
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: monoamine transport is plausible as a context-specific PICK1 localization, binding,
+        or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking
+        function.
+      action: KEEP_AS_NON_CORE
+      reason: monoamine transport is secondary to PICK1 membrane protein trafficking and synaptic
+        receptor organization.
       supported_by:
-        - reference_id: PMID:11343649
-          supporting_text: Functional interaction between monoamine plasma 
-            membrane transporters and the synaptic PDZ domain-containing protein
-            PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0042734
       label: presynaptic membrane
     evidence_type: IDA
     original_reference_id: PMID:11343649
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: presynaptic membrane is plausible as a context-specific PICK1 localization, binding,
+        or downstream process, but it is secondary to the core PDZ/BAR receptor-trafficking
+        function.
+      action: KEEP_AS_NON_CORE
+      reason: presynaptic membrane is secondary to PICK1 membrane protein trafficking and synaptic
+        receptor organization.
       supported_by:
-        - reference_id: PMID:11343649
-          supporting_text: Functional interaction between monoamine plasma 
-            membrane transporters and the synaptic PDZ domain-containing protein
-            PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+            membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+            strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+            internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+            partner switching and regulated complex formation.
   - term:
       id: GO:0045161
       label: neuronal ion channel clustering
     evidence_type: TAS
     original_reference_id: PMID:11343649
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: Neuronal ion channel clustering is consistent with PICK1 synaptic receptor clustering
+        and trafficking roles.
+      action: ACCEPT
+      reason: neuronal ion channel clustering is supported as part of PICK1 PDZ/BAR scaffold,
+        membrane-remodeling, or synaptic receptor-trafficking function.
       supported_by:
-        - reference_id: PMID:11343649
-          supporting_text: Functional interaction between monoamine plasma 
-            membrane transporters and the synaptic PDZ domain-containing protein
-            PICK1.
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+            described as a **PDZ/BAR scaffold that regulates the trafficking and surface
+            availability of membrane proteins—especially AMPA-type glutamate receptors—by
+            coordinating protein complex assembly with membrane remodeling and endocytic/recycling
+            processes**
+        - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+          supporting_text: PICK1 is described as enriched in brain and localized to **pre- and
+            postsynaptic compartments**, consistent with its role in regulating synaptic receptor
+            trafficking
 references:
   - id: GO_REF:0000002
-    title: Gene Ontology annotation through association of InterPro records with
-      GO terms
+    title: Gene Ontology annotation through association of InterPro records with GO terms
     findings: []
   - id: GO_REF:0000024
-    title: Manual transfer of experimentally-verified manual GO annotation data 
-      to orthologs by curator judgment of sequence similarity
+    title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by
+      curator judgment of sequence similarity
     findings: []
   - id: GO_REF:0000033
     title: Annotation inferences using phylogenetic trees
     findings: []
   - id: GO_REF:0000043
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword 
-      mapping
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
     findings: []
   - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt
+    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+      mapping, accompanied by conservative changes to GO terms applied by UniProt
     findings: []
   - id: GO_REF:0000052
     title: Gene Ontology annotation based on curation of immunofluorescence data
     findings: []
   - id: GO_REF:0000117
-    title: Electronic Gene Ontology annotations created by ARBA machine learning
-      models
+    title: Electronic Gene Ontology annotations created by ARBA machine learning models
     findings: []
   - id: GO_REF:0000120
     title: Combined Automated Annotation using Multiple IEA Methods
     findings: []
   - id: PMID:11343649
-    title: Functional interaction between monoamine plasma membrane transporters
-      and the synaptic PDZ domain-containing protein PICK1.
+    title: Functional interaction between monoamine plasma membrane transporters and the synaptic
+      PDZ domain-containing protein PICK1.
     findings: []
   - id: PMID:11802773
-    title: Interaction of the synaptic protein PICK1 (protein interacting with C
-      kinase 1) with the non-voltage gated sodium channels BNC1 (brain Na+ 
-      channel 1) and ASIC (acid-sensing ion channel).
+    title: Interaction of the synaptic protein PICK1 (protein interacting with C kinase 1) with the
+      non-voltage gated sodium channels BNC1 (brain Na+ channel 1) and ASIC (acid-sensing ion
+      channel).
     findings: []
   - id: PMID:16314870
     title: 'Serine racemase binds to PICK1: potential relevance to schizophrenia.'
     findings: []
   - id: PMID:16713569
-    title: A protein-protein interaction network for human inherited ataxias and
-      disorders of Purkinje cell degeneration.
+    title: A protein-protein interaction network for human inherited ataxias and disorders of
+      Purkinje cell degeneration.
     findings: []
   - id: PMID:21653829
-    title: Protein interactome reveals converging molecular pathways among 
-      autism disorders.
+    title: Protein interactome reveals converging molecular pathways among autism disorders.
     findings: []
   - id: PMID:26787460
-    title: Proteomic peptide phage display uncovers novel interactions of the 
-      PDZ1-2 supramodule of syntenin.
+    title: Proteomic peptide phage display uncovers novel interactions of the PDZ1-2 supramodule of
+      syntenin.
     findings: []
   - id: PMID:28514442
-    title: Architecture of the human interactome defines protein communities and
-      disease networks.
+    title: Architecture of the human interactome defines protein communities and disease networks.
     findings: []
   - id: PMID:29768204
-    title: An Amphipathic Helix Directs Cellular Membrane Curvature Sensing and 
-      Function of the BAR Domain Protein PICK1.
+    title: An Amphipathic Helix Directs Cellular Membrane Curvature Sensing and Function of the BAR
+      Domain Protein PICK1.
     findings: []
   - id: PMID:31413325
     title: HENA, heterogeneous network-based data set for Alzheimer's disease.
@@ -746,19 +1507,18 @@ references:
     title: A reference map of the human binary protein interactome.
     findings: []
   - id: PMID:32814053
-    title: Interactome Mapping Provides a Network of Neurodegenerative Disease 
-      Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.
+    title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers
+      Widespread Protein Aggregation in Affected Brains.
     findings: []
   - id: PMID:33961781
-    title: Dual proteome-scale networks reveal cell-specific remodeling of the 
-      human interactome.
+    title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
     findings: []
   - id: PMID:36115835
     title: Quantitative fragmentomics allow affinity mapping of interactomes.
     findings: []
   - id: PMID:37207277
-    title: Using brain cell-type-specific protein interactomes to interpret 
-      neurodevelopmental genetic signals in schizophrenia.
+    title: Using brain cell-type-specific protein interactomes to interpret neurodevelopmental
+      genetic signals in schizophrenia.
     findings: []
   - id: Reactome:R-HSA-416639
     title: Trafficking of GluR2-containing AMPA receptors to extrasynaptic sites
@@ -769,3 +1529,73 @@ references:
   - id: Reactome:R-HSA-421007
     title: Endocytosis of Ca impermeable AMPA receptors
     findings: []
+  - id: file:human/PICK1/PICK1-deep-research-falcon.md
+    title: Falcon deep research synthesis for PICK1
+    findings: []
+core_functions:
+  - description: PDZ-domain scaffold activity that selects receptor/cargo partners such as AMPAR
+      GluA2/GluA3 and regulates receptor internalization, clustering, and synaptic trafficking.
+    molecular_function:
+      id: GO:0019904
+      label: protein domain specific binding
+    directly_involved_in:
+      - id: GO:0002092
+        label: positive regulation of receptor internalization
+      - id: GO:0043113
+        label: receptor clustering
+      - id: GO:0006886
+        label: intracellular protein transport
+      - id: GO:0060292
+        label: long-term synaptic depression
+    locations:
+      - id: GO:0014069
+        label: postsynaptic density
+      - id: GO:0045202
+        label: synapse
+      - id: GO:0005886
+        label: plasma membrane
+    supported_by:
+      - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+        supporting_text: '**PDZ domain (protein interaction module):** In AMPAR biology, authoritative
+          review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly
+          to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain'
+      - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+        supporting_text: In vivo evidence from mouse hippocampus (kainic acid model) supports a
+          mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from
+          GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization; PP2A-mediated
+          dephosphorylation reverses this and disfavors PICK1 association
+      - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+        supporting_text: Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and
+          membrane-remodeling protein** that controls **membrane protein trafficking**, with the
+          strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3)
+          internalization/recycling and synaptic plasticity** through phosphorylation-dependent
+          partner switching and regulated complex formation.
+  - description: BAR/N-BAR membrane binding and curvature-sensing activity that couples PICK1 cargo
+      complexes to membrane remodeling and compartmentalized trafficking.
+    molecular_function:
+      id: GO:0140090
+      label: membrane curvature sensor activity
+    directly_involved_in:
+      - id: GO:0006886
+        label: intracellular protein transport
+      - id: GO:0002092
+        label: positive regulation of receptor internalization
+    locations:
+      - id: GO:0030666
+        label: endocytic vesicle membrane
+    supported_by:
+      - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+        supporting_text: '**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated
+          binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane
+          binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization'
+      - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+        supporting_text: '**BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically
+          crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking.'
+      - reference_id: file:human/PICK1/PICK1-deep-research-falcon.md
+        supporting_text: Across the recent literature, PICK1’s primary molecular role is best
+          described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability
+          of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein
+          complex assembly with membrane remodeling and endocytic/recycling processes**
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []

--- a/genes/human/PICK1/PICK1-deep-research-falcon.md
+++ b/genes/human/PICK1/PICK1-deep-research-falcon.md
@@ -1,0 +1,336 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-12T00:13:27.954226'
+end_time: '2026-05-12T00:25:00.312279'
+duration_seconds: 692.36
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: PICK1
+  gene_symbol: PICK1
+  uniprot_accession: Q9NRD5
+  protein_description: 'RecName: Full=PRKCA-binding protein; AltName: Full=Protein
+    interacting with C kinase 1; AltName: Full=Protein kinase C-alpha-binding protein;'
+  gene_info: Name=PICK1; Synonyms=PRKCABP;
+  organism_full: Homo sapiens (Human).
+  protein_family: Not specified in UniProt
+  protein_domains: AH/BAR_dom_sf. (IPR027267); AH_dom. (IPR010504); Arfaptin_fam.
+    (IPR030798); PDZ. (IPR001478); PDZ_sf. (IPR036034)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 24
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9NRD5
+- **Protein Description:** RecName: Full=PRKCA-binding protein; AltName: Full=Protein interacting with C kinase 1; AltName: Full=Protein kinase C-alpha-binding protein;
+- **Gene Information:** Name=PICK1; Synonyms=PRKCABP;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** AH/BAR_dom_sf. (IPR027267); AH_dom. (IPR010504); Arfaptin_fam. (IPR030798); PDZ. (IPR001478); PDZ_sf. (IPR036034)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "PICK1" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'PICK1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **PICK1** (gene ID: PICK1, UniProt: Q9NRD5) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9NRD5
+- **Protein Description:** RecName: Full=PRKCA-binding protein; AltName: Full=Protein interacting with C kinase 1; AltName: Full=Protein kinase C-alpha-binding protein;
+- **Gene Information:** Name=PICK1; Synonyms=PRKCABP;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** AH/BAR_dom_sf. (IPR027267); AH_dom. (IPR010504); Arfaptin_fam. (IPR030798); PDZ. (IPR001478); PDZ_sf. (IPR036034)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "PICK1" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'PICK1' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **PICK1** (gene ID: PICK1, UniProt: Q9NRD5) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research Report: Human **PICK1** (UniProt Q9NRD5) — Functional Annotation and Recent Research (2023–2024)
+
+### 0. Target verification (mandatory)
+The gene symbol **PICK1** in the retrieved literature corresponds to **Protein interacting with C kinase 1 / PRKCA-binding protein** in **Homo sapiens**, matching the UniProt entry **Q9NRD5**. Multiple 2023–2024 sources explicitly describe PICK1 as a **PKCα-binding** protein containing **both a PDZ domain and a BAR (N‑BAR) domain**, consistent with the UniProt-provided domain architecture and synonyms (zhu2023them1muscarinic pages 1-4, song2023investigatingthemechanical pages 1-2).
+
+### 1. Key concepts and definitions (current understanding)
+
+#### 1.1. What PICK1 is
+**PICK1 is a dual-domain scaffolding/adaptor protein** that couples (i) **PDZ-domain–mediated binding** to C-terminal motifs on cargo proteins with (ii) **BAR/N‑BAR–mediated lipid/membrane binding and remodeling**, enabling regulation of membrane protein trafficking and compartmentalization (rathod2023ampaglua2subunit pages 1-4, cao2023molecularmechanismsof pages 1-2, song2023investigatingthemechanical pages 1-2).
+
+#### 1.2. Core domains and what they imply functionally
+- **PDZ domain (protein interaction module):** In AMPAR biology, authoritative review evidence states that the **GluA2 C-terminus** contains a PDZ ligand that binds directly to **PICK1** (and GRIP1), and that PICK1 binds GluA2 via its PDZ domain (cao2023molecularmechanismsof pages 1-2). A high-quality 2024 translational study similarly states that the **PICK1 PDZ domain interacts with GluA2/GluA3 C termini to regulate receptor trafficking** (fadahunsi2024targetingpostsynapticglutamate pages 2-4).
+- **BAR / N‑BAR domain (membrane remodeling module):** BAR domains are classically crescent-shaped, lipid-binding modules involved in membrane curvature during trafficking. A 2023 molecular-dynamics study positions PICK1’s N‑BAR dimer as a mechanically specialized membrane-remodeling unit, whose inter-monomer interaction networks and flexibility are proposed to facilitate membrane binding and curvature-related function (song2023investigatingthemechanical pages 1-2, song2023investigatingthemechanical pages 6-7).
+
+#### 1.3. Primary molecular function (functional annotation statement)
+Across the recent literature, PICK1’s primary molecular role is best described as a **PDZ/BAR scaffold that regulates the trafficking and surface availability of membrane proteins—especially AMPA-type glutamate receptors—by coordinating protein complex assembly with membrane remodeling and endocytic/recycling processes** (cao2023molecularmechanismsof pages 1-2, rathod2023ampaglua2subunit pages 1-4, zhu2023them1muscarinic pages 1-4).
+
+### 2. Biological processes, pathways, and binding partners
+
+#### 2.1. AMPA receptor (AMPAR) trafficking and synaptic plasticity (central pathway)
+**AMPAR trafficking is the dominant experimentally supported pathway for PICK1 in the retrieved 2023–2024 corpus.**
+
+**(a) PICK1–GluA2/3 binding and ER-to-synapse trafficking logic**
+A 2023 AMPAR trafficking review states that PICK1 binds the **GluA2 C-terminal domain** via its PDZ domain and reports that PICK1 can **“stimulate the transportation of GluA2 to the ER membrane”**, placing PICK1 activity in early AMPAR biogenesis/trafficking steps (cao2023molecularmechanismsof pages 1-2).
+
+**(b) Phosphorylation-dependent switching: GRIP1 ↔ PICK1 on GluA2**
+In vivo evidence from mouse hippocampus (kainic acid model) supports a mechanistic switch in which **GluA2 Ser880 phosphorylation** promotes dissociation from GRIP1 and association with PICK1, driving AMPAR endocytosis/internalization; PP2A-mediated dephosphorylation reverses this and disfavors PICK1 association (lee2023pdiaugmentskainic pages 9-11).
+
+**(c) Quantitative evidence: increasing GluA2:PICK1 binding promotes internalization**
+Lee et al. (2023) directly tested whether PICK1-mediated internalization is enhanced when upstream redox regulation perturbs PP2A. In mouse hippocampus, **PDI knockdown increased GluA2:PICK1 binding to 1.27-fold of control** (p < 0.001), and kainic acid (KA) further enhanced binding under PDI knockdown (lee2023pdiaugmentskainic pages 9-11). The authors interpret this as a mechanism facilitating **PICK1-mediated AMPAR internalization via increased GluA2 S880 phosphorylation** (lee2023pdiaugmentskainic pages 9-11).
+
+**(d) Cholinergic regulation: M1 muscarinic receptor → PICK1 → GluA2 endocytosis**
+Zhu et al. (2023) report that activation of the **M1 muscarinic acetylcholine receptor** (77-LH-28-1; 5 µL of 5 µM i.c.v.) promoted **surface endocytosis of GluA2**, reduced its postsynaptic colocalization with PSD-95, and increased GluA2 Ser880 phosphorylation, with the **PICK1–GluA2 interaction required** for M1-mediated postsynaptic GluA2 regulation (zhu2023them1muscarinic pages 1-4).
+
+#### 2.2. PKCα (PRKCA) linkage
+PICK1 was originally cloned/recognized as a **PKCα-binding protein**, a point reiterated in 2023 work on synaptic receptor regulation (zhu2023them1muscarinic pages 1-4). In a broader mechanistic synthesis of PICK1 biology, PICK1 is described as targeting activated PKC to AMPAR-associated complexes and thereby influencing receptor surface levels (hendrix2025utilizingafdesignfor pages 8-9).
+
+#### 2.3. CaMKII linkage
+In an authoritative 2023 review of AMPAR trafficking, Ca2+-dependent CaMKII activation is reported to promote formation of a **CaMKII–PICK1 complex** (cao2023molecularmechanismsof pages 1-2). This supports a model in which PICK1 participates in activity-dependent receptor trafficking regulated by Ca2+-linked kinases.
+
+### 3. Subcellular localization (where PICK1 acts)
+
+#### 3.1. Neuronal compartments: pre-/postsynaptic regions
+PICK1 is described as enriched in brain and localized to **pre- and postsynaptic compartments**, consistent with its role in regulating synaptic receptor trafficking (rathod2023ampaglua2subunit pages 1-4, zhu2023them1muscarinic pages 1-4).
+
+#### 3.2. ER membrane trafficking context
+The 2023 AMPAR trafficking review explicitly situates PICK1 in early trafficking steps by stating that PICK1 binds GluA2 and can stimulate its transport to the **ER membrane**, implying a role beyond the plasma membrane/PSD alone (cao2023molecularmechanismsof pages 1-2).
+
+#### 3.3. Cytosol/perinuclear localization and stress-induced aggresome recruitment
+A 2024 Molecular Biology of the Cell study reports that in nonpolarized cells PICK1 is typically **cytosolic**, but under **sodium arsenite** stress it relocalizes to **perinuclear aggresomes**, identifying PICK1 as a stress-responsive organizer of protein sequestration/aggregation compartments (lai2024sodiumarseniteinduces pages 1-2, lai2024sodiumarseniteinduces pages 6-8).
+
+Mechanistically, arsenite:
+- **Abolished** a PDZ-mediated interaction (reported as the PICK1–GluR2 interaction being “completely abolished”) and
+- Strongly promoted PICK1 BAR-dependent homodimerization (**+544.3 ± 19.52%, P < 0.0001**) (lai2024sodiumarseniteinduces pages 6-8).
+
+This connects PICK1’s BAR domain to conditional relocalization and higher-order assembly at perinuclear quality-control organelles (lai2024sodiumarseniteinduces pages 6-8).
+
+### 4. Recent developments and latest research (prioritizing 2023–2024)
+
+| Section | Item | System/Context | Function / Key Result | Quantitative detail | Citation |
+|---|---|---|---|---|---|
+| Domain | PDZ domain | Human PICK1 scaffold | Recognizes C-terminal PDZ ligands on partner proteins; mediates protein-protein interactions central to AMPAR/GluA2 trafficking and synaptic targeting; originally identified in a PKCα-binding protein context | No single universal value reported in the cited excerpts | (rathod2023ampaglua2subunit pages 1-4, zhu2023them1muscarinic pages 1-4, cao2023molecularmechanismsof pages 1-2) |
+| Domain | BAR / N-BAR domain | Human PICK1 scaffold | Lipid-binding, membrane-remodeling, curvature-sensing/inducing module; supports synaptic targeting, membrane association, receptor trafficking, and stress-induced higher-order assembly | MD simulations found directional asymmetry: during downward steering all 67 native inter-monomer residue pairs broke and 17 new pairs formed, whereas upward steering retained 35/67 native pairs and formed 23 new pairs | (zhu2023them1muscarinic pages 1-4, song2023investigatingthemechanical pages 6-7) |
+| Partner / pathway | PRKCA / PKCα | Original PICK1 identification; synaptic signaling | PICK1 is described as a PKCα-binding protein and can target activated PKC to AMPAR-associated complexes, linking phosphorylation to receptor trafficking/plasticity | Qualitative mechanism in cited excerpts | (hendrix2025utilizingafdesignfor pages 8-9, zhu2023them1muscarinic pages 1-4) |
+| Partner / pathway | AMPAR GluA2 | Postsynaptic receptor trafficking | Best-established PICK1 cargo/partner in the cited literature; PICK1 binds the GluA2 C-terminus via its PDZ domain and promotes internalization / intracellular retention during LTD-related processes | GluA2:PICK1 binding increased to 1.27-fold after PDI knockdown in mouse hippocampus | (rathod2023ampaglua2subunit pages 1-4, zhu2023them1muscarinic pages 1-4, cao2023molecularmechanismsof pages 1-2, lee2023pdiaugmentskainic pages 9-11) |
+| Partner / pathway | GRIP1 | AMPAR trafficking switch | GRIP1 opposes PICK1 on GluA2 trafficking: GRIP1 favors surface expression, while GluA2 S880 phosphorylation promotes GRIP1 dissociation and PICK1 association, driving AMPAR endocytosis | Mechanistic switch centered on GluA2 Ser880 dephosphorylation/phosphorylation; no single effect size in excerpt | (lee2023pdiaugmentskainic pages 9-11) |
+| Partner / pathway | PP2A | GluA2 phosphorylation control | PP2A dephosphorylates GluA2 Ser880, weakening PICK1 association and favoring GRIP1 rebinding; inhibition of PP2A facilitates PICK1-mediated AMPAR internalization | In Lee 2023, oxidation-linked PP2A inhibition was proposed to increase PICK1-mediated internalization; GluA2:PICK1 binding rose 1.27-fold | (lee2023pdiaugmentskainic pages 9-11) |
+| Partner / pathway | CaMKII | Activity-dependent AMPAR regulation | Ca2+-dependent CaMKII activation forms a CaMKII-PICK1 complex in AMPAR trafficking models; both CaMKII and PKC impinge on AMPAR phosphosites relevant to PICK1 function | No standalone numeric value in cited excerpt | (cao2023molecularmechanismsof pages 1-2, lee2023pdiaugmentskainic pages 9-11) |
+| Partner / pathway | M1 muscarinic acetylcholine receptor pathway | Cholinergic control of postsynaptic AMPARs | M1 receptor activation regulates postsynaptic GluA2 surface expression through PICK1-dependent mechanisms, coupling cholinergic signaling to AMPAR endocytosis | 77-LH-28-1 delivered i.c.v. at 5 µL of 5 µM; Fsc231 used at 5 µL of 50 µM in the study | (zhu2023them1muscarinic pages 1-4) |
+| Localization | Synapse / postsynaptic density | Neurons | PICK1 is enriched in pre/postsynaptic neural compartments and acts at postsynaptic AMPAR complexes to regulate receptor localization and plasticity | Qualitative localization in cited excerpts | (rathod2023ampaglua2subunit pages 1-4, zhu2023them1muscarinic pages 1-4) |
+| Localization | ER / early secretory pathway | AMPAR trafficking pathway | Review evidence states PICK1 binds GluA2 and stimulates trafficking toward the ER membrane / early secretory pathway steps in AMPAR biogenesis and movement | Qualitative localization in cited excerpt | (cao2023molecularmechanismsof pages 1-2) |
+| Localization | Cytosol / perinuclear region | Nonpolarized cells, heterologous cells | PICK1 is generally cytosolic with occasional perinuclear structures under basal conditions | Qualitative basal localization | (rathod2023ampaglua2subunit pages 1-4, lai2024sodiumarseniteinduces pages 1-2) |
+| Localization | Perinuclear aggresome | Stress response in HEK293T cells | Under arsenite stress, PICK1 relocalizes from diffuse cytosol to perinuclear aggresomes in a BAR-domain-dependent manner | Detergent-insoluble PICK1 increased by ~191.2 ± 20.79 (P = 0.008); soluble fraction decreased by 32.77 ± 3.28% (P = 0.006) | (lai2024sodiumarseniteinduces pages 6-8) |
+| Recent study (2023) | Cao 2023 review | Nervous system / AMPAR trafficking review | Summarizes that GluA2 C-terminal PDZ ligands bind PICK1 and GRIP1; PICK1 binds GluA2 via its PDZ domain and participates in ER-to-synapse trafficking logic and CaMKII-linked regulation | Review, no primary effect size | (cao2023molecularmechanismsof pages 1-2) |
+| Recent study (2023) | Zhu 2023 | Mouse brain, M1 mAChR activation | M1 receptor activation promoted postsynaptic GluA2 endocytosis, reduced GluA2-PSD95 colocalization, and increased GluA2 Ser880 phosphorylation in a PICK1-dependent pathway | 77-LH-28-1: 5 µL of 5 µM i.c.v.; surface biotinylation used 1 mg/mL sulfo-NHS-LC-biotin; Fsc231: 5 µL of 50 µM; n = 3 replicates | (zhu2023them1muscarinic pages 1-4) |
+| Recent study (2023) | Lee 2023 | Mouse hippocampus / kainic acid model | PDI knockdown facilitated PICK1-mediated AMPAR internalization by increasing GluA2 Ser880 phosphorylation and strengthening GluA2:PICK1 interaction | GluA2:PICK1 binding increased to 1.27-fold of control (p < 0.001); KA further enhanced binding in PDI-siRNA animals; n = 7 | (lee2023pdiaugmentskainic pages 9-11) |
+| Recent study (2023) | Rathod 2023 | In silico PDZ inhibitor discovery | Pharmacophore/docking/MD campaign identified candidate competitive and allosteric PICK1 PDZ inhibitors as potential neurological leads | 10 libraries; 340,731,400 molecules and 1,603,779,177 conformers screened; docking scores: Hit_I -9.0, Hit_III -8.9, Hit_IV -9.2, control BQA -8.6 kcal/mol; Hit_II ESOL LogS -3.47 | (rathod2023ampaglua2subunit pages 22-26) |
+| Recent study (2023) | Song 2023 | Molecular dynamics of PICK1 N-BAR dimer | Mechanical simulations support that helix kinks and interaction networks confer flexibility needed for membrane engagement and asymmetric responses to force | Downward steering broke all 67 native residue pairs and formed 17 new ones; upward steering retained 35/67 and formed 23 new ones | (song2023investigatingthemechanical pages 6-7) |
+| Recent study (2024) | Fadahunsi 2024 | Human genetics + obese mouse intervention | GWAS linked PICK1 locus to adiposity; pharmacologic PDZ inhibition with mPD5 produced sustained anti-obesity effects in mice, supporting translational targeting of PICK1 | Lead SNP rs4821764 P = 4.9 × 10−12; rs17752670 blood eQTL P = 3.3 × 10−106; 56 mg/kg tolerated; 14-day daily s.c. mPD5 caused 9.8% vehicle-corrected weight loss | (fadahunsi2024targetingpostsynapticglutamate pages 1-2, fadahunsi2024targetingpostsynapticglutamate pages 2-4) |
+| Recent study (2024) | Lai 2024 | HEK293T arsenite stress / aggresome biology | Arsenite drove PICK1 BAR-dependent homodimerization, abolished PICK1-GluR2 interaction, shifted PICK1 to aggresomes, and promoted insoluble aggregate formation | PICK1 homodimerization +544.3 ± 19.52% (P < 0.0001); competitive coIP favored PICK1-PICK1 +397.7 ± 4.27% vs PICK1-ICA1 +59.8 ± 3.31%; insoluble pellet +191.2 ± 20.79 (P = 0.008) | (lai2024sodiumarseniteinduces pages 6-8) |
+| Recent study (2024) | Ou 2024 | Nasopharyngeal carcinoma cells and xenografts | PICK1 acted as a tumor suppressor in NPC by inhibiting migration, invasion, proliferation, tumor growth, metastasis, and Wnt/β-catenin pathway output | Tail-vein metastasis experiments used n = 5 mice/group; in vitro and in vivo differences were reported as significant with **p < 0.01 / ***p < 0.001, but effect sizes were not numerically tabulated in the excerpt | (ou2024pick1inhibitsthe pages 2-7) |
+
+
+*Table: This table consolidates the core functional annotation of human PICK1, including its PDZ and BAR domains, key partners and pathways, subcellular localization, and major 2023–2024 findings. It is designed to support a narrative research report with quick access to mechanisms, applications, and quantitative study results.*
+
+#### 4.1. 2024 translational advance: PDZ-domain targeting for obesity treatment (real-world implementation trend)
+Fadahunsi et al. (Science Advances, **March 2024**, https://doi.org/10.1126/sciadv.adg2636) integrated human genetics and mouse pharmacology:
+- **Human genetics:** loci in/near **PICK1** reached genome-wide significance for adiposity traits; the paper reports a lead SNP **rs4821764 (P = 4.9 × 10−12)** and a blood eQTL for PICK1 **rs17752670 (P = 3.3 × 10−106)** (fadahunsi2024targetingpostsynapticglutamate pages 1-2, fadahunsi2024targetingpostsynapticglutamate pages 2-4).
+- **In vivo intervention:** a lipidated dimeric PICK1 PDZ-targeting peptide inhibitor (**mPD5**) produced **9.8% vehicle-corrected weight loss** over **14 days** (once-daily s.c.), with **56 mg/kg** identified as a tolerated dose for chronic studies (fadahunsi2024targetingpostsynapticglutamate pages 2-4).
+
+This is among the strongest recent in vivo demonstrations that PICK1 PDZ targeting can drive a durable physiological phenotype with therapeutic framing (fadahunsi2024targetingpostsynapticglutamate pages 2-4).
+
+#### 4.2. 2024 mechanistic advance: arsenite stress, BAR-domain homodimerization, and aggresomes
+Lai et al. (Molecular Biology of the Cell, **October 2024**, https://doi.org/10.1091/mbc.e24-05-0201) provide quantitative evidence that arsenite selectively promotes PICK1–PICK1 assembly and insolubility:
+- PICK1 homodimerization increased **+544.3 ± 19.52% (P < 0.0001)**.
+- PICK1 shifted toward detergent-insoluble fractions (pellet **~+191.2 ± 20.79**, P = 0.008) with decreased soluble fraction (−32.77 ± 3.28%, P = 0.006) (lai2024sodiumarseniteinduces pages 6-8).
+
+This work expands PICK1 biology beyond synapses, tying it to proteostasis-related compartmentalization relevant to neurodegeneration hypotheses (lai2024sodiumarseniteinduces pages 6-8).
+
+#### 4.3. 2023 mechanistic evidence: PP2A–GluA2 S880–PICK1 axis in vivo
+Lee et al. (Scientific Reports, **August 2023**, https://doi.org/10.1038/s41598-023-41014-7) support a model in which upstream redox state (via PDI) can enhance **PICK1-mediated AMPAR internalization** by promoting GluA2 S880 phosphorylation and increasing PICK1 binding (lee2023pdiaugmentskainic pages 9-11). The directly quantified increase in **GluA2:PICK1 binding (1.27-fold, p < 0.001)** provides an experimentally anchored statistic linking PICK1 complex formation to trafficking outcomes (lee2023pdiaugmentskainic pages 9-11).
+
+#### 4.4. 2023–2024 receptor-signaling linkage: M1 mAChR → PICK1 → GluA2 trafficking
+Zhu et al. (Psychopharmacology, **December 2023**, https://doi.org/10.1007/s00213-022-06304-4) provide a pathway-level example of how a GPCR (M1 mAChR) can modulate postsynaptic receptor composition through PICK1-dependent GluA2 trafficking (zhu2023them1muscarinic pages 1-4).
+
+#### 4.5. 2023 structural/biophysical developments: BAR-domain mechanics
+Song et al. (Current Protein & Peptide Science, **December 2023**, https://doi.org/10.2174/1389203724666230522093842) used steered molecular dynamics to infer anisotropic mechanical responses of the PICK1 BAR dimer and detailed inter-monomer contact changes under force (e.g., **downward steering broke all 67 native residue pairs**; **upward steering retained 35/67 and formed 23 new pairs**) (song2023investigatingthemechanical pages 6-7, song2023investigatingthemechanical pages 1-2). While computational, this supports current mechanistic thinking that BAR-domain flexibility and interaction networks underlie membrane engagement and curvature-related function (song2023investigatingthemechanical pages 1-2).
+
+### 5. Current applications and real-world implementations
+
+#### 5.1. Therapeutic targeting of PICK1 PDZ interactions
+Three convergent application streams appear in 2023–2024 evidence:
+1. **Anti-obesity intervention:** pharmacological PDZ targeting with mPD5 produces sustained weight loss in obese mice (9.8% vehicle-corrected) (fadahunsi2024targetingpostsynapticglutamate pages 2-4).
+2. **Neurological disease targeting rationale:** PDZ-mediated PICK1–GluA2 interactions are widely framed as druggable points for conditions involving synaptic plasticity dysregulation; 2023 inhibitor-design work positions the PDZ domain as a therapeutic target (rathod2023ampaglua2subunit pages 1-4, rathod2023ampaglua2subunit pages 22-26).
+3. **Neurodegeneration/proteostasis hypothesis:** arsenite-triggered aggresome localization and insolubility suggest PICK1 could participate in stress-linked aggregation pathways, relevant to neurodegenerative disease models (lai2024sodiumarseniteinduces pages 6-8).
+
+#### 5.2. Cancer biology and biomarker potential
+Ou et al. (Cell Death & Disease, **April 2024**, https://doi.org/10.1038/s41419-024-06687-6) report that PICK1 suppresses migration/invasion and inhibits tumor growth and lung metastasis in nasopharyngeal carcinoma models; in tail-vein metastasis experiments they report **n = 5 mice per group**, and mechanistically find that PICK1 inhibits classical **Wnt/β-catenin signaling** (β-catenin, c-Myc, CyclinD1) (ou2024pick1inhibitsthe pages 2-7). This positions PICK1 as a potential **tumor suppressor/prognostic marker** in NPC, although generalization beyond this cancer context requires caution (ou2024pick1inhibitsthe pages 2-7).
+
+### 6. Expert opinions and authoritative synthesis (with analysis)
+
+#### 6.1. Consensus model
+Across authoritative 2023–2024 review/primary sources, the consensus is:
+- **PICK1 is a PDZ/BAR scaffold** whose PDZ interactions with receptor C-termini (especially AMPAR GluA2/3) place it at the center of activity-dependent receptor trafficking and plasticity mechanisms (cao2023molecularmechanismsof pages 1-2, fadahunsi2024targetingpostsynapticglutamate pages 2-4, zhu2023them1muscarinic pages 1-4).
+- **Phosphorylation state controls partner switching** (GRIP1 ↔ PICK1) on GluA2, providing a biochemical mechanism for directional trafficking (surface retention versus internalization) (lee2023pdiaugmentskainic pages 9-11).
+- **BAR-domain–dependent membrane/proteostasis behaviors** extend PICK1’s functions beyond synapses, enabling stress-induced relocalization and assembly (lai2024sodiumarseniteinduces pages 6-8, song2023investigatingthemechanical pages 1-2).
+
+#### 6.2. Reconciling apparent “pleiotropy”
+The recent evidence supports a unifying interpretation: PICK1’s apparent pleiotropy (synaptic plasticity, obesity, cancer, aggresomes) is consistent with a **core mechanistic toolkit—PDZ-based cargo selection + BAR-based membrane/assembly control**—deployed in different cellular contexts (fadahunsi2024targetingpostsynapticglutamate pages 2-4, lai2024sodiumarseniteinduces pages 6-8, ou2024pick1inhibitsthe pages 2-7).
+
+### 7. Relevant statistics and data points (from recent studies)
+- **Obesity genetics:** rs4821764 associated with adiposity traits (**P = 4.9 × 10−12**); rs17752670 as blood eQTL for PICK1 (**P = 3.3 × 10−106**) (Science Advances, Mar 2024) (fadahunsi2024targetingpostsynapticglutamate pages 2-4).
+- **Anti-obesity pharmacology:** mPD5 caused **9.8% vehicle-corrected weight loss in 14 days**; **56 mg/kg** tolerated (fadahunsi2024targetingpostsynapticglutamate pages 2-4).
+- **Synaptic trafficking biochemistry:** GluA2:PICK1 binding increased to **1.27-fold** after PDI knockdown (**p < 0.001**, n = 7) (Scientific Reports, Aug 2023) (lee2023pdiaugmentskainic pages 9-11).
+- **Stress/aggresome biology:** arsenite increased PICK1 homodimerization **+544.3 ± 19.52% (P < 0.0001)** and increased detergent-insoluble pellet signal **~+191.2 ± 20.79 (P = 0.008)** (MBoC, Oct 2024) (lai2024sodiumarseniteinduces pages 6-8).
+- **In silico inhibitor discovery scale:** virtual screen of **340,731,400 molecules** and **1,603,779,177 conformers**; docking scores down to **−9.2 kcal/mol** for reported hits (Journal of Biomolecular Structure and Dynamics, Nov 2023) (rathod2023ampaglua2subunit pages 22-26).
+
+### 8. Disease associations (database-level context)
+OpenTargets reports PICK1 disease-target associations including **Alzheimer disease**, **Parkinson disease**, broader **neurodegenerative disease**, **lysosomal storage disease**, and **male infertility due to globozoospermia** (OpenTargets context) (OpenTargets Search: -PICK1). These associations are useful for hypothesis generation but should be interpreted alongside direct mechanistic evidence from primary studies.
+
+### 9. Summary (functional annotation statement)
+Human **PICK1 (Q9NRD5)** is best annotated as a **PDZ/BAR scaffolding and membrane-remodeling protein** that controls **membrane protein trafficking**, with the strongest 2023–2024 evidence supporting roles in **AMPAR (GluA2/3) internalization/recycling and synaptic plasticity** through phosphorylation-dependent partner switching and regulated complex formation. Recent work extends PICK1 relevance to **system-level phenotypes (obesity via PDZ targeting)**, **stress-driven aggresome biology**, and **context-specific tumor suppressor signaling via Wnt/β-catenin**, motivating ongoing therapeutic and mechanistic studies (fadahunsi2024targetingpostsynapticglutamate pages 2-4, lee2023pdiaugmentskainic pages 9-11, lai2024sodiumarseniteinduces pages 6-8, ou2024pick1inhibitsthe pages 2-7).
+
+References
+
+1. (zhu2023them1muscarinic pages 1-4): Zengyan Zhu, Wenjuan Wang, Chao Gu, Mei Wang, and Yinghui Yan. The m1 muscarinic acetylcholine receptor regulates the surface expression of the ampa receptor subunit glua2 via pick1. Psychopharmacology, 240:239-248, Dec 2023. URL: https://doi.org/10.1007/s00213-022-06304-4, doi:10.1007/s00213-022-06304-4. This article has 3 citations and is from a peer-reviewed journal.
+
+2. (song2023investigatingthemechanical pages 1-2): Shenghan Song, Tongtong Li, Amy O. Stevens, Taha Raad, and Yi He. Investigating the mechanical properties and flexibility of n-bar domains in pick1 by molecular dynamics simulations. Current Protein &amp; Peptide Science, 24:865-877, Dec 2023. URL: https://doi.org/10.2174/1389203724666230522093842, doi:10.2174/1389203724666230522093842. This article has 5 citations and is from a peer-reviewed journal.
+
+3. (rathod2023ampaglua2subunit pages 1-4): Shravan B. Rathod, Pravin B. Prajapati, Ranjana Pal, and Mohmedyasin F. Mansuri. Ampa glua2 subunit competitive inhibitors for pick1 pdz domain: pharmacophore-based virtual screening, molecular docking, molecular dynamics simulation, and adme studies. Journal of Biomolecular Structure and Dynamics, 41:336-351, Nov 2023. URL: https://doi.org/10.1080/07391102.2021.2006086, doi:10.1080/07391102.2021.2006086. This article has 7 citations and is from a peer-reviewed journal.
+
+4. (cao2023molecularmechanismsof pages 1-2): Yi-Yang Cao, Ling-Ling Wu, Xiao-Nan Li, Yu-Lian Yuan, Wan-Wei Zhao, Jing-Xuan Qi, Xu-Yu Zhao, Natalie Ward, and Jiao Wang. Molecular mechanisms of ampa receptor trafficking in the nervous system. International Journal of Molecular Sciences, 25:111, Dec 2023. URL: https://doi.org/10.3390/ijms25010111, doi:10.3390/ijms25010111. This article has 30 citations.
+
+5. (fadahunsi2024targetingpostsynapticglutamate pages 2-4): Nicole Fadahunsi, Jonas Petersen, Sophia Metz, Alexander Jakobsen, Cecilie Vad Mathiesen, Alberte Silke Buch-Rasmussen, Nigel Kurgan, Jeppe Kjærgaard Larsen, Rita C. Andersen, Thomas Topilko, Charlotte Svendsen, Mia Apuschkin, Grethe Skovbjerg, Jan Hendrik Schmidt, Grace Houser, Sara Elgaard Jager, Anders Bach, Atul S. Deshmukh, Tuomas O. Kilpeläinen, Kristian Strømgaard, Kenneth L. Madsen, and Christoffer Clemmensen. Targeting postsynaptic glutamate receptor scaffolding proteins psd-95 and pick1 for obesity treatment. Science Advances, Mar 2024. URL: https://doi.org/10.1126/sciadv.adg2636, doi:10.1126/sciadv.adg2636. This article has 17 citations and is from a highest quality peer-reviewed journal.
+
+6. (song2023investigatingthemechanical pages 6-7): Shenghan Song, Tongtong Li, Amy O. Stevens, Taha Raad, and Yi He. Investigating the mechanical properties and flexibility of n-bar domains in pick1 by molecular dynamics simulations. Current Protein &amp; Peptide Science, 24:865-877, Dec 2023. URL: https://doi.org/10.2174/1389203724666230522093842, doi:10.2174/1389203724666230522093842. This article has 5 citations and is from a peer-reviewed journal.
+
+7. (lee2023pdiaugmentskainic pages 9-11): Duk-shin Lee, Tae-Hyun Kim, Hana Park, and Ji-eun Kim. Pdi augments kainic acid-induced seizure activity and neuronal death by inhibiting pp2a-glua2-pick1-mediated ampa receptor internalization in the mouse hippocampus. Scientific Reports, Aug 2023. URL: https://doi.org/10.1038/s41598-023-41014-7, doi:10.1038/s41598-023-41014-7. This article has 6 citations and is from a peer-reviewed journal.
+
+8. (hendrix2025utilizingafdesignfor pages 8-9): Emily Hendrix, Xinyu Xia, Amy O. Stevens, and Yi He. Utilizing afdesign for developing a small molecule inhibitor of pick 1-pdz. Current protein & peptide science, Aug 2025. URL: https://doi.org/10.2174/0113892037316932240806102854, doi:10.2174/0113892037316932240806102854. This article has 2 citations and is from a peer-reviewed journal.
+
+9. (lai2024sodiumarseniteinduces pages 1-2): John Ho Chun Lai, Marianthi Tsogka, and Jun Xia. Sodium arsenite induces aggresome formation by promoting pick1 bar domain homodimer formation. Molecular Biology of the Cell, Oct 2024. URL: https://doi.org/10.1091/mbc.e24-05-0201, doi:10.1091/mbc.e24-05-0201. This article has 0 citations and is from a domain leading peer-reviewed journal.
+
+10. (lai2024sodiumarseniteinduces pages 6-8): John Ho Chun Lai, Marianthi Tsogka, and Jun Xia. Sodium arsenite induces aggresome formation by promoting pick1 bar domain homodimer formation. Molecular Biology of the Cell, Oct 2024. URL: https://doi.org/10.1091/mbc.e24-05-0201, doi:10.1091/mbc.e24-05-0201. This article has 0 citations and is from a domain leading peer-reviewed journal.
+
+11. (rathod2023ampaglua2subunit pages 22-26): Shravan B. Rathod, Pravin B. Prajapati, Ranjana Pal, and Mohmedyasin F. Mansuri. Ampa glua2 subunit competitive inhibitors for pick1 pdz domain: pharmacophore-based virtual screening, molecular docking, molecular dynamics simulation, and adme studies. Journal of Biomolecular Structure and Dynamics, 41:336-351, Nov 2023. URL: https://doi.org/10.1080/07391102.2021.2006086, doi:10.1080/07391102.2021.2006086. This article has 7 citations and is from a peer-reviewed journal.
+
+12. (fadahunsi2024targetingpostsynapticglutamate pages 1-2): Nicole Fadahunsi, Jonas Petersen, Sophia Metz, Alexander Jakobsen, Cecilie Vad Mathiesen, Alberte Silke Buch-Rasmussen, Nigel Kurgan, Jeppe Kjærgaard Larsen, Rita C. Andersen, Thomas Topilko, Charlotte Svendsen, Mia Apuschkin, Grethe Skovbjerg, Jan Hendrik Schmidt, Grace Houser, Sara Elgaard Jager, Anders Bach, Atul S. Deshmukh, Tuomas O. Kilpeläinen, Kristian Strømgaard, Kenneth L. Madsen, and Christoffer Clemmensen. Targeting postsynaptic glutamate receptor scaffolding proteins psd-95 and pick1 for obesity treatment. Science Advances, Mar 2024. URL: https://doi.org/10.1126/sciadv.adg2636, doi:10.1126/sciadv.adg2636. This article has 17 citations and is from a highest quality peer-reviewed journal.
+
+13. (ou2024pick1inhibitsthe pages 2-7): Xiaomin Ou, Yingzi Zhang, Yiqing Xu, Yi Liu, Wenzhi Tu, Chaosu Hu, and Yong Liu. Pick1 inhibits the malignancy of nasopharyngeal carcinoma and serves as a novel prognostic marker. Cell Death &amp; Disease, Apr 2024. URL: https://doi.org/10.1038/s41419-024-06687-6, doi:10.1038/s41419-024-06687-6. This article has 3 citations and is from a peer-reviewed journal.
+
+14. (OpenTargets Search: -PICK1): Open Targets Query (-PICK1, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+## Citations
+
+1. cao2023molecularmechanismsof pages 1-2
+2. fadahunsi2024targetingpostsynapticglutamate pages 2-4
+3. lee2023pdiaugmentskainic pages 9-11
+4. hendrix2025utilizingafdesignfor pages 8-9
+5. lai2024sodiumarseniteinduces pages 6-8
+6. song2023investigatingthemechanical pages 6-7
+7. song2023investigatingthemechanical pages 1-2
+8. lai2024sodiumarseniteinduces pages 1-2
+9. fadahunsi2024targetingpostsynapticglutamate pages 1-2
+10. https://doi.org/10.1126/sciadv.adg2636
+11. https://doi.org/10.1091/mbc.e24-05-0201
+12. https://doi.org/10.1038/s41598-023-41014-7
+13. https://doi.org/10.1007/s00213-022-06304-4
+14. https://doi.org/10.2174/1389203724666230522093842
+15. https://doi.org/10.1038/s41419-024-06687-6
+16. https://doi.org/10.1007/s00213-022-06304-4,
+17. https://doi.org/10.2174/1389203724666230522093842,
+18. https://doi.org/10.1080/07391102.2021.2006086,
+19. https://doi.org/10.3390/ijms25010111,
+20. https://doi.org/10.1126/sciadv.adg2636,
+21. https://doi.org/10.1038/s41598-023-41014-7,
+22. https://doi.org/10.2174/0113892037316932240806102854,
+23. https://doi.org/10.1091/mbc.e24-05-0201,
+24. https://doi.org/10.1038/s41419-024-06687-6,

--- a/genes/human/RUNX3/RUNX3-ai-review.html
+++ b/genes/human/RUNX3/RUNX3-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>RUNX3</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q13761" target="_blank" class="term-link">
                         Q13761
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-initialized">
-                    INITIALIZED
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="Q13761" data-a="DESCRIPTION: TODO: Add description for RUNX3..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="Q13761" data-a="DESCRIPTION: RUNX3 encodes Runt-related transcription factor 3,..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for RUNX3</p>
+        <p>RUNX3 encodes Runt-related transcription factor 3, a nuclear Runt-domain DNA-binding transcription factor that heterodimerizes with CBFβ/core-binding factor complexes to regulate RNA polymerase II target-gene programs. Its core function is sequence-specific regulatory DNA and chromatin binding for context-dependent transcriptional activation or repression, with important downstream roles in development, TGF-beta/Wnt/Hippo signaling, CD8 T-cell biology, and cancer-associated mislocalization or degradation.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,3920 +758,5955 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000978" target="_blank" class="term-link">
                                     GO:0000978
                                 </a>
                             </span>
                             <span class="term-label">RNA polymerase II cis-regulatory region sequence-specific DNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000978" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000978" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> RNA polymerase II cis-regulatory region sequence-specific DNA binding is supported by RUNX3 Runt-domain sequence-specific DNA binding.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Sequence-specific regulatory-region DNA binding is central to RUNX3 transcription factor function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target protein is **human RUNX3** (gene symbol **RUNX3**, UniProt **Q13761**), described in UniProt as *Runt-related transcription factor 3* with a conserved **Runt (AML1_Runt) DNA-binding domain** and C-terminal RUNX interaction region. In the literature retrieved here, the entity called RUNX3 is consistently described as a **Runt-domain transcription factor that heterodimerizes with CBFβ (core-binding factor β)** and regulates gene expression through sequence-specific DNA binding—matching the defining biochemical/structural properties expected for UniProt Q13761.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001503" target="_blank" class="term-link">
                                     GO:0001503
                                 </a>
                             </span>
                             <span class="term-label">ossification</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0001503" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0001503" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ossification is consistent with RUNX3 developmental or disease-associated transcriptional programs but is not the core molecular function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of RUNX3 transcription factor activity and should not be treated as the core function itself.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**RUNX3 is a master developmental transcription factor** whose dysregulation can impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2024 review of RUNX transcription factors synthesizes RUNX3 as a regulator embedded in major cancer-relevant pathways, including **TGF-β/SMAD**, **Wnt/β-catenin**, and **Hippo–YAP** crosstalk, and emphasizes frequent RUNX3 inactivation through **promoter hypermethylation, histone modifications, and mislocalization**.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030097" target="_blank" class="term-link">
                                     GO:0030097
                                 </a>
                             </span>
                             <span class="term-label">hemopoiesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0030097" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0030097" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> hemopoiesis is consistent with RUNX3 developmental or disease-associated transcriptional programs but is not the core molecular function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of RUNX3 transcription factor activity and should not be treated as the core function itself.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**RUNX3 is a master developmental transcription factor** whose dysregulation can impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2024 review of RUNX transcription factors synthesizes RUNX3 as a regulator embedded in major cancer-relevant pathways, including **TGF-β/SMAD**, **Wnt/β-catenin**, and **Hippo–YAP** crosstalk, and emphasizes frequent RUNX3 inactivation through **promoter hypermethylation, histone modifications, and mislocalization**.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030182" target="_blank" class="term-link">
                                     GO:0030182
                                 </a>
                             </span>
                             <span class="term-label">neuron differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0030182" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0030182" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> neuron differentiation is consistent with RUNX3 developmental or disease-associated transcriptional programs but is not the core molecular function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of RUNX3 transcription factor activity and should not be treated as the core function itself.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**RUNX3 is a master developmental transcription factor** whose dysregulation can impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2024 review of RUNX transcription factors synthesizes RUNX3 as a regulator embedded in major cancer-relevant pathways, including **TGF-β/SMAD**, **Wnt/β-catenin**, and **Hippo–YAP** crosstalk, and emphasizes frequent RUNX3 inactivation through **promoter hypermethylation, histone modifications, and mislocalization**.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045595" target="_blank" class="term-link">
                                     GO:0045595
                                 </a>
                             </span>
                             <span class="term-label">regulation of cell differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0045595" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0045595" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> regulation of cell differentiation is consistent with RUNX3 developmental or disease-associated transcriptional programs but is not the core molecular function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of RUNX3 transcription factor activity and should not be treated as the core function itself.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**RUNX3 is a master developmental transcription factor** whose dysregulation can impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2024 review of RUNX transcription factors synthesizes RUNX3 as a regulator embedded in major cancer-relevant pathways, including **TGF-β/SMAD**, **Wnt/β-catenin**, and **Hippo–YAP** crosstalk, and emphasizes frequent RUNX3 inactivation through **promoter hypermethylation, histone modifications, and mislocalization**.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
                                     GO:0006357
                                 </a>
                             </span>
                             <span class="term-label">regulation of transcription by RNA polymerase II</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0006357" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0006357" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Regulation of transcription by RNA polymerase II is a core RUNX3 biological process.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 regulates gene-expression programs as a nuclear sequence-specific transcription factor.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000981" target="_blank" class="term-link">
                                     GO:0000981
                                 </a>
                             </span>
                             <span class="term-label">DNA-binding transcription factor activity, RNA polymerase II-specific</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000981" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000981" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> DNA-binding transcription factor activity, RNA polymerase II-specific is the best-supported core molecular function of RUNX3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 is a sequence-specific Runt-domain transcription factor that regulates RNA polymerase II transcription through DNA/chromatin binding and CBFβ-associated complexes.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002062" target="_blank" class="term-link">
                                     GO:0002062
                                 </a>
                             </span>
                             <span class="term-label">chondrocyte differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0002062" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0002062" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> chondrocyte differentiation is consistent with RUNX3 developmental or disease-associated transcriptional programs but is not the core molecular function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of RUNX3 transcription factor activity and should not be treated as the core function itself.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**RUNX3 is a master developmental transcription factor** whose dysregulation can impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2024 review of RUNX transcription factors synthesizes RUNX3 as a regulator embedded in major cancer-relevant pathways, including **TGF-β/SMAD**, **Wnt/β-catenin**, and **Hippo–YAP** crosstalk, and emphasizes frequent RUNX3 inactivation through **promoter hypermethylation, histone modifications, and mislocalization**.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003677" target="_blank" class="term-link">
                                     GO:0003677
                                 </a>
                             </span>
                             <span class="term-label">DNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0003677" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0003677" data-r="GO_REF:0000120" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic DNA binding is directionally correct but less precise than RUNX3 sequence-specific regulatory DNA binding.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 is not merely a generic DNA-binding protein; its supported molecular role is sequence-specific Runt-domain binding at regulatory regions.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990837" target="_blank" class="term-link">
+                                    sequence-specific double-stranded DNA binding
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000978" target="_blank" class="term-link">
+                                    RNA polymerase II cis-regulatory region sequence-specific DNA binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target protein is **human RUNX3** (gene symbol **RUNX3**, UniProt **Q13761**), described in UniProt as *Runt-related transcription factor 3* with a conserved **Runt (AML1_Runt) DNA-binding domain** and C-terminal RUNX interaction region. In the literature retrieved here, the entity called RUNX3 is consistently described as a **Runt-domain transcription factor that heterodimerizes with CBFβ (core-binding factor β)** and regulates gene expression through sequence-specific DNA binding—matching the defining biochemical/structural properties expected for UniProt Q13761.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003700" target="_blank" class="term-link">
                                     GO:0003700
                                 </a>
                             </span>
                             <span class="term-label">DNA-binding transcription factor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0003700" data-r="GO_REF:0000002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0003700" data-r="GO_REF:0000002" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic DNA-binding transcription factor activity is correct but less precise than the RNA polymerase II-specific term already present.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 functions as a sequence-specific RNA polymerase II transcription factor, so the more specific term is preferred.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000981" target="_blank" class="term-link">
+                                    DNA-binding transcription factor activity, RNA polymerase II-specific
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ATP binding is not supported as a RUNX3 molecular function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 is a non-enzymatic DNA-binding transcription factor; ATP-dependent chromatin-remodeling context should not be transferred to RUNX3 as ATP binding.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005634" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005634" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleus localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytoplasm localization is supported, but mainly as a mislocalization/export or degradation context rather than the canonical site of RUNX3 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic localization is best treated as a regulated non-core or inactivation-associated state.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This provides a mechanistic explanation for the often-cited phenomenon of RUNX3 cytoplasmic mislocalization as a route to functional loss.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006355" target="_blank" class="term-link">
                                     GO:0006355
                                 </a>
                             </span>
                             <span class="term-label">regulation of DNA-templated transcription</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0006355" data-r="GO_REF:0000002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0006355" data-r="GO_REF:0000002" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic regulation of DNA-templated transcription is supported but should be captured with the RNA polymerase II-specific process.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 target-gene regulation is best represented by regulation of transcription by RNA polymerase II.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
+                                    regulation of transcription by RNA polymerase II
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045893" target="_blank" class="term-link">
                                     GO:0045893
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of DNA-templated transcription</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0045893" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0045893" data-r="GO_REF:0000117" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Positive regulation of DNA-templated transcription is supported in context-specific RUNX3 target-gene programs.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 can activate transcriptional targets, although the direction of regulation is context dependent.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2024 study (Cancer Research Communications) presented evidence that RUNX3 can be **pro-metastatic** in a gastric cancer model (HGC-27), where CRISPR KO reduced migration/invasion/anchorage-independent growth and suppressed liver metastasis in vivo. Multi-omic mapping (ChIP-seq, HiChIP) supported direct transcriptional control of metastasis-associated targets including **WNT5A**, **CD44**, and **VIM**, with WNT5A functioning as a major effector.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990837" target="_blank" class="term-link">
                                     GO:1990837
                                 </a>
                             </span>
                             <span class="term-label">sequence-specific double-stranded DNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:1990837" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:1990837" data-r="GO_REF:0000117" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> sequence-specific double-stranded DNA binding is supported by RUNX3 Runt-domain sequence-specific DNA binding.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Sequence-specific regulatory-region DNA binding is central to RUNX3 transcription factor function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target protein is **human RUNX3** (gene symbol **RUNX3**, UniProt **Q13761**), described in UniProt as *Runt-related transcription factor 3* with a conserved **Runt (AML1_Runt) DNA-binding domain** and C-terminal RUNX interaction region. In the literature retrieved here, the entity called RUNX3 is consistently described as a **Runt-domain transcription factor that heterodimerizes with CBFβ (core-binding factor β)** and regulates gene expression through sequence-specific DNA binding—matching the defining biochemical/structural properties expected for UniProt Q13761.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18772112" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18772112
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     RUNX3 attenuates beta-catenin/T cell factors in intestinal t...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:18772112" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:18772112" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is supported in many RUNX3 contexts but is too generic to describe the main function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and chromatin factors, but the unqualified protein binding term is not informative for curation.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18772112" target="_blank" class="term-link">
-                                        PMID:18772112
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">RUNX3 attenuates beta-catenin/T cell factors in intestinal tumorigenesis.</div>
-                                
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key 2023 advance demonstrated a **direct protein–protein mechanism** linking RUNX3 to oncogene control: RUNX3 binds **MYC** directly via the **Runt domain**, disrupts MYC’s transcriptionally active complexes (MYC–MAX and MYC–MIZ1), increases **GSK3β-mediated phosphorylation of MYC at T58**, and promotes **FBXW7-dependent K48-linked ubiquitination** and proteasomal degradation of MYC.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24229708" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24229708
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Runx3 inactivation is a crucial early event in the developme...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:24229708" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:24229708" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is supported in many RUNX3 contexts but is too generic to describe the main function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and chromatin factors, but the unqualified protein binding term is not informative for curation.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24229708" target="_blank" class="term-link">
-                                        PMID:24229708
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Runx3 inactivation is a crucial early event in the development of lung adenocarcinoma.</div>
-                                
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key 2023 advance demonstrated a **direct protein–protein mechanism** linking RUNX3 to oncogene control: RUNX3 binds **MYC** directly via the **Runt domain**, disrupts MYC’s transcriptionally active complexes (MYC–MAX and MYC–MIZ1), increases **GSK3β-mediated phosphorylation of MYC at T58**, and promotes **FBXW7-dependent K48-linked ubiquitination** and proteasomal degradation of MYC.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:33961781" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is supported in many RUNX3 contexts but is too generic to describe the main function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and chromatin factors, but the unqualified protein binding term is not informative for curation.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
-                                        PMID:33961781
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2021 May 6. Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                                
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key 2023 advance demonstrated a **direct protein–protein mechanism** linking RUNX3 to oncogene control: RUNX3 binds **MYC** directly via the **Runt domain**, disrupts MYC’s transcriptionally active complexes (MYC–MAX and MYC–MIZ1), increases **GSK3β-mediated phosphorylation of MYC at T58**, and promotes **FBXW7-dependent K48-linked ubiquitination** and proteasomal degradation of MYC.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/38424632" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:38424632
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Ubiquitylation of RUNX3 by RNA-binding ubiquitin ligase MEX3...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:38424632" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:38424632" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is supported in many RUNX3 contexts but is too generic to describe the main function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and chromatin factors, but the unqualified protein binding term is not informative for curation.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/38424632" target="_blank" class="term-link">
-                                        PMID:38424632
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Ubiquitylation of RUNX3 by RNA-binding ubiquitin ligase MEX3C promotes tumorigenesis in lung adenocarcinoma.</div>
-                                
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key 2023 advance demonstrated a **direct protein–protein mechanism** linking RUNX3 to oncogene control: RUNX3 binds **MYC** directly via the **Runt domain**, disrupts MYC’s transcriptionally active complexes (MYC–MAX and MYC–MIZ1), increases **GSK3β-mediated phosphorylation of MYC at T58**, and promotes **FBXW7-dependent K48-linked ubiquitination** and proteasomal degradation of MYC.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9751710" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9751710
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Transcriptional repression by AML1 and LEF-1 is mediated by ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:9751710" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:9751710" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is supported in many RUNX3 contexts but is too generic to describe the main function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and chromatin factors, but the unqualified protein binding term is not informative for curation.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9751710" target="_blank" class="term-link">
-                                        PMID:9751710
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Transcriptional repression by AML1 and LEF-1 is mediated by the TLE/Groucho corepressors.</div>
-                                
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key 2023 advance demonstrated a **direct protein–protein mechanism** linking RUNX3 to oncogene control: RUNX3 binds **MYC** directly via the **Runt domain**, disrupts MYC’s transcriptionally active complexes (MYC–MAX and MYC–MIZ1), increases **GSK3β-mediated phosphorylation of MYC at T58**, and promotes **FBXW7-dependent K48-linked ubiquitination** and proteasomal degradation of MYC.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="GO_REF:0000052" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="GO_REF:0000052" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported, but mainly as a mislocalization/export or degradation context rather than the canonical site of RUNX3 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic localization is best treated as a regulated non-core or inactivation-associated state.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This provides a mechanistic explanation for the often-cited phenomenon of RUNX3 cytoplasmic mislocalization as a route to functional loss.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
                                     GO:0006357
                                 </a>
                             </span>
                             <span class="term-label">regulation of transcription by RNA polymerase II</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20591170" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20591170
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Runx transcriptional co-activator, CBFbeta, is essential...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0006357" data-r="PMID:20591170" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0006357" data-r="PMID:20591170" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Regulation of transcription by RNA polymerase II is a core RUNX3 biological process.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 regulates gene-expression programs as a nuclear sequence-specific transcription factor.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20591170" target="_blank" class="term-link">
-                                        PMID:20591170
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">The Runx transcriptional co-activator, CBFbeta, is essential for invasion of breast cancer cells.</div>
-                                
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001222" target="_blank" class="term-link">
                                     GO:0001222
                                 </a>
                             </span>
                             <span class="term-label">transcription corepressor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9751710" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9751710
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Transcriptional repression by AML1 and LEF-1 is mediated by ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0001222" data-r="PMID:9751710" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0001222" data-r="PMID:9751710" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Transcription corepressor binding is supported by RUNX/Runt-domain recruitment of TLE/Groucho corepressors.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> This is a more informative binding annotation than generic protein binding for RUNX3-associated transcriptional repression.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9751710" target="_blank" class="term-link">
                                         PMID:9751710
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Transcriptional repression by AML1 and LEF-1 is mediated by the TLE/Groucho corepressors.</div>
-                                
+
+                                <div class="support-text">The mammalian AML/CBFalpha runt domain (RD) transcription factors regulate hematopoiesis and osteoblast differentiation. Like their Drosophila counterparts, most mammalian RD proteins terminate in a common pentapeptide, VWRPY, which serves to recruit the corepressor Groucho (Gro).</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1990837" target="_blank" class="term-link">
                                     GO:1990837
                                 </a>
                             </span>
                             <span class="term-label">sequence-specific double-stranded DNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28473536" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28473536
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Impact of cytosine methylation on DNA binding specificities ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:1990837" data-r="PMID:28473536" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:1990837" data-r="PMID:28473536" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> sequence-specific double-stranded DNA binding is supported by RUNX3 Runt-domain sequence-specific DNA binding.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Sequence-specific regulatory-region DNA binding is central to RUNX3 transcription factor function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28473536" target="_blank" class="term-link">
-                                        PMID:28473536
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Impact of cytosine methylation on DNA binding specificities of human transcription factors.</div>
-                                
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target protein is **human RUNX3** (gene symbol **RUNX3**, UniProt **Q13761**), described in UniProt as *Runt-related transcription factor 3* with a conserved **Runt (AML1_Runt) DNA-binding domain** and C-terminal RUNX interaction region. In the literature retrieved here, the entity called RUNX3 is consistently described as a **Runt-domain transcription factor that heterodimerizes with CBFβ (core-binding factor β)** and regulates gene expression through sequence-specific DNA binding—matching the defining biochemical/structural properties expected for UniProt Q13761.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000785" target="_blank" class="term-link">
                                     GO:0000785
                                 </a>
                             </span>
                             <span class="term-label">chromatin</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000113
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000785" data-r="GO_REF:0000113" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000785" data-r="GO_REF:0000113" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Chromatin localization is supported by RUNX3 DNA, mononucleosome, and chromatin-remodeler-associated activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 binds chromatin-associated regulatory DNA as part of its transcription factor function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 associates with **CBFβ** and chromatin remodeler machinery including SWI/SNF components; the **Runt domain** is implicated as critical for interactions with chromatin factors in this metastatic gastric cancer model.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000981" target="_blank" class="term-link">
                                     GO:0000981
                                 </a>
                             </span>
                             <span class="term-label">DNA-binding transcription factor activity, RNA polymerase II-specific</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000113
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000981" data-r="GO_REF:0000113" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000981" data-r="GO_REF:0000113" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> DNA-binding transcription factor activity, RNA polymerase II-specific is the best-supported core molecular function of RUNX3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 is a sequence-specific Runt-domain transcription factor that regulates RNA polymerase II transcription through DNA/chromatin binding and CBFβ-associated complexes.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016513" target="_blank" class="term-link">
                                     GO:0016513
                                 </a>
                             </span>
                             <span class="term-label">core-binding factor complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18258917" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18258917
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Repression of the transcription factor Th-POK by Runx comple...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0016513" data-r="PMID:18258917" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0016513" data-r="PMID:18258917" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Core-binding factor complex is the canonical RUNX3 transcription factor complex context.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 heterodimerizes with CBFβ, placing it in the core-binding factor complex for DNA-binding transcriptional regulation.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18258917" target="_blank" class="term-link">
-                                        PMID:18258917
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Repression of the transcription factor Th-POK by Runx complexes in cytotoxic T cell development.</div>
-                                
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 associates with **CBFβ** and chromatin remodeler machinery including SWI/SNF components; the **Runt domain** is implicated as critical for interactions with chromatin factors in this metastatic gastric cancer model.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043371" target="_blank" class="term-link">
                                     GO:0043371
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of CD4-positive, alpha-beta T cell differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0043371" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0043371" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> negative regulation of CD4-positive, alpha-beta T cell differentiation is a supported RUNX3 biological role, especially in immune differentiation, but it is downstream of the transcription factor core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> T-cell differentiation phenotypes reflect RUNX3-regulated transcriptional programs rather than a separate core molecular activity.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is a key regulator of **CD8+ T-cell differentiation, infiltration, effector/memory fate, and residency**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**RUNX3 is a master developmental transcription factor** whose dysregulation can impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043378" target="_blank" class="term-link">
                                     GO:0043378
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of CD8-positive, alpha-beta T cell differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0043378" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0043378" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> positive regulation of CD8-positive, alpha-beta T cell differentiation is a supported RUNX3 biological role, especially in immune differentiation, but it is downstream of the transcription factor core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> T-cell differentiation phenotypes reflect RUNX3-regulated transcriptional programs rather than a separate core molecular activity.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is a key regulator of **CD8+ T-cell differentiation, infiltration, effector/memory fate, and residency**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**RUNX3 is a master developmental transcription factor** whose dysregulation can impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8952419
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952419" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952419" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8952399
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005829" data-r="Reactome:R-HSA-8952399" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005829" data-r="Reactome:R-HSA-8952399" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported, but mainly as a mislocalization/export or degradation context rather than the canonical site of RUNX3 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic localization is best treated as a regulated non-core or inactivation-associated state.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This provides a mechanistic explanation for the often-cited phenomenon of RUNX3 cytoplasmic mislocalization as a route to functional loss.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8952408
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005829" data-r="Reactome:R-HSA-8952408" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005829" data-r="Reactome:R-HSA-8952408" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported, but mainly as a mislocalization/export or degradation context rather than the canonical site of RUNX3 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic localization is best treated as a regulated non-core or inactivation-associated state.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This provides a mechanistic explanation for the often-cited phenomenon of RUNX3 cytoplasmic mislocalization as a route to functional loss.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8952382
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952382" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952382" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8952399
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952399" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952399" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8951966
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8951966" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8951966" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8951977
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8951977" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8951977" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8952058
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952058" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952058" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8952062
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952062" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952062" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8952069
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952069" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952069" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8937792
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005829" data-r="Reactome:R-HSA-8937792" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005829" data-r="Reactome:R-HSA-8937792" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported, but mainly as a mislocalization/export or degradation context rather than the canonical site of RUNX3 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic localization is best treated as a regulated non-core or inactivation-associated state.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This provides a mechanistic explanation for the often-cited phenomenon of RUNX3 cytoplasmic mislocalization as a route to functional loss.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8937807
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005829" data-r="Reactome:R-HSA-8937807" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005829" data-r="Reactome:R-HSA-8937807" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported, but mainly as a mislocalization/export or degradation context rather than the canonical site of RUNX3 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic localization is best treated as a regulated non-core or inactivation-associated state.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This provides a mechanistic explanation for the often-cited phenomenon of RUNX3 cytoplasmic mislocalization as a route to functional loss.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8937814
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005829" data-r="Reactome:R-HSA-8937814" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005829" data-r="Reactome:R-HSA-8937814" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytosol localization is supported, but mainly as a mislocalization/export or degradation context rather than the canonical site of RUNX3 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic localization is best treated as a regulated non-core or inactivation-associated state.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This provides a mechanistic explanation for the often-cited phenomenon of RUNX3 cytoplasmic mislocalization as a route to functional loss.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8865454
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8865454" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8865454" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8878117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8878117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8878117" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8878143
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8878143" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8878143" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8878178
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8878178" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8878178" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8878193
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8878193" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8878193" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8878220
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8878220" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8878220" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8878237
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8878237" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8878237" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8937814
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8937814" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8937814" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8949335
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8949335" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8949335" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8951428
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8951428" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8951428" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8951676
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8951676" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8951676" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8951910
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8951910" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8951910" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8951951
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8951951" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8951951" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8952128
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952128" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952128" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8952226
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952226" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952226" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8952371
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952371" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005654" data-r="Reactome:R-HSA-8952371" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20599712" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20599712
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tumor suppressor, AT motif binding factor 1 (ATBF1), translo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:20599712" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:20599712" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is supported in many RUNX3 contexts but is too generic to describe the main function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and chromatin factors, but the unqualified protein binding term is not informative for curation.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20599712" target="_blank" class="term-link">
-                                        PMID:20599712
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Tumor suppressor, AT motif binding factor 1 (ATBF1), translocates to the nucleus with runt domain transcription factor 3 (RUNX3) in response to TGF-beta signal transduction.</div>
-                                
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key 2023 advance demonstrated a **direct protein–protein mechanism** linking RUNX3 to oncogene control: RUNX3 binds **MYC** directly via the **Runt domain**, disrupts MYC’s transcriptionally active complexes (MYC–MAX and MYC–MIZ1), increases **GSK3β-mediated phosphorylation of MYC at T58**, and promotes **FBXW7-dependent K48-linked ubiquitination** and proteasomal degradation of MYC.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20599712" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20599712
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tumor suppressor, AT motif binding factor 1 (ATBF1), translo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005634" data-r="PMID:20599712" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005634" data-r="PMID:20599712" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleus localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20599712" target="_blank" class="term-link">
-                                        PMID:20599712
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Tumor suppressor, AT motif binding factor 1 (ATBF1), translocates to the nucleus with runt domain transcription factor 3 (RUNX3) in response to TGF-beta signal transduction.</div>
-                                
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20599712" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20599712
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tumor suppressor, AT motif binding factor 1 (ATBF1), translo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005737" data-r="PMID:20599712" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005737" data-r="PMID:20599712" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytoplasm localization is supported, but mainly as a mislocalization/export or degradation context rather than the canonical site of RUNX3 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic localization is best treated as a regulated non-core or inactivation-associated state.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20599712" target="_blank" class="term-link">
-                                        PMID:20599712
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Tumor suppressor, AT motif binding factor 1 (ATBF1), translocates to the nucleus with runt domain transcription factor 3 (RUNX3) in response to TGF-beta signal transduction.</div>
-                                
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This provides a mechanistic explanation for the often-cited phenomenon of RUNX3 cytoplasmic mislocalization as a route to functional loss.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045893" target="_blank" class="term-link">
                                     GO:0045893
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of DNA-templated transcription</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20599712" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20599712
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tumor suppressor, AT motif binding factor 1 (ATBF1), translo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0045893" data-r="PMID:20599712" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0045893" data-r="PMID:20599712" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Positive regulation of DNA-templated transcription is supported in context-specific RUNX3 target-gene programs.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 can activate transcriptional targets, although the direction of regulation is context dependent.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20599712" target="_blank" class="term-link">
-                                        PMID:20599712
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Tumor suppressor, AT motif binding factor 1 (ATBF1), translocates to the nucleus with runt domain transcription factor 3 (RUNX3) in response to TGF-beta signal transduction.</div>
-                                
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2024 study (Cancer Research Communications) presented evidence that RUNX3 can be **pro-metastatic** in a gastric cancer model (HGC-27), where CRISPR KO reduced migration/invasion/anchorage-independent growth and suppressed liver metastasis in vivo. Multi-omic mapping (ChIP-seq, HiChIP) supported direct transcriptional control of metastasis-associated targets including **WNT5A**, **CD44**, and **VIM**, with WNT5A functioning as a major effector.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071559" target="_blank" class="term-link">
                                     GO:0071559
                                 </a>
                             </span>
                             <span class="term-label">response to transforming growth factor beta</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20599712" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20599712
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tumor suppressor, AT motif binding factor 1 (ATBF1), translo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0071559" data-r="PMID:20599712" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0071559" data-r="PMID:20599712" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Response to transforming growth factor beta is supported as a pathway context for RUNX3 transcriptional regulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> TGF-beta/SMAD effects are important context-specific biology, but the core function remains nuclear sequence-specific transcriptional regulation.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20599712" target="_blank" class="term-link">
-                                        PMID:20599712
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Tumor suppressor, AT motif binding factor 1 (ATBF1), translocates to the nucleus with runt domain transcription factor 3 (RUNX3) in response to TGF-beta signal transduction.</div>
-                                
+
+                                <div class="support-text">A 2024 review of RUNX transcription factors synthesizes RUNX3 as a regulator embedded in major cancer-relevant pathways, including **TGF-β/SMAD**, **Wnt/β-catenin**, and **Hippo–YAP** crosstalk, and emphasizes frequent RUNX3 inactivation through **promoter hypermethylation, histone modifications, and mislocalization**.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**RUNX3 is a master developmental transcription factor** whose dysregulation can impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17377532" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17377532
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Foxp3 controls regulatory T-cell function by interacting wit...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:17377532" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:17377532" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is supported in many RUNX3 contexts but is too generic to describe the main function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and chromatin factors, but the unqualified protein binding term is not informative for curation.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17377532" target="_blank" class="term-link">
-                                        PMID:17377532
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Foxp3 controls regulatory T-cell function by interacting with AML1/Runx1.</div>
-                                
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key 2023 advance demonstrated a **direct protein–protein mechanism** linking RUNX3 to oncogene control: RUNX3 binds **MYC** directly via the **Runt domain**, disrupts MYC’s transcriptionally active complexes (MYC–MAX and MYC–MIZ1), increases **GSK3β-mediated phosphorylation of MYC at T58**, and promotes **FBXW7-dependent K48-linked ubiquitination** and proteasomal degradation of MYC.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000785" target="_blank" class="term-link">
                                     GO:0000785
                                 </a>
                             </span>
                             <span class="term-label">chromatin</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000785" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000785" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Chromatin localization is supported by RUNX3 DNA, mononucleosome, and chromatin-remodeler-associated activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 binds chromatin-associated regulatory DNA as part of its transcription factor function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 associates with **CBFβ** and chromatin remodeler machinery including SWI/SNF components; the **Runt domain** is implicated as critical for interactions with chromatin factors in this metastatic gastric cancer model.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000977" target="_blank" class="term-link">
                                     GO:0000977
                                 </a>
                             </span>
                             <span class="term-label">RNA polymerase II transcription regulatory region sequence-specific DNA binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000977" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000977" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> RNA polymerase II transcription regulatory region sequence-specific DNA binding is supported by RUNX3 Runt-domain sequence-specific DNA binding.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Sequence-specific regulatory-region DNA binding is central to RUNX3 transcription factor function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The target protein is **human RUNX3** (gene symbol **RUNX3**, UniProt **Q13761**), described in UniProt as *Runt-related transcription factor 3* with a conserved **Runt (AML1_Runt) DNA-binding domain** and C-terminal RUNX interaction region. In the literature retrieved here, the entity called RUNX3 is consistently described as a **Runt-domain transcription factor that heterodimerizes with CBFβ (core-binding factor β)** and regulates gene expression through sequence-specific DNA binding—matching the defining biochemical/structural properties expected for UniProt Q13761.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000122" target="_blank" class="term-link">
                                     GO:0000122
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of transcription by RNA polymerase II</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000122" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000122" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Negative regulation of transcription by RNA polymerase II is supported for RUNX3 in repressive target-gene and Wnt/TCF contexts.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 can repress transcriptional outputs through protein complexes and target-gene regulation.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18772112" target="_blank" class="term-link">
+                                        PMID:18772112
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here we found that RUNX3, a gastric tumor suppressor, forms a ternary complex with beta-catenin/TCF4 and attenuates Wnt signaling activity.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000981" target="_blank" class="term-link">
                                     GO:0000981
                                 </a>
                             </span>
                             <span class="term-label">DNA-binding transcription factor activity, RNA polymerase II-specific</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000981" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0000981" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> DNA-binding transcription factor activity, RNA polymerase II-specific is the best-supported core molecular function of RUNX3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 is a sequence-specific Runt-domain transcription factor that regulates RNA polymerase II transcription through DNA/chromatin binding and CBFβ-associated complexes.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048935" target="_blank" class="term-link">
                                     GO:0048935
                                 </a>
                             </span>
                             <span class="term-label">peripheral nervous system neuron development</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20096094" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20096094
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Brn3a regulates neuronal subtype specification in the trigem...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0048935" data-r="PMID:20096094" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0048935" data-r="PMID:20096094" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> peripheral nervous system neuron development is consistent with RUNX3 developmental or disease-associated transcriptional programs but is not the core molecular function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of RUNX3 transcription factor activity and should not be treated as the core function itself.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20096094" target="_blank" class="term-link">
-                                        PMID:20096094
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Brn3a regulates neuronal subtype specification in the trigeminal ganglion by promoting Runx expression during sensory differentiation.</div>
-                                
+
+                                <div class="support-text">**RUNX3 is a master developmental transcription factor** whose dysregulation can impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2024 review of RUNX transcription factors synthesizes RUNX3 as a regulator embedded in major cancer-relevant pathways, including **TGF-β/SMAD**, **Wnt/β-catenin**, and **Hippo–YAP** crosstalk, and emphasizes frequent RUNX3 inactivation through **promoter hypermethylation, histone modifications, and mislocalization**.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20100835" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20100835
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Src kinase phosphorylates RUNX3 at tyrosine residues and loc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005634" data-r="PMID:20100835" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005634" data-r="PMID:20100835" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nucleus localization is central to RUNX3 canonical transcription factor activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20100835" target="_blank" class="term-link">
-                                        PMID:20100835
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Epub 2010 Jan 25. Src kinase phosphorylates RUNX3 at tyrosine residues and localizes the protein in the cytoplasm.</div>
-                                
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006468" target="_blank" class="term-link">
                                     GO:0006468
                                 </a>
                             </span>
                             <span class="term-label">protein phosphorylation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20100835" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20100835
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Src kinase phosphorylates RUNX3 at tyrosine residues and loc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -4683,1283 +6718,2099 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> MISANNOTATION: RUNX3 is a Runt-domain transcription factor that is extensively PHOSPHORYLATED by kinases. PMID:20100835 title is &#34;Src kinase phosphorylates RUNX3 at tyrosine residues&#34; - RUNX3 is the SUBSTRATE of Src kinase, not an enzyme. The paper states &#34;overexpression of Src results in the tyrosine phosphorylation... of RUNX3&#34; and shows Src phosphorylates RUNX3 in vitro. RUNX3 has DNA-binding and transcription factor activity, not kinase activity. Phosphorylation of RUNX3 by Src leads to its cytoplasmic mislocalization.
+                            <strong>Summary:</strong> Protein phosphorylation is not supported as a process carried out by RUNX3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The cited biology describes Src-mediated phosphorylation of RUNX3, making RUNX3 the substrate rather than the kinase or causal gene product for protein phosphorylation.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20100835" target="_blank" class="term-link">
                                         PMID:20100835
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Epub 2010 Jan 25. Src kinase phosphorylates RUNX3 at tyrosine residues and localizes the protein in the cytoplasm.</div>
-                                
+
+                                <div class="support-text">In this study, we found that the overexpression of Src results in the tyrosine phosphorylation and cytoplasmic localization of RUNX3.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20100835" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20100835
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Src kinase phosphorylates RUNX3 at tyrosine residues and loc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:20100835" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005515" data-r="PMID:20100835" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is supported in many RUNX3 contexts but is too generic to describe the main function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and chromatin factors, but the unqualified protein binding term is not informative for curation.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20100835" target="_blank" class="term-link">
-                                        PMID:20100835
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Epub 2010 Jan 25. Src kinase phosphorylates RUNX3 at tyrosine residues and localizes the protein in the cytoplasm.</div>
-                                
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A key 2023 advance demonstrated a **direct protein–protein mechanism** linking RUNX3 to oncogene control: RUNX3 binds **MYC** directly via the **Runt domain**, disrupts MYC’s transcriptionally active complexes (MYC–MAX and MYC–MIZ1), increases **GSK3β-mediated phosphorylation of MYC at T58**, and promotes **FBXW7-dependent K48-linked ubiquitination** and proteasomal degradation of MYC.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20100835" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20100835
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Src kinase phosphorylates RUNX3 at tyrosine residues and loc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005737" data-r="PMID:20100835" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005737" data-r="PMID:20100835" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> cytoplasm localization is supported, but mainly as a mislocalization/export or degradation context rather than the canonical site of RUNX3 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic localization is best treated as a regulated non-core or inactivation-associated state.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20100835" target="_blank" class="term-link">
-                                        PMID:20100835
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Epub 2010 Jan 25. Src kinase phosphorylates RUNX3 at tyrosine residues and localizes the protein in the cytoplasm.</div>
-                                
+
+                                <div class="support-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">This provides a mechanistic explanation for the often-cited phenomenon of RUNX3 cytoplasmic mislocalization as a route to functional loss.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045786" target="_blank" class="term-link">
                                     GO:0045786
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of cell cycle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0045786" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0045786" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> negative regulation of cell cycle is consistent with RUNX3 developmental or disease-associated transcriptional programs but is not the core molecular function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of RUNX3 transcription factor activity and should not be treated as the core function itself.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**RUNX3 is a master developmental transcription factor** whose dysregulation can impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2024 review of RUNX transcription factors synthesizes RUNX3 as a regulator embedded in major cancer-relevant pathways, including **TGF-β/SMAD**, **Wnt/β-catenin**, and **Hippo–YAP** crosstalk, and emphasizes frequent RUNX3 inactivation through **promoter hypermethylation, histone modifications, and mislocalization**.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050680" target="_blank" class="term-link">
                                     GO:0050680
                                 </a>
                             </span>
                             <span class="term-label">negative regulation of epithelial cell proliferation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0050680" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0050680" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> negative regulation of epithelial cell proliferation is consistent with RUNX3 developmental or disease-associated transcriptional programs but is not the core molecular function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of RUNX3 transcription factor activity and should not be treated as the core function itself.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**RUNX3 is a master developmental transcription factor** whose dysregulation can impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2024 review of RUNX transcription factors synthesizes RUNX3 as a regulator embedded in major cancer-relevant pathways, including **TGF-β/SMAD**, **Wnt/β-catenin**, and **Hippo–YAP** crosstalk, and emphasizes frequent RUNX3 inactivation through **promoter hypermethylation, histone modifications, and mislocalization**.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003700" target="_blank" class="term-link">
                                     GO:0003700
                                 </a>
                             </span>
                             <span class="term-label">DNA-binding transcription factor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7607690" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7607690
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of a new murine runt domain-containing gene, ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0003700" data-r="PMID:7607690" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0003700" data-r="PMID:7607690" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic DNA-binding transcription factor activity is correct but less precise than the RNA polymerase II-specific term already present.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 functions as a sequence-specific RNA polymerase II transcription factor, so the more specific term is preferred.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000981" target="_blank" class="term-link">
+                                    DNA-binding transcription factor activity, RNA polymerase II-specific
+                                </a>
+                            </span>
+
+                        </div>
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7607690" target="_blank" class="term-link">
-                                        PMID:7607690
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Identification of a new murine runt domain-containing gene, Cbfa3, and localization of the human homolog, CBFA3, to chromosome 1p35-pter.</div>
-                                
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7835892" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7835892
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     AML1, AML2, and AML3, the human members of the runt domain g...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005524" data-r="PMID:7835892" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0005524" data-r="PMID:7835892" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ATP binding is not supported as a RUNX3 molecular function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 is a non-enzymatic DNA-binding transcription factor; ATP-dependent chromatin-remodeling context should not be transferred to RUNX3 as ATP binding.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7835892" target="_blank" class="term-link">
-                                        PMID:7835892
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">AML1, AML2, and AML3, the human members of the runt domain gene-family: cDNA structure, expression, and chromosomal localization.</div>
-                                
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006355" target="_blank" class="term-link">
                                     GO:0006355
                                 </a>
                             </span>
                             <span class="term-label">regulation of DNA-templated transcription</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7622058" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7622058
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cloning, mapping and expression of PEBP2 alpha C, a third ge...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0006355" data-r="PMID:7622058" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q13761" data-a="GO:0006355" data-r="PMID:7622058" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic regulation of DNA-templated transcription is supported but should be captured with the RNA polymerase II-specific process.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> RUNX3 target-gene regulation is best represented by regulation of transcription by RNA polymerase II.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
+                                    regulation of transcription by RNA polymerase II
+                                </a>
+                            </span>
+
+                        </div>
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/7622058" target="_blank" class="term-link">
-                                        PMID:7622058
-                                    </a>
-                                    
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Cloning, mapping and expression of PEBP2 alpha C, a third gene encoding the mammalian Runt domain.</div>
-                                
+
+                                <div class="support-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Nuclear Runt-domain sequence-specific transcription factor activity in CBFβ/core-binding factor complexes, regulating RNA polymerase II target-gene programs through chromatin and regulatory-region DNA binding.</h3>
+                <span class="vote-buttons" data-g="Q13761" data-a="FUNCTION: Nuclear Runt-domain sequence-specific transcriptio..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000981" target="_blank" class="term-link">
+                            DNA-binding transcription factor activity, RNA polymerase II-specific
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
+                                regulation of transcription by RNA polymerase II
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045893" target="_blank" class="term-link">
+                                positive regulation of DNA-templated transcription
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000122" target="_blank" class="term-link">
+                                negative regulation of transcription by RNA polymerase II
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                nucleoplasm
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000785" target="_blank" class="term-link">
+                                chromatin
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016513" target="_blank" class="term-link">
+                            core-binding factor complex
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
                             GO_REF:0000024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000113.md" target="_blank" class="term-link">
                             GO_REF:0000113
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation of human sequence-specific DNA binding transcription factors (DbTFs) based on the TFClass database</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17377532" target="_blank" class="term-link">
                             PMID:17377532
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Foxp3 controls regulatory T-cell function by interacting with AML1/Runx1.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18258917" target="_blank" class="term-link">
                             PMID:18258917
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Repression of the transcription factor Th-POK by Runx complexes in cytotoxic T cell development.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18772112" target="_blank" class="term-link">
                             PMID:18772112
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3 attenuates beta-catenin/T cell factors in intestinal tumorigenesis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20096094" target="_blank" class="term-link">
                             PMID:20096094
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Brn3a regulates neuronal subtype specification in the trigeminal ganglion by promoting Runx expression during sensory differentiation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20100835" target="_blank" class="term-link">
                             PMID:20100835
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Src kinase phosphorylates RUNX3 at tyrosine residues and localizes the protein in the cytoplasm.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20591170" target="_blank" class="term-link">
                             PMID:20591170
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Runx transcriptional co-activator, CBFbeta, is essential for invasion of breast cancer cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20599712" target="_blank" class="term-link">
                             PMID:20599712
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tumor suppressor, AT motif binding factor 1 (ATBF1), translocates to the nucleus with runt domain transcription factor 3 (RUNX3) in response to TGF-beta signal transduction.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24229708" target="_blank" class="term-link">
                             PMID:24229708
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Runx3 inactivation is a crucial early event in the development of lung adenocarcinoma.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28473536" target="_blank" class="term-link">
                             PMID:28473536
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Impact of cytosine methylation on DNA binding specificities of human transcription factors.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/38424632" target="_blank" class="term-link">
                             PMID:38424632
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Ubiquitylation of RUNX3 by RNA-binding ubiquitin ligase MEX3C promotes tumorigenesis in lung adenocarcinoma.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/7607690" target="_blank" class="term-link">
                             PMID:7607690
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification of a new murine runt domain-containing gene, Cbfa3, and localization of the human homolog, CBFA3, to chromosome 1p35-pter.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/7622058" target="_blank" class="term-link">
                             PMID:7622058
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cloning, mapping and expression of PEBP2 alpha C, a third gene encoding the mammalian Runt domain.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/7835892" target="_blank" class="term-link">
                             PMID:7835892
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">AML1, AML2, and AML3, the human members of the runt domain gene-family: cDNA structure, expression, and chromosomal localization.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9751710" target="_blank" class="term-link">
                             PMID:9751710
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Transcriptional repression by AML1 and LEF-1 is mediated by the TLE/Groucho corepressors.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8865454
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CBFB binds RUNX3</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8878117
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3 binds ZFHX3</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8878143
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3 binds SMAD3 and SMAD4</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8878178
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The complex of RUNX3, SMAD3 and SMAD4 binds the CDKN1A gene promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8878193
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3 binds the JAG1 gene promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8878220
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3 binds the NOTCH1 coactivator complex</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8878237
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3:NOTCH1 coactivator complex binds the HES1 gene promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8937792
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3 binds SRC</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8937807
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">SRC phosphorylates RUNX3</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8937814
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3 translocates to the nucleus</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8949335
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3:CBFB binds the ITGAL gene,(ITGA4 gene) promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8951428
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3 binds CTNNB1:TCF7L2,(LEF1,TCF7L1,TCF7)</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8951676
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3 binds TEADs and YAP1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8951910
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3 binds the RUNX1 promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8951951
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3 binds EP300</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8951966
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">EP300 acetylates RUNX3</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8951977
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Acetylated RUNX3 binds to BRD2</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8952058
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CCND1 binds RUNX3 and displaces EP300</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8952062
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CCND1 recruits HDAC4 to RUNX3</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8952069
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">HDAC4 deacetylates RUNX3</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8952128
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3 binds TP53</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8952226
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3 binds the BCL2L11 (BIM) gene</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8952371
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MDM2 binds RUNX3</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8952382
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MDM2 polyubiquitinates RUNX3</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8952399
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Polyubiquitinated RUNX3 translocates to the cytosol</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8952408
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Polyubiquitinated RUNX3 is degraded by the proteasome</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8952419
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">SMURFs ubiquitinate RUNX3</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/RUNX3/RUNX3-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research synthesis for RUNX3</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(RUNX3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q13761" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-12T00:40:12.704795'<br />
+end_time: '2026-05-12T00:59:19.684433'<br />
+duration_seconds: 1146.98<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: RUNX3<br />
+  gene_symbol: RUNX3<br />
+  uniprot_accession: Q13761<br />
+  protein_description: 'RecName: Full=Runt-related transcription factor 3; AltName:<br />
+    Full=Acute myeloid leukemia 2 protein; AltName: Full=Core-binding factor subunit<br />
+    alpha-3; Short=CBF-alpha-3; AltName: Full=Oncogene AML-2; AltName: Full=Polyomavirus<br />
+    enhancer-binding protein 2 alpha C subunit; Short=PEA2-alpha C; Short=PEBP2-alpha<br />
+    C; AltName: Full=SL3-3 enhancer factor 1 alpha C subunit; AltName: Full=SL3/AKV<br />
+    core-binding factor alpha C subunit;'<br />
+  gene_info: Name=RUNX3; Synonyms=AML2, CBFA3, PEBP2A3;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Not specified in UniProt<br />
+  protein_domains: AML1_Runt. (IPR000040); p53-like_TF_DNA-bd_sf. (IPR008967); p53/RUNT-type_TF_DNA-bd_sf.<br />
+    (IPR012346); Runt_dom. (IPR013524); RunxI_C_dom. (IPR013711)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 46</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q13761</li>
+<li><strong>Protein Description:</strong> RecName: Full=Runt-related transcription factor 3; AltName: Full=Acute myeloid leukemia 2 protein; AltName: Full=Core-binding factor subunit alpha-3; Short=CBF-alpha-3; AltName: Full=Oncogene AML-2; AltName: Full=Polyomavirus enhancer-binding protein 2 alpha C subunit; Short=PEA2-alpha C; Short=PEBP2-alpha C; AltName: Full=SL3-3 enhancer factor 1 alpha C subunit; AltName: Full=SL3/AKV core-binding factor alpha C subunit;</li>
+<li><strong>Gene Information:</strong> Name=RUNX3; Synonyms=AML2, CBFA3, PEBP2A3;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> AML1_Runt. (IPR000040); p53-like_TF_DNA-bd_sf. (IPR008967); p53/RUNT-type_TF_DNA-bd_sf. (IPR012346); Runt_dom. (IPR013524); RunxI_C_dom. (IPR013711)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "RUNX3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'RUNX3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>RUNX3</strong> (gene ID: RUNX3, UniProt: Q13761) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q13761</li>
+<li><strong>Protein Description:</strong> RecName: Full=Runt-related transcription factor 3; AltName: Full=Acute myeloid leukemia 2 protein; AltName: Full=Core-binding factor subunit alpha-3; Short=CBF-alpha-3; AltName: Full=Oncogene AML-2; AltName: Full=Polyomavirus enhancer-binding protein 2 alpha C subunit; Short=PEA2-alpha C; Short=PEBP2-alpha C; AltName: Full=SL3-3 enhancer factor 1 alpha C subunit; AltName: Full=SL3/AKV core-binding factor alpha C subunit;</li>
+<li><strong>Gene Information:</strong> Name=RUNX3; Synonyms=AML2, CBFA3, PEBP2A3;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Not specified in UniProt</li>
+<li><strong>Key Domains:</strong> AML1_Runt. (IPR000040); p53-like_TF_DNA-bd_sf. (IPR008967); p53/RUNT-type_TF_DNA-bd_sf. (IPR012346); Runt_dom. (IPR013524); RunxI_C_dom. (IPR013711)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "RUNX3" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'RUNX3' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>RUNX3</strong> (gene ID: RUNX3, UniProt: Q13761) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="comprehensive-research-report-human-runx3-uniprot-q13761">Comprehensive research report: Human RUNX3 (UniProt Q13761)</h2>
+<h3 id="scope-and-identity-verification-critical">Scope and identity verification (critical)</h3>
+<p>The target protein is <strong>human RUNX3</strong> (gene symbol <strong>RUNX3</strong>, UniProt <strong>Q13761</strong>), described in UniProt as <em>Runt-related transcription factor 3</em> with a conserved <strong>Runt (AML1_Runt) DNA-binding domain</strong> and C-terminal RUNX interaction region. In the literature retrieved here, the entity called RUNX3 is consistently described as a <strong>Runt-domain transcription factor that heterodimerizes with CBFβ (core-binding factor β)</strong> and regulates gene expression through sequence-specific DNA binding—matching the defining biochemical/structural properties expected for UniProt Q13761. However, within the retrieved full-text sources, <strong>the UniProt accession “Q13761” is not explicitly mentioned</strong>, so mapping is based on concordance of gene/protein name, organism (human), and domain/function description rather than a direct accession cross-reference. (chen2024runxtranscriptionfactors pages 1-2, mahmoud2024runx3actsas pages 6-8)</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-runx3-as-a-runt-domain-transcription-factor-and-cbf-complex-component">1.1 RUNX3 as a Runt-domain transcription factor and CBF complex component</h4>
+<p>RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved <strong>Runt DNA-binding domain</strong>; they functionally <strong>heterodimerize with CBFβ</strong>, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity. This “core-binding factor” logic is foundational for interpreting RUNX3 function as a transcriptional regulator rather than an enzyme or transporter. (chen2024runxtranscriptionfactors pages 1-2)</p>
+<h4 id="12-runx3-molecular-function-transcriptional-regulation-plus-chromatin-linked-activities">1.2 RUNX3 molecular function: transcriptional regulation plus chromatin-linked activities</h4>
+<p>Beyond “transcription factor” as a label, recent mechanistic work supports RUNX3 as a chromatin-associated regulator with features often attributed to <strong>pioneer/chromatin-binding factors</strong>:<br />
+- RUNX3 can bind DNA and <strong>mononucleosomes</strong>, and RUNX3 loss alters chromatin accessibility and transcriptional programs (ATAC-seq/RNA-seq integration). (mahmoud2024runx3actsas pages 36-38, mahmoud2024runx3actsas pages 38-43)<br />
+- RUNX3 associates with <strong>CBFβ</strong> and chromatin remodeler machinery including SWI/SNF components; the <strong>Runt domain</strong> is implicated as critical for interactions with chromatin factors in this metastatic gastric cancer model. (mahmoud2024runx3actsas pages 6-8, mahmoud2024runx3actsas pages 38-43)</p>
+<h4 id="13-subcellular-localization-as-a-functional-control-point">1.3 Subcellular localization as a functional control point</h4>
+<p>Because RUNX3 is a transcription factor, <strong>nuclear localization</strong> is essential for its canonical function. A recurring cancer mechanism is <strong>functional inactivation by cytoplasmic mislocalization</strong> (i.e., preventing nuclear transcriptional regulation). RUNX3 mislocalization is not merely correlative: oxidative stress can actively shift RUNX3 from nucleus to cytoplasm via a defined pathway (HDAC1/G9a→Src→RUNX3 phosphorylation→JAB1/CRM1-mediated export), coupled to proteasomal loss. (kang2024oxidativestressmediatedrunx3 pages 4-9, kang2024oxidativestressmediatedrunx3 pages 9-13)</p>
+<h3 id="2-recent-developments-and-latest-research-prioritizing-20232024">2) Recent developments and latest research (prioritizing 2023–2024)</h3>
+<h4 id="21-a-2023-mechanistic-advance-runx3-directly-destabilizes-oncogenic-myc">2.1 A 2023 mechanistic advance: RUNX3 directly destabilizes oncogenic MYC</h4>
+<p>A key 2023 advance demonstrated a <strong>direct protein–protein mechanism</strong> linking RUNX3 to oncogene control: RUNX3 binds <strong>MYC</strong> directly via the <strong>Runt domain</strong>, disrupts MYC’s transcriptionally active complexes (MYC–MAX and MYC–MIZ1), increases <strong>GSK3β-mediated phosphorylation of MYC at T58</strong>, and promotes <strong>FBXW7-dependent K48-linked ubiquitination</strong> and proteasomal degradation of MYC. This provides a concrete molecular basis for tumor-suppressive activity in contexts where MYC is a driver. (oei2023runx3inactivatesoncogenic pages 1-2, oei2023runx3inactivatesoncogenic pages 4-7, oei2023runx3inactivatesoncogenic pages 7-9, oei2023runx3inactivatesoncogenic pages 9-11)</p>
+<p>Quantitative kinetic evidence was provided in cell systems: RUNX3 expression shortened MYC half-life (e.g., ~30→20 minutes in one system and ~32→23 minutes in another), supporting rapid post-translational control. (oei2023runx3inactivatesoncogenic pages 4-7)</p>
+<h4 id="22-2024-runx3-regulation-by-stressepigenetic-enzymes-and-mislocalization-oxidative-stress-inactivation">2.2 2024: RUNX3 regulation by stress/epigenetic enzymes and mislocalization (oxidative stress → inactivation)</h4>
+<p>A 2024 study elucidated a pathway by which oxidative stress in colon cancer cells induces RUNX3 inactivation by <strong>nuclear export and cytoplasmic accumulation</strong>, integrating chromatin-modifier activity with signaling:<br />
+- Oxidative stress increased <strong>HDAC1</strong> and <strong>G9a/EHMT2</strong> and activated <strong>Src</strong>, resulting in RUNX3 tyrosine phosphorylation.<br />
+- RUNX3 interacted with <strong>JAB1</strong> and <strong>CRM1</strong>, promoting CRM1-dependent export and proteasome-mediated depletion; JAB1 knockdown or CRM1 inhibition restored nuclear RUNX3.<br />
+This provides a mechanistic explanation for the often-cited phenomenon of RUNX3 cytoplasmic mislocalization as a route to functional loss. (kang2024oxidativestressmediatedrunx3 pages 4-9, kang2024oxidativestressmediatedrunx3 pages 9-13)</p>
+<h4 id="23-2024-post-translational-downregulation-by-ubiquitin-ligase-mex3c-in-lung-adenocarcinoma">2.3 2024: post-translational downregulation by ubiquitin ligase MEX3C in lung adenocarcinoma</h4>
+<p>A 2024 translational mechanistic study in lung adenocarcinoma (LUAD) reported that the RNA-binding E3 ligase <strong>MEX3C</strong> promotes tumor phenotypes by <strong>ubiquitylating and degrading RUNX3</strong> (protein-level regulation without corresponding mRNA change). The same study supports a downstream transcriptional axis where RUNX3 represses <strong>Suv39H1</strong>, positioning MEX3C→RUNX3↓→Suv39H1↑ as a tumor-promoting pathway. (he2024ubiquitylationofrunx3 pages 9-11, he2024ubiquitylationofrunx3 pages 11-15)</p>
+<h4 id="24-2024-runx3-can-be-contextually-pro-metastatic-in-gastric-cancer-via-wnt5a-and-developmental-programs">2.4 2024: RUNX3 can be contextually pro-metastatic in gastric cancer via WNT5A and developmental programs</h4>
+<p>A 2024 study (Cancer Research Communications) presented evidence that RUNX3 can be <strong>pro-metastatic</strong> in a gastric cancer model (HGC-27), where CRISPR KO reduced migration/invasion/anchorage-independent growth and suppressed liver metastasis in vivo. Multi-omic mapping (ChIP-seq, HiChIP) supported direct transcriptional control of metastasis-associated targets including <strong>WNT5A</strong>, <strong>CD44</strong>, and <strong>VIM</strong>, with WNT5A functioning as a major effector. This highlights a key modern theme: <strong>RUNX3 can act as tumor suppressor or oncogenic driver depending on cellular context and regulatory state</strong>. (suda2024aberrantupregulationof pages 5-8, suda2024aberrantupregulationof pages 8-10, suda2024aberrantupregulationof pages 1-2, suda2024aberrantupregulationof pages 10-11)</p>
+<h4 id="25-2024-review-synthesis-runx3-intersects-canonical-signaling-pathways-tgf-smad-wnt-hippo">2.5 2024 review synthesis: RUNX3 intersects canonical signaling pathways (TGF-β/SMAD; Wnt; Hippo)</h4>
+<p>A 2024 review of RUNX transcription factors synthesizes RUNX3 as a regulator embedded in major cancer-relevant pathways, including <strong>TGF-β/SMAD</strong>, <strong>Wnt/β-catenin</strong>, and <strong>Hippo–YAP</strong> crosstalk, and emphasizes frequent RUNX3 inactivation through <strong>promoter hypermethylation, histone modifications, and mislocalization</strong>. (chen2024runxtranscriptionfactors pages 1-2, chen2024runxtranscriptionfactors pages 18-19)</p>
+<p>Within TGF-β signaling specifically, the 2024 review cites contexts where RUNX3 overexpression suppresses <strong>Smad2/3 phosphorylation</strong> and inhibits TGF-β/Smad-driven EMT and invasion, while also noting context-dependence (e.g., SMAD4/Dpc4 status in pancreatic cancer). (chen2024runxtranscriptionfactors pages 12-14)</p>
+<h3 id="3-current-applications-and-real-world-implementations">3) Current applications and real-world implementations</h3>
+<h4 id="31-immunotherapy-sensitization-via-runx3-epigenetic-reprogramming-clinical-translational-mechanism">3.1 Immunotherapy sensitization via RUNX3 epigenetic reprogramming (clinical translational mechanism)</h4>
+<p>A 2023 Molecular Cancer study connects RUNX3 to a clinically relevant immunotherapy strategy: <strong>decitabine (DNA-demethylating agent) priming</strong> can demethylate the <strong>RUNX3 promoter</strong> in CD8+ T cells, increase RUNX3 expression, promote CD8+ infiltration, and reduce exhaustion; crucially, conditional Runx3 loss in T cells abrogated the benefit of decitabine as a sensitizer for anti-PD-1 therapy in mouse models. (liu2023epigeneticreprogrammingof pages 1-2, liu2023epigeneticreprogrammingof pages 2-4, liu2023epigeneticreprogrammingof pages 9-12, liu2023epigeneticreprogrammingof pages 7-9)</p>
+<p>This work explicitly reports clinically relevant response statistics (from prior clinical work cited within the paper): combining low-dose decitabine with PD-1 blockade increased complete response in classical Hodgkin lymphoma from <strong>32% to 71%</strong>. (liu2023epigeneticreprogrammingof pages 1-2, liu2023epigeneticreprogrammingof pages 2-4)</p>
+<h4 id="32-real-world-engineered-cell-therapy-runx3-coexpressing-car-t-phase-i-trial">3.2 Real-world engineered cell therapy: RUNX3-coexpressing CAR-T (phase I trial)</h4>
+<p>A direct “real-world implementation” of RUNX3 biology is its use as an engineered transcription factor cargo in CAR-T products. Fu et al. reported a first-in-human, single-center, single-arm phase I trial (NCT03980288) of <strong>CT017</strong>, a <strong>GPC3-targeting CAR T cell</strong> product that <strong>co-expresses RUNX3</strong> (via an F2A peptide) for heavily pretreated, GPC3+ hepatocellular carcinoma. (fu2023runx3expressingcart pages 1-2, fu2023runx3expressingcart pages 2-3)</p>
+<p>Key clinical statistics:<br />
+- <strong>N=6</strong> evaluable patients (7 infusions; one patient treated twice); dose 250×10^6 cells. (fu2023runx3expressingcart pages 1-2, fu2023runx3expressingcart pages 5-6)<br />
+- Safety: cytokine release syndrome (CRS) occurred in all patients; <strong>3/6 grade 3</strong> CRS; no ICANS observed; CRS resolved. (fu2023runx3expressingcart pages 1-2, fu2023runx3expressingcart pages 6-7, fu2023runx3expressingcart media 6458455b)<br />
+- Efficacy: <strong>ORR 16.7%</strong> (1 partial response) and <strong>DCR 50%</strong> (PR+SD); median PFS 3.5 months; median OS 7.9 months. (fu2023runx3expressingcart pages 1-2, fu2023runx3expressingcart pages 7-8)<br />
+- Persistence: CAR-GPC3 DNA peaked around day 7 and was detectable at day 28, with reported persistence duration (median ~34 days). (fu2023runx3expressingcart pages 6-7, fu2023runx3expressingcart media 006d89ce)</p>
+<p>(Visual evidence supporting the above endpoints is available in the trial’s Table/Figure crops.) (fu2023runx3expressingcart media 6458455b, fu2023runx3expressingcart media 006d89ce, fu2023runx3expressingcart media 9604a628)</p>
+<h3 id="4-expert-opinions-and-authoritative-analysis-20232024-emphasis">4) Expert opinions and authoritative analysis (2023–2024 emphasis)</h3>
+<h4 id="41-consensus-themes-from-recent-reviews">4.1 Consensus themes from recent reviews</h4>
+<p>Recent reviews converge on several expert-level interpretations:<br />
+1. <strong>RUNX3 is a master developmental transcription factor</strong> whose dysregulation can impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.). (chen2024runxtranscriptionfactors pages 1-2, chen2024runxtranscriptionfactors pages 18-19)<br />
+2. RUNX3 exhibits <strong>context dependence</strong>, with the same factor acting as tumor suppressor or tumor promoter depending on tumor type, stage, co-mutations, and signaling context. (chen2024runxtranscriptionfactors pages 18-19, chen2024runxtranscriptionfactors pages 12-14, suda2024aberrantupregulationof pages 5-8)<br />
+3. Non-genetic mechanisms—<strong>promoter hypermethylation</strong>, histone/chromatin changes, and <strong>protein mislocalization</strong>—are repeatedly emphasized as major routes to RUNX3 functional loss, often more prominent than coding mutations. (chen2024runxtranscriptionfactors pages 1-2, kang2024oxidativestressmediatedrunx3 pages 4-9)</p>
+<h4 id="42-runx3-as-a-hippo-pathway-brake-via-tead-competition">4.2 RUNX3 as a Hippo pathway brake via TEAD competition</h4>
+<p>A 2023 gastric cancer Hippo-pathway review specifically highlights a downstream mechanism in which factors including <strong>RUNX3</strong> can bind <strong>TEAD</strong> and antagonize <strong>YAP–TEAD</strong> interaction via competitive binding dynamics, positioning RUNX3 as a negative regulator of oncogenic YAP/TEAD transcriptional output in relevant contexts. (messina2023hippopathwaydysregulation pages 2-3, messina2023hippopathwaydysregulation pages 10-11)</p>
+<h3 id="5-relevant-statistics-and-data-from-recent-studies">5) Relevant statistics and data from recent studies</h3>
+<h4 id="51-human-cohortclinical-data-examples-20232024">5.1 Human cohort/clinical data examples (2023–2024)</h4>
+<ul>
+<li><strong>RUNX3 epigenetic immunotherapy link (2023):</strong> cited clinical improvement with DAC+anti-PD-1 in cHL from <strong>32% to 71% complete response</strong>; multiomic profiling included methylation arrays with <strong>829,120 CpGs in 25 samples</strong> after QC and expression validation in <strong>48</strong> patients for qRT-PCR. (liu2023epigeneticreprogrammingof pages 1-2, liu2023epigeneticreprogrammingof pages 2-4, liu2023epigeneticreprogrammingof pages 4-5)</li>
+<li><strong>RUNX3-engineered CAR-T phase I in HCC (2023):</strong> N=6 evaluable; ORR <strong>16.7%</strong>, DCR <strong>50%</strong>; CRS grade 3 in <strong>3/6</strong>; no ICANS; median PFS <strong>3.5 months</strong>; median OS <strong>7.9 months</strong>. (fu2023runx3expressingcart pages 1-2, fu2023runx3expressingcart pages 7-8, fu2023runx3expressingcart pages 6-7, fu2023runx3expressingcart media 6458455b)</li>
+<li><strong>MEX3C–RUNX3 axis in LUAD (2024):</strong> clinical paired-sample cohort <strong>n=55</strong>; negative mRNA correlation (r≈−0.615, p&lt;0.0001) between MEX3C and RUNX3; xenograft/metastasis animal experiments reported <strong>n=5/group</strong>. (he2024ubiquitylationofrunx3 pages 11-15, he2024ubiquitylationofrunx3 pages 6-9)</li>
+<li><strong>Gastric metastasis program (2024):</strong> tumor immunofluorescence correlation between RUNX3 and WNT5A in cancer cells reported in resected tumors (<strong>n=35</strong>, r≈0.474, P&lt;0.01). (suda2024aberrantupregulationof pages 11-13)</li>
+</ul>
+<h4 id="52-disease-association-landscape-database-summary">5.2 Disease-association landscape (database summary)</h4>
+<p>Open Targets links RUNX3 to immune/allergic disease phenotypes (e.g., asthma, psoriasis, allergic rhinitis, eczematoid dermatitis) with moderate association scores and supporting literature evidence counts, consistent with RUNX3’s known roles in immune cell differentiation and tissue inflammation. (OpenTargets Search: -RUNX3)</p>
+<hr />
+<h2 id="functional-annotation-summary-what-runx3-does-where-it-acts-and-pathways">Functional annotation summary (what RUNX3 “does,” where it acts, and pathways)</h2>
+<h3 id="primary-molecular-role">Primary molecular role</h3>
+<p>RUNX3 is <strong>not an enzyme</strong> and does not catalyze a chemical reaction; its primary function is as a <strong>sequence-specific DNA-binding transcription factor</strong> that regulates gene expression programs by binding target regulatory elements via the <strong>Runt domain</strong>, typically stabilized by heterodimerization with <strong>CBFβ</strong>. (chen2024runxtranscriptionfactors pages 1-2)</p>
+<h3 id="where-runx3-acts-in-the-cell">Where RUNX3 acts in the cell</h3>
+<p>RUNX3’s canonical site of action is the <strong>nucleus</strong>, where it binds chromatin and regulates transcription. Multiple studies emphasize that <strong>cytoplasmic mislocalization</strong> can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery. (kang2024oxidativestressmediatedrunx3 pages 4-9, kang2024oxidativestressmediatedrunx3 pages 9-13)</p>
+<h3 id="pathway-level-roles-mechanistic-examples">Pathway-level roles (mechanistic examples)</h3>
+<ol>
+<li><strong>MYC control:</strong> RUNX3 binds MYC and triggers phosphorylation-dependent ubiquitin-mediated MYC degradation via GSK3β–FBXW7. (oei2023runx3inactivatesoncogenic pages 1-2, oei2023runx3inactivatesoncogenic pages 7-9)</li>
+<li><strong>TGF-β/SMAD:</strong> RUNX3 is repeatedly linked to TGF-β/Smad EMT regulation; review synthesis includes suppression of Smad2/3 phosphorylation and context dependence (e.g., SMAD4 status). (chen2024runxtranscriptionfactors pages 12-14)</li>
+<li><strong>Hippo–YAP/TEAD:</strong> RUNX3 is cited as a TEAD-binding competitor that can inhibit YAP–TEAD complex formation and activity in gastric cancer–relevant Hippo pathway frameworks. (messina2023hippopathwaydysregulation pages 2-3, messina2023hippopathwaydysregulation pages 10-11)</li>
+<li><strong>Noncanonical Wnt/metastasis program:</strong> in a gastric cancer model, RUNX3 directly activates WNT5A and other metastasis-related targets (CD44, VIM) using enhancer–promoter topology. (suda2024aberrantupregulationof pages 5-8, suda2024aberrantupregulationof pages 8-10)</li>
+<li><strong>Immune differentiation and therapy response:</strong> RUNX3 promoter methylation status controls RUNX3 expression in CD8+ T cells, shaping infiltration/exhaustion and determining whether demethylating therapy can sensitize to PD-1 blockade. (liu2023epigeneticreprogrammingof pages 1-2, liu2023epigeneticreprogrammingof pages 2-4, liu2023epigeneticreprogrammingof pages 9-12)</li>
+</ol>
+<hr />
+<h2 id="summary-table-of-mechanisms-and-applications">Summary table of mechanisms and applications</h2>
+<p>The following table consolidates RUNX3 identity, pathways, localization, and translational evidence, emphasizing 2023–2024 results and quantitative endpoints:</p>
+<table>
+<thead>
+<tr>
+<th>Aspect</th>
+<th>Summary for human RUNX3 (UniProt Q13761)</th>
+<th>Representative recent study / quantitative detail</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Molecular identity</td>
+<td>RUNX3 matches the human <strong>Runt-related transcription factor 3</strong> described for UniProt Q13761; RUNX proteins are sequence-specific transcription factors with a conserved <strong>Runt DNA-binding domain</strong> that heterodimerize with <strong>CBFβ</strong>, which stabilizes DNA binding and transcriptional function. RUNX3 is repeatedly discussed in cancer and immune literature as this CBFβ-partnered Runt-domain TF, consistent with the UniProt annotation and domain architecture (chen2024runxtranscriptionfactors pages 1-2, mahmoud2024runx3actsas pages 6-8).</td>
+<td>Chen et al., <strong>2024-03</strong>, <em>Clinical and Experimental Medicine</em>, https://doi.org/10.1007/s10238-023-01281-0; Mahmoud et al., <strong>2024-08</strong>, <em>bioRxiv</em>, https://doi.org/10.1101/2024.08.16.608297 (chen2024runxtranscriptionfactors pages 1-2, mahmoud2024runx3actsas pages 6-8)</td>
+</tr>
+<tr>
+<td>Primary molecular functions</td>
+<td>RUNX3 functions as a <strong>DNA-binding transcriptional regulator</strong> and protein-interaction hub. Beyond canonical transcriptional control, recent work supports <strong>chromatin/pioneer-like activity</strong>: RUNX3 binds DNA and mononucleosomes, associates with SWI/SNF and other chromatin factors, and the Runt domain is required for interactions with chromatin remodelers. Proteomics identified <strong>1,227 candidate interacting proteins</strong>, with enrichment for ATP-dependent chromatin remodeling; RUNX3 loss reduced SWI/SNF components and altered chromatin accessibility/transcriptional programs (mahmoud2024runx3actsas pages 6-8, mahmoud2024runx3actsas pages 36-38, mahmoud2024runx3actsas pages 38-43, mahmoud2024runx3actsas pages 24-26).</td>
+<td>Mahmoud et al., <strong>2024-08</strong>, https://doi.org/10.1101/2024.08.16.608297; tissue array <strong>n=59</strong>, KM-plotter gastric cohort <strong>n=875</strong>; low vs high RUNX3 groups <strong>526 vs 349</strong>, <em>P</em>=0.0002 (mahmoud2024runx3actsas pages 6-8, mahmoud2024runx3actsas pages 38-43)</td>
+</tr>
+<tr>
+<td>TGF-β/SMAD axis</td>
+<td>RUNX3 is a major RUNX-family node in <strong>TGF-β signaling</strong>. Review-level synthesis indicates that RUNX3 overexpression can <strong>suppress Smad2/3 phosphorylation</strong>, inhibit TGF-β/Smad-driven EMT/invasion, and that loss of RUNX3 by hypermethylation is linked to metastatic progression. However, this role is <strong>context dependent</strong>; in pancreatic ductal adenocarcinoma, RUNX3 may restrain proliferation yet facilitate migration/invasion depending on <strong>SMAD4/Dpc4 status</strong> (chen2024runxtranscriptionfactors pages 12-14, chen2024runxtranscriptionfactors pages 17-18).</td>
+<td>Chen et al., <strong>2024-03</strong>, https://doi.org/10.1007/s10238-023-01281-0 (chen2024runxtranscriptionfactors pages 12-14, chen2024runxtranscriptionfactors pages 17-18)</td>
+</tr>
+<tr>
+<td>Hippo–YAP/TEAD axis</td>
+<td>RUNX3 is described as a <strong>negative regulator of the oncogenic TEAD–YAP complex</strong>. Recent reviews summarize that RUNX3 can <strong>bind TEAD competitively</strong> and antagonize YAP–TEAD transcriptional output, placing RUNX3 as a Hippo-pathway brake; gastric-cancer Hippo review cites RUNX3 among factors that inhibit YAP–TEAD interaction in a competitive dynamic (chen2024runxtranscriptionfactors pages 18-19, messina2023hippopathwaydysregulation pages 2-3, messina2023hippopathwaydysregulation pages 10-11).</td>
+<td>Messina et al., <strong>2023-01</strong>, <em>Cell Death &amp; Disease</em>, https://doi.org/10.1038/s41419-023-05568-8; Chen et al., <strong>2024-03</strong>, https://doi.org/10.1007/s10238-023-01281-0 (chen2024runxtranscriptionfactors pages 18-19, messina2023hippopathwaydysregulation pages 2-3, messina2023hippopathwaydysregulation pages 10-11)</td>
+</tr>
+<tr>
+<td>MYC control / tumor-suppressive protein interaction</td>
+<td>A 2023 mechanistic study showed RUNX3 directly binds <strong>MYC</strong> via the <strong>Runt domain</strong>, disrupts <strong>MYC–MAX</strong> and <strong>MYC–MIZ1</strong> complexes, enhances <strong>GSK3β-mediated T58 phosphorylation</strong>, recruits <strong>FBXW7</strong>, and drives <strong>K48-linked ubiquitin-proteasomal MYC degradation</strong>. Interaction occurs mainly in the nucleus, and a Runt-domain mutant (<strong>R122C</strong>) loses this MYC-destabilizing activity (oei2023runx3inactivatesoncogenic pages 1-2, oei2023runx3inactivatesoncogenic pages 4-7, oei2023runx3inactivatesoncogenic pages 7-9, oei2023runx3inactivatesoncogenic pages 9-11).</td>
+<td>Oei et al., <strong>2023-07</strong>, <em>Communications Biology</em>, https://doi.org/10.1038/s42003-023-05037-0; MYC half-life shortened from ~<strong>30→20 min</strong> in HeLa and ~<strong>32→23 min</strong> in MKN28 with RUNX3 expression (oei2023runx3inactivatesoncogenic pages 4-7)</td>
+</tr>
+<tr>
+<td>Subcellular localization / inactivation</td>
+<td>RUNX3 is primarily a <strong>nuclear transcription factor</strong>, but <strong>cytoplasmic mislocalization</strong> is a recurrent inactivation mechanism in cancer. Oxidative stress can drive nuclear-to-cytoplasmic relocalization through <strong>HDAC1/G9a upregulation → Src activation → RUNX3 tyrosine phosphorylation → JAB1/CRM1-mediated export</strong>, with subsequent proteasomal degradation; NAC, HDAC1/G9a knockdown, JAB1 knockdown, or CRM1 inhibition restore nuclear RUNX3 (chen2024runxtranscriptionfactors pages 1-2, kang2024oxidativestressmediatedrunx3 pages 4-9, kang2024oxidativestressmediatedrunx3 pages 9-13, kang2024oxidativestressmediatedrunx3 pages 1-4).</td>
+<td>Kang et al., <strong>2024-04</strong>, <em>Applied Biochemistry and Biotechnology</em>, https://doi.org/10.1007/s12010-024-04944-0; oxidative stress model used <strong>100 μM H2O2</strong> (kang2024oxidativestressmediatedrunx3 pages 4-9)</td>
+</tr>
+<tr>
+<td>Post-translational downregulation by MEX3C</td>
+<td>In lung adenocarcinoma, the RNA-binding E3 ligase <strong>MEX3C</strong> binds RUNX3 and promotes <strong>RUNX3 ubiquitylation/proteasomal degradation</strong>, without materially changing RUNX3 mRNA. Downstream, RUNX3 represses <strong>Suv39H1</strong>; thus the <strong>MEX3C→RUNX3↓→Suv39H1↑</strong> axis promotes proliferation, migration, invasion, EMT-like programs, and tumor growth/metastasis (he2024ubiquitylationofrunx3 pages 9-11, he2024ubiquitylationofrunx3 pages 11-15, he2024ubiquitylationofrunx3 pages 6-9).</td>
+<td>He et al., <strong>2024-02</strong>, <em>Journal of Translational Medicine</em>, https://doi.org/10.1186/s12967-023-04700-8; clinical LUAD cohort <strong>n=55</strong> paired tumors, MEX3C–RUNX3 mRNA correlation <strong>r = -0.6151, p &lt; 0.0001</strong>; xenograft/metastasis assays reported <strong>n=5/group</strong> (he2024ubiquitylationofrunx3 pages 11-15, he2024ubiquitylationofrunx3 pages 15-18, he2024ubiquitylationofrunx3 pages 6-9)</td>
+</tr>
+<tr>
+<td>WNT5A / gastric metastasis axis</td>
+<td>RUNX3 can also act <strong>pro-metastatically in gastric cancer</strong>. CRISPR KO in HGC-27 cells reduced migration, invasion, anchorage-independent growth, xenograft growth, and liver metastasis. Multi-omic mapping showed RUNX3 directly regulates metastasis/developmental genes including <strong>WNT5A, CD44, VIM</strong>, with ChIP-seq and HiChIP linking RUNX3-bound distal elements/promoters to these loci; <strong>WNT5A</strong> emerged as a main functional effector (suda2024aberrantupregulationof pages 5-8, suda2024aberrantupregulationof pages 8-10, suda2024aberrantupregulationof pages 1-2, suda2024aberrantupregulationof pages 11-13).</td>
+<td>Suda et al., <strong>2024-02</strong>, <em>Cancer Research Communications</em>, https://doi.org/10.1158/2767-9764.crc-22-0165; resected tumor IF showed RUNX3–WNT5A correlation in cancer cells <strong>n=35</strong>, Pearson <strong>r = 0.4744, P &lt; 0.01</strong> (suda2024aberrantupregulationof pages 11-13)</td>
+</tr>
+<tr>
+<td>CD8+ T-cell differentiation / immunotherapy</td>
+<td>RUNX3 is a key regulator of <strong>CD8+ T-cell differentiation, infiltration, effector/memory fate, and residency</strong>. In Hodgkin lymphoma immunotherapy studies, <strong>promoter P2 demethylation</strong> increased RUNX3 expression, promoted CD8+ TIL infiltration, reduced exhaustion, and was required for decitabine (DAC) to sensitize tumors to anti-PD-1; conditional Runx3 loss reduced effector/memory T cells and CCR3/CCR5 and abrogated DAC benefit (liu2023epigeneticreprogrammingof pages 1-2, liu2023epigeneticreprogrammingof pages 2-4, liu2023epigeneticreprogrammingof pages 9-12, liu2023epigeneticreprogrammingof pages 7-9).</td>
+<td>Liu et al., <strong>2023-05</strong>, <em>Molecular Cancer</em>, https://doi.org/10.1186/s12943-023-01768-0; low-dose DAC + anti-PD-1 increased complete response in cHL from <strong>32% to 71%</strong>; prior PD-1 failures had <strong>70%</strong> re-response and <strong>28%</strong> CR; EPIC/RNA-seq high-throughput subset <strong>10 samples</strong>; <strong>829,120 CpGs in 25 samples</strong> after QC; qRT-PCR cohort <strong>48 patients</strong> (liu2023epigeneticreprogrammingof pages 1-2, liu2023epigeneticreprogrammingof pages 2-4, liu2023epigeneticreprogrammingof pages 4-5)</td>
+</tr>
+<tr>
+<td>Real-world implementation: RUNX3-engineered cell therapy</td>
+<td>RUNX3 has already been used in a <strong>first-in-human CAR-T implementation</strong>: CT017 co-expresses a GPC3 CAR and <strong>RUNX3</strong> (via F2A peptide) to enhance tumor infiltration, persistence, and tissue-resident features. This is a real-world therapeutic implementation of RUNX3 biology in advanced hepatocellular carcinoma (fu2023runx3expressingcart pages 1-2, fu2023runx3expressingcart pages 2-3, fu2023runx3expressingcart pages 10-10).</td>
+<td>Fu et al., <strong>2023-09</strong>, <em>eClinicalMedicine</em>, https://doi.org/10.1016/j.eclinm.2023.102175; phase I, <strong>N=6</strong> evaluable, <strong>1 PR + 2 SD</strong> → <strong>ORR 16.7%</strong>, <strong>DCR 50%</strong>, median <strong>PFS 3.5 mo</strong>, median <strong>OS 7.9 mo</strong>; all had CRS, <strong>3/6 grade 3</strong>, no ICANS; CAR DNA peaked day 7, detectable median <strong>34 days</strong> (fu2023runx3expressingcart pages 1-2, fu2023runx3expressingcart pages 7-8, fu2023runx3expressingcart pages 6-7, fu2023runx3expressingcart media 6458455b)</td>
+</tr>
+<tr>
+<td>Biomarker / prognostic use</td>
+<td>Current expert opinion supports RUNX3 as a <strong>biomarker candidate</strong> rather than a routine standalone clinical marker. RUNX3 expression or pathway signatures have been associated with prognosis, immunotherapy response, and epigenetic state; reviews emphasize its potential value but also note strong <strong>tumor-context dependence</strong> and bidirectional roles in solid tumors (chen2024runxtranscriptionfactors pages 18-19, chen2024runxtranscriptionfactors pages 17-18, liu2023epigeneticreprogrammingof pages 12-14).</td>
+<td>Wang et al., <strong>2024-01</strong>, <em>BMC Urology</em>, https://doi.org/10.1186/s12894-023-01356-w; in advanced RCC, high RUNX3 pathway signature associated with shorter PFS in two IO/TKI cohorts (<strong>P=0.025</strong> and <strong>P=0.019</strong>) and correlated with fewer <strong>GZMB+ CD8+ T cells</strong> (ρ = <strong>-0.42</strong>, <em>P</em>=0.006) (liu2023epigeneticreprogrammingof pages 12-14)</td>
+</tr>
+<tr>
+<td>Disease-association landscape</td>
+<td>Open Targets links RUNX3 to immune/allergic disease traits including <strong>asthma, psoriasis, allergic rhinitis, eczematoid dermatitis</strong>, supporting its broader immunoregulatory relevance beyond cancer, though evidence strength is moderate and disease-specific mechanisms vary (OpenTargets Search: -RUNX3).</td>
+<td>Open Targets association scores: asthma <strong>0.5383</strong>, psoriasis <strong>0.5274</strong>, allergic disease <strong>0.5233</strong>, allergic rhinitis <strong>0.4926</strong>, eczematoid dermatitis <strong>0.4782</strong> (OpenTargets Search: -RUNX3)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table condenses verified identity, mechanisms, localization, pathways, and translational evidence for human RUNX3 (UniProt Q13761). It is designed to support a comprehensive annotation narrative while highlighting key 2023–2024 studies and quantitative findings.</em></p>
+<h2 id="figurestables-supporting-clinical-implementation-evidence">Figures/tables supporting clinical implementation evidence</h2>
+<ul>
+<li>CT017 trial safety table and CAR-T kinetics/response plots (cropped visual evidence). (fu2023runx3expressingcart media 6458455b, fu2023runx3expressingcart media 006d89ce, fu2023runx3expressingcart media 9604a628)</li>
+</ul>
+<h2 id="limitations-of-this-evidence-set">Limitations of this evidence set</h2>
+<ol>
+<li><strong>Direct UniProt accession linkage:</strong> none of the retrieved full texts explicitly mention “UniProt Q13761,” so accession-level verification is inferential (name/domain/organism concordance). (chen2024runxtranscriptionfactors pages 1-2)</li>
+<li><strong>Context dependence:</strong> RUNX3 can act as tumor suppressor or promoter depending on tissue and regulatory context; mechanistic claims should therefore be interpreted within the experimental system described (e.g., LUAD vs gastric cancer metastasis models). (chen2024runxtranscriptionfactors pages 12-14, suda2024aberrantupregulationof pages 5-8)</li>
+</ol>
+<h2 id="key-references-publication-date-url">Key references (publication date; URL)</h2>
+<ul>
+<li>Chen X et al. <strong>2024-03</strong>. <em>Clinical and Experimental Medicine.</em> RUNX transcription factors: biological functions and implications in cancer. https://doi.org/10.1007/s10238-023-01281-0 (chen2024runxtranscriptionfactors pages 1-2)</li>
+<li>Oei V et al. <strong>2023-07</strong>. <em>Communications Biology.</em> RUNX3 inactivates oncogenic MYC via MYC/MAX disruption and GSK3β–FBXW7. https://doi.org/10.1038/s42003-023-05037-0 (oei2023runx3inactivatesoncogenic pages 1-2)</li>
+<li>Kang KA et al. <strong>2024-04</strong>. <em>Applied Biochemistry and Biotechnology.</em> Oxidative stress-mediated RUNX3 mislocalization via JAB1 and histone modification. https://doi.org/10.1007/s12010-024-04944-0 (kang2024oxidativestressmediatedrunx3 pages 4-9)</li>
+<li>He Z et al. <strong>2024-02</strong>. <em>Journal of Translational Medicine.</em> MEX3C ubiquitylates RUNX3 in LUAD. https://doi.org/10.1186/s12967-023-04700-8 (he2024ubiquitylationofrunx3 pages 11-15)</li>
+<li>Suda K et al. <strong>2024-02</strong>. <em>Cancer Research Communications.</em> RUNX3 upregulation drives gastric cancer metastasis via WNT5A. https://doi.org/10.1158/2767-9764.crc-22-0165 (suda2024aberrantupregulationof pages 5-8)</li>
+<li>Liu Z et al. <strong>2023-05</strong>. <em>Molecular Cancer.</em> RUNX3 epigenetic reprogramming reinforces CD8+ T cells and improves immunotherapy response. https://doi.org/10.1186/s12943-023-01768-0 (liu2023epigeneticreprogrammingof pages 1-2)</li>
+<li>Fu Q et al. <strong>2023-09</strong>. <em>eClinicalMedicine.</em> RUNX-3-expressing CAR-T cells targeting GPC3 in advanced HCC (phase I). https://doi.org/10.1016/j.eclinm.2023.102175 (fu2023runx3expressingcart pages 1-2)</li>
+<li>Messina B et al. <strong>2023-01</strong>. <em>Cell Death &amp; Disease.</em> Hippo pathway dysregulation in gastric cancer; TEAD-binding competitors including RUNX3. https://doi.org/10.1038/s41419-023-05568-8 (messina2023hippopathwaydysregulation pages 2-3)</li>
+<li>Open Targets Platform (retrieved via tool): RUNX3 disease associations (asthma/psoriasis/allergic traits). https://platform.opentargets.org/target/ENSG00000020633 (OpenTargets Search: -RUNX3)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(chen2024runxtranscriptionfactors pages 1-2): Xinyi Chen, Lu Wang, Mu Yang, Weiheng Zhao, Jingyao Tu, Bo Liu, and Xianglin Yuan. Runx transcription factors: biological functions and implications in cancer. Clinical and Experimental Medicine, Mar 2024. URL: https://doi.org/10.1007/s10238-023-01281-0, doi:10.1007/s10238-023-01281-0. This article has 17 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mahmoud2024runx3actsas pages 6-8): Salma Awad Mahmoud, Isabelle Bonne, Aik Yong Sim, and Gehan Labib Abuelenain. Runx3 acts as homodimeric chromatin binding factor regulating heterochromatin-mediated cancerous phenotype. bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.08.16.608297, doi:10.1101/2024.08.16.608297. This article has 1 citations.</p>
+</li>
+<li>
+<p>(mahmoud2024runx3actsas pages 36-38): Salma Awad Mahmoud, Isabelle Bonne, Aik Yong Sim, and Gehan Labib Abuelenain. Runx3 acts as homodimeric chromatin binding factor regulating heterochromatin-mediated cancerous phenotype. bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.08.16.608297, doi:10.1101/2024.08.16.608297. This article has 1 citations.</p>
+</li>
+<li>
+<p>(mahmoud2024runx3actsas pages 38-43): Salma Awad Mahmoud, Isabelle Bonne, Aik Yong Sim, and Gehan Labib Abuelenain. Runx3 acts as homodimeric chromatin binding factor regulating heterochromatin-mediated cancerous phenotype. bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.08.16.608297, doi:10.1101/2024.08.16.608297. This article has 1 citations.</p>
+</li>
+<li>
+<p>(kang2024oxidativestressmediatedrunx3 pages 4-9): Kyoung Ah Kang, Mei Jing Piao, Pincha Devage Sameera Madushan Fernando, Herath Mudiyanselage Udari Lakmini Herath, Hye-Jin Boo, Sang Pil Yoon, and Jin Won Hyun. Oxidative stress-mediated runx3 mislocalization occurs via jun activation domain-binding protein 1 and histone modification. Applied Biochemistry and Biotechnology, 196:8082-8095, Apr 2024. URL: https://doi.org/10.1007/s12010-024-04944-0, doi:10.1007/s12010-024-04944-0. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kang2024oxidativestressmediatedrunx3 pages 9-13): Kyoung Ah Kang, Mei Jing Piao, Pincha Devage Sameera Madushan Fernando, Herath Mudiyanselage Udari Lakmini Herath, Hye-Jin Boo, Sang Pil Yoon, and Jin Won Hyun. Oxidative stress-mediated runx3 mislocalization occurs via jun activation domain-binding protein 1 and histone modification. Applied Biochemistry and Biotechnology, 196:8082-8095, Apr 2024. URL: https://doi.org/10.1007/s12010-024-04944-0, doi:10.1007/s12010-024-04944-0. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(oei2023runx3inactivatesoncogenic pages 1-2): Vincent Oei, Linda Shyue Huey Chuang, Junichi Matsuo, Supriya Srivastava, Ming Teh, and Yoshiaki Ito. Runx3 inactivates oncogenic myc through disruption of myc/max complex and subsequent recruitment of gsk3β-fbxw7 cascade. Communications Biology, Jul 2023. URL: https://doi.org/10.1038/s42003-023-05037-0, doi:10.1038/s42003-023-05037-0. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(oei2023runx3inactivatesoncogenic pages 4-7): Vincent Oei, Linda Shyue Huey Chuang, Junichi Matsuo, Supriya Srivastava, Ming Teh, and Yoshiaki Ito. Runx3 inactivates oncogenic myc through disruption of myc/max complex and subsequent recruitment of gsk3β-fbxw7 cascade. Communications Biology, Jul 2023. URL: https://doi.org/10.1038/s42003-023-05037-0, doi:10.1038/s42003-023-05037-0. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(oei2023runx3inactivatesoncogenic pages 7-9): Vincent Oei, Linda Shyue Huey Chuang, Junichi Matsuo, Supriya Srivastava, Ming Teh, and Yoshiaki Ito. Runx3 inactivates oncogenic myc through disruption of myc/max complex and subsequent recruitment of gsk3β-fbxw7 cascade. Communications Biology, Jul 2023. URL: https://doi.org/10.1038/s42003-023-05037-0, doi:10.1038/s42003-023-05037-0. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(oei2023runx3inactivatesoncogenic pages 9-11): Vincent Oei, Linda Shyue Huey Chuang, Junichi Matsuo, Supriya Srivastava, Ming Teh, and Yoshiaki Ito. Runx3 inactivates oncogenic myc through disruption of myc/max complex and subsequent recruitment of gsk3β-fbxw7 cascade. Communications Biology, Jul 2023. URL: https://doi.org/10.1038/s42003-023-05037-0, doi:10.1038/s42003-023-05037-0. This article has 5 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(he2024ubiquitylationofrunx3 pages 9-11): Zelai He, Huijun Zhang, Hai-bo Xiao, Xiangyu Zhang, Hongbo Xu, Ruifen Sun, and Siwen Li. Ubiquitylation of runx3 by rna-binding ubiquitin ligase mex3c promotes tumorigenesis in lung adenocarcinoma. Journal of Translational Medicine, Feb 2024. URL: https://doi.org/10.1186/s12967-023-04700-8, doi:10.1186/s12967-023-04700-8. This article has 10 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(he2024ubiquitylationofrunx3 pages 11-15): Zelai He, Huijun Zhang, Hai-bo Xiao, Xiangyu Zhang, Hongbo Xu, Ruifen Sun, and Siwen Li. Ubiquitylation of runx3 by rna-binding ubiquitin ligase mex3c promotes tumorigenesis in lung adenocarcinoma. Journal of Translational Medicine, Feb 2024. URL: https://doi.org/10.1186/s12967-023-04700-8, doi:10.1186/s12967-023-04700-8. This article has 10 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(suda2024aberrantupregulationof pages 5-8): Kazuto Suda, Atsushi Okabe, Junichi Matsuo, Linda Shyue Huey Chuang, Ying Li, Nawaphat Jangphattananont, Naing Naing Mon, Khine Nyein Myint, Akihiro Yamamura, Jimmy Bok-Yan So, Dominic Chih-Cheng Voon, Henry Yang, Khay Guan Yeoh, Atsushi Kaneda, and Yoshiaki Ito. Aberrant upregulation of runx3 activates developmental genes to drive metastasis in gastric cancer. Cancer Research Communications, 4:279-292, Feb 2024. URL: https://doi.org/10.1158/2767-9764.crc-22-0165, doi:10.1158/2767-9764.crc-22-0165. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(suda2024aberrantupregulationof pages 8-10): Kazuto Suda, Atsushi Okabe, Junichi Matsuo, Linda Shyue Huey Chuang, Ying Li, Nawaphat Jangphattananont, Naing Naing Mon, Khine Nyein Myint, Akihiro Yamamura, Jimmy Bok-Yan So, Dominic Chih-Cheng Voon, Henry Yang, Khay Guan Yeoh, Atsushi Kaneda, and Yoshiaki Ito. Aberrant upregulation of runx3 activates developmental genes to drive metastasis in gastric cancer. Cancer Research Communications, 4:279-292, Feb 2024. URL: https://doi.org/10.1158/2767-9764.crc-22-0165, doi:10.1158/2767-9764.crc-22-0165. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(suda2024aberrantupregulationof pages 1-2): Kazuto Suda, Atsushi Okabe, Junichi Matsuo, Linda Shyue Huey Chuang, Ying Li, Nawaphat Jangphattananont, Naing Naing Mon, Khine Nyein Myint, Akihiro Yamamura, Jimmy Bok-Yan So, Dominic Chih-Cheng Voon, Henry Yang, Khay Guan Yeoh, Atsushi Kaneda, and Yoshiaki Ito. Aberrant upregulation of runx3 activates developmental genes to drive metastasis in gastric cancer. Cancer Research Communications, 4:279-292, Feb 2024. URL: https://doi.org/10.1158/2767-9764.crc-22-0165, doi:10.1158/2767-9764.crc-22-0165. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(suda2024aberrantupregulationof pages 10-11): Kazuto Suda, Atsushi Okabe, Junichi Matsuo, Linda Shyue Huey Chuang, Ying Li, Nawaphat Jangphattananont, Naing Naing Mon, Khine Nyein Myint, Akihiro Yamamura, Jimmy Bok-Yan So, Dominic Chih-Cheng Voon, Henry Yang, Khay Guan Yeoh, Atsushi Kaneda, and Yoshiaki Ito. Aberrant upregulation of runx3 activates developmental genes to drive metastasis in gastric cancer. Cancer Research Communications, 4:279-292, Feb 2024. URL: https://doi.org/10.1158/2767-9764.crc-22-0165, doi:10.1158/2767-9764.crc-22-0165. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chen2024runxtranscriptionfactors pages 18-19): Xinyi Chen, Lu Wang, Mu Yang, Weiheng Zhao, Jingyao Tu, Bo Liu, and Xianglin Yuan. Runx transcription factors: biological functions and implications in cancer. Clinical and Experimental Medicine, Mar 2024. URL: https://doi.org/10.1007/s10238-023-01281-0, doi:10.1007/s10238-023-01281-0. This article has 17 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chen2024runxtranscriptionfactors pages 12-14): Xinyi Chen, Lu Wang, Mu Yang, Weiheng Zhao, Jingyao Tu, Bo Liu, and Xianglin Yuan. Runx transcription factors: biological functions and implications in cancer. Clinical and Experimental Medicine, Mar 2024. URL: https://doi.org/10.1007/s10238-023-01281-0, doi:10.1007/s10238-023-01281-0. This article has 17 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2023epigeneticreprogrammingof pages 1-2): Zongzhi Liu, Xiang Li, Yibo Gao, Jiejie Liu, Yating Feng, Yang Liu, Junyun Wang, Chunmeng Wang, Dongrui Wang, Jie He, Weidong Han, Qian Mei, and Yingli Sun. Epigenetic reprogramming of runx3 reinforces cd8 + t-cell function and improves the clinical response to immunotherapy. Molecular Cancer, May 2023. URL: https://doi.org/10.1186/s12943-023-01768-0, doi:10.1186/s12943-023-01768-0. This article has 56 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2023epigeneticreprogrammingof pages 2-4): Zongzhi Liu, Xiang Li, Yibo Gao, Jiejie Liu, Yating Feng, Yang Liu, Junyun Wang, Chunmeng Wang, Dongrui Wang, Jie He, Weidong Han, Qian Mei, and Yingli Sun. Epigenetic reprogramming of runx3 reinforces cd8 + t-cell function and improves the clinical response to immunotherapy. Molecular Cancer, May 2023. URL: https://doi.org/10.1186/s12943-023-01768-0, doi:10.1186/s12943-023-01768-0. This article has 56 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2023epigeneticreprogrammingof pages 9-12): Zongzhi Liu, Xiang Li, Yibo Gao, Jiejie Liu, Yating Feng, Yang Liu, Junyun Wang, Chunmeng Wang, Dongrui Wang, Jie He, Weidong Han, Qian Mei, and Yingli Sun. Epigenetic reprogramming of runx3 reinforces cd8 + t-cell function and improves the clinical response to immunotherapy. Molecular Cancer, May 2023. URL: https://doi.org/10.1186/s12943-023-01768-0, doi:10.1186/s12943-023-01768-0. This article has 56 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2023epigeneticreprogrammingof pages 7-9): Zongzhi Liu, Xiang Li, Yibo Gao, Jiejie Liu, Yating Feng, Yang Liu, Junyun Wang, Chunmeng Wang, Dongrui Wang, Jie He, Weidong Han, Qian Mei, and Yingli Sun. Epigenetic reprogramming of runx3 reinforces cd8 + t-cell function and improves the clinical response to immunotherapy. Molecular Cancer, May 2023. URL: https://doi.org/10.1186/s12943-023-01768-0, doi:10.1186/s12943-023-01768-0. This article has 56 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fu2023runx3expressingcart pages 1-2): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fu2023runx3expressingcart pages 2-3): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fu2023runx3expressingcart pages 5-6): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fu2023runx3expressingcart pages 6-7): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fu2023runx3expressingcart media 6458455b): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fu2023runx3expressingcart pages 7-8): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fu2023runx3expressingcart media 006d89ce): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fu2023runx3expressingcart media 9604a628): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(messina2023hippopathwaydysregulation pages 2-3): Beatrice Messina, Federica Lo Sardo, Stefano Scalera, Lorenzo Memeo, Cristina Colarossi, Marzia Mare, Giovanni Blandino, Gennaro Ciliberto, Marcello Maugeri-Saccà, and Giulia Bon. Hippo pathway dysregulation in gastric cancer: from helicobacter pylori infection to tumor promotion and progression. Cell Death &amp; Disease, Jan 2023. URL: https://doi.org/10.1038/s41419-023-05568-8, doi:10.1038/s41419-023-05568-8. This article has 67 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(messina2023hippopathwaydysregulation pages 10-11): Beatrice Messina, Federica Lo Sardo, Stefano Scalera, Lorenzo Memeo, Cristina Colarossi, Marzia Mare, Giovanni Blandino, Gennaro Ciliberto, Marcello Maugeri-Saccà, and Giulia Bon. Hippo pathway dysregulation in gastric cancer: from helicobacter pylori infection to tumor promotion and progression. Cell Death &amp; Disease, Jan 2023. URL: https://doi.org/10.1038/s41419-023-05568-8, doi:10.1038/s41419-023-05568-8. This article has 67 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2023epigeneticreprogrammingof pages 4-5): Zongzhi Liu, Xiang Li, Yibo Gao, Jiejie Liu, Yating Feng, Yang Liu, Junyun Wang, Chunmeng Wang, Dongrui Wang, Jie He, Weidong Han, Qian Mei, and Yingli Sun. Epigenetic reprogramming of runx3 reinforces cd8 + t-cell function and improves the clinical response to immunotherapy. Molecular Cancer, May 2023. URL: https://doi.org/10.1186/s12943-023-01768-0, doi:10.1186/s12943-023-01768-0. This article has 56 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(he2024ubiquitylationofrunx3 pages 6-9): Zelai He, Huijun Zhang, Hai-bo Xiao, Xiangyu Zhang, Hongbo Xu, Ruifen Sun, and Siwen Li. Ubiquitylation of runx3 by rna-binding ubiquitin ligase mex3c promotes tumorigenesis in lung adenocarcinoma. Journal of Translational Medicine, Feb 2024. URL: https://doi.org/10.1186/s12967-023-04700-8, doi:10.1186/s12967-023-04700-8. This article has 10 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(suda2024aberrantupregulationof pages 11-13): Kazuto Suda, Atsushi Okabe, Junichi Matsuo, Linda Shyue Huey Chuang, Ying Li, Nawaphat Jangphattananont, Naing Naing Mon, Khine Nyein Myint, Akihiro Yamamura, Jimmy Bok-Yan So, Dominic Chih-Cheng Voon, Henry Yang, Khay Guan Yeoh, Atsushi Kaneda, and Yoshiaki Ito. Aberrant upregulation of runx3 activates developmental genes to drive metastasis in gastric cancer. Cancer Research Communications, 4:279-292, Feb 2024. URL: https://doi.org/10.1158/2767-9764.crc-22-0165, doi:10.1158/2767-9764.crc-22-0165. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(OpenTargets Search: -RUNX3): Open Targets Query (-RUNX3, 6 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+<li>
+<p>(mahmoud2024runx3actsas pages 24-26): Salma Awad Mahmoud, Isabelle Bonne, Aik Yong Sim, and Gehan Labib Abuelenain. Runx3 acts as homodimeric chromatin binding factor regulating heterochromatin-mediated cancerous phenotype. bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.08.16.608297, doi:10.1101/2024.08.16.608297. This article has 1 citations.</p>
+</li>
+<li>
+<p>(chen2024runxtranscriptionfactors pages 17-18): Xinyi Chen, Lu Wang, Mu Yang, Weiheng Zhao, Jingyao Tu, Bo Liu, and Xianglin Yuan. Runx transcription factors: biological functions and implications in cancer. Clinical and Experimental Medicine, Mar 2024. URL: https://doi.org/10.1007/s10238-023-01281-0, doi:10.1007/s10238-023-01281-0. This article has 17 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(kang2024oxidativestressmediatedrunx3 pages 1-4): Kyoung Ah Kang, Mei Jing Piao, Pincha Devage Sameera Madushan Fernando, Herath Mudiyanselage Udari Lakmini Herath, Hye-Jin Boo, Sang Pil Yoon, and Jin Won Hyun. Oxidative stress-mediated runx3 mislocalization occurs via jun activation domain-binding protein 1 and histone modification. Applied Biochemistry and Biotechnology, 196:8082-8095, Apr 2024. URL: https://doi.org/10.1007/s12010-024-04944-0, doi:10.1007/s12010-024-04944-0. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(he2024ubiquitylationofrunx3 pages 15-18): Zelai He, Huijun Zhang, Hai-bo Xiao, Xiangyu Zhang, Hongbo Xu, Ruifen Sun, and Siwen Li. Ubiquitylation of runx3 by rna-binding ubiquitin ligase mex3c promotes tumorigenesis in lung adenocarcinoma. Journal of Translational Medicine, Feb 2024. URL: https://doi.org/10.1186/s12967-023-04700-8, doi:10.1186/s12967-023-04700-8. This article has 10 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(fu2023runx3expressingcart pages 10-10): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(liu2023epigeneticreprogrammingof pages 12-14): Zongzhi Liu, Xiang Li, Yibo Gao, Jiejie Liu, Yating Feng, Yang Liu, Junyun Wang, Chunmeng Wang, Dongrui Wang, Jie He, Weidong Han, Qian Mei, and Yingli Sun. Epigenetic reprogramming of runx3 reinforces cd8 + t-cell function and improves the clinical response to immunotherapy. Molecular Cancer, May 2023. URL: https://doi.org/10.1186/s12943-023-01768-0, doi:10.1186/s12943-023-01768-0. This article has 56 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>chen2024runxtranscriptionfactors pages 1-2</li>
+<li>chen2024runxtranscriptionfactors pages 12-14</li>
+<li>suda2024aberrantupregulationof pages 11-13</li>
+<li>liu2023epigeneticreprogrammingof pages 12-14</li>
+<li>suda2024aberrantupregulationof pages 5-8</li>
+<li>liu2023epigeneticreprogrammingof pages 1-2</li>
+<li>messina2023hippopathwaydysregulation pages 2-3</li>
+<li>suda2024aberrantupregulationof pages 8-10</li>
+<li>suda2024aberrantupregulationof pages 1-2</li>
+<li>suda2024aberrantupregulationof pages 10-11</li>
+<li>chen2024runxtranscriptionfactors pages 18-19</li>
+<li>liu2023epigeneticreprogrammingof pages 2-4</li>
+<li>liu2023epigeneticreprogrammingof pages 9-12</li>
+<li>liu2023epigeneticreprogrammingof pages 7-9</li>
+<li>messina2023hippopathwaydysregulation pages 10-11</li>
+<li>liu2023epigeneticreprogrammingof pages 4-5</li>
+<li>chen2024runxtranscriptionfactors pages 17-18</li>
+<li>https://doi.org/10.1007/s10238-023-01281-0;</li>
+<li>https://doi.org/10.1101/2024.08.16.608297</li>
+<li>https://doi.org/10.1101/2024.08.16.608297;</li>
+<li>https://doi.org/10.1007/s10238-023-01281-0</li>
+<li>https://doi.org/10.1038/s41419-023-05568-8;</li>
+<li>https://doi.org/10.1038/s42003-023-05037-0;</li>
+<li>https://doi.org/10.1007/s12010-024-04944-0;</li>
+<li>https://doi.org/10.1186/s12967-023-04700-8;</li>
+<li>https://doi.org/10.1158/2767-9764.crc-22-0165;</li>
+<li>https://doi.org/10.1186/s12943-023-01768-0;</li>
+<li>https://doi.org/10.1016/j.eclinm.2023.102175;</li>
+<li>https://doi.org/10.1186/s12894-023-01356-w;</li>
+<li>https://doi.org/10.1038/s42003-023-05037-0</li>
+<li>https://doi.org/10.1007/s12010-024-04944-0</li>
+<li>https://doi.org/10.1186/s12967-023-04700-8</li>
+<li>https://doi.org/10.1158/2767-9764.crc-22-0165</li>
+<li>https://doi.org/10.1186/s12943-023-01768-0</li>
+<li>https://doi.org/10.1016/j.eclinm.2023.102175</li>
+<li>https://doi.org/10.1038/s41419-023-05568-8</li>
+<li>https://platform.opentargets.org/target/ENSG00000020633</li>
+<li>https://doi.org/10.1007/s10238-023-01281-0,</li>
+<li>https://doi.org/10.1101/2024.08.16.608297,</li>
+<li>https://doi.org/10.1007/s12010-024-04944-0,</li>
+<li>https://doi.org/10.1038/s42003-023-05037-0,</li>
+<li>https://doi.org/10.1186/s12967-023-04700-8,</li>
+<li>https://doi.org/10.1158/2767-9764.crc-22-0165,</li>
+<li>https://doi.org/10.1186/s12943-023-01768-0,</li>
+<li>https://doi.org/10.1016/j.eclinm.2023.102175,</li>
+<li>https://doi.org/10.1038/s41419-023-05568-8,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -5971,945 +8822,1289 @@
                 <pre><code>id: Q13761
 gene_symbol: RUNX3
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: &#39;TODO: Add description for RUNX3&#39;
+description: &#39;RUNX3 encodes Runt-related transcription factor 3, a nuclear Runt-domain DNA-binding transcription
+  factor that heterodimerizes with CBFβ/core-binding factor complexes to regulate RNA polymerase II target-gene
+  programs. Its core function is sequence-specific regulatory DNA and chromatin binding for context-dependent
+  transcriptional activation or repression, with important downstream roles in development, TGF-beta/Wnt/Hippo
+  signaling, CD8 T-cell biology, and cancer-associated mislocalization or degradation.&#39;
 existing_annotations:
-  - term:
-      id: GO:0000978
-      label: RNA polymerase II cis-regulatory region sequence-specific DNA 
-        binding
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0001503
-      label: ossification
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0030097
-      label: hemopoiesis
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0030182
-      label: neuron differentiation
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0045595
-      label: regulation of cell differentiation
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0006357
-      label: regulation of transcription by RNA polymerase II
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0000981
-      label: DNA-binding transcription factor activity, RNA polymerase 
-        II-specific
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0002062
-      label: chondrocyte differentiation
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0003677
-      label: DNA binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0003700
-      label: DNA-binding transcription factor activity
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005524
-      label: ATP binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005634
-      label: nucleus
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000044
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0006355
-      label: regulation of DNA-templated transcription
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0045893
-      label: positive regulation of DNA-templated transcription
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:1990837
+- term:
+    id: GO:0000978
+    label: RNA polymerase II cis-regulatory region sequence-specific DNA binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: RNA polymerase II cis-regulatory region sequence-specific DNA binding is supported by
+      RUNX3 Runt-domain sequence-specific DNA binding.
+    action: ACCEPT
+    reason: Sequence-specific regulatory-region DNA binding is central to RUNX3 transcription factor
+      function.
+    supported_by: &amp;id003
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its
+        primary function is as a **sequence-specific DNA-binding transcription factor** that
+        regulates gene expression programs by binding target regulatory elements via the **Runt
+        domain**, typically stabilized by heterodimerization with **CBFβ**.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: The target protein is **human RUNX3** (gene symbol **RUNX3**, UniProt
+        **Q13761**), described in UniProt as *Runt-related transcription factor 3* with a conserved
+        **Runt (AML1_Runt) DNA-binding domain** and C-terminal RUNX interaction region. In the
+        literature retrieved here, the entity called RUNX3 is consistently described as a
+        **Runt-domain transcription factor that heterodimerizes with CBFβ (core-binding factor β)**
+        and regulates gene expression through sequence-specific DNA binding—matching the defining
+        biochemical/structural properties expected for UniProt Q13761.
+- term:
+    id: GO:0001503
+    label: ossification
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: ossification is consistent with RUNX3 developmental or disease-associated
+      transcriptional programs but is not the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: &amp;id001
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: &#39;**RUNX3 is a master developmental transcription factor** whose dysregulation can
+        impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).&#39;
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: A 2024 review of RUNX transcription factors synthesizes RUNX3 as a regulator
+        embedded in major cancer-relevant pathways, including **TGF-β/SMAD**, **Wnt/β-catenin**, and
+        **Hippo–YAP** crosstalk, and emphasizes frequent RUNX3 inactivation through **promoter
+        hypermethylation, histone modifications, and mislocalization**.
+- term:
+    id: GO:0030097
+    label: hemopoiesis
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: hemopoiesis is consistent with RUNX3 developmental or disease-associated
+      transcriptional programs but is not the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: *id001
+- term:
+    id: GO:0030182
+    label: neuron differentiation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: neuron differentiation is consistent with RUNX3 developmental or disease-associated
+      transcriptional programs but is not the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: *id001
+- term:
+    id: GO:0045595
+    label: regulation of cell differentiation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: regulation of cell differentiation is consistent with RUNX3 developmental or
+      disease-associated transcriptional programs but is not the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: *id001
+- term:
+    id: GO:0006357
+    label: regulation of transcription by RNA polymerase II
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Regulation of transcription by RNA polymerase II is a core RUNX3 biological process.
+    action: ACCEPT
+    reason: RUNX3 regulates gene-expression programs as a nuclear sequence-specific transcription
+      factor.
+    supported_by: &amp;id002
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its
+        primary function is as a **sequence-specific DNA-binding transcription factor** that
+        regulates gene expression programs by binding target regulatory elements via the **Runt
+        domain**, typically stabilized by heterodimerization with **CBFβ**.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors
+        defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with
+        CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and
+        modulates transcriptional activity.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin
+        accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).
+- term:
+    id: GO:0000981
+    label: DNA-binding transcription factor activity, RNA polymerase II-specific
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: DNA-binding transcription factor activity, RNA polymerase II-specific is the
+      best-supported core molecular function of RUNX3.
+    action: ACCEPT
+    reason: RUNX3 is a sequence-specific Runt-domain transcription factor that regulates RNA
+      polymerase II transcription through DNA/chromatin binding and CBFβ-associated complexes.
+    supported_by: *id002
+- term:
+    id: GO:0002062
+    label: chondrocyte differentiation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: chondrocyte differentiation is consistent with RUNX3 developmental or
+      disease-associated transcriptional programs but is not the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: *id001
+- term:
+    id: GO:0003677
+    label: DNA binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Generic DNA binding is directionally correct but less precise than RUNX3
+      sequence-specific regulatory DNA binding.
+    action: MODIFY
+    reason: RUNX3 is not merely a generic DNA-binding protein; its supported molecular role is
+      sequence-specific Runt-domain binding at regulatory regions.
+    proposed_replacement_terms:
+    - id: GO:1990837
       label: sequence-specific double-stranded DNA binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:18772112
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:18772112
-          supporting_text: RUNX3 attenuates beta-catenin/T cell factors in 
-            intestinal tumorigenesis.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:24229708
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:24229708
-          supporting_text: Runx3 inactivation is a crucial early event in the 
-            development of lung adenocarcinoma.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:33961781
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:33961781
-          supporting_text: 2021 May 6. Dual proteome-scale networks reveal 
-            cell-specific remodeling of the human interactome.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:38424632
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:38424632
-          supporting_text: Ubiquitylation of RUNX3 by RNA-binding ubiquitin 
-            ligase MEX3C promotes tumorigenesis in lung adenocarcinoma.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:9751710
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9751710
-          supporting_text: Transcriptional repression by AML1 and LEF-1 is 
-            mediated by the TLE/Groucho corepressors.
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: IDA
-    original_reference_id: GO_REF:0000052
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: IDA
-    original_reference_id: GO_REF:0000052
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0006357
+    - id: GO:0000978
+      label: RNA polymerase II cis-regulatory region sequence-specific DNA binding
+    supported_by: *id003
+- term:
+    id: GO:0003700
+    label: DNA-binding transcription factor activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Generic DNA-binding transcription factor activity is correct but less precise than the
+      RNA polymerase II-specific term already present.
+    action: MODIFY
+    reason: RUNX3 functions as a sequence-specific RNA polymerase II transcription factor, so the
+      more specific term is preferred.
+    proposed_replacement_terms: &amp;id010
+    - id: GO:0000981
+      label: DNA-binding transcription factor activity, RNA polymerase II-specific
+    supported_by: *id002
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: ATP binding is not supported as a RUNX3 molecular function.
+    action: REMOVE
+    reason: RUNX3 is a non-enzymatic DNA-binding transcription factor; ATP-dependent
+      chromatin-remodeling context should not be transferred to RUNX3 as ATP binding.
+    supported_by: &amp;id011
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its
+        primary function is as a **sequence-specific DNA-binding transcription factor** that
+        regulates gene expression programs by binding target regulatory elements via the **Runt
+        domain**, typically stabilized by heterodimerization with **CBFβ**.
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: nucleus localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: &amp;id005
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin
+        and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization**
+        can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides
+        a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export
+        machinery.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: Because RUNX3 is a transcription factor, **nuclear localization** is
+        essential for its canonical function. A recurring cancer mechanism is **functional
+        inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional
+        regulation).
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: cytoplasm localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: &amp;id006
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin
+        and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization**
+        can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides
+        a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export
+        machinery.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: This provides a mechanistic explanation for the often-cited phenomenon of
+        RUNX3 cytoplasmic mislocalization as a route to functional loss.
+- term:
+    id: GO:0006355
+    label: regulation of DNA-templated transcription
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Generic regulation of DNA-templated transcription is supported but should be captured
+      with the RNA polymerase II-specific process.
+    action: MODIFY
+    reason: RUNX3 target-gene regulation is best represented by regulation of transcription by RNA
+      polymerase II.
+    proposed_replacement_terms: &amp;id012
+    - id: GO:0006357
       label: regulation of transcription by RNA polymerase II
-    evidence_type: IDA
-    original_reference_id: PMID:20591170
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20591170
-          supporting_text: The Runx transcriptional co-activator, CBFbeta, is 
-            essential for invasion of breast cancer cells.
-  - term:
-      id: GO:0001222
-      label: transcription corepressor binding
-    evidence_type: IPI
-    original_reference_id: PMID:9751710
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9751710
-          supporting_text: Transcriptional repression by AML1 and LEF-1 is 
-            mediated by the TLE/Groucho corepressors.
-  - term:
-      id: GO:1990837
-      label: sequence-specific double-stranded DNA binding
-    evidence_type: IDA
-    original_reference_id: PMID:28473536
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:28473536
-          supporting_text: Impact of cytosine methylation on DNA binding 
-            specificities of human transcription factors.
-  - term:
-      id: GO:0000785
-      label: chromatin
-    evidence_type: ISA
-    original_reference_id: GO_REF:0000113
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0000981
-      label: DNA-binding transcription factor activity, RNA polymerase 
-        II-specific
-    evidence_type: ISA
-    original_reference_id: GO_REF:0000113
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0016513
-      label: core-binding factor complex
-    evidence_type: TAS
-    original_reference_id: PMID:18258917
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:18258917
-          supporting_text: Repression of the transcription factor Th-POK by Runx
-            complexes in cytotoxic T cell development.
-  - term:
-      id: GO:0043371
-      label: negative regulation of CD4-positive, alpha-beta T cell 
-        differentiation
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0043378
-      label: positive regulation of CD8-positive, alpha-beta T cell 
-        differentiation
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952419
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952399
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952408
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952382
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952399
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8951966
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8951977
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952058
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952062
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952069
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8937792
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8937807
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8937814
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8865454
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8878117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8878143
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8878178
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8878193
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8878220
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8878237
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8937814
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8949335
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8951428
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8951676
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8951910
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8951951
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952128
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952226
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952371
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:20599712
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20599712
-          supporting_text: Tumor suppressor, AT motif binding factor 1 (ATBF1), 
-            translocates to the nucleus with runt domain transcription factor 3 
-            (RUNX3) in response to TGF-beta signal transduction.
-  - term:
-      id: GO:0005634
-      label: nucleus
-    evidence_type: IDA
-    original_reference_id: PMID:20599712
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20599712
-          supporting_text: Tumor suppressor, AT motif binding factor 1 (ATBF1), 
-            translocates to the nucleus with runt domain transcription factor 3 
-            (RUNX3) in response to TGF-beta signal transduction.
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IDA
-    original_reference_id: PMID:20599712
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20599712
-          supporting_text: Tumor suppressor, AT motif binding factor 1 (ATBF1), 
-            translocates to the nucleus with runt domain transcription factor 3 
-            (RUNX3) in response to TGF-beta signal transduction.
-  - term:
-      id: GO:0045893
-      label: positive regulation of DNA-templated transcription
-    evidence_type: IDA
-    original_reference_id: PMID:20599712
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20599712
-          supporting_text: Tumor suppressor, AT motif binding factor 1 (ATBF1), 
-            translocates to the nucleus with runt domain transcription factor 3 
-            (RUNX3) in response to TGF-beta signal transduction.
-  - term:
-      id: GO:0071559
-      label: response to transforming growth factor beta
-    evidence_type: IDA
-    original_reference_id: PMID:20599712
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20599712
-          supporting_text: Tumor suppressor, AT motif binding factor 1 (ATBF1), 
-            translocates to the nucleus with runt domain transcription factor 3 
-            (RUNX3) in response to TGF-beta signal transduction.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:17377532
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17377532
-          supporting_text: Foxp3 controls regulatory T-cell function by 
-            interacting with AML1/Runx1.
-  - term:
-      id: GO:0000785
-      label: chromatin
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0000977
-      label: RNA polymerase II transcription regulatory region sequence-specific
-        DNA binding
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0000122
-      label: negative regulation of transcription by RNA polymerase II
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0000981
-      label: DNA-binding transcription factor activity, RNA polymerase 
-        II-specific
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0048935
-      label: peripheral nervous system neuron development
-    evidence_type: TAS
-    original_reference_id: PMID:20096094
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20096094
-          supporting_text: Brn3a regulates neuronal subtype specification in the
-            trigeminal ganglion by promoting Runx expression during sensory 
-            differentiation.
-  - term:
-      id: GO:0005634
-      label: nucleus
-    evidence_type: IDA
-    original_reference_id: PMID:20100835
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20100835
-          supporting_text: Epub 2010 Jan 25. Src kinase phosphorylates RUNX3 at 
-            tyrosine residues and localizes the protein in the cytoplasm.
-  - term:
-      id: GO:0006468
-      label: protein phosphorylation
-    evidence_type: IDA
-    original_reference_id: PMID:20100835
-    review:
-      summary: &gt;-
-        MISANNOTATION: RUNX3 is a Runt-domain transcription factor that is extensively
-        PHOSPHORYLATED by kinases. PMID:20100835 title is &#34;Src kinase phosphorylates
-        RUNX3 at tyrosine residues&#34; - RUNX3 is the SUBSTRATE of Src kinase, not an
-        enzyme. The paper states &#34;overexpression of Src results in the tyrosine
-        phosphorylation... of RUNX3&#34; and shows Src phosphorylates RUNX3 in vitro.
-        RUNX3 has DNA-binding and transcription factor activity, not kinase activity.
-        Phosphorylation of RUNX3 by Src leads to its cytoplasmic mislocalization.
-      action: REMOVE
-      supported_by:
-        - reference_id: PMID:20100835
-          supporting_text: Epub 2010 Jan 25. Src kinase phosphorylates RUNX3 at 
-            tyrosine residues and localizes the protein in the cytoplasm.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:20100835
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20100835
-          supporting_text: Epub 2010 Jan 25. Src kinase phosphorylates RUNX3 at 
-            tyrosine residues and localizes the protein in the cytoplasm.
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IDA
-    original_reference_id: PMID:20100835
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20100835
-          supporting_text: Epub 2010 Jan 25. Src kinase phosphorylates RUNX3 at 
-            tyrosine residues and localizes the protein in the cytoplasm.
-  - term:
-      id: GO:0045786
-      label: negative regulation of cell cycle
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0050680
-      label: negative regulation of epithelial cell proliferation
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0003700
-      label: DNA-binding transcription factor activity
-    evidence_type: TAS
-    original_reference_id: PMID:7607690
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:7607690
-          supporting_text: Identification of a new murine runt domain-containing
-            gene, Cbfa3, and localization of the human homolog, CBFA3, to 
-            chromosome 1p35-pter.
-  - term:
-      id: GO:0005524
-      label: ATP binding
-    evidence_type: NAS
-    original_reference_id: PMID:7835892
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:7835892
-          supporting_text: &#39;AML1, AML2, and AML3, the human members of the runt domain
-            gene-family: cDNA structure, expression, and chromosomal localization.&#39;
-  - term:
-      id: GO:0006355
-      label: regulation of DNA-templated transcription
-    evidence_type: NAS
-    original_reference_id: PMID:7622058
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:7622058
-          supporting_text: Cloning, mapping and expression of PEBP2 alpha C, a 
-            third gene encoding the mammalian Runt domain.
-references:
-  - id: GO_REF:0000002
-    title: Gene Ontology annotation through association of InterPro records with
-      GO terms
-    findings: []
-  - id: GO_REF:0000024
-    title: Manual transfer of experimentally-verified manual GO annotation data 
-      to orthologs by curator judgment of sequence similarity
-    findings: []
-  - id: GO_REF:0000033
-    title: Annotation inferences using phylogenetic trees
-    findings: []
-  - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt
-    findings: []
-  - id: GO_REF:0000052
-    title: Gene Ontology annotation based on curation of immunofluorescence data
-    findings: []
-  - id: GO_REF:0000113
-    title: Gene Ontology annotation of human sequence-specific DNA binding 
-      transcription factors (DbTFs) based on the TFClass database
-    findings: []
-  - id: GO_REF:0000117
-    title: Electronic Gene Ontology annotations created by ARBA machine learning
-      models
-    findings: []
-  - id: GO_REF:0000120
-    title: Combined Automated Annotation using Multiple IEA Methods
-    findings: []
-  - id: PMID:17377532
-    title: Foxp3 controls regulatory T-cell function by interacting with 
-      AML1/Runx1.
-    findings: []
-  - id: PMID:18258917
-    title: Repression of the transcription factor Th-POK by Runx complexes in 
-      cytotoxic T cell development.
-    findings: []
-  - id: PMID:18772112
-    title: RUNX3 attenuates beta-catenin/T cell factors in intestinal 
-      tumorigenesis.
-    findings: []
-  - id: PMID:20096094
-    title: Brn3a regulates neuronal subtype specification in the trigeminal 
-      ganglion by promoting Runx expression during sensory differentiation.
-    findings: []
-  - id: PMID:20100835
-    title: Src kinase phosphorylates RUNX3 at tyrosine residues and localizes 
-      the protein in the cytoplasm.
-    findings: []
-  - id: PMID:20591170
-    title: The Runx transcriptional co-activator, CBFbeta, is essential for 
-      invasion of breast cancer cells.
-    findings: []
-  - id: PMID:20599712
-    title: Tumor suppressor, AT motif binding factor 1 (ATBF1), translocates to 
-      the nucleus with runt domain transcription factor 3 (RUNX3) in response to
-      TGF-beta signal transduction.
-    findings: []
-  - id: PMID:24229708
-    title: Runx3 inactivation is a crucial early event in the development of 
-      lung adenocarcinoma.
-    findings: []
-  - id: PMID:28473536
-    title: Impact of cytosine methylation on DNA binding specificities of human 
-      transcription factors.
-    findings: []
-  - id: PMID:33961781
-    title: Dual proteome-scale networks reveal cell-specific remodeling of the 
-      human interactome.
-    findings: []
-  - id: PMID:38424632
-    title: Ubiquitylation of RUNX3 by RNA-binding ubiquitin ligase MEX3C 
-      promotes tumorigenesis in lung adenocarcinoma.
-    findings: []
-  - id: PMID:7607690
-    title: Identification of a new murine runt domain-containing gene, Cbfa3, 
-      and localization of the human homolog, CBFA3, to chromosome 1p35-pter.
-    findings: []
-  - id: PMID:7622058
-    title: Cloning, mapping and expression of PEBP2 alpha C, a third gene 
-      encoding the mammalian Runt domain.
-    findings: []
-  - id: PMID:7835892
-    title: &#39;AML1, AML2, and AML3, the human members of the runt domain gene-family:
-      cDNA structure, expression, and chromosomal localization.&#39;
-    findings: []
-  - id: PMID:9751710
-    title: Transcriptional repression by AML1 and LEF-1 is mediated by the 
+    supported_by: *id002
+- term:
+    id: GO:0045893
+    label: positive regulation of DNA-templated transcription
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Positive regulation of DNA-templated transcription is supported in context-specific
+      RUNX3 target-gene programs.
+    action: ACCEPT
+    reason: RUNX3 can activate transcriptional targets, although the direction of regulation is
+      context dependent.
+    supported_by: &amp;id008
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its
+        primary function is as a **sequence-specific DNA-binding transcription factor** that
+        regulates gene expression programs by binding target regulatory elements via the **Runt
+        domain**, typically stabilized by heterodimerization with **CBFβ**.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: A 2024 study (Cancer Research Communications) presented evidence that RUNX3
+        can be **pro-metastatic** in a gastric cancer model (HGC-27), where CRISPR KO reduced
+        migration/invasion/anchorage-independent growth and suppressed liver metastasis in vivo.
+        Multi-omic mapping (ChIP-seq, HiChIP) supported direct transcriptional control of
+        metastasis-associated targets including **WNT5A**, **CD44**, and **VIM**, with WNT5A
+        functioning as a major effector.
+- term:
+    id: GO:1990837
+    label: sequence-specific double-stranded DNA binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: sequence-specific double-stranded DNA binding is supported by RUNX3 Runt-domain
+      sequence-specific DNA binding.
+    action: ACCEPT
+    reason: Sequence-specific regulatory-region DNA binding is central to RUNX3 transcription factor
+      function.
+    supported_by: *id003
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:18772112
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: &amp;id004
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors
+        defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with
+        CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and
+        modulates transcriptional activity.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: &#39;A key 2023 advance demonstrated a **direct protein–protein mechanism** linking
+        RUNX3 to oncogene control: RUNX3 binds **MYC** directly via the **Runt domain**, disrupts MYC’s
+        transcriptionally active complexes (MYC–MAX and MYC–MIZ1), increases **GSK3β-mediated phosphorylation
+        of MYC at T58**, and promotes **FBXW7-dependent K48-linked ubiquitination** and proteasomal degradation
+        of MYC.&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:24229708
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: *id004
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: *id004
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:38424632
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: *id004
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:9751710
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: *id004
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: cytosol localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0006357
+    label: regulation of transcription by RNA polymerase II
+  evidence_type: IDA
+  original_reference_id: PMID:20591170
+  review:
+    summary: Regulation of transcription by RNA polymerase II is a core RUNX3 biological process.
+    action: ACCEPT
+    reason: RUNX3 regulates gene-expression programs as a nuclear sequence-specific transcription
+      factor.
+    supported_by: *id002
+- term:
+    id: GO:0001222
+    label: transcription corepressor binding
+  evidence_type: IPI
+  original_reference_id: PMID:9751710
+  review:
+    summary: Transcription corepressor binding is supported by RUNX/Runt-domain recruitment of
       TLE/Groucho corepressors.
-    findings: []
-  - id: Reactome:R-HSA-8865454
-    title: CBFB binds RUNX3
-    findings: []
-  - id: Reactome:R-HSA-8878117
-    title: RUNX3 binds ZFHX3
-    findings: []
-  - id: Reactome:R-HSA-8878143
-    title: RUNX3 binds SMAD3 and SMAD4
-    findings: []
-  - id: Reactome:R-HSA-8878178
-    title: The complex of RUNX3, SMAD3 and SMAD4 binds the CDKN1A gene promoter
-    findings: []
-  - id: Reactome:R-HSA-8878193
-    title: RUNX3 binds the JAG1 gene promoter
-    findings: []
-  - id: Reactome:R-HSA-8878220
-    title: RUNX3 binds the NOTCH1 coactivator complex
-    findings: []
-  - id: Reactome:R-HSA-8878237
-    title: RUNX3:NOTCH1 coactivator complex binds the HES1 gene promoter
-    findings: []
-  - id: Reactome:R-HSA-8937792
-    title: RUNX3 binds SRC
-    findings: []
-  - id: Reactome:R-HSA-8937807
-    title: SRC phosphorylates RUNX3
-    findings: []
-  - id: Reactome:R-HSA-8937814
-    title: RUNX3 translocates to the nucleus
-    findings: []
-  - id: Reactome:R-HSA-8949335
-    title: RUNX3:CBFB binds the ITGAL gene,(ITGA4 gene) promoter
-    findings: []
-  - id: Reactome:R-HSA-8951428
-    title: RUNX3 binds CTNNB1:TCF7L2,(LEF1,TCF7L1,TCF7)
-    findings: []
-  - id: Reactome:R-HSA-8951676
-    title: RUNX3 binds TEADs and YAP1
-    findings: []
-  - id: Reactome:R-HSA-8951910
-    title: RUNX3 binds the RUNX1 promoter
-    findings: []
-  - id: Reactome:R-HSA-8951951
-    title: RUNX3 binds EP300
-    findings: []
-  - id: Reactome:R-HSA-8951966
-    title: EP300 acetylates RUNX3
-    findings: []
-  - id: Reactome:R-HSA-8951977
-    title: Acetylated RUNX3 binds to BRD2
-    findings: []
-  - id: Reactome:R-HSA-8952058
-    title: CCND1 binds RUNX3 and displaces EP300
-    findings: []
-  - id: Reactome:R-HSA-8952062
-    title: CCND1 recruits HDAC4 to RUNX3
-    findings: []
-  - id: Reactome:R-HSA-8952069
-    title: HDAC4 deacetylates RUNX3
-    findings: []
-  - id: Reactome:R-HSA-8952128
-    title: RUNX3 binds TP53
-    findings: []
-  - id: Reactome:R-HSA-8952226
-    title: RUNX3 binds the BCL2L11 (BIM) gene
-    findings: []
-  - id: Reactome:R-HSA-8952371
-    title: MDM2 binds RUNX3
-    findings: []
-  - id: Reactome:R-HSA-8952382
-    title: MDM2 polyubiquitinates RUNX3
-    findings: []
-  - id: Reactome:R-HSA-8952399
-    title: Polyubiquitinated RUNX3 translocates to the cytosol
-    findings: []
-  - id: Reactome:R-HSA-8952408
-    title: Polyubiquitinated RUNX3 is degraded by the proteasome
-    findings: []
-  - id: Reactome:R-HSA-8952419
-    title: SMURFs ubiquitinate RUNX3
-    findings: []
+    action: ACCEPT
+    reason: This is a more informative binding annotation than generic protein binding for
+      RUNX3-associated transcriptional repression.
+    supported_by:
+    - reference_id: PMID:9751710
+      supporting_text: The mammalian AML/CBFalpha runt domain (RD) transcription factors regulate
+        hematopoiesis and osteoblast differentiation. Like their Drosophila counterparts, most
+        mammalian RD proteins terminate in a common pentapeptide, VWRPY, which serves to recruit the
+        corepressor Groucho (Gro).
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its
+        primary function is as a **sequence-specific DNA-binding transcription factor** that
+        regulates gene expression programs by binding target regulatory elements via the **Runt
+        domain**, typically stabilized by heterodimerization with **CBFβ**.
+- term:
+    id: GO:1990837
+    label: sequence-specific double-stranded DNA binding
+  evidence_type: IDA
+  original_reference_id: PMID:28473536
+  review:
+    summary: sequence-specific double-stranded DNA binding is supported by RUNX3 Runt-domain
+      sequence-specific DNA binding.
+    action: ACCEPT
+    reason: Sequence-specific regulatory-region DNA binding is central to RUNX3 transcription factor
+      function.
+    supported_by: *id003
+- term:
+    id: GO:0000785
+    label: chromatin
+  evidence_type: ISA
+  original_reference_id: GO_REF:0000113
+  review:
+    summary: Chromatin localization is supported by RUNX3 DNA, mononucleosome, and
+      chromatin-remodeler-associated activity.
+    action: ACCEPT
+    reason: RUNX3 binds chromatin-associated regulatory DNA as part of its transcription factor
+      function.
+    supported_by: &amp;id009
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin
+        accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 associates with **CBFβ** and chromatin remodeler machinery including
+        SWI/SNF components; the **Runt domain** is implicated as critical for interactions with
+        chromatin factors in this metastatic gastric cancer model.
+- term:
+    id: GO:0000981
+    label: DNA-binding transcription factor activity, RNA polymerase II-specific
+  evidence_type: ISA
+  original_reference_id: GO_REF:0000113
+  review:
+    summary: DNA-binding transcription factor activity, RNA polymerase II-specific is the
+      best-supported core molecular function of RUNX3.
+    action: ACCEPT
+    reason: RUNX3 is a sequence-specific Runt-domain transcription factor that regulates RNA
+      polymerase II transcription through DNA/chromatin binding and CBFβ-associated complexes.
+    supported_by: *id002
+- term:
+    id: GO:0016513
+    label: core-binding factor complex
+  evidence_type: TAS
+  original_reference_id: PMID:18258917
+  review:
+    summary: Core-binding factor complex is the canonical RUNX3 transcription factor complex
+      context.
+    action: ACCEPT
+    reason: RUNX3 heterodimerizes with CBFβ, placing it in the core-binding factor complex for
+      DNA-binding transcriptional regulation.
+    supported_by:
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors
+        defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with
+        CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and
+        modulates transcriptional activity.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 associates with **CBFβ** and chromatin remodeler machinery including
+        SWI/SNF components; the **Runt domain** is implicated as critical for interactions with
+        chromatin factors in this metastatic gastric cancer model.
+- term:
+    id: GO:0043371
+    label: negative regulation of CD4-positive, alpha-beta T cell differentiation
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: negative regulation of CD4-positive, alpha-beta T cell differentiation is a supported
+      RUNX3 biological role, especially in immune differentiation, but it is downstream of the
+      transcription factor core function.
+    action: KEEP_AS_NON_CORE
+    reason: T-cell differentiation phenotypes reflect RUNX3-regulated transcriptional programs
+      rather than a separate core molecular activity.
+    supported_by: &amp;id007
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 is a key regulator of **CD8+ T-cell differentiation, infiltration,
+        effector/memory fate, and residency**.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: &#39;**RUNX3 is a master developmental transcription factor** whose dysregulation can
+        impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).&#39;
+- term:
+    id: GO:0043378
+    label: positive regulation of CD8-positive, alpha-beta T cell differentiation
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: positive regulation of CD8-positive, alpha-beta T cell differentiation is a supported
+      RUNX3 biological role, especially in immune differentiation, but it is downstream of the
+      transcription factor core function.
+    action: KEEP_AS_NON_CORE
+    reason: T-cell differentiation phenotypes reflect RUNX3-regulated transcriptional programs
+      rather than a separate core molecular activity.
+    supported_by: *id007
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952419
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952399
+  review:
+    summary: cytosol localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952408
+  review:
+    summary: cytosol localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952382
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952399
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8951966
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8951977
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952058
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952062
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952069
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8937792
+  review:
+    summary: cytosol localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8937807
+  review:
+    summary: cytosol localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8937814
+  review:
+    summary: cytosol localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8865454
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8878117
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8878143
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8878178
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8878193
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8878220
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8878237
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8937814
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8949335
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8951428
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8951676
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8951910
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8951951
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952128
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952226
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952371
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20599712
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: *id004
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IDA
+  original_reference_id: PMID:20599712
+  review:
+    summary: nucleus localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:20599712
+  review:
+    summary: cytoplasm localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0045893
+    label: positive regulation of DNA-templated transcription
+  evidence_type: IDA
+  original_reference_id: PMID:20599712
+  review:
+    summary: Positive regulation of DNA-templated transcription is supported in context-specific
+      RUNX3 target-gene programs.
+    action: ACCEPT
+    reason: RUNX3 can activate transcriptional targets, although the direction of regulation is
+      context dependent.
+    supported_by: *id008
+- term:
+    id: GO:0071559
+    label: response to transforming growth factor beta
+  evidence_type: IDA
+  original_reference_id: PMID:20599712
+  review:
+    summary: Response to transforming growth factor beta is supported as a pathway context for RUNX3
+      transcriptional regulation.
+    action: KEEP_AS_NON_CORE
+    reason: TGF-beta/SMAD effects are important context-specific biology, but the core function
+      remains nuclear sequence-specific transcriptional regulation.
+    supported_by:
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: A 2024 review of RUNX transcription factors synthesizes RUNX3 as a regulator
+        embedded in major cancer-relevant pathways, including **TGF-β/SMAD**, **Wnt/β-catenin**, and
+        **Hippo–YAP** crosstalk, and emphasizes frequent RUNX3 inactivation through **promoter
+        hypermethylation, histone modifications, and mislocalization**.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: &#39;**RUNX3 is a master developmental transcription factor** whose dysregulation can
+        impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:17377532
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: *id004
+- term:
+    id: GO:0000785
+    label: chromatin
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: Chromatin localization is supported by RUNX3 DNA, mononucleosome, and
+      chromatin-remodeler-associated activity.
+    action: ACCEPT
+    reason: RUNX3 binds chromatin-associated regulatory DNA as part of its transcription factor
+      function.
+    supported_by: *id009
+- term:
+    id: GO:0000977
+    label: RNA polymerase II transcription regulatory region sequence-specific DNA binding
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: RNA polymerase II transcription regulatory region sequence-specific DNA binding is
+      supported by RUNX3 Runt-domain sequence-specific DNA binding.
+    action: ACCEPT
+    reason: Sequence-specific regulatory-region DNA binding is central to RUNX3 transcription factor
+      function.
+    supported_by: *id003
+- term:
+    id: GO:0000122
+    label: negative regulation of transcription by RNA polymerase II
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: Negative regulation of transcription by RNA polymerase II is supported for RUNX3 in
+      repressive target-gene and Wnt/TCF contexts.
+    action: ACCEPT
+    reason: RUNX3 can repress transcriptional outputs through protein complexes and target-gene
+      regulation.
+    supported_by:
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its
+        primary function is as a **sequence-specific DNA-binding transcription factor** that
+        regulates gene expression programs by binding target regulatory elements via the **Runt
+        domain**, typically stabilized by heterodimerization with **CBFβ**.
+    - reference_id: PMID:18772112
+      supporting_text: Here we found that RUNX3, a gastric tumor suppressor, forms a ternary complex
+        with beta-catenin/TCF4 and attenuates Wnt signaling activity.
+- term:
+    id: GO:0000981
+    label: DNA-binding transcription factor activity, RNA polymerase II-specific
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: DNA-binding transcription factor activity, RNA polymerase II-specific is the
+      best-supported core molecular function of RUNX3.
+    action: ACCEPT
+    reason: RUNX3 is a sequence-specific Runt-domain transcription factor that regulates RNA
+      polymerase II transcription through DNA/chromatin binding and CBFβ-associated complexes.
+    supported_by: *id002
+- term:
+    id: GO:0048935
+    label: peripheral nervous system neuron development
+  evidence_type: TAS
+  original_reference_id: PMID:20096094
+  review:
+    summary: peripheral nervous system neuron development is consistent with RUNX3 developmental or
+      disease-associated transcriptional programs but is not the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: *id001
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IDA
+  original_reference_id: PMID:20100835
+  review:
+    summary: nucleus localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0006468
+    label: protein phosphorylation
+  evidence_type: IDA
+  original_reference_id: PMID:20100835
+  review:
+    summary: Protein phosphorylation is not supported as a process carried out by RUNX3.
+    action: REMOVE
+    reason: The cited biology describes Src-mediated phosphorylation of RUNX3, making RUNX3 the
+      substrate rather than the kinase or causal gene product for protein phosphorylation.
+    supported_by:
+    - reference_id: PMID:20100835
+      supporting_text: In this study, we found that the overexpression of Src results in the
+        tyrosine phosphorylation and cytoplasmic localization of RUNX3.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin
+        and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization**
+        can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides
+        a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export
+        machinery.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20100835
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: *id004
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:20100835
+  review:
+    summary: cytoplasm localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0045786
+    label: negative regulation of cell cycle
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: negative regulation of cell cycle is consistent with RUNX3 developmental or
+      disease-associated transcriptional programs but is not the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: *id001
+- term:
+    id: GO:0050680
+    label: negative regulation of epithelial cell proliferation
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: negative regulation of epithelial cell proliferation is consistent with RUNX3
+      developmental or disease-associated transcriptional programs but is not the core molecular
+      function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: *id001
+- term:
+    id: GO:0003700
+    label: DNA-binding transcription factor activity
+  evidence_type: TAS
+  original_reference_id: PMID:7607690
+  review:
+    summary: Generic DNA-binding transcription factor activity is correct but less precise than the
+      RNA polymerase II-specific term already present.
+    action: MODIFY
+    reason: RUNX3 functions as a sequence-specific RNA polymerase II transcription factor, so the
+      more specific term is preferred.
+    proposed_replacement_terms: *id010
+    supported_by: *id002
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: NAS
+  original_reference_id: PMID:7835892
+  review:
+    summary: ATP binding is not supported as a RUNX3 molecular function.
+    action: REMOVE
+    reason: RUNX3 is a non-enzymatic DNA-binding transcription factor; ATP-dependent
+      chromatin-remodeling context should not be transferred to RUNX3 as ATP binding.
+    supported_by: *id011
+- term:
+    id: GO:0006355
+    label: regulation of DNA-templated transcription
+  evidence_type: NAS
+  original_reference_id: PMID:7622058
+  review:
+    summary: Generic regulation of DNA-templated transcription is supported but should be captured
+      with the RNA polymerase II-specific process.
+    action: MODIFY
+    reason: RUNX3 target-gene regulation is best represented by regulation of transcription by RNA
+      polymerase II.
+    proposed_replacement_terms: *id012
+    supported_by: *id002
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by
+    curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000113
+  title: Gene Ontology annotation of human sequence-specific DNA binding transcription factors
+    (DbTFs) based on the TFClass database
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:17377532
+  title: Foxp3 controls regulatory T-cell function by interacting with AML1/Runx1.
+  findings: []
+- id: PMID:18258917
+  title: Repression of the transcription factor Th-POK by Runx complexes in cytotoxic T cell
+    development.
+  findings: []
+- id: PMID:18772112
+  title: RUNX3 attenuates beta-catenin/T cell factors in intestinal tumorigenesis.
+  findings: []
+- id: PMID:20096094
+  title: Brn3a regulates neuronal subtype specification in the trigeminal ganglion by promoting Runx
+    expression during sensory differentiation.
+  findings: []
+- id: PMID:20100835
+  title: Src kinase phosphorylates RUNX3 at tyrosine residues and localizes the protein in the
+    cytoplasm.
+  findings: []
+- id: PMID:20591170
+  title: The Runx transcriptional co-activator, CBFbeta, is essential for invasion of breast cancer
+    cells.
+  findings: []
+- id: PMID:20599712
+  title: Tumor suppressor, AT motif binding factor 1 (ATBF1), translocates to the nucleus with runt
+    domain transcription factor 3 (RUNX3) in response to TGF-beta signal transduction.
+  findings: []
+- id: PMID:24229708
+  title: Runx3 inactivation is a crucial early event in the development of lung adenocarcinoma.
+  findings: []
+- id: PMID:28473536
+  title: Impact of cytosine methylation on DNA binding specificities of human transcription factors.
+  findings: []
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
+  findings: []
+- id: PMID:38424632
+  title: Ubiquitylation of RUNX3 by RNA-binding ubiquitin ligase MEX3C promotes tumorigenesis in
+    lung adenocarcinoma.
+  findings: []
+- id: PMID:7607690
+  title: Identification of a new murine runt domain-containing gene, Cbfa3, and localization of the
+    human homolog, CBFA3, to chromosome 1p35-pter.
+  findings: []
+- id: PMID:7622058
+  title: Cloning, mapping and expression of PEBP2 alpha C, a third gene encoding the mammalian Runt
+    domain.
+  findings: []
+- id: PMID:7835892
+  title: &#39;AML1, AML2, and AML3, the human members of the runt domain gene-family: cDNA structure, expression,
+    and chromosomal localization.&#39;
+  findings: []
+- id: PMID:9751710
+  title: Transcriptional repression by AML1 and LEF-1 is mediated by the TLE/Groucho corepressors.
+  findings: []
+- id: Reactome:R-HSA-8865454
+  title: CBFB binds RUNX3
+  findings: []
+- id: Reactome:R-HSA-8878117
+  title: RUNX3 binds ZFHX3
+  findings: []
+- id: Reactome:R-HSA-8878143
+  title: RUNX3 binds SMAD3 and SMAD4
+  findings: []
+- id: Reactome:R-HSA-8878178
+  title: The complex of RUNX3, SMAD3 and SMAD4 binds the CDKN1A gene promoter
+  findings: []
+- id: Reactome:R-HSA-8878193
+  title: RUNX3 binds the JAG1 gene promoter
+  findings: []
+- id: Reactome:R-HSA-8878220
+  title: RUNX3 binds the NOTCH1 coactivator complex
+  findings: []
+- id: Reactome:R-HSA-8878237
+  title: RUNX3:NOTCH1 coactivator complex binds the HES1 gene promoter
+  findings: []
+- id: Reactome:R-HSA-8937792
+  title: RUNX3 binds SRC
+  findings: []
+- id: Reactome:R-HSA-8937807
+  title: SRC phosphorylates RUNX3
+  findings: []
+- id: Reactome:R-HSA-8937814
+  title: RUNX3 translocates to the nucleus
+  findings: []
+- id: Reactome:R-HSA-8949335
+  title: RUNX3:CBFB binds the ITGAL gene,(ITGA4 gene) promoter
+  findings: []
+- id: Reactome:R-HSA-8951428
+  title: RUNX3 binds CTNNB1:TCF7L2,(LEF1,TCF7L1,TCF7)
+  findings: []
+- id: Reactome:R-HSA-8951676
+  title: RUNX3 binds TEADs and YAP1
+  findings: []
+- id: Reactome:R-HSA-8951910
+  title: RUNX3 binds the RUNX1 promoter
+  findings: []
+- id: Reactome:R-HSA-8951951
+  title: RUNX3 binds EP300
+  findings: []
+- id: Reactome:R-HSA-8951966
+  title: EP300 acetylates RUNX3
+  findings: []
+- id: Reactome:R-HSA-8951977
+  title: Acetylated RUNX3 binds to BRD2
+  findings: []
+- id: Reactome:R-HSA-8952058
+  title: CCND1 binds RUNX3 and displaces EP300
+  findings: []
+- id: Reactome:R-HSA-8952062
+  title: CCND1 recruits HDAC4 to RUNX3
+  findings: []
+- id: Reactome:R-HSA-8952069
+  title: HDAC4 deacetylates RUNX3
+  findings: []
+- id: Reactome:R-HSA-8952128
+  title: RUNX3 binds TP53
+  findings: []
+- id: Reactome:R-HSA-8952226
+  title: RUNX3 binds the BCL2L11 (BIM) gene
+  findings: []
+- id: Reactome:R-HSA-8952371
+  title: MDM2 binds RUNX3
+  findings: []
+- id: Reactome:R-HSA-8952382
+  title: MDM2 polyubiquitinates RUNX3
+  findings: []
+- id: Reactome:R-HSA-8952399
+  title: Polyubiquitinated RUNX3 translocates to the cytosol
+  findings: []
+- id: Reactome:R-HSA-8952408
+  title: Polyubiquitinated RUNX3 is degraded by the proteasome
+  findings: []
+- id: Reactome:R-HSA-8952419
+  title: SMURFs ubiquitinate RUNX3
+  findings: []
+- id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+  title: Falcon deep research synthesis for RUNX3
+  findings: []
+core_functions:
+- description: Nuclear Runt-domain sequence-specific transcription factor activity in
+    CBFβ/core-binding factor complexes, regulating RNA polymerase II target-gene programs through
+    chromatin and regulatory-region DNA binding.
+  molecular_function:
+    id: GO:0000981
+    label: DNA-binding transcription factor activity, RNA polymerase II-specific
+  directly_involved_in:
+  - id: GO:0006357
+    label: regulation of transcription by RNA polymerase II
+  - id: GO:0045893
+    label: positive regulation of DNA-templated transcription
+  - id: GO:0000122
+    label: negative regulation of transcription by RNA polymerase II
+  locations:
+  - id: GO:0005634
+    label: nucleus
+  - id: GO:0005654
+    label: nucleoplasm
+  - id: GO:0000785
+    label: chromatin
+  in_complex:
+    id: GO:0016513
+    label: core-binding factor complex
+  supported_by:
+  - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+    supporting_text: RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its
+      primary function is as a **sequence-specific DNA-binding transcription factor** that regulates
+      gene expression programs by binding target regulatory elements via the **Runt domain**,
+      typically stabilized by heterodimerization with **CBFβ**.
+  - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+    supporting_text: RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors
+      defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with
+      CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and
+      modulates transcriptional activity.
+  - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+    supporting_text: RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin
+      accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).
+  - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+    supporting_text: RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin
+      and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization**
+      can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a
+      mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/RUNX3/RUNX3-ai-review.yaml
+++ b/genes/human/RUNX3/RUNX3-ai-review.yaml
@@ -1,935 +1,1279 @@
 id: Q13761
 gene_symbol: RUNX3
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for RUNX3'
+description: 'RUNX3 encodes Runt-related transcription factor 3, a nuclear Runt-domain DNA-binding transcription
+  factor that heterodimerizes with CBFβ/core-binding factor complexes to regulate RNA polymerase II target-gene
+  programs. Its core function is sequence-specific regulatory DNA and chromatin binding for context-dependent
+  transcriptional activation or repression, with important downstream roles in development, TGF-beta/Wnt/Hippo
+  signaling, CD8 T-cell biology, and cancer-associated mislocalization or degradation.'
 existing_annotations:
-  - term:
-      id: GO:0000978
-      label: RNA polymerase II cis-regulatory region sequence-specific DNA 
-        binding
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0001503
-      label: ossification
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0030097
-      label: hemopoiesis
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0030182
-      label: neuron differentiation
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0045595
-      label: regulation of cell differentiation
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0006357
-      label: regulation of transcription by RNA polymerase II
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0000981
-      label: DNA-binding transcription factor activity, RNA polymerase 
-        II-specific
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0002062
-      label: chondrocyte differentiation
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0003677
-      label: DNA binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0003700
-      label: DNA-binding transcription factor activity
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005524
-      label: ATP binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005634
-      label: nucleus
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000044
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0006355
-      label: regulation of DNA-templated transcription
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0045893
-      label: positive regulation of DNA-templated transcription
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:1990837
+- term:
+    id: GO:0000978
+    label: RNA polymerase II cis-regulatory region sequence-specific DNA binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: RNA polymerase II cis-regulatory region sequence-specific DNA binding is supported by
+      RUNX3 Runt-domain sequence-specific DNA binding.
+    action: ACCEPT
+    reason: Sequence-specific regulatory-region DNA binding is central to RUNX3 transcription factor
+      function.
+    supported_by: &id003
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its
+        primary function is as a **sequence-specific DNA-binding transcription factor** that
+        regulates gene expression programs by binding target regulatory elements via the **Runt
+        domain**, typically stabilized by heterodimerization with **CBFβ**.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: The target protein is **human RUNX3** (gene symbol **RUNX3**, UniProt
+        **Q13761**), described in UniProt as *Runt-related transcription factor 3* with a conserved
+        **Runt (AML1_Runt) DNA-binding domain** and C-terminal RUNX interaction region. In the
+        literature retrieved here, the entity called RUNX3 is consistently described as a
+        **Runt-domain transcription factor that heterodimerizes with CBFβ (core-binding factor β)**
+        and regulates gene expression through sequence-specific DNA binding—matching the defining
+        biochemical/structural properties expected for UniProt Q13761.
+- term:
+    id: GO:0001503
+    label: ossification
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: ossification is consistent with RUNX3 developmental or disease-associated
+      transcriptional programs but is not the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: &id001
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: '**RUNX3 is a master developmental transcription factor** whose dysregulation can
+        impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).'
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: A 2024 review of RUNX transcription factors synthesizes RUNX3 as a regulator
+        embedded in major cancer-relevant pathways, including **TGF-β/SMAD**, **Wnt/β-catenin**, and
+        **Hippo–YAP** crosstalk, and emphasizes frequent RUNX3 inactivation through **promoter
+        hypermethylation, histone modifications, and mislocalization**.
+- term:
+    id: GO:0030097
+    label: hemopoiesis
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: hemopoiesis is consistent with RUNX3 developmental or disease-associated
+      transcriptional programs but is not the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: *id001
+- term:
+    id: GO:0030182
+    label: neuron differentiation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: neuron differentiation is consistent with RUNX3 developmental or disease-associated
+      transcriptional programs but is not the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: *id001
+- term:
+    id: GO:0045595
+    label: regulation of cell differentiation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: regulation of cell differentiation is consistent with RUNX3 developmental or
+      disease-associated transcriptional programs but is not the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: *id001
+- term:
+    id: GO:0006357
+    label: regulation of transcription by RNA polymerase II
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Regulation of transcription by RNA polymerase II is a core RUNX3 biological process.
+    action: ACCEPT
+    reason: RUNX3 regulates gene-expression programs as a nuclear sequence-specific transcription
+      factor.
+    supported_by: &id002
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its
+        primary function is as a **sequence-specific DNA-binding transcription factor** that
+        regulates gene expression programs by binding target regulatory elements via the **Runt
+        domain**, typically stabilized by heterodimerization with **CBFβ**.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors
+        defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with
+        CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and
+        modulates transcriptional activity.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin
+        accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).
+- term:
+    id: GO:0000981
+    label: DNA-binding transcription factor activity, RNA polymerase II-specific
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: DNA-binding transcription factor activity, RNA polymerase II-specific is the
+      best-supported core molecular function of RUNX3.
+    action: ACCEPT
+    reason: RUNX3 is a sequence-specific Runt-domain transcription factor that regulates RNA
+      polymerase II transcription through DNA/chromatin binding and CBFβ-associated complexes.
+    supported_by: *id002
+- term:
+    id: GO:0002062
+    label: chondrocyte differentiation
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: chondrocyte differentiation is consistent with RUNX3 developmental or
+      disease-associated transcriptional programs but is not the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: *id001
+- term:
+    id: GO:0003677
+    label: DNA binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Generic DNA binding is directionally correct but less precise than RUNX3
+      sequence-specific regulatory DNA binding.
+    action: MODIFY
+    reason: RUNX3 is not merely a generic DNA-binding protein; its supported molecular role is
+      sequence-specific Runt-domain binding at regulatory regions.
+    proposed_replacement_terms:
+    - id: GO:1990837
       label: sequence-specific double-stranded DNA binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:18772112
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:18772112
-          supporting_text: RUNX3 attenuates beta-catenin/T cell factors in 
-            intestinal tumorigenesis.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:24229708
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:24229708
-          supporting_text: Runx3 inactivation is a crucial early event in the 
-            development of lung adenocarcinoma.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:33961781
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:33961781
-          supporting_text: 2021 May 6. Dual proteome-scale networks reveal 
-            cell-specific remodeling of the human interactome.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:38424632
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:38424632
-          supporting_text: Ubiquitylation of RUNX3 by RNA-binding ubiquitin 
-            ligase MEX3C promotes tumorigenesis in lung adenocarcinoma.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:9751710
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9751710
-          supporting_text: Transcriptional repression by AML1 and LEF-1 is 
-            mediated by the TLE/Groucho corepressors.
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: IDA
-    original_reference_id: GO_REF:0000052
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: IDA
-    original_reference_id: GO_REF:0000052
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0006357
+    - id: GO:0000978
+      label: RNA polymerase II cis-regulatory region sequence-specific DNA binding
+    supported_by: *id003
+- term:
+    id: GO:0003700
+    label: DNA-binding transcription factor activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Generic DNA-binding transcription factor activity is correct but less precise than the
+      RNA polymerase II-specific term already present.
+    action: MODIFY
+    reason: RUNX3 functions as a sequence-specific RNA polymerase II transcription factor, so the
+      more specific term is preferred.
+    proposed_replacement_terms: &id010
+    - id: GO:0000981
+      label: DNA-binding transcription factor activity, RNA polymerase II-specific
+    supported_by: *id002
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: ATP binding is not supported as a RUNX3 molecular function.
+    action: REMOVE
+    reason: RUNX3 is a non-enzymatic DNA-binding transcription factor; ATP-dependent
+      chromatin-remodeling context should not be transferred to RUNX3 as ATP binding.
+    supported_by: &id011
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its
+        primary function is as a **sequence-specific DNA-binding transcription factor** that
+        regulates gene expression programs by binding target regulatory elements via the **Runt
+        domain**, typically stabilized by heterodimerization with **CBFβ**.
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: nucleus localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: &id005
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin
+        and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization**
+        can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides
+        a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export
+        machinery.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: Because RUNX3 is a transcription factor, **nuclear localization** is
+        essential for its canonical function. A recurring cancer mechanism is **functional
+        inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional
+        regulation).
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: cytoplasm localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: &id006
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin
+        and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization**
+        can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides
+        a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export
+        machinery.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: This provides a mechanistic explanation for the often-cited phenomenon of
+        RUNX3 cytoplasmic mislocalization as a route to functional loss.
+- term:
+    id: GO:0006355
+    label: regulation of DNA-templated transcription
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Generic regulation of DNA-templated transcription is supported but should be captured
+      with the RNA polymerase II-specific process.
+    action: MODIFY
+    reason: RUNX3 target-gene regulation is best represented by regulation of transcription by RNA
+      polymerase II.
+    proposed_replacement_terms: &id012
+    - id: GO:0006357
       label: regulation of transcription by RNA polymerase II
-    evidence_type: IDA
-    original_reference_id: PMID:20591170
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20591170
-          supporting_text: The Runx transcriptional co-activator, CBFbeta, is 
-            essential for invasion of breast cancer cells.
-  - term:
-      id: GO:0001222
-      label: transcription corepressor binding
-    evidence_type: IPI
-    original_reference_id: PMID:9751710
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9751710
-          supporting_text: Transcriptional repression by AML1 and LEF-1 is 
-            mediated by the TLE/Groucho corepressors.
-  - term:
-      id: GO:1990837
-      label: sequence-specific double-stranded DNA binding
-    evidence_type: IDA
-    original_reference_id: PMID:28473536
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:28473536
-          supporting_text: Impact of cytosine methylation on DNA binding 
-            specificities of human transcription factors.
-  - term:
-      id: GO:0000785
-      label: chromatin
-    evidence_type: ISA
-    original_reference_id: GO_REF:0000113
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0000981
-      label: DNA-binding transcription factor activity, RNA polymerase 
-        II-specific
-    evidence_type: ISA
-    original_reference_id: GO_REF:0000113
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0016513
-      label: core-binding factor complex
-    evidence_type: TAS
-    original_reference_id: PMID:18258917
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:18258917
-          supporting_text: Repression of the transcription factor Th-POK by Runx
-            complexes in cytotoxic T cell development.
-  - term:
-      id: GO:0043371
-      label: negative regulation of CD4-positive, alpha-beta T cell 
-        differentiation
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0043378
-      label: positive regulation of CD8-positive, alpha-beta T cell 
-        differentiation
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952419
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952399
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952408
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952382
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952399
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8951966
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8951977
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952058
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952062
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952069
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8937792
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8937807
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8937814
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8865454
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8878117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8878143
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8878178
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8878193
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8878220
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8878237
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8937814
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8949335
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8951428
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8951676
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8951910
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8951951
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952128
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952226
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005654
-      label: nucleoplasm
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8952371
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:20599712
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20599712
-          supporting_text: Tumor suppressor, AT motif binding factor 1 (ATBF1), 
-            translocates to the nucleus with runt domain transcription factor 3 
-            (RUNX3) in response to TGF-beta signal transduction.
-  - term:
-      id: GO:0005634
-      label: nucleus
-    evidence_type: IDA
-    original_reference_id: PMID:20599712
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20599712
-          supporting_text: Tumor suppressor, AT motif binding factor 1 (ATBF1), 
-            translocates to the nucleus with runt domain transcription factor 3 
-            (RUNX3) in response to TGF-beta signal transduction.
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IDA
-    original_reference_id: PMID:20599712
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20599712
-          supporting_text: Tumor suppressor, AT motif binding factor 1 (ATBF1), 
-            translocates to the nucleus with runt domain transcription factor 3 
-            (RUNX3) in response to TGF-beta signal transduction.
-  - term:
-      id: GO:0045893
-      label: positive regulation of DNA-templated transcription
-    evidence_type: IDA
-    original_reference_id: PMID:20599712
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20599712
-          supporting_text: Tumor suppressor, AT motif binding factor 1 (ATBF1), 
-            translocates to the nucleus with runt domain transcription factor 3 
-            (RUNX3) in response to TGF-beta signal transduction.
-  - term:
-      id: GO:0071559
-      label: response to transforming growth factor beta
-    evidence_type: IDA
-    original_reference_id: PMID:20599712
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20599712
-          supporting_text: Tumor suppressor, AT motif binding factor 1 (ATBF1), 
-            translocates to the nucleus with runt domain transcription factor 3 
-            (RUNX3) in response to TGF-beta signal transduction.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:17377532
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17377532
-          supporting_text: Foxp3 controls regulatory T-cell function by 
-            interacting with AML1/Runx1.
-  - term:
-      id: GO:0000785
-      label: chromatin
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0000977
-      label: RNA polymerase II transcription regulatory region sequence-specific
-        DNA binding
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0000122
-      label: negative regulation of transcription by RNA polymerase II
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0000981
-      label: DNA-binding transcription factor activity, RNA polymerase 
-        II-specific
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0048935
-      label: peripheral nervous system neuron development
-    evidence_type: TAS
-    original_reference_id: PMID:20096094
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20096094
-          supporting_text: Brn3a regulates neuronal subtype specification in the
-            trigeminal ganglion by promoting Runx expression during sensory 
-            differentiation.
-  - term:
-      id: GO:0005634
-      label: nucleus
-    evidence_type: IDA
-    original_reference_id: PMID:20100835
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20100835
-          supporting_text: Epub 2010 Jan 25. Src kinase phosphorylates RUNX3 at 
-            tyrosine residues and localizes the protein in the cytoplasm.
-  - term:
-      id: GO:0006468
-      label: protein phosphorylation
-    evidence_type: IDA
-    original_reference_id: PMID:20100835
-    review:
-      summary: >-
-        MISANNOTATION: RUNX3 is a Runt-domain transcription factor that is extensively
-        PHOSPHORYLATED by kinases. PMID:20100835 title is "Src kinase phosphorylates
-        RUNX3 at tyrosine residues" - RUNX3 is the SUBSTRATE of Src kinase, not an
-        enzyme. The paper states "overexpression of Src results in the tyrosine
-        phosphorylation... of RUNX3" and shows Src phosphorylates RUNX3 in vitro.
-        RUNX3 has DNA-binding and transcription factor activity, not kinase activity.
-        Phosphorylation of RUNX3 by Src leads to its cytoplasmic mislocalization.
-      action: REMOVE
-      supported_by:
-        - reference_id: PMID:20100835
-          supporting_text: Epub 2010 Jan 25. Src kinase phosphorylates RUNX3 at 
-            tyrosine residues and localizes the protein in the cytoplasm.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:20100835
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20100835
-          supporting_text: Epub 2010 Jan 25. Src kinase phosphorylates RUNX3 at 
-            tyrosine residues and localizes the protein in the cytoplasm.
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IDA
-    original_reference_id: PMID:20100835
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20100835
-          supporting_text: Epub 2010 Jan 25. Src kinase phosphorylates RUNX3 at 
-            tyrosine residues and localizes the protein in the cytoplasm.
-  - term:
-      id: GO:0045786
-      label: negative regulation of cell cycle
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0050680
-      label: negative regulation of epithelial cell proliferation
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0003700
-      label: DNA-binding transcription factor activity
-    evidence_type: TAS
-    original_reference_id: PMID:7607690
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:7607690
-          supporting_text: Identification of a new murine runt domain-containing
-            gene, Cbfa3, and localization of the human homolog, CBFA3, to 
-            chromosome 1p35-pter.
-  - term:
-      id: GO:0005524
-      label: ATP binding
-    evidence_type: NAS
-    original_reference_id: PMID:7835892
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:7835892
-          supporting_text: 'AML1, AML2, and AML3, the human members of the runt domain
-            gene-family: cDNA structure, expression, and chromosomal localization.'
-  - term:
-      id: GO:0006355
-      label: regulation of DNA-templated transcription
-    evidence_type: NAS
-    original_reference_id: PMID:7622058
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:7622058
-          supporting_text: Cloning, mapping and expression of PEBP2 alpha C, a 
-            third gene encoding the mammalian Runt domain.
-references:
-  - id: GO_REF:0000002
-    title: Gene Ontology annotation through association of InterPro records with
-      GO terms
-    findings: []
-  - id: GO_REF:0000024
-    title: Manual transfer of experimentally-verified manual GO annotation data 
-      to orthologs by curator judgment of sequence similarity
-    findings: []
-  - id: GO_REF:0000033
-    title: Annotation inferences using phylogenetic trees
-    findings: []
-  - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt
-    findings: []
-  - id: GO_REF:0000052
-    title: Gene Ontology annotation based on curation of immunofluorescence data
-    findings: []
-  - id: GO_REF:0000113
-    title: Gene Ontology annotation of human sequence-specific DNA binding 
-      transcription factors (DbTFs) based on the TFClass database
-    findings: []
-  - id: GO_REF:0000117
-    title: Electronic Gene Ontology annotations created by ARBA machine learning
-      models
-    findings: []
-  - id: GO_REF:0000120
-    title: Combined Automated Annotation using Multiple IEA Methods
-    findings: []
-  - id: PMID:17377532
-    title: Foxp3 controls regulatory T-cell function by interacting with 
-      AML1/Runx1.
-    findings: []
-  - id: PMID:18258917
-    title: Repression of the transcription factor Th-POK by Runx complexes in 
-      cytotoxic T cell development.
-    findings: []
-  - id: PMID:18772112
-    title: RUNX3 attenuates beta-catenin/T cell factors in intestinal 
-      tumorigenesis.
-    findings: []
-  - id: PMID:20096094
-    title: Brn3a regulates neuronal subtype specification in the trigeminal 
-      ganglion by promoting Runx expression during sensory differentiation.
-    findings: []
-  - id: PMID:20100835
-    title: Src kinase phosphorylates RUNX3 at tyrosine residues and localizes 
-      the protein in the cytoplasm.
-    findings: []
-  - id: PMID:20591170
-    title: The Runx transcriptional co-activator, CBFbeta, is essential for 
-      invasion of breast cancer cells.
-    findings: []
-  - id: PMID:20599712
-    title: Tumor suppressor, AT motif binding factor 1 (ATBF1), translocates to 
-      the nucleus with runt domain transcription factor 3 (RUNX3) in response to
-      TGF-beta signal transduction.
-    findings: []
-  - id: PMID:24229708
-    title: Runx3 inactivation is a crucial early event in the development of 
-      lung adenocarcinoma.
-    findings: []
-  - id: PMID:28473536
-    title: Impact of cytosine methylation on DNA binding specificities of human 
-      transcription factors.
-    findings: []
-  - id: PMID:33961781
-    title: Dual proteome-scale networks reveal cell-specific remodeling of the 
-      human interactome.
-    findings: []
-  - id: PMID:38424632
-    title: Ubiquitylation of RUNX3 by RNA-binding ubiquitin ligase MEX3C 
-      promotes tumorigenesis in lung adenocarcinoma.
-    findings: []
-  - id: PMID:7607690
-    title: Identification of a new murine runt domain-containing gene, Cbfa3, 
-      and localization of the human homolog, CBFA3, to chromosome 1p35-pter.
-    findings: []
-  - id: PMID:7622058
-    title: Cloning, mapping and expression of PEBP2 alpha C, a third gene 
-      encoding the mammalian Runt domain.
-    findings: []
-  - id: PMID:7835892
-    title: 'AML1, AML2, and AML3, the human members of the runt domain gene-family:
-      cDNA structure, expression, and chromosomal localization.'
-    findings: []
-  - id: PMID:9751710
-    title: Transcriptional repression by AML1 and LEF-1 is mediated by the 
+    supported_by: *id002
+- term:
+    id: GO:0045893
+    label: positive regulation of DNA-templated transcription
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Positive regulation of DNA-templated transcription is supported in context-specific
+      RUNX3 target-gene programs.
+    action: ACCEPT
+    reason: RUNX3 can activate transcriptional targets, although the direction of regulation is
+      context dependent.
+    supported_by: &id008
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its
+        primary function is as a **sequence-specific DNA-binding transcription factor** that
+        regulates gene expression programs by binding target regulatory elements via the **Runt
+        domain**, typically stabilized by heterodimerization with **CBFβ**.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: A 2024 study (Cancer Research Communications) presented evidence that RUNX3
+        can be **pro-metastatic** in a gastric cancer model (HGC-27), where CRISPR KO reduced
+        migration/invasion/anchorage-independent growth and suppressed liver metastasis in vivo.
+        Multi-omic mapping (ChIP-seq, HiChIP) supported direct transcriptional control of
+        metastasis-associated targets including **WNT5A**, **CD44**, and **VIM**, with WNT5A
+        functioning as a major effector.
+- term:
+    id: GO:1990837
+    label: sequence-specific double-stranded DNA binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: sequence-specific double-stranded DNA binding is supported by RUNX3 Runt-domain
+      sequence-specific DNA binding.
+    action: ACCEPT
+    reason: Sequence-specific regulatory-region DNA binding is central to RUNX3 transcription factor
+      function.
+    supported_by: *id003
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:18772112
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: &id004
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors
+        defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with
+        CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and
+        modulates transcriptional activity.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: 'A key 2023 advance demonstrated a **direct protein–protein mechanism** linking
+        RUNX3 to oncogene control: RUNX3 binds **MYC** directly via the **Runt domain**, disrupts MYC’s
+        transcriptionally active complexes (MYC–MAX and MYC–MIZ1), increases **GSK3β-mediated phosphorylation
+        of MYC at T58**, and promotes **FBXW7-dependent K48-linked ubiquitination** and proteasomal degradation
+        of MYC.'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:24229708
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: *id004
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: *id004
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:38424632
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: *id004
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:9751710
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: *id004
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: cytosol localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0006357
+    label: regulation of transcription by RNA polymerase II
+  evidence_type: IDA
+  original_reference_id: PMID:20591170
+  review:
+    summary: Regulation of transcription by RNA polymerase II is a core RUNX3 biological process.
+    action: ACCEPT
+    reason: RUNX3 regulates gene-expression programs as a nuclear sequence-specific transcription
+      factor.
+    supported_by: *id002
+- term:
+    id: GO:0001222
+    label: transcription corepressor binding
+  evidence_type: IPI
+  original_reference_id: PMID:9751710
+  review:
+    summary: Transcription corepressor binding is supported by RUNX/Runt-domain recruitment of
       TLE/Groucho corepressors.
-    findings: []
-  - id: Reactome:R-HSA-8865454
-    title: CBFB binds RUNX3
-    findings: []
-  - id: Reactome:R-HSA-8878117
-    title: RUNX3 binds ZFHX3
-    findings: []
-  - id: Reactome:R-HSA-8878143
-    title: RUNX3 binds SMAD3 and SMAD4
-    findings: []
-  - id: Reactome:R-HSA-8878178
-    title: The complex of RUNX3, SMAD3 and SMAD4 binds the CDKN1A gene promoter
-    findings: []
-  - id: Reactome:R-HSA-8878193
-    title: RUNX3 binds the JAG1 gene promoter
-    findings: []
-  - id: Reactome:R-HSA-8878220
-    title: RUNX3 binds the NOTCH1 coactivator complex
-    findings: []
-  - id: Reactome:R-HSA-8878237
-    title: RUNX3:NOTCH1 coactivator complex binds the HES1 gene promoter
-    findings: []
-  - id: Reactome:R-HSA-8937792
-    title: RUNX3 binds SRC
-    findings: []
-  - id: Reactome:R-HSA-8937807
-    title: SRC phosphorylates RUNX3
-    findings: []
-  - id: Reactome:R-HSA-8937814
-    title: RUNX3 translocates to the nucleus
-    findings: []
-  - id: Reactome:R-HSA-8949335
-    title: RUNX3:CBFB binds the ITGAL gene,(ITGA4 gene) promoter
-    findings: []
-  - id: Reactome:R-HSA-8951428
-    title: RUNX3 binds CTNNB1:TCF7L2,(LEF1,TCF7L1,TCF7)
-    findings: []
-  - id: Reactome:R-HSA-8951676
-    title: RUNX3 binds TEADs and YAP1
-    findings: []
-  - id: Reactome:R-HSA-8951910
-    title: RUNX3 binds the RUNX1 promoter
-    findings: []
-  - id: Reactome:R-HSA-8951951
-    title: RUNX3 binds EP300
-    findings: []
-  - id: Reactome:R-HSA-8951966
-    title: EP300 acetylates RUNX3
-    findings: []
-  - id: Reactome:R-HSA-8951977
-    title: Acetylated RUNX3 binds to BRD2
-    findings: []
-  - id: Reactome:R-HSA-8952058
-    title: CCND1 binds RUNX3 and displaces EP300
-    findings: []
-  - id: Reactome:R-HSA-8952062
-    title: CCND1 recruits HDAC4 to RUNX3
-    findings: []
-  - id: Reactome:R-HSA-8952069
-    title: HDAC4 deacetylates RUNX3
-    findings: []
-  - id: Reactome:R-HSA-8952128
-    title: RUNX3 binds TP53
-    findings: []
-  - id: Reactome:R-HSA-8952226
-    title: RUNX3 binds the BCL2L11 (BIM) gene
-    findings: []
-  - id: Reactome:R-HSA-8952371
-    title: MDM2 binds RUNX3
-    findings: []
-  - id: Reactome:R-HSA-8952382
-    title: MDM2 polyubiquitinates RUNX3
-    findings: []
-  - id: Reactome:R-HSA-8952399
-    title: Polyubiquitinated RUNX3 translocates to the cytosol
-    findings: []
-  - id: Reactome:R-HSA-8952408
-    title: Polyubiquitinated RUNX3 is degraded by the proteasome
-    findings: []
-  - id: Reactome:R-HSA-8952419
-    title: SMURFs ubiquitinate RUNX3
-    findings: []
+    action: ACCEPT
+    reason: This is a more informative binding annotation than generic protein binding for
+      RUNX3-associated transcriptional repression.
+    supported_by:
+    - reference_id: PMID:9751710
+      supporting_text: The mammalian AML/CBFalpha runt domain (RD) transcription factors regulate
+        hematopoiesis and osteoblast differentiation. Like their Drosophila counterparts, most
+        mammalian RD proteins terminate in a common pentapeptide, VWRPY, which serves to recruit the
+        corepressor Groucho (Gro).
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its
+        primary function is as a **sequence-specific DNA-binding transcription factor** that
+        regulates gene expression programs by binding target regulatory elements via the **Runt
+        domain**, typically stabilized by heterodimerization with **CBFβ**.
+- term:
+    id: GO:1990837
+    label: sequence-specific double-stranded DNA binding
+  evidence_type: IDA
+  original_reference_id: PMID:28473536
+  review:
+    summary: sequence-specific double-stranded DNA binding is supported by RUNX3 Runt-domain
+      sequence-specific DNA binding.
+    action: ACCEPT
+    reason: Sequence-specific regulatory-region DNA binding is central to RUNX3 transcription factor
+      function.
+    supported_by: *id003
+- term:
+    id: GO:0000785
+    label: chromatin
+  evidence_type: ISA
+  original_reference_id: GO_REF:0000113
+  review:
+    summary: Chromatin localization is supported by RUNX3 DNA, mononucleosome, and
+      chromatin-remodeler-associated activity.
+    action: ACCEPT
+    reason: RUNX3 binds chromatin-associated regulatory DNA as part of its transcription factor
+      function.
+    supported_by: &id009
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin
+        accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 associates with **CBFβ** and chromatin remodeler machinery including
+        SWI/SNF components; the **Runt domain** is implicated as critical for interactions with
+        chromatin factors in this metastatic gastric cancer model.
+- term:
+    id: GO:0000981
+    label: DNA-binding transcription factor activity, RNA polymerase II-specific
+  evidence_type: ISA
+  original_reference_id: GO_REF:0000113
+  review:
+    summary: DNA-binding transcription factor activity, RNA polymerase II-specific is the
+      best-supported core molecular function of RUNX3.
+    action: ACCEPT
+    reason: RUNX3 is a sequence-specific Runt-domain transcription factor that regulates RNA
+      polymerase II transcription through DNA/chromatin binding and CBFβ-associated complexes.
+    supported_by: *id002
+- term:
+    id: GO:0016513
+    label: core-binding factor complex
+  evidence_type: TAS
+  original_reference_id: PMID:18258917
+  review:
+    summary: Core-binding factor complex is the canonical RUNX3 transcription factor complex
+      context.
+    action: ACCEPT
+    reason: RUNX3 heterodimerizes with CBFβ, placing it in the core-binding factor complex for
+      DNA-binding transcriptional regulation.
+    supported_by:
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors
+        defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with
+        CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and
+        modulates transcriptional activity.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 associates with **CBFβ** and chromatin remodeler machinery including
+        SWI/SNF components; the **Runt domain** is implicated as critical for interactions with
+        chromatin factors in this metastatic gastric cancer model.
+- term:
+    id: GO:0043371
+    label: negative regulation of CD4-positive, alpha-beta T cell differentiation
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: negative regulation of CD4-positive, alpha-beta T cell differentiation is a supported
+      RUNX3 biological role, especially in immune differentiation, but it is downstream of the
+      transcription factor core function.
+    action: KEEP_AS_NON_CORE
+    reason: T-cell differentiation phenotypes reflect RUNX3-regulated transcriptional programs
+      rather than a separate core molecular activity.
+    supported_by: &id007
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 is a key regulator of **CD8+ T-cell differentiation, infiltration,
+        effector/memory fate, and residency**.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: '**RUNX3 is a master developmental transcription factor** whose dysregulation can
+        impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).'
+- term:
+    id: GO:0043378
+    label: positive regulation of CD8-positive, alpha-beta T cell differentiation
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: positive regulation of CD8-positive, alpha-beta T cell differentiation is a supported
+      RUNX3 biological role, especially in immune differentiation, but it is downstream of the
+      transcription factor core function.
+    action: KEEP_AS_NON_CORE
+    reason: T-cell differentiation phenotypes reflect RUNX3-regulated transcriptional programs
+      rather than a separate core molecular activity.
+    supported_by: *id007
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952419
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952399
+  review:
+    summary: cytosol localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952408
+  review:
+    summary: cytosol localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952382
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952399
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8951966
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8951977
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952058
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952062
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952069
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8937792
+  review:
+    summary: cytosol localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8937807
+  review:
+    summary: cytosol localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8937814
+  review:
+    summary: cytosol localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8865454
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8878117
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8878143
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8878178
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8878193
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8878220
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8878237
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8937814
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8949335
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8951428
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8951676
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8951910
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8951951
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952128
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952226
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005654
+    label: nucleoplasm
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8952371
+  review:
+    summary: nucleoplasm localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20599712
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: *id004
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IDA
+  original_reference_id: PMID:20599712
+  review:
+    summary: nucleus localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:20599712
+  review:
+    summary: cytoplasm localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0045893
+    label: positive regulation of DNA-templated transcription
+  evidence_type: IDA
+  original_reference_id: PMID:20599712
+  review:
+    summary: Positive regulation of DNA-templated transcription is supported in context-specific
+      RUNX3 target-gene programs.
+    action: ACCEPT
+    reason: RUNX3 can activate transcriptional targets, although the direction of regulation is
+      context dependent.
+    supported_by: *id008
+- term:
+    id: GO:0071559
+    label: response to transforming growth factor beta
+  evidence_type: IDA
+  original_reference_id: PMID:20599712
+  review:
+    summary: Response to transforming growth factor beta is supported as a pathway context for RUNX3
+      transcriptional regulation.
+    action: KEEP_AS_NON_CORE
+    reason: TGF-beta/SMAD effects are important context-specific biology, but the core function
+      remains nuclear sequence-specific transcriptional regulation.
+    supported_by:
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: A 2024 review of RUNX transcription factors synthesizes RUNX3 as a regulator
+        embedded in major cancer-relevant pathways, including **TGF-β/SMAD**, **Wnt/β-catenin**, and
+        **Hippo–YAP** crosstalk, and emphasizes frequent RUNX3 inactivation through **promoter
+        hypermethylation, histone modifications, and mislocalization**.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: '**RUNX3 is a master developmental transcription factor** whose dysregulation can
+        impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.).'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:17377532
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: *id004
+- term:
+    id: GO:0000785
+    label: chromatin
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: Chromatin localization is supported by RUNX3 DNA, mononucleosome, and
+      chromatin-remodeler-associated activity.
+    action: ACCEPT
+    reason: RUNX3 binds chromatin-associated regulatory DNA as part of its transcription factor
+      function.
+    supported_by: *id009
+- term:
+    id: GO:0000977
+    label: RNA polymerase II transcription regulatory region sequence-specific DNA binding
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: RNA polymerase II transcription regulatory region sequence-specific DNA binding is
+      supported by RUNX3 Runt-domain sequence-specific DNA binding.
+    action: ACCEPT
+    reason: Sequence-specific regulatory-region DNA binding is central to RUNX3 transcription factor
+      function.
+    supported_by: *id003
+- term:
+    id: GO:0000122
+    label: negative regulation of transcription by RNA polymerase II
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: Negative regulation of transcription by RNA polymerase II is supported for RUNX3 in
+      repressive target-gene and Wnt/TCF contexts.
+    action: ACCEPT
+    reason: RUNX3 can repress transcriptional outputs through protein complexes and target-gene
+      regulation.
+    supported_by:
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its
+        primary function is as a **sequence-specific DNA-binding transcription factor** that
+        regulates gene expression programs by binding target regulatory elements via the **Runt
+        domain**, typically stabilized by heterodimerization with **CBFβ**.
+    - reference_id: PMID:18772112
+      supporting_text: Here we found that RUNX3, a gastric tumor suppressor, forms a ternary complex
+        with beta-catenin/TCF4 and attenuates Wnt signaling activity.
+- term:
+    id: GO:0000981
+    label: DNA-binding transcription factor activity, RNA polymerase II-specific
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: DNA-binding transcription factor activity, RNA polymerase II-specific is the
+      best-supported core molecular function of RUNX3.
+    action: ACCEPT
+    reason: RUNX3 is a sequence-specific Runt-domain transcription factor that regulates RNA
+      polymerase II transcription through DNA/chromatin binding and CBFβ-associated complexes.
+    supported_by: *id002
+- term:
+    id: GO:0048935
+    label: peripheral nervous system neuron development
+  evidence_type: TAS
+  original_reference_id: PMID:20096094
+  review:
+    summary: peripheral nervous system neuron development is consistent with RUNX3 developmental or
+      disease-associated transcriptional programs but is not the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: *id001
+- term:
+    id: GO:0005634
+    label: nucleus
+  evidence_type: IDA
+  original_reference_id: PMID:20100835
+  review:
+    summary: nucleus localization is central to RUNX3 canonical transcription factor activity.
+    action: ACCEPT
+    reason: RUNX3 acts in the nucleus/nucleoplasm to bind chromatin and regulate transcription.
+    supported_by: *id005
+- term:
+    id: GO:0006468
+    label: protein phosphorylation
+  evidence_type: IDA
+  original_reference_id: PMID:20100835
+  review:
+    summary: Protein phosphorylation is not supported as a process carried out by RUNX3.
+    action: REMOVE
+    reason: The cited biology describes Src-mediated phosphorylation of RUNX3, making RUNX3 the
+      substrate rather than the kinase or causal gene product for protein phosphorylation.
+    supported_by:
+    - reference_id: PMID:20100835
+      supporting_text: In this study, we found that the overexpression of Src results in the
+        tyrosine phosphorylation and cytoplasmic localization of RUNX3.
+    - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+      supporting_text: RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin
+        and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization**
+        can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides
+        a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export
+        machinery.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20100835
+  review:
+    summary: Protein binding is supported in many RUNX3 contexts but is too generic to describe the
+      main function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: RUNX3 has specific partner interactions such as CBFβ, MYC, TLE/corepressors, SMADs, and
+      chromatin factors, but the unqualified protein binding term is not informative for curation.
+    supported_by: *id004
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IDA
+  original_reference_id: PMID:20100835
+  review:
+    summary: cytoplasm localization is supported, but mainly as a mislocalization/export or
+      degradation context rather than the canonical site of RUNX3 function.
+    action: KEEP_AS_NON_CORE
+    reason: RUNX3 core activity is nuclear transcriptional regulation; cytoplasmic/cytosolic
+      localization is best treated as a regulated non-core or inactivation-associated state.
+    supported_by: *id006
+- term:
+    id: GO:0045786
+    label: negative regulation of cell cycle
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: negative regulation of cell cycle is consistent with RUNX3 developmental or
+      disease-associated transcriptional programs but is not the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: *id001
+- term:
+    id: GO:0050680
+    label: negative regulation of epithelial cell proliferation
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: negative regulation of epithelial cell proliferation is consistent with RUNX3
+      developmental or disease-associated transcriptional programs but is not the core molecular
+      function.
+    action: KEEP_AS_NON_CORE
+    reason: These developmental, cell-cycle, or tissue-level outcomes are downstream consequences of
+      RUNX3 transcription factor activity and should not be treated as the core function itself.
+    supported_by: *id001
+- term:
+    id: GO:0003700
+    label: DNA-binding transcription factor activity
+  evidence_type: TAS
+  original_reference_id: PMID:7607690
+  review:
+    summary: Generic DNA-binding transcription factor activity is correct but less precise than the
+      RNA polymerase II-specific term already present.
+    action: MODIFY
+    reason: RUNX3 functions as a sequence-specific RNA polymerase II transcription factor, so the
+      more specific term is preferred.
+    proposed_replacement_terms: *id010
+    supported_by: *id002
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: NAS
+  original_reference_id: PMID:7835892
+  review:
+    summary: ATP binding is not supported as a RUNX3 molecular function.
+    action: REMOVE
+    reason: RUNX3 is a non-enzymatic DNA-binding transcription factor; ATP-dependent
+      chromatin-remodeling context should not be transferred to RUNX3 as ATP binding.
+    supported_by: *id011
+- term:
+    id: GO:0006355
+    label: regulation of DNA-templated transcription
+  evidence_type: NAS
+  original_reference_id: PMID:7622058
+  review:
+    summary: Generic regulation of DNA-templated transcription is supported but should be captured
+      with the RNA polymerase II-specific process.
+    action: MODIFY
+    reason: RUNX3 target-gene regulation is best represented by regulation of transcription by RNA
+      polymerase II.
+    proposed_replacement_terms: *id012
+    supported_by: *id002
+references:
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by
+    curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000113
+  title: Gene Ontology annotation of human sequence-specific DNA binding transcription factors
+    (DbTFs) based on the TFClass database
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:17377532
+  title: Foxp3 controls regulatory T-cell function by interacting with AML1/Runx1.
+  findings: []
+- id: PMID:18258917
+  title: Repression of the transcription factor Th-POK by Runx complexes in cytotoxic T cell
+    development.
+  findings: []
+- id: PMID:18772112
+  title: RUNX3 attenuates beta-catenin/T cell factors in intestinal tumorigenesis.
+  findings: []
+- id: PMID:20096094
+  title: Brn3a regulates neuronal subtype specification in the trigeminal ganglion by promoting Runx
+    expression during sensory differentiation.
+  findings: []
+- id: PMID:20100835
+  title: Src kinase phosphorylates RUNX3 at tyrosine residues and localizes the protein in the
+    cytoplasm.
+  findings: []
+- id: PMID:20591170
+  title: The Runx transcriptional co-activator, CBFbeta, is essential for invasion of breast cancer
+    cells.
+  findings: []
+- id: PMID:20599712
+  title: Tumor suppressor, AT motif binding factor 1 (ATBF1), translocates to the nucleus with runt
+    domain transcription factor 3 (RUNX3) in response to TGF-beta signal transduction.
+  findings: []
+- id: PMID:24229708
+  title: Runx3 inactivation is a crucial early event in the development of lung adenocarcinoma.
+  findings: []
+- id: PMID:28473536
+  title: Impact of cytosine methylation on DNA binding specificities of human transcription factors.
+  findings: []
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
+  findings: []
+- id: PMID:38424632
+  title: Ubiquitylation of RUNX3 by RNA-binding ubiquitin ligase MEX3C promotes tumorigenesis in
+    lung adenocarcinoma.
+  findings: []
+- id: PMID:7607690
+  title: Identification of a new murine runt domain-containing gene, Cbfa3, and localization of the
+    human homolog, CBFA3, to chromosome 1p35-pter.
+  findings: []
+- id: PMID:7622058
+  title: Cloning, mapping and expression of PEBP2 alpha C, a third gene encoding the mammalian Runt
+    domain.
+  findings: []
+- id: PMID:7835892
+  title: 'AML1, AML2, and AML3, the human members of the runt domain gene-family: cDNA structure, expression,
+    and chromosomal localization.'
+  findings: []
+- id: PMID:9751710
+  title: Transcriptional repression by AML1 and LEF-1 is mediated by the TLE/Groucho corepressors.
+  findings: []
+- id: Reactome:R-HSA-8865454
+  title: CBFB binds RUNX3
+  findings: []
+- id: Reactome:R-HSA-8878117
+  title: RUNX3 binds ZFHX3
+  findings: []
+- id: Reactome:R-HSA-8878143
+  title: RUNX3 binds SMAD3 and SMAD4
+  findings: []
+- id: Reactome:R-HSA-8878178
+  title: The complex of RUNX3, SMAD3 and SMAD4 binds the CDKN1A gene promoter
+  findings: []
+- id: Reactome:R-HSA-8878193
+  title: RUNX3 binds the JAG1 gene promoter
+  findings: []
+- id: Reactome:R-HSA-8878220
+  title: RUNX3 binds the NOTCH1 coactivator complex
+  findings: []
+- id: Reactome:R-HSA-8878237
+  title: RUNX3:NOTCH1 coactivator complex binds the HES1 gene promoter
+  findings: []
+- id: Reactome:R-HSA-8937792
+  title: RUNX3 binds SRC
+  findings: []
+- id: Reactome:R-HSA-8937807
+  title: SRC phosphorylates RUNX3
+  findings: []
+- id: Reactome:R-HSA-8937814
+  title: RUNX3 translocates to the nucleus
+  findings: []
+- id: Reactome:R-HSA-8949335
+  title: RUNX3:CBFB binds the ITGAL gene,(ITGA4 gene) promoter
+  findings: []
+- id: Reactome:R-HSA-8951428
+  title: RUNX3 binds CTNNB1:TCF7L2,(LEF1,TCF7L1,TCF7)
+  findings: []
+- id: Reactome:R-HSA-8951676
+  title: RUNX3 binds TEADs and YAP1
+  findings: []
+- id: Reactome:R-HSA-8951910
+  title: RUNX3 binds the RUNX1 promoter
+  findings: []
+- id: Reactome:R-HSA-8951951
+  title: RUNX3 binds EP300
+  findings: []
+- id: Reactome:R-HSA-8951966
+  title: EP300 acetylates RUNX3
+  findings: []
+- id: Reactome:R-HSA-8951977
+  title: Acetylated RUNX3 binds to BRD2
+  findings: []
+- id: Reactome:R-HSA-8952058
+  title: CCND1 binds RUNX3 and displaces EP300
+  findings: []
+- id: Reactome:R-HSA-8952062
+  title: CCND1 recruits HDAC4 to RUNX3
+  findings: []
+- id: Reactome:R-HSA-8952069
+  title: HDAC4 deacetylates RUNX3
+  findings: []
+- id: Reactome:R-HSA-8952128
+  title: RUNX3 binds TP53
+  findings: []
+- id: Reactome:R-HSA-8952226
+  title: RUNX3 binds the BCL2L11 (BIM) gene
+  findings: []
+- id: Reactome:R-HSA-8952371
+  title: MDM2 binds RUNX3
+  findings: []
+- id: Reactome:R-HSA-8952382
+  title: MDM2 polyubiquitinates RUNX3
+  findings: []
+- id: Reactome:R-HSA-8952399
+  title: Polyubiquitinated RUNX3 translocates to the cytosol
+  findings: []
+- id: Reactome:R-HSA-8952408
+  title: Polyubiquitinated RUNX3 is degraded by the proteasome
+  findings: []
+- id: Reactome:R-HSA-8952419
+  title: SMURFs ubiquitinate RUNX3
+  findings: []
+- id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+  title: Falcon deep research synthesis for RUNX3
+  findings: []
+core_functions:
+- description: Nuclear Runt-domain sequence-specific transcription factor activity in
+    CBFβ/core-binding factor complexes, regulating RNA polymerase II target-gene programs through
+    chromatin and regulatory-region DNA binding.
+  molecular_function:
+    id: GO:0000981
+    label: DNA-binding transcription factor activity, RNA polymerase II-specific
+  directly_involved_in:
+  - id: GO:0006357
+    label: regulation of transcription by RNA polymerase II
+  - id: GO:0045893
+    label: positive regulation of DNA-templated transcription
+  - id: GO:0000122
+    label: negative regulation of transcription by RNA polymerase II
+  locations:
+  - id: GO:0005634
+    label: nucleus
+  - id: GO:0005654
+    label: nucleoplasm
+  - id: GO:0000785
+    label: chromatin
+  in_complex:
+    id: GO:0016513
+    label: core-binding factor complex
+  supported_by:
+  - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+    supporting_text: RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its
+      primary function is as a **sequence-specific DNA-binding transcription factor** that regulates
+      gene expression programs by binding target regulatory elements via the **Runt domain**,
+      typically stabilized by heterodimerization with **CBFβ**.
+  - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+    supporting_text: RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors
+      defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with
+      CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and
+      modulates transcriptional activity.
+  - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+    supporting_text: RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin
+      accessibility and transcriptional programs (ATAC-seq/RNA-seq integration).
+  - reference_id: file:human/RUNX3/RUNX3-deep-research-falcon.md
+    supporting_text: RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin
+      and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization**
+      can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a
+      mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery.
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []

--- a/genes/human/RUNX3/RUNX3-deep-research-falcon.md
+++ b/genes/human/RUNX3/RUNX3-deep-research-falcon.md
@@ -1,0 +1,416 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-12T00:40:12.704795'
+end_time: '2026-05-12T00:59:19.684433'
+duration_seconds: 1146.98
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: RUNX3
+  gene_symbol: RUNX3
+  uniprot_accession: Q13761
+  protein_description: 'RecName: Full=Runt-related transcription factor 3; AltName:
+    Full=Acute myeloid leukemia 2 protein; AltName: Full=Core-binding factor subunit
+    alpha-3; Short=CBF-alpha-3; AltName: Full=Oncogene AML-2; AltName: Full=Polyomavirus
+    enhancer-binding protein 2 alpha C subunit; Short=PEA2-alpha C; Short=PEBP2-alpha
+    C; AltName: Full=SL3-3 enhancer factor 1 alpha C subunit; AltName: Full=SL3/AKV
+    core-binding factor alpha C subunit;'
+  gene_info: Name=RUNX3; Synonyms=AML2, CBFA3, PEBP2A3;
+  organism_full: Homo sapiens (Human).
+  protein_family: Not specified in UniProt
+  protein_domains: AML1_Runt. (IPR000040); p53-like_TF_DNA-bd_sf. (IPR008967); p53/RUNT-type_TF_DNA-bd_sf.
+    (IPR012346); Runt_dom. (IPR013524); RunxI_C_dom. (IPR013711)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 46
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q13761
+- **Protein Description:** RecName: Full=Runt-related transcription factor 3; AltName: Full=Acute myeloid leukemia 2 protein; AltName: Full=Core-binding factor subunit alpha-3; Short=CBF-alpha-3; AltName: Full=Oncogene AML-2; AltName: Full=Polyomavirus enhancer-binding protein 2 alpha C subunit; Short=PEA2-alpha C; Short=PEBP2-alpha C; AltName: Full=SL3-3 enhancer factor 1 alpha C subunit; AltName: Full=SL3/AKV core-binding factor alpha C subunit;
+- **Gene Information:** Name=RUNX3; Synonyms=AML2, CBFA3, PEBP2A3;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** AML1_Runt. (IPR000040); p53-like_TF_DNA-bd_sf. (IPR008967); p53/RUNT-type_TF_DNA-bd_sf. (IPR012346); Runt_dom. (IPR013524); RunxI_C_dom. (IPR013711)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "RUNX3" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'RUNX3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **RUNX3** (gene ID: RUNX3, UniProt: Q13761) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q13761
+- **Protein Description:** RecName: Full=Runt-related transcription factor 3; AltName: Full=Acute myeloid leukemia 2 protein; AltName: Full=Core-binding factor subunit alpha-3; Short=CBF-alpha-3; AltName: Full=Oncogene AML-2; AltName: Full=Polyomavirus enhancer-binding protein 2 alpha C subunit; Short=PEA2-alpha C; Short=PEBP2-alpha C; AltName: Full=SL3-3 enhancer factor 1 alpha C subunit; AltName: Full=SL3/AKV core-binding factor alpha C subunit;
+- **Gene Information:** Name=RUNX3; Synonyms=AML2, CBFA3, PEBP2A3;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Not specified in UniProt
+- **Key Domains:** AML1_Runt. (IPR000040); p53-like_TF_DNA-bd_sf. (IPR008967); p53/RUNT-type_TF_DNA-bd_sf. (IPR012346); Runt_dom. (IPR013524); RunxI_C_dom. (IPR013711)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "RUNX3" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'RUNX3' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **RUNX3** (gene ID: RUNX3, UniProt: Q13761) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Comprehensive research report: Human RUNX3 (UniProt Q13761)
+
+### Scope and identity verification (critical)
+The target protein is **human RUNX3** (gene symbol **RUNX3**, UniProt **Q13761**), described in UniProt as *Runt-related transcription factor 3* with a conserved **Runt (AML1_Runt) DNA-binding domain** and C-terminal RUNX interaction region. In the literature retrieved here, the entity called RUNX3 is consistently described as a **Runt-domain transcription factor that heterodimerizes with CBFβ (core-binding factor β)** and regulates gene expression through sequence-specific DNA binding—matching the defining biochemical/structural properties expected for UniProt Q13761. However, within the retrieved full-text sources, **the UniProt accession “Q13761” is not explicitly mentioned**, so mapping is based on concordance of gene/protein name, organism (human), and domain/function description rather than a direct accession cross-reference. (chen2024runxtranscriptionfactors pages 1-2, mahmoud2024runx3actsas pages 6-8)
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 RUNX3 as a Runt-domain transcription factor and CBF complex component
+RUNX family proteins (RUNX1/2/3) are sequence-specific transcription factors defined by a conserved **Runt DNA-binding domain**; they functionally **heterodimerize with CBFβ**, a non–DNA-binding partner that stabilizes RUNX binding to target DNA elements and modulates transcriptional activity. This “core-binding factor” logic is foundational for interpreting RUNX3 function as a transcriptional regulator rather than an enzyme or transporter. (chen2024runxtranscriptionfactors pages 1-2)
+
+#### 1.2 RUNX3 molecular function: transcriptional regulation plus chromatin-linked activities
+Beyond “transcription factor” as a label, recent mechanistic work supports RUNX3 as a chromatin-associated regulator with features often attributed to **pioneer/chromatin-binding factors**:
+- RUNX3 can bind DNA and **mononucleosomes**, and RUNX3 loss alters chromatin accessibility and transcriptional programs (ATAC-seq/RNA-seq integration). (mahmoud2024runx3actsas pages 36-38, mahmoud2024runx3actsas pages 38-43)
+- RUNX3 associates with **CBFβ** and chromatin remodeler machinery including SWI/SNF components; the **Runt domain** is implicated as critical for interactions with chromatin factors in this metastatic gastric cancer model. (mahmoud2024runx3actsas pages 6-8, mahmoud2024runx3actsas pages 38-43)
+
+#### 1.3 Subcellular localization as a functional control point
+Because RUNX3 is a transcription factor, **nuclear localization** is essential for its canonical function. A recurring cancer mechanism is **functional inactivation by cytoplasmic mislocalization** (i.e., preventing nuclear transcriptional regulation). RUNX3 mislocalization is not merely correlative: oxidative stress can actively shift RUNX3 from nucleus to cytoplasm via a defined pathway (HDAC1/G9a→Src→RUNX3 phosphorylation→JAB1/CRM1-mediated export), coupled to proteasomal loss. (kang2024oxidativestressmediatedrunx3 pages 4-9, kang2024oxidativestressmediatedrunx3 pages 9-13)
+
+### 2) Recent developments and latest research (prioritizing 2023–2024)
+
+#### 2.1 A 2023 mechanistic advance: RUNX3 directly destabilizes oncogenic MYC
+A key 2023 advance demonstrated a **direct protein–protein mechanism** linking RUNX3 to oncogene control: RUNX3 binds **MYC** directly via the **Runt domain**, disrupts MYC’s transcriptionally active complexes (MYC–MAX and MYC–MIZ1), increases **GSK3β-mediated phosphorylation of MYC at T58**, and promotes **FBXW7-dependent K48-linked ubiquitination** and proteasomal degradation of MYC. This provides a concrete molecular basis for tumor-suppressive activity in contexts where MYC is a driver. (oei2023runx3inactivatesoncogenic pages 1-2, oei2023runx3inactivatesoncogenic pages 4-7, oei2023runx3inactivatesoncogenic pages 7-9, oei2023runx3inactivatesoncogenic pages 9-11)
+
+Quantitative kinetic evidence was provided in cell systems: RUNX3 expression shortened MYC half-life (e.g., ~30→20 minutes in one system and ~32→23 minutes in another), supporting rapid post-translational control. (oei2023runx3inactivatesoncogenic pages 4-7)
+
+#### 2.2 2024: RUNX3 regulation by stress/epigenetic enzymes and mislocalization (oxidative stress → inactivation)
+A 2024 study elucidated a pathway by which oxidative stress in colon cancer cells induces RUNX3 inactivation by **nuclear export and cytoplasmic accumulation**, integrating chromatin-modifier activity with signaling:
+- Oxidative stress increased **HDAC1** and **G9a/EHMT2** and activated **Src**, resulting in RUNX3 tyrosine phosphorylation.
+- RUNX3 interacted with **JAB1** and **CRM1**, promoting CRM1-dependent export and proteasome-mediated depletion; JAB1 knockdown or CRM1 inhibition restored nuclear RUNX3.
+This provides a mechanistic explanation for the often-cited phenomenon of RUNX3 cytoplasmic mislocalization as a route to functional loss. (kang2024oxidativestressmediatedrunx3 pages 4-9, kang2024oxidativestressmediatedrunx3 pages 9-13)
+
+#### 2.3 2024: post-translational downregulation by ubiquitin ligase MEX3C in lung adenocarcinoma
+A 2024 translational mechanistic study in lung adenocarcinoma (LUAD) reported that the RNA-binding E3 ligase **MEX3C** promotes tumor phenotypes by **ubiquitylating and degrading RUNX3** (protein-level regulation without corresponding mRNA change). The same study supports a downstream transcriptional axis where RUNX3 represses **Suv39H1**, positioning MEX3C→RUNX3↓→Suv39H1↑ as a tumor-promoting pathway. (he2024ubiquitylationofrunx3 pages 9-11, he2024ubiquitylationofrunx3 pages 11-15)
+
+#### 2.4 2024: RUNX3 can be contextually pro-metastatic in gastric cancer via WNT5A and developmental programs
+A 2024 study (Cancer Research Communications) presented evidence that RUNX3 can be **pro-metastatic** in a gastric cancer model (HGC-27), where CRISPR KO reduced migration/invasion/anchorage-independent growth and suppressed liver metastasis in vivo. Multi-omic mapping (ChIP-seq, HiChIP) supported direct transcriptional control of metastasis-associated targets including **WNT5A**, **CD44**, and **VIM**, with WNT5A functioning as a major effector. This highlights a key modern theme: **RUNX3 can act as tumor suppressor or oncogenic driver depending on cellular context and regulatory state**. (suda2024aberrantupregulationof pages 5-8, suda2024aberrantupregulationof pages 8-10, suda2024aberrantupregulationof pages 1-2, suda2024aberrantupregulationof pages 10-11)
+
+#### 2.5 2024 review synthesis: RUNX3 intersects canonical signaling pathways (TGF-β/SMAD; Wnt; Hippo)
+A 2024 review of RUNX transcription factors synthesizes RUNX3 as a regulator embedded in major cancer-relevant pathways, including **TGF-β/SMAD**, **Wnt/β-catenin**, and **Hippo–YAP** crosstalk, and emphasizes frequent RUNX3 inactivation through **promoter hypermethylation, histone modifications, and mislocalization**. (chen2024runxtranscriptionfactors pages 1-2, chen2024runxtranscriptionfactors pages 18-19)
+
+Within TGF-β signaling specifically, the 2024 review cites contexts where RUNX3 overexpression suppresses **Smad2/3 phosphorylation** and inhibits TGF-β/Smad-driven EMT and invasion, while also noting context-dependence (e.g., SMAD4/Dpc4 status in pancreatic cancer). (chen2024runxtranscriptionfactors pages 12-14)
+
+### 3) Current applications and real-world implementations
+
+#### 3.1 Immunotherapy sensitization via RUNX3 epigenetic reprogramming (clinical translational mechanism)
+A 2023 Molecular Cancer study connects RUNX3 to a clinically relevant immunotherapy strategy: **decitabine (DNA-demethylating agent) priming** can demethylate the **RUNX3 promoter** in CD8+ T cells, increase RUNX3 expression, promote CD8+ infiltration, and reduce exhaustion; crucially, conditional Runx3 loss in T cells abrogated the benefit of decitabine as a sensitizer for anti-PD-1 therapy in mouse models. (liu2023epigeneticreprogrammingof pages 1-2, liu2023epigeneticreprogrammingof pages 2-4, liu2023epigeneticreprogrammingof pages 9-12, liu2023epigeneticreprogrammingof pages 7-9)
+
+This work explicitly reports clinically relevant response statistics (from prior clinical work cited within the paper): combining low-dose decitabine with PD-1 blockade increased complete response in classical Hodgkin lymphoma from **32% to 71%**. (liu2023epigeneticreprogrammingof pages 1-2, liu2023epigeneticreprogrammingof pages 2-4)
+
+#### 3.2 Real-world engineered cell therapy: RUNX3-coexpressing CAR-T (phase I trial)
+A direct “real-world implementation” of RUNX3 biology is its use as an engineered transcription factor cargo in CAR-T products. Fu et al. reported a first-in-human, single-center, single-arm phase I trial (NCT03980288) of **CT017**, a **GPC3-targeting CAR T cell** product that **co-expresses RUNX3** (via an F2A peptide) for heavily pretreated, GPC3+ hepatocellular carcinoma. (fu2023runx3expressingcart pages 1-2, fu2023runx3expressingcart pages 2-3)
+
+Key clinical statistics:
+- **N=6** evaluable patients (7 infusions; one patient treated twice); dose 250×10^6 cells. (fu2023runx3expressingcart pages 1-2, fu2023runx3expressingcart pages 5-6)
+- Safety: cytokine release syndrome (CRS) occurred in all patients; **3/6 grade 3** CRS; no ICANS observed; CRS resolved. (fu2023runx3expressingcart pages 1-2, fu2023runx3expressingcart pages 6-7, fu2023runx3expressingcart media 6458455b)
+- Efficacy: **ORR 16.7%** (1 partial response) and **DCR 50%** (PR+SD); median PFS 3.5 months; median OS 7.9 months. (fu2023runx3expressingcart pages 1-2, fu2023runx3expressingcart pages 7-8)
+- Persistence: CAR-GPC3 DNA peaked around day 7 and was detectable at day 28, with reported persistence duration (median ~34 days). (fu2023runx3expressingcart pages 6-7, fu2023runx3expressingcart media 006d89ce)
+
+(Visual evidence supporting the above endpoints is available in the trial’s Table/Figure crops.) (fu2023runx3expressingcart media 6458455b, fu2023runx3expressingcart media 006d89ce, fu2023runx3expressingcart media 9604a628)
+
+### 4) Expert opinions and authoritative analysis (2023–2024 emphasis)
+
+#### 4.1 Consensus themes from recent reviews
+Recent reviews converge on several expert-level interpretations:
+1. **RUNX3 is a master developmental transcription factor** whose dysregulation can impact multiple hallmark pathways (TGF-β, Wnt/β-catenin, Hippo-YAP, Notch/MAPK, etc.). (chen2024runxtranscriptionfactors pages 1-2, chen2024runxtranscriptionfactors pages 18-19)
+2. RUNX3 exhibits **context dependence**, with the same factor acting as tumor suppressor or tumor promoter depending on tumor type, stage, co-mutations, and signaling context. (chen2024runxtranscriptionfactors pages 18-19, chen2024runxtranscriptionfactors pages 12-14, suda2024aberrantupregulationof pages 5-8)
+3. Non-genetic mechanisms—**promoter hypermethylation**, histone/chromatin changes, and **protein mislocalization**—are repeatedly emphasized as major routes to RUNX3 functional loss, often more prominent than coding mutations. (chen2024runxtranscriptionfactors pages 1-2, kang2024oxidativestressmediatedrunx3 pages 4-9)
+
+#### 4.2 RUNX3 as a Hippo pathway brake via TEAD competition
+A 2023 gastric cancer Hippo-pathway review specifically highlights a downstream mechanism in which factors including **RUNX3** can bind **TEAD** and antagonize **YAP–TEAD** interaction via competitive binding dynamics, positioning RUNX3 as a negative regulator of oncogenic YAP/TEAD transcriptional output in relevant contexts. (messina2023hippopathwaydysregulation pages 2-3, messina2023hippopathwaydysregulation pages 10-11)
+
+### 5) Relevant statistics and data from recent studies
+
+#### 5.1 Human cohort/clinical data examples (2023–2024)
+- **RUNX3 epigenetic immunotherapy link (2023):** cited clinical improvement with DAC+anti-PD-1 in cHL from **32% to 71% complete response**; multiomic profiling included methylation arrays with **829,120 CpGs in 25 samples** after QC and expression validation in **48** patients for qRT-PCR. (liu2023epigeneticreprogrammingof pages 1-2, liu2023epigeneticreprogrammingof pages 2-4, liu2023epigeneticreprogrammingof pages 4-5)
+- **RUNX3-engineered CAR-T phase I in HCC (2023):** N=6 evaluable; ORR **16.7%**, DCR **50%**; CRS grade 3 in **3/6**; no ICANS; median PFS **3.5 months**; median OS **7.9 months**. (fu2023runx3expressingcart pages 1-2, fu2023runx3expressingcart pages 7-8, fu2023runx3expressingcart pages 6-7, fu2023runx3expressingcart media 6458455b)
+- **MEX3C–RUNX3 axis in LUAD (2024):** clinical paired-sample cohort **n=55**; negative mRNA correlation (r≈−0.615, p<0.0001) between MEX3C and RUNX3; xenograft/metastasis animal experiments reported **n=5/group**. (he2024ubiquitylationofrunx3 pages 11-15, he2024ubiquitylationofrunx3 pages 6-9)
+- **Gastric metastasis program (2024):** tumor immunofluorescence correlation between RUNX3 and WNT5A in cancer cells reported in resected tumors (**n=35**, r≈0.474, P<0.01). (suda2024aberrantupregulationof pages 11-13)
+
+#### 5.2 Disease-association landscape (database summary)
+Open Targets links RUNX3 to immune/allergic disease phenotypes (e.g., asthma, psoriasis, allergic rhinitis, eczematoid dermatitis) with moderate association scores and supporting literature evidence counts, consistent with RUNX3’s known roles in immune cell differentiation and tissue inflammation. (OpenTargets Search: -RUNX3)
+
+---
+
+## Functional annotation summary (what RUNX3 “does,” where it acts, and pathways)
+
+### Primary molecular role
+RUNX3 is **not an enzyme** and does not catalyze a chemical reaction; its primary function is as a **sequence-specific DNA-binding transcription factor** that regulates gene expression programs by binding target regulatory elements via the **Runt domain**, typically stabilized by heterodimerization with **CBFβ**. (chen2024runxtranscriptionfactors pages 1-2)
+
+### Where RUNX3 acts in the cell
+RUNX3’s canonical site of action is the **nucleus**, where it binds chromatin and regulates transcription. Multiple studies emphasize that **cytoplasmic mislocalization** can functionally inactivate RUNX3 by preventing nuclear activity; oxidative stress provides a mechanistic route for nuclear export via Src phosphorylation and JAB1/CRM1 export machinery. (kang2024oxidativestressmediatedrunx3 pages 4-9, kang2024oxidativestressmediatedrunx3 pages 9-13)
+
+### Pathway-level roles (mechanistic examples)
+1. **MYC control:** RUNX3 binds MYC and triggers phosphorylation-dependent ubiquitin-mediated MYC degradation via GSK3β–FBXW7. (oei2023runx3inactivatesoncogenic pages 1-2, oei2023runx3inactivatesoncogenic pages 7-9)
+2. **TGF-β/SMAD:** RUNX3 is repeatedly linked to TGF-β/Smad EMT regulation; review synthesis includes suppression of Smad2/3 phosphorylation and context dependence (e.g., SMAD4 status). (chen2024runxtranscriptionfactors pages 12-14)
+3. **Hippo–YAP/TEAD:** RUNX3 is cited as a TEAD-binding competitor that can inhibit YAP–TEAD complex formation and activity in gastric cancer–relevant Hippo pathway frameworks. (messina2023hippopathwaydysregulation pages 2-3, messina2023hippopathwaydysregulation pages 10-11)
+4. **Noncanonical Wnt/metastasis program:** in a gastric cancer model, RUNX3 directly activates WNT5A and other metastasis-related targets (CD44, VIM) using enhancer–promoter topology. (suda2024aberrantupregulationof pages 5-8, suda2024aberrantupregulationof pages 8-10)
+5. **Immune differentiation and therapy response:** RUNX3 promoter methylation status controls RUNX3 expression in CD8+ T cells, shaping infiltration/exhaustion and determining whether demethylating therapy can sensitize to PD-1 blockade. (liu2023epigeneticreprogrammingof pages 1-2, liu2023epigeneticreprogrammingof pages 2-4, liu2023epigeneticreprogrammingof pages 9-12)
+
+---
+
+## Summary table of mechanisms and applications
+The following table consolidates RUNX3 identity, pathways, localization, and translational evidence, emphasizing 2023–2024 results and quantitative endpoints:
+
+| Aspect | Summary for human RUNX3 (UniProt Q13761) | Representative recent study / quantitative detail |
+|---|---|---|
+| Molecular identity | RUNX3 matches the human **Runt-related transcription factor 3** described for UniProt Q13761; RUNX proteins are sequence-specific transcription factors with a conserved **Runt DNA-binding domain** that heterodimerize with **CBFβ**, which stabilizes DNA binding and transcriptional function. RUNX3 is repeatedly discussed in cancer and immune literature as this CBFβ-partnered Runt-domain TF, consistent with the UniProt annotation and domain architecture (chen2024runxtranscriptionfactors pages 1-2, mahmoud2024runx3actsas pages 6-8). | Chen et al., **2024-03**, *Clinical and Experimental Medicine*, https://doi.org/10.1007/s10238-023-01281-0; Mahmoud et al., **2024-08**, *bioRxiv*, https://doi.org/10.1101/2024.08.16.608297 (chen2024runxtranscriptionfactors pages 1-2, mahmoud2024runx3actsas pages 6-8) |
+| Primary molecular functions | RUNX3 functions as a **DNA-binding transcriptional regulator** and protein-interaction hub. Beyond canonical transcriptional control, recent work supports **chromatin/pioneer-like activity**: RUNX3 binds DNA and mononucleosomes, associates with SWI/SNF and other chromatin factors, and the Runt domain is required for interactions with chromatin remodelers. Proteomics identified **1,227 candidate interacting proteins**, with enrichment for ATP-dependent chromatin remodeling; RUNX3 loss reduced SWI/SNF components and altered chromatin accessibility/transcriptional programs (mahmoud2024runx3actsas pages 6-8, mahmoud2024runx3actsas pages 36-38, mahmoud2024runx3actsas pages 38-43, mahmoud2024runx3actsas pages 24-26). | Mahmoud et al., **2024-08**, https://doi.org/10.1101/2024.08.16.608297; tissue array **n=59**, KM-plotter gastric cohort **n=875**; low vs high RUNX3 groups **526 vs 349**, *P*=0.0002 (mahmoud2024runx3actsas pages 6-8, mahmoud2024runx3actsas pages 38-43) |
+| TGF-β/SMAD axis | RUNX3 is a major RUNX-family node in **TGF-β signaling**. Review-level synthesis indicates that RUNX3 overexpression can **suppress Smad2/3 phosphorylation**, inhibit TGF-β/Smad-driven EMT/invasion, and that loss of RUNX3 by hypermethylation is linked to metastatic progression. However, this role is **context dependent**; in pancreatic ductal adenocarcinoma, RUNX3 may restrain proliferation yet facilitate migration/invasion depending on **SMAD4/Dpc4 status** (chen2024runxtranscriptionfactors pages 12-14, chen2024runxtranscriptionfactors pages 17-18). | Chen et al., **2024-03**, https://doi.org/10.1007/s10238-023-01281-0 (chen2024runxtranscriptionfactors pages 12-14, chen2024runxtranscriptionfactors pages 17-18) |
+| Hippo–YAP/TEAD axis | RUNX3 is described as a **negative regulator of the oncogenic TEAD–YAP complex**. Recent reviews summarize that RUNX3 can **bind TEAD competitively** and antagonize YAP–TEAD transcriptional output, placing RUNX3 as a Hippo-pathway brake; gastric-cancer Hippo review cites RUNX3 among factors that inhibit YAP–TEAD interaction in a competitive dynamic (chen2024runxtranscriptionfactors pages 18-19, messina2023hippopathwaydysregulation pages 2-3, messina2023hippopathwaydysregulation pages 10-11). | Messina et al., **2023-01**, *Cell Death & Disease*, https://doi.org/10.1038/s41419-023-05568-8; Chen et al., **2024-03**, https://doi.org/10.1007/s10238-023-01281-0 (chen2024runxtranscriptionfactors pages 18-19, messina2023hippopathwaydysregulation pages 2-3, messina2023hippopathwaydysregulation pages 10-11) |
+| MYC control / tumor-suppressive protein interaction | A 2023 mechanistic study showed RUNX3 directly binds **MYC** via the **Runt domain**, disrupts **MYC–MAX** and **MYC–MIZ1** complexes, enhances **GSK3β-mediated T58 phosphorylation**, recruits **FBXW7**, and drives **K48-linked ubiquitin-proteasomal MYC degradation**. Interaction occurs mainly in the nucleus, and a Runt-domain mutant (**R122C**) loses this MYC-destabilizing activity (oei2023runx3inactivatesoncogenic pages 1-2, oei2023runx3inactivatesoncogenic pages 4-7, oei2023runx3inactivatesoncogenic pages 7-9, oei2023runx3inactivatesoncogenic pages 9-11). | Oei et al., **2023-07**, *Communications Biology*, https://doi.org/10.1038/s42003-023-05037-0; MYC half-life shortened from ~**30→20 min** in HeLa and ~**32→23 min** in MKN28 with RUNX3 expression (oei2023runx3inactivatesoncogenic pages 4-7) |
+| Subcellular localization / inactivation | RUNX3 is primarily a **nuclear transcription factor**, but **cytoplasmic mislocalization** is a recurrent inactivation mechanism in cancer. Oxidative stress can drive nuclear-to-cytoplasmic relocalization through **HDAC1/G9a upregulation → Src activation → RUNX3 tyrosine phosphorylation → JAB1/CRM1-mediated export**, with subsequent proteasomal degradation; NAC, HDAC1/G9a knockdown, JAB1 knockdown, or CRM1 inhibition restore nuclear RUNX3 (chen2024runxtranscriptionfactors pages 1-2, kang2024oxidativestressmediatedrunx3 pages 4-9, kang2024oxidativestressmediatedrunx3 pages 9-13, kang2024oxidativestressmediatedrunx3 pages 1-4). | Kang et al., **2024-04**, *Applied Biochemistry and Biotechnology*, https://doi.org/10.1007/s12010-024-04944-0; oxidative stress model used **100 μM H2O2** (kang2024oxidativestressmediatedrunx3 pages 4-9) |
+| Post-translational downregulation by MEX3C | In lung adenocarcinoma, the RNA-binding E3 ligase **MEX3C** binds RUNX3 and promotes **RUNX3 ubiquitylation/proteasomal degradation**, without materially changing RUNX3 mRNA. Downstream, RUNX3 represses **Suv39H1**; thus the **MEX3C→RUNX3↓→Suv39H1↑** axis promotes proliferation, migration, invasion, EMT-like programs, and tumor growth/metastasis (he2024ubiquitylationofrunx3 pages 9-11, he2024ubiquitylationofrunx3 pages 11-15, he2024ubiquitylationofrunx3 pages 6-9). | He et al., **2024-02**, *Journal of Translational Medicine*, https://doi.org/10.1186/s12967-023-04700-8; clinical LUAD cohort **n=55** paired tumors, MEX3C–RUNX3 mRNA correlation **r = -0.6151, p < 0.0001**; xenograft/metastasis assays reported **n=5/group** (he2024ubiquitylationofrunx3 pages 11-15, he2024ubiquitylationofrunx3 pages 15-18, he2024ubiquitylationofrunx3 pages 6-9) |
+| WNT5A / gastric metastasis axis | RUNX3 can also act **pro-metastatically in gastric cancer**. CRISPR KO in HGC-27 cells reduced migration, invasion, anchorage-independent growth, xenograft growth, and liver metastasis. Multi-omic mapping showed RUNX3 directly regulates metastasis/developmental genes including **WNT5A, CD44, VIM**, with ChIP-seq and HiChIP linking RUNX3-bound distal elements/promoters to these loci; **WNT5A** emerged as a main functional effector (suda2024aberrantupregulationof pages 5-8, suda2024aberrantupregulationof pages 8-10, suda2024aberrantupregulationof pages 1-2, suda2024aberrantupregulationof pages 11-13). | Suda et al., **2024-02**, *Cancer Research Communications*, https://doi.org/10.1158/2767-9764.crc-22-0165; resected tumor IF showed RUNX3–WNT5A correlation in cancer cells **n=35**, Pearson **r = 0.4744, P < 0.01** (suda2024aberrantupregulationof pages 11-13) |
+| CD8+ T-cell differentiation / immunotherapy | RUNX3 is a key regulator of **CD8+ T-cell differentiation, infiltration, effector/memory fate, and residency**. In Hodgkin lymphoma immunotherapy studies, **promoter P2 demethylation** increased RUNX3 expression, promoted CD8+ TIL infiltration, reduced exhaustion, and was required for decitabine (DAC) to sensitize tumors to anti-PD-1; conditional Runx3 loss reduced effector/memory T cells and CCR3/CCR5 and abrogated DAC benefit (liu2023epigeneticreprogrammingof pages 1-2, liu2023epigeneticreprogrammingof pages 2-4, liu2023epigeneticreprogrammingof pages 9-12, liu2023epigeneticreprogrammingof pages 7-9). | Liu et al., **2023-05**, *Molecular Cancer*, https://doi.org/10.1186/s12943-023-01768-0; low-dose DAC + anti-PD-1 increased complete response in cHL from **32% to 71%**; prior PD-1 failures had **70%** re-response and **28%** CR; EPIC/RNA-seq high-throughput subset **10 samples**; **829,120 CpGs in 25 samples** after QC; qRT-PCR cohort **48 patients** (liu2023epigeneticreprogrammingof pages 1-2, liu2023epigeneticreprogrammingof pages 2-4, liu2023epigeneticreprogrammingof pages 4-5) |
+| Real-world implementation: RUNX3-engineered cell therapy | RUNX3 has already been used in a **first-in-human CAR-T implementation**: CT017 co-expresses a GPC3 CAR and **RUNX3** (via F2A peptide) to enhance tumor infiltration, persistence, and tissue-resident features. This is a real-world therapeutic implementation of RUNX3 biology in advanced hepatocellular carcinoma (fu2023runx3expressingcart pages 1-2, fu2023runx3expressingcart pages 2-3, fu2023runx3expressingcart pages 10-10). | Fu et al., **2023-09**, *eClinicalMedicine*, https://doi.org/10.1016/j.eclinm.2023.102175; phase I, **N=6** evaluable, **1 PR + 2 SD** → **ORR 16.7%**, **DCR 50%**, median **PFS 3.5 mo**, median **OS 7.9 mo**; all had CRS, **3/6 grade 3**, no ICANS; CAR DNA peaked day 7, detectable median **34 days** (fu2023runx3expressingcart pages 1-2, fu2023runx3expressingcart pages 7-8, fu2023runx3expressingcart pages 6-7, fu2023runx3expressingcart media 6458455b) |
+| Biomarker / prognostic use | Current expert opinion supports RUNX3 as a **biomarker candidate** rather than a routine standalone clinical marker. RUNX3 expression or pathway signatures have been associated with prognosis, immunotherapy response, and epigenetic state; reviews emphasize its potential value but also note strong **tumor-context dependence** and bidirectional roles in solid tumors (chen2024runxtranscriptionfactors pages 18-19, chen2024runxtranscriptionfactors pages 17-18, liu2023epigeneticreprogrammingof pages 12-14). | Wang et al., **2024-01**, *BMC Urology*, https://doi.org/10.1186/s12894-023-01356-w; in advanced RCC, high RUNX3 pathway signature associated with shorter PFS in two IO/TKI cohorts (**P=0.025** and **P=0.019**) and correlated with fewer **GZMB+ CD8+ T cells** (ρ = **-0.42**, *P*=0.006) (liu2023epigeneticreprogrammingof pages 12-14) |
+| Disease-association landscape | Open Targets links RUNX3 to immune/allergic disease traits including **asthma, psoriasis, allergic rhinitis, eczematoid dermatitis**, supporting its broader immunoregulatory relevance beyond cancer, though evidence strength is moderate and disease-specific mechanisms vary (OpenTargets Search: -RUNX3). | Open Targets association scores: asthma **0.5383**, psoriasis **0.5274**, allergic disease **0.5233**, allergic rhinitis **0.4926**, eczematoid dermatitis **0.4782** (OpenTargets Search: -RUNX3) |
+
+
+*Table: This table condenses verified identity, mechanisms, localization, pathways, and translational evidence for human RUNX3 (UniProt Q13761). It is designed to support a comprehensive annotation narrative while highlighting key 2023–2024 studies and quantitative findings.*
+
+## Figures/tables supporting clinical implementation evidence
+- CT017 trial safety table and CAR-T kinetics/response plots (cropped visual evidence). (fu2023runx3expressingcart media 6458455b, fu2023runx3expressingcart media 006d89ce, fu2023runx3expressingcart media 9604a628)
+
+## Limitations of this evidence set
+1. **Direct UniProt accession linkage:** none of the retrieved full texts explicitly mention “UniProt Q13761,” so accession-level verification is inferential (name/domain/organism concordance). (chen2024runxtranscriptionfactors pages 1-2)
+2. **Context dependence:** RUNX3 can act as tumor suppressor or promoter depending on tissue and regulatory context; mechanistic claims should therefore be interpreted within the experimental system described (e.g., LUAD vs gastric cancer metastasis models). (chen2024runxtranscriptionfactors pages 12-14, suda2024aberrantupregulationof pages 5-8)
+
+## Key references (publication date; URL)
+- Chen X et al. **2024-03**. *Clinical and Experimental Medicine.* RUNX transcription factors: biological functions and implications in cancer. https://doi.org/10.1007/s10238-023-01281-0 (chen2024runxtranscriptionfactors pages 1-2)
+- Oei V et al. **2023-07**. *Communications Biology.* RUNX3 inactivates oncogenic MYC via MYC/MAX disruption and GSK3β–FBXW7. https://doi.org/10.1038/s42003-023-05037-0 (oei2023runx3inactivatesoncogenic pages 1-2)
+- Kang KA et al. **2024-04**. *Applied Biochemistry and Biotechnology.* Oxidative stress-mediated RUNX3 mislocalization via JAB1 and histone modification. https://doi.org/10.1007/s12010-024-04944-0 (kang2024oxidativestressmediatedrunx3 pages 4-9)
+- He Z et al. **2024-02**. *Journal of Translational Medicine.* MEX3C ubiquitylates RUNX3 in LUAD. https://doi.org/10.1186/s12967-023-04700-8 (he2024ubiquitylationofrunx3 pages 11-15)
+- Suda K et al. **2024-02**. *Cancer Research Communications.* RUNX3 upregulation drives gastric cancer metastasis via WNT5A. https://doi.org/10.1158/2767-9764.crc-22-0165 (suda2024aberrantupregulationof pages 5-8)
+- Liu Z et al. **2023-05**. *Molecular Cancer.* RUNX3 epigenetic reprogramming reinforces CD8+ T cells and improves immunotherapy response. https://doi.org/10.1186/s12943-023-01768-0 (liu2023epigeneticreprogrammingof pages 1-2)
+- Fu Q et al. **2023-09**. *eClinicalMedicine.* RUNX-3-expressing CAR-T cells targeting GPC3 in advanced HCC (phase I). https://doi.org/10.1016/j.eclinm.2023.102175 (fu2023runx3expressingcart pages 1-2)
+- Messina B et al. **2023-01**. *Cell Death & Disease.* Hippo pathway dysregulation in gastric cancer; TEAD-binding competitors including RUNX3. https://doi.org/10.1038/s41419-023-05568-8 (messina2023hippopathwaydysregulation pages 2-3)
+- Open Targets Platform (retrieved via tool): RUNX3 disease associations (asthma/psoriasis/allergic traits). https://platform.opentargets.org/target/ENSG00000020633 (OpenTargets Search: -RUNX3)
+
+
+References
+
+1. (chen2024runxtranscriptionfactors pages 1-2): Xinyi Chen, Lu Wang, Mu Yang, Weiheng Zhao, Jingyao Tu, Bo Liu, and Xianglin Yuan. Runx transcription factors: biological functions and implications in cancer. Clinical and Experimental Medicine, Mar 2024. URL: https://doi.org/10.1007/s10238-023-01281-0, doi:10.1007/s10238-023-01281-0. This article has 17 citations and is from a peer-reviewed journal.
+
+2. (mahmoud2024runx3actsas pages 6-8): Salma Awad Mahmoud, Isabelle Bonne, Aik Yong Sim, and Gehan Labib Abuelenain. Runx3 acts as homodimeric chromatin binding factor regulating heterochromatin-mediated cancerous phenotype. bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.08.16.608297, doi:10.1101/2024.08.16.608297. This article has 1 citations.
+
+3. (mahmoud2024runx3actsas pages 36-38): Salma Awad Mahmoud, Isabelle Bonne, Aik Yong Sim, and Gehan Labib Abuelenain. Runx3 acts as homodimeric chromatin binding factor regulating heterochromatin-mediated cancerous phenotype. bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.08.16.608297, doi:10.1101/2024.08.16.608297. This article has 1 citations.
+
+4. (mahmoud2024runx3actsas pages 38-43): Salma Awad Mahmoud, Isabelle Bonne, Aik Yong Sim, and Gehan Labib Abuelenain. Runx3 acts as homodimeric chromatin binding factor regulating heterochromatin-mediated cancerous phenotype. bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.08.16.608297, doi:10.1101/2024.08.16.608297. This article has 1 citations.
+
+5. (kang2024oxidativestressmediatedrunx3 pages 4-9): Kyoung Ah Kang, Mei Jing Piao, Pincha Devage Sameera Madushan Fernando, Herath Mudiyanselage Udari Lakmini Herath, Hye-Jin Boo, Sang Pil Yoon, and Jin Won Hyun. Oxidative stress-mediated runx3 mislocalization occurs via jun activation domain-binding protein 1 and histone modification. Applied Biochemistry and Biotechnology, 196:8082-8095, Apr 2024. URL: https://doi.org/10.1007/s12010-024-04944-0, doi:10.1007/s12010-024-04944-0. This article has 7 citations and is from a peer-reviewed journal.
+
+6. (kang2024oxidativestressmediatedrunx3 pages 9-13): Kyoung Ah Kang, Mei Jing Piao, Pincha Devage Sameera Madushan Fernando, Herath Mudiyanselage Udari Lakmini Herath, Hye-Jin Boo, Sang Pil Yoon, and Jin Won Hyun. Oxidative stress-mediated runx3 mislocalization occurs via jun activation domain-binding protein 1 and histone modification. Applied Biochemistry and Biotechnology, 196:8082-8095, Apr 2024. URL: https://doi.org/10.1007/s12010-024-04944-0, doi:10.1007/s12010-024-04944-0. This article has 7 citations and is from a peer-reviewed journal.
+
+7. (oei2023runx3inactivatesoncogenic pages 1-2): Vincent Oei, Linda Shyue Huey Chuang, Junichi Matsuo, Supriya Srivastava, Ming Teh, and Yoshiaki Ito. Runx3 inactivates oncogenic myc through disruption of myc/max complex and subsequent recruitment of gsk3β-fbxw7 cascade. Communications Biology, Jul 2023. URL: https://doi.org/10.1038/s42003-023-05037-0, doi:10.1038/s42003-023-05037-0. This article has 5 citations and is from a peer-reviewed journal.
+
+8. (oei2023runx3inactivatesoncogenic pages 4-7): Vincent Oei, Linda Shyue Huey Chuang, Junichi Matsuo, Supriya Srivastava, Ming Teh, and Yoshiaki Ito. Runx3 inactivates oncogenic myc through disruption of myc/max complex and subsequent recruitment of gsk3β-fbxw7 cascade. Communications Biology, Jul 2023. URL: https://doi.org/10.1038/s42003-023-05037-0, doi:10.1038/s42003-023-05037-0. This article has 5 citations and is from a peer-reviewed journal.
+
+9. (oei2023runx3inactivatesoncogenic pages 7-9): Vincent Oei, Linda Shyue Huey Chuang, Junichi Matsuo, Supriya Srivastava, Ming Teh, and Yoshiaki Ito. Runx3 inactivates oncogenic myc through disruption of myc/max complex and subsequent recruitment of gsk3β-fbxw7 cascade. Communications Biology, Jul 2023. URL: https://doi.org/10.1038/s42003-023-05037-0, doi:10.1038/s42003-023-05037-0. This article has 5 citations and is from a peer-reviewed journal.
+
+10. (oei2023runx3inactivatesoncogenic pages 9-11): Vincent Oei, Linda Shyue Huey Chuang, Junichi Matsuo, Supriya Srivastava, Ming Teh, and Yoshiaki Ito. Runx3 inactivates oncogenic myc through disruption of myc/max complex and subsequent recruitment of gsk3β-fbxw7 cascade. Communications Biology, Jul 2023. URL: https://doi.org/10.1038/s42003-023-05037-0, doi:10.1038/s42003-023-05037-0. This article has 5 citations and is from a peer-reviewed journal.
+
+11. (he2024ubiquitylationofrunx3 pages 9-11): Zelai He, Huijun Zhang, Hai-bo Xiao, Xiangyu Zhang, Hongbo Xu, Ruifen Sun, and Siwen Li. Ubiquitylation of runx3 by rna-binding ubiquitin ligase mex3c promotes tumorigenesis in lung adenocarcinoma. Journal of Translational Medicine, Feb 2024. URL: https://doi.org/10.1186/s12967-023-04700-8, doi:10.1186/s12967-023-04700-8. This article has 10 citations and is from a peer-reviewed journal.
+
+12. (he2024ubiquitylationofrunx3 pages 11-15): Zelai He, Huijun Zhang, Hai-bo Xiao, Xiangyu Zhang, Hongbo Xu, Ruifen Sun, and Siwen Li. Ubiquitylation of runx3 by rna-binding ubiquitin ligase mex3c promotes tumorigenesis in lung adenocarcinoma. Journal of Translational Medicine, Feb 2024. URL: https://doi.org/10.1186/s12967-023-04700-8, doi:10.1186/s12967-023-04700-8. This article has 10 citations and is from a peer-reviewed journal.
+
+13. (suda2024aberrantupregulationof pages 5-8): Kazuto Suda, Atsushi Okabe, Junichi Matsuo, Linda Shyue Huey Chuang, Ying Li, Nawaphat Jangphattananont, Naing Naing Mon, Khine Nyein Myint, Akihiro Yamamura, Jimmy Bok-Yan So, Dominic Chih-Cheng Voon, Henry Yang, Khay Guan Yeoh, Atsushi Kaneda, and Yoshiaki Ito. Aberrant upregulation of runx3 activates developmental genes to drive metastasis in gastric cancer. Cancer Research Communications, 4:279-292, Feb 2024. URL: https://doi.org/10.1158/2767-9764.crc-22-0165, doi:10.1158/2767-9764.crc-22-0165. This article has 7 citations and is from a peer-reviewed journal.
+
+14. (suda2024aberrantupregulationof pages 8-10): Kazuto Suda, Atsushi Okabe, Junichi Matsuo, Linda Shyue Huey Chuang, Ying Li, Nawaphat Jangphattananont, Naing Naing Mon, Khine Nyein Myint, Akihiro Yamamura, Jimmy Bok-Yan So, Dominic Chih-Cheng Voon, Henry Yang, Khay Guan Yeoh, Atsushi Kaneda, and Yoshiaki Ito. Aberrant upregulation of runx3 activates developmental genes to drive metastasis in gastric cancer. Cancer Research Communications, 4:279-292, Feb 2024. URL: https://doi.org/10.1158/2767-9764.crc-22-0165, doi:10.1158/2767-9764.crc-22-0165. This article has 7 citations and is from a peer-reviewed journal.
+
+15. (suda2024aberrantupregulationof pages 1-2): Kazuto Suda, Atsushi Okabe, Junichi Matsuo, Linda Shyue Huey Chuang, Ying Li, Nawaphat Jangphattananont, Naing Naing Mon, Khine Nyein Myint, Akihiro Yamamura, Jimmy Bok-Yan So, Dominic Chih-Cheng Voon, Henry Yang, Khay Guan Yeoh, Atsushi Kaneda, and Yoshiaki Ito. Aberrant upregulation of runx3 activates developmental genes to drive metastasis in gastric cancer. Cancer Research Communications, 4:279-292, Feb 2024. URL: https://doi.org/10.1158/2767-9764.crc-22-0165, doi:10.1158/2767-9764.crc-22-0165. This article has 7 citations and is from a peer-reviewed journal.
+
+16. (suda2024aberrantupregulationof pages 10-11): Kazuto Suda, Atsushi Okabe, Junichi Matsuo, Linda Shyue Huey Chuang, Ying Li, Nawaphat Jangphattananont, Naing Naing Mon, Khine Nyein Myint, Akihiro Yamamura, Jimmy Bok-Yan So, Dominic Chih-Cheng Voon, Henry Yang, Khay Guan Yeoh, Atsushi Kaneda, and Yoshiaki Ito. Aberrant upregulation of runx3 activates developmental genes to drive metastasis in gastric cancer. Cancer Research Communications, 4:279-292, Feb 2024. URL: https://doi.org/10.1158/2767-9764.crc-22-0165, doi:10.1158/2767-9764.crc-22-0165. This article has 7 citations and is from a peer-reviewed journal.
+
+17. (chen2024runxtranscriptionfactors pages 18-19): Xinyi Chen, Lu Wang, Mu Yang, Weiheng Zhao, Jingyao Tu, Bo Liu, and Xianglin Yuan. Runx transcription factors: biological functions and implications in cancer. Clinical and Experimental Medicine, Mar 2024. URL: https://doi.org/10.1007/s10238-023-01281-0, doi:10.1007/s10238-023-01281-0. This article has 17 citations and is from a peer-reviewed journal.
+
+18. (chen2024runxtranscriptionfactors pages 12-14): Xinyi Chen, Lu Wang, Mu Yang, Weiheng Zhao, Jingyao Tu, Bo Liu, and Xianglin Yuan. Runx transcription factors: biological functions and implications in cancer. Clinical and Experimental Medicine, Mar 2024. URL: https://doi.org/10.1007/s10238-023-01281-0, doi:10.1007/s10238-023-01281-0. This article has 17 citations and is from a peer-reviewed journal.
+
+19. (liu2023epigeneticreprogrammingof pages 1-2): Zongzhi Liu, Xiang Li, Yibo Gao, Jiejie Liu, Yating Feng, Yang Liu, Junyun Wang, Chunmeng Wang, Dongrui Wang, Jie He, Weidong Han, Qian Mei, and Yingli Sun. Epigenetic reprogramming of runx3 reinforces cd8 + t-cell function and improves the clinical response to immunotherapy. Molecular Cancer, May 2023. URL: https://doi.org/10.1186/s12943-023-01768-0, doi:10.1186/s12943-023-01768-0. This article has 56 citations and is from a highest quality peer-reviewed journal.
+
+20. (liu2023epigeneticreprogrammingof pages 2-4): Zongzhi Liu, Xiang Li, Yibo Gao, Jiejie Liu, Yating Feng, Yang Liu, Junyun Wang, Chunmeng Wang, Dongrui Wang, Jie He, Weidong Han, Qian Mei, and Yingli Sun. Epigenetic reprogramming of runx3 reinforces cd8 + t-cell function and improves the clinical response to immunotherapy. Molecular Cancer, May 2023. URL: https://doi.org/10.1186/s12943-023-01768-0, doi:10.1186/s12943-023-01768-0. This article has 56 citations and is from a highest quality peer-reviewed journal.
+
+21. (liu2023epigeneticreprogrammingof pages 9-12): Zongzhi Liu, Xiang Li, Yibo Gao, Jiejie Liu, Yating Feng, Yang Liu, Junyun Wang, Chunmeng Wang, Dongrui Wang, Jie He, Weidong Han, Qian Mei, and Yingli Sun. Epigenetic reprogramming of runx3 reinforces cd8 + t-cell function and improves the clinical response to immunotherapy. Molecular Cancer, May 2023. URL: https://doi.org/10.1186/s12943-023-01768-0, doi:10.1186/s12943-023-01768-0. This article has 56 citations and is from a highest quality peer-reviewed journal.
+
+22. (liu2023epigeneticreprogrammingof pages 7-9): Zongzhi Liu, Xiang Li, Yibo Gao, Jiejie Liu, Yating Feng, Yang Liu, Junyun Wang, Chunmeng Wang, Dongrui Wang, Jie He, Weidong Han, Qian Mei, and Yingli Sun. Epigenetic reprogramming of runx3 reinforces cd8 + t-cell function and improves the clinical response to immunotherapy. Molecular Cancer, May 2023. URL: https://doi.org/10.1186/s12943-023-01768-0, doi:10.1186/s12943-023-01768-0. This article has 56 citations and is from a highest quality peer-reviewed journal.
+
+23. (fu2023runx3expressingcart pages 1-2): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.
+
+24. (fu2023runx3expressingcart pages 2-3): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.
+
+25. (fu2023runx3expressingcart pages 5-6): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.
+
+26. (fu2023runx3expressingcart pages 6-7): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.
+
+27. (fu2023runx3expressingcart media 6458455b): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.
+
+28. (fu2023runx3expressingcart pages 7-8): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.
+
+29. (fu2023runx3expressingcart media 006d89ce): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.
+
+30. (fu2023runx3expressingcart media 9604a628): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.
+
+31. (messina2023hippopathwaydysregulation pages 2-3): Beatrice Messina, Federica Lo Sardo, Stefano Scalera, Lorenzo Memeo, Cristina Colarossi, Marzia Mare, Giovanni Blandino, Gennaro Ciliberto, Marcello Maugeri-Saccà, and Giulia Bon. Hippo pathway dysregulation in gastric cancer: from helicobacter pylori infection to tumor promotion and progression. Cell Death &amp; Disease, Jan 2023. URL: https://doi.org/10.1038/s41419-023-05568-8, doi:10.1038/s41419-023-05568-8. This article has 67 citations and is from a peer-reviewed journal.
+
+32. (messina2023hippopathwaydysregulation pages 10-11): Beatrice Messina, Federica Lo Sardo, Stefano Scalera, Lorenzo Memeo, Cristina Colarossi, Marzia Mare, Giovanni Blandino, Gennaro Ciliberto, Marcello Maugeri-Saccà, and Giulia Bon. Hippo pathway dysregulation in gastric cancer: from helicobacter pylori infection to tumor promotion and progression. Cell Death &amp; Disease, Jan 2023. URL: https://doi.org/10.1038/s41419-023-05568-8, doi:10.1038/s41419-023-05568-8. This article has 67 citations and is from a peer-reviewed journal.
+
+33. (liu2023epigeneticreprogrammingof pages 4-5): Zongzhi Liu, Xiang Li, Yibo Gao, Jiejie Liu, Yating Feng, Yang Liu, Junyun Wang, Chunmeng Wang, Dongrui Wang, Jie He, Weidong Han, Qian Mei, and Yingli Sun. Epigenetic reprogramming of runx3 reinforces cd8 + t-cell function and improves the clinical response to immunotherapy. Molecular Cancer, May 2023. URL: https://doi.org/10.1186/s12943-023-01768-0, doi:10.1186/s12943-023-01768-0. This article has 56 citations and is from a highest quality peer-reviewed journal.
+
+34. (he2024ubiquitylationofrunx3 pages 6-9): Zelai He, Huijun Zhang, Hai-bo Xiao, Xiangyu Zhang, Hongbo Xu, Ruifen Sun, and Siwen Li. Ubiquitylation of runx3 by rna-binding ubiquitin ligase mex3c promotes tumorigenesis in lung adenocarcinoma. Journal of Translational Medicine, Feb 2024. URL: https://doi.org/10.1186/s12967-023-04700-8, doi:10.1186/s12967-023-04700-8. This article has 10 citations and is from a peer-reviewed journal.
+
+35. (suda2024aberrantupregulationof pages 11-13): Kazuto Suda, Atsushi Okabe, Junichi Matsuo, Linda Shyue Huey Chuang, Ying Li, Nawaphat Jangphattananont, Naing Naing Mon, Khine Nyein Myint, Akihiro Yamamura, Jimmy Bok-Yan So, Dominic Chih-Cheng Voon, Henry Yang, Khay Guan Yeoh, Atsushi Kaneda, and Yoshiaki Ito. Aberrant upregulation of runx3 activates developmental genes to drive metastasis in gastric cancer. Cancer Research Communications, 4:279-292, Feb 2024. URL: https://doi.org/10.1158/2767-9764.crc-22-0165, doi:10.1158/2767-9764.crc-22-0165. This article has 7 citations and is from a peer-reviewed journal.
+
+36. (OpenTargets Search: -RUNX3): Open Targets Query (-RUNX3, 6 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+37. (mahmoud2024runx3actsas pages 24-26): Salma Awad Mahmoud, Isabelle Bonne, Aik Yong Sim, and Gehan Labib Abuelenain. Runx3 acts as homodimeric chromatin binding factor regulating heterochromatin-mediated cancerous phenotype. bioRxiv, Aug 2024. URL: https://doi.org/10.1101/2024.08.16.608297, doi:10.1101/2024.08.16.608297. This article has 1 citations.
+
+38. (chen2024runxtranscriptionfactors pages 17-18): Xinyi Chen, Lu Wang, Mu Yang, Weiheng Zhao, Jingyao Tu, Bo Liu, and Xianglin Yuan. Runx transcription factors: biological functions and implications in cancer. Clinical and Experimental Medicine, Mar 2024. URL: https://doi.org/10.1007/s10238-023-01281-0, doi:10.1007/s10238-023-01281-0. This article has 17 citations and is from a peer-reviewed journal.
+
+39. (kang2024oxidativestressmediatedrunx3 pages 1-4): Kyoung Ah Kang, Mei Jing Piao, Pincha Devage Sameera Madushan Fernando, Herath Mudiyanselage Udari Lakmini Herath, Hye-Jin Boo, Sang Pil Yoon, and Jin Won Hyun. Oxidative stress-mediated runx3 mislocalization occurs via jun activation domain-binding protein 1 and histone modification. Applied Biochemistry and Biotechnology, 196:8082-8095, Apr 2024. URL: https://doi.org/10.1007/s12010-024-04944-0, doi:10.1007/s12010-024-04944-0. This article has 7 citations and is from a peer-reviewed journal.
+
+40. (he2024ubiquitylationofrunx3 pages 15-18): Zelai He, Huijun Zhang, Hai-bo Xiao, Xiangyu Zhang, Hongbo Xu, Ruifen Sun, and Siwen Li. Ubiquitylation of runx3 by rna-binding ubiquitin ligase mex3c promotes tumorigenesis in lung adenocarcinoma. Journal of Translational Medicine, Feb 2024. URL: https://doi.org/10.1186/s12967-023-04700-8, doi:10.1186/s12967-023-04700-8. This article has 10 citations and is from a peer-reviewed journal.
+
+41. (fu2023runx3expressingcart pages 10-10): Qihan Fu, Yi Zheng, Weijia Fang, Qingwei Zhao, Peng Zhao, Lulu Liu, You Zhai, Zhou Tong, Hangyu Zhang, Meihua Lin, Xudong Zhu, Huamao Wang, Yumeng Wang, Zhen Liu, Daijing Yuan, Xuanwen Bao, Wanwan Gao, Xiaomeng Dai, Zonghai Li, and Tingbo Liang. Runx-3-expressing car t cells targeting glypican-3 in patients with heavily pretreated advanced hepatocellular carcinoma: a phase i trial. eClinicalMedicine, 63:102175, Sep 2023. URL: https://doi.org/10.1016/j.eclinm.2023.102175, doi:10.1016/j.eclinm.2023.102175. This article has 69 citations and is from a peer-reviewed journal.
+
+42. (liu2023epigeneticreprogrammingof pages 12-14): Zongzhi Liu, Xiang Li, Yibo Gao, Jiejie Liu, Yating Feng, Yang Liu, Junyun Wang, Chunmeng Wang, Dongrui Wang, Jie He, Weidong Han, Qian Mei, and Yingli Sun. Epigenetic reprogramming of runx3 reinforces cd8 + t-cell function and improves the clinical response to immunotherapy. Molecular Cancer, May 2023. URL: https://doi.org/10.1186/s12943-023-01768-0, doi:10.1186/s12943-023-01768-0. This article has 56 citations and is from a highest quality peer-reviewed journal.
+
+## Citations
+
+1. chen2024runxtranscriptionfactors pages 1-2
+2. chen2024runxtranscriptionfactors pages 12-14
+3. suda2024aberrantupregulationof pages 11-13
+4. liu2023epigeneticreprogrammingof pages 12-14
+5. suda2024aberrantupregulationof pages 5-8
+6. liu2023epigeneticreprogrammingof pages 1-2
+7. messina2023hippopathwaydysregulation pages 2-3
+8. suda2024aberrantupregulationof pages 8-10
+9. suda2024aberrantupregulationof pages 1-2
+10. suda2024aberrantupregulationof pages 10-11
+11. chen2024runxtranscriptionfactors pages 18-19
+12. liu2023epigeneticreprogrammingof pages 2-4
+13. liu2023epigeneticreprogrammingof pages 9-12
+14. liu2023epigeneticreprogrammingof pages 7-9
+15. messina2023hippopathwaydysregulation pages 10-11
+16. liu2023epigeneticreprogrammingof pages 4-5
+17. chen2024runxtranscriptionfactors pages 17-18
+18. https://doi.org/10.1007/s10238-023-01281-0;
+19. https://doi.org/10.1101/2024.08.16.608297
+20. https://doi.org/10.1101/2024.08.16.608297;
+21. https://doi.org/10.1007/s10238-023-01281-0
+22. https://doi.org/10.1038/s41419-023-05568-8;
+23. https://doi.org/10.1038/s42003-023-05037-0;
+24. https://doi.org/10.1007/s12010-024-04944-0;
+25. https://doi.org/10.1186/s12967-023-04700-8;
+26. https://doi.org/10.1158/2767-9764.crc-22-0165;
+27. https://doi.org/10.1186/s12943-023-01768-0;
+28. https://doi.org/10.1016/j.eclinm.2023.102175;
+29. https://doi.org/10.1186/s12894-023-01356-w;
+30. https://doi.org/10.1038/s42003-023-05037-0
+31. https://doi.org/10.1007/s12010-024-04944-0
+32. https://doi.org/10.1186/s12967-023-04700-8
+33. https://doi.org/10.1158/2767-9764.crc-22-0165
+34. https://doi.org/10.1186/s12943-023-01768-0
+35. https://doi.org/10.1016/j.eclinm.2023.102175
+36. https://doi.org/10.1038/s41419-023-05568-8
+37. https://platform.opentargets.org/target/ENSG00000020633
+38. https://doi.org/10.1007/s10238-023-01281-0,
+39. https://doi.org/10.1101/2024.08.16.608297,
+40. https://doi.org/10.1007/s12010-024-04944-0,
+41. https://doi.org/10.1038/s42003-023-05037-0,
+42. https://doi.org/10.1186/s12967-023-04700-8,
+43. https://doi.org/10.1158/2767-9764.crc-22-0165,
+44. https://doi.org/10.1186/s12943-023-01768-0,
+45. https://doi.org/10.1016/j.eclinm.2023.102175,
+46. https://doi.org/10.1038/s41419-023-05568-8,

--- a/genes/human/TOLLIP/TOLLIP-ai-review.html
+++ b/genes/human/TOLLIP/TOLLIP-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>TOLLIP</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q9H0E2" target="_blank" class="term-link">
                         Q9H0E2
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-initialized">
-                    INITIALIZED
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="Q9H0E2" data-a="DESCRIPTION: TODO: Add description for TOLLIP..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="Q9H0E2" data-a="DESCRIPTION: TOLLIP encodes Toll-interacting protein, a non-enz..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for TOLLIP</p>
+        <p>TOLLIP encodes Toll-interacting protein, a non-enzymatic ubiquitin/phosphoinositide-binding adaptor that links endosomal membranes, TOM1/clathrin-associated trafficking, and TLR/IL-1 receptor signaling. Its core roles are CUE-domain ubiquitin recognition, C2-domain membrane/endosome targeting, PI3P-dependent endolysosomal routing of ubiquitinated or aberrant cargo, and regulated restraint of IRAK-dependent innate immune signaling.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,4453 +758,5724 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytoplasm is the broad cellular compartment for TOLLIP adaptor activity and endosomal trafficking.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytoplasm is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006511" target="_blank" class="term-link">
                                     GO:0006511
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin-dependent protein catabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0006511" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0006511" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Ubiquitin-dependent protein catabolic process is supported by TOLLIP-mediated routing of ubiquitinated or aberrant cargo to endolysosomal degradation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ubiquitin-dependent protein catabolic process is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal routing and degradation, operating alongside ERAD</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031624" target="_blank" class="term-link">
                                     GO:0031624
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin conjugating enzyme binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0031624" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0031624" data-r="GO_REF:0000033" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The evidence supports CUE-domain recognition of ubiquitin conjugates rather than a specific ubiquitin-conjugating enzyme binding function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ubiquitin conjugating enzyme binding is less precise than the supported TOLLIP mechanism.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043130" target="_blank" class="term-link">
+                                    ubiquitin binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043130" target="_blank" class="term-link">
                                     GO:0043130
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0043130" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0043130" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Ubiquitin binding is a core CUE-domain molecular function of TOLLIP.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ubiquitin binding is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002376" target="_blank" class="term-link">
                                     GO:0002376
                                 </a>
                             </span>
                             <span class="term-label">immune system process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0002376" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0002376" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> immune system process is plausible as a context-specific or secondary TOLLIP-associated annotation, but it is not the most precise core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> immune system process is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R signaling roles.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells; BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger NF‑κB signaling</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytoplasm is the broad cellular compartment for TOLLIP adaptor activity and endosomal trafficking.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytoplasm is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
                                     GO:0005768
                                 </a>
                             </span>
                             <span class="term-label">endosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005768" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005768" data-r="GO_REF:0000044" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Endosome localization is central to TOLLIP PI3P-dependent cargo routing.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> endosome is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal routing and degradation, operating alongside ERAD</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005769" target="_blank" class="term-link">
                                     GO:0005769
                                 </a>
                             </span>
                             <span class="term-label">early endosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005769" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005769" data-r="GO_REF:0000044" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Early endosome localization is supported by TOLLIP coupling of PI3P vesicles to cargo trafficking.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> early endosome is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal routing and degradation, operating alongside ERAD</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006914" target="_blank" class="term-link">
                                     GO:0006914
                                 </a>
                             </span>
                             <span class="term-label">autophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0006914" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0006914" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> autophagy is plausible as a context-specific or secondary TOLLIP-associated annotation, but it is not the most precise core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> autophagy is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R signaling roles.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal routing and degradation, operating alongside ERAD</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006954" target="_blank" class="term-link">
                                     GO:0006954
                                 </a>
                             </span>
                             <span class="term-label">inflammatory response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0006954" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0006954" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> inflammatory response is plausible as a context-specific or secondary TOLLIP-associated annotation, but it is not the most precise core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> inflammatory response is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R signaling roles.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells; BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger NF‑κB signaling</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043130" target="_blank" class="term-link">
                                     GO:0043130
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0043130" data-r="GO_REF:0000002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0043130" data-r="GO_REF:0000002" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Ubiquitin binding is a core CUE-domain molecular function of TOLLIP.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ubiquitin binding is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045087" target="_blank" class="term-link">
                                     GO:0045087
                                 </a>
                             </span>
                             <span class="term-label">innate immune response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0045087" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0045087" data-r="GO_REF:0000043" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Innate immune response is supported through TOLLIP regulation of TLR/IL-1R signaling outputs.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> innate immune response is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells; BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger NF‑κB signaling</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14563850" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14563850
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tom1, a VHS domain-containing protein, interacts with tollip...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:14563850" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:14563850" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/14563850" target="_blank" class="term-link">
-                                        PMID:14563850
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2003 Oct 15. Tom1, a VHS domain-containing protein, interacts with tollip, ubiquitin, and clathrin.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16189514" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16189514
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Towards a proteome-scale map of the human protein-protein in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:16189514" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:16189514" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16189514" target="_blank" class="term-link">
-                                        PMID:16189514
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Towards a proteome-scale map of the human protein-protein interaction network.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16713569" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16713569
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A protein-protein interaction network for human inherited at...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:16713569" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:16713569" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16713569" target="_blank" class="term-link">
-                                        PMID:16713569
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">A protein-protein interaction network for human inherited ataxias and disorders of Purkinje cell degeneration.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19060904" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19060904
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An empirical framework for binary interactome mapping.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:19060904" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:19060904" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19060904" target="_blank" class="term-link">
-                                        PMID:19060904
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">An empirical framework for binary interactome mapping.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19447967" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19447967
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Shifted Transversal Design smart-pooling for high coverage i...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:19447967" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:19447967" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19447967" target="_blank" class="term-link">
-                                        PMID:19447967
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Shifted Transversal Design smart-pooling for high coverage interactome mapping.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20936779" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20936779
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A human MAP kinase interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:20936779" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:20936779" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20936779" target="_blank" class="term-link">
-                                        PMID:20936779
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">A human MAP kinase interactome.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21903422" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21903422
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mapping a dynamic innate immunity protein interaction networ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:21903422" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:21903422" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21903422" target="_blank" class="term-link">
-                                        PMID:21903422
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2011 Sep 8. Mapping a dynamic innate immunity protein interaction network regulating type I interferon production.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21988832
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Toward an understanding of the protein interaction network o...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:21988832" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:21988832" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link">
-                                        PMID:21988832
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Toward an understanding of the protein interaction network of the human liver.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25042851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25042851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Autophagic clearance of polyQ proteins mediated by ubiquitin...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:25042851" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:25042851" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25042851" target="_blank" class="term-link">
-                                        PMID:25042851
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Jul 18. Autophagic clearance of polyQ proteins mediated by ubiquitin-Atg8 adaptors of the conserved CUET protein family.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25416956
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A proteome-scale map of the human interactome network.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:25416956" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:25416956" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
-                                        PMID:25416956
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">A proteome-scale map of the human interactome network.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25910212
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Widespread macromolecular interaction perturbations in human...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:25910212" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:25910212" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
-                                        PMID:25910212
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Widespread macromolecular interaction perturbations in human genetic disorders.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27107014
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An inter-species protein-protein interaction network across ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:27107014" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:27107014" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link">
-                                        PMID:27107014
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">An inter-species protein-protein interaction network across vast evolutionary distance.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31515488
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extensive disruption of protein interactions by genetic vari...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:31515488" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:31515488" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
-                                        PMID:31515488
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Extensive disruption of protein interactions by genetic variants across the allele frequency spectrum in human populations.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:32296183" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
-                                        PMID:32296183
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Apr 8. A reference map of the human binary protein interactome.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:32814053" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:32814053" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
-                                        PMID:32814053
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:33961781" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
-                                        PMID:33961781
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2021 May 6. Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34524948" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34524948
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global Proximity Interactome of the Human Macroautophagy Pat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:34524948" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:34524948" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/34524948" target="_blank" class="term-link">
-                                        PMID:34524948
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2021 Sep 15. Global Proximity Interactome of the Human Macroautophagy Pathway.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35271311
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     OpenCell: Endogenous tagging for the cartography of human ce...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:35271311" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:35271311" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
-                                        PMID:35271311
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2022 Mar 11. OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:40205054" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
-                                        PMID:40205054
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Apr 9. Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005150" target="_blank" class="term-link">
                                     GO:0005150
                                 </a>
                             </span>
                             <span class="term-label">interleukin-1, type I receptor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005150" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005150" data-r="GO_REF:0000107" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Interleukin-1 type I receptor binding is supported as part of the IL-1R/TLR signaling adaptor-regulator role.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> interleukin-1, type I receptor binding is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells; BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger NF‑κB signaling</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016604" target="_blank" class="term-link">
                                     GO:0016604
                                 </a>
                             </span>
                             <span class="term-label">nuclear body</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0016604" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0016604" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> nuclear body is plausible as a context-specific or secondary TOLLIP-associated annotation, but it is not the most precise core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> nuclear body is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R signaling roles.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal routing and degradation, operating alongside ERAD</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031624" target="_blank" class="term-link">
                                     GO:0031624
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin conjugating enzyme binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0031624" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0031624" data-r="GO_REF:0000107" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The evidence supports CUE-domain recognition of ubiquitin conjugates rather than a specific ubiquitin-conjugating enzyme binding function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ubiquitin conjugating enzyme binding is less precise than the supported TOLLIP mechanism.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043130" target="_blank" class="term-link">
+                                    ubiquitin binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031625" target="_blank" class="term-link">
                                     GO:0031625
                                 </a>
                             </span>
                             <span class="term-label">ubiquitin protein ligase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0031625" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0031625" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Ubiquitin protein ligase binding is not the main supported activity; the reviewed evidence emphasizes ubiquitin conjugate binding and adaptor function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ubiquitin protein ligase binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032183" target="_blank" class="term-link">
                                     GO:0032183
                                 </a>
                             </span>
                             <span class="term-label">SUMO binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0032183" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0032183" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> SUMO binding is not supported by the Falcon synthesis as a core or well-grounded TOLLIP function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> SUMO binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0032991" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0032991" data-r="GO_REF:0000107" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein-containing complex is supported because TOLLIP acts in TOM1/clathrin, cargo, IRAK, and receptor-proximal complexes.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein-containing complex is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells; BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger NF‑κB signaling</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033235" target="_blank" class="term-link">
                                     GO:0033235
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of protein sumoylation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0033235" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0033235" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Positive regulation of protein sumoylation is not supported as a TOLLIP core function in the reviewed evidence.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> positive regulation of protein sumoylation overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048471" target="_blank" class="term-link">
                                     GO:0048471
                                 </a>
                             </span>
                             <span class="term-label">perinuclear region of cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0048471" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0048471" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> perinuclear region of cytoplasm is plausible as a context-specific or secondary TOLLIP-associated annotation, but it is not the most precise core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> perinuclear region of cytoplasm is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R signaling roles.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal routing and degradation, operating alongside ERAD</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070498" target="_blank" class="term-link">
                                     GO:0070498
                                 </a>
                             </span>
                             <span class="term-label">interleukin-1-mediated signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0070498" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0070498" data-r="GO_REF:0000107" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Interleukin-1-mediated signaling pathway is a supported core immune-signaling context for TOLLIP.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> interleukin-1-mediated signaling pathway is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells; BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger NF‑κB signaling</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal and receptor-signaling compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26320582" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26320582
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tom1 Modulates Binding of Tollip to Phosphatidylinositol 3-P...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:26320582" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:26320582" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/26320582" target="_blank" class="term-link">
-                                        PMID:26320582
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2015 Aug 27. Tom1 Modulates Binding of Tollip to Phosphatidylinositol 3-Phosphate via a Coupled Folding and Binding Mechanism.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31263572" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31263572
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dominant TOM1 mutation associated with combined immunodefici...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:31263572" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:31263572" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31263572" target="_blank" class="term-link">
-                                        PMID:31263572
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Dominant TOM1 mutation associated with combined immunodeficiency and autoimmune disease.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15047686" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15047686
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tollip and Tom1 form a complex and recruit ubiquitin-conjuga...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:15047686" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:15047686" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15047686" target="_blank" class="term-link">
-                                        PMID:15047686
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2004 Mar 26. Tollip and Tom1 form a complex and recruit ubiquitin-conjugated proteins onto early endosomes.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019897" target="_blank" class="term-link">
                                     GO:0019897
                                 </a>
                             </span>
                             <span class="term-label">extrinsic component of plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IC</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10854325" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10854325
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tollip, a new component of the IL-1RI pathway, links IRAK to...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0019897" data-r="PMID:10854325" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0019897" data-r="PMID:10854325" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> extrinsic component of plasma membrane is plausible as a context-specific or secondary TOLLIP-associated annotation, but it is not the most precise core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> extrinsic component of plasma membrane is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R signaling roles.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10854325" target="_blank" class="term-link">
-                                        PMID:10854325
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Tollip, a new component of the IL-1RI pathway, links IRAK to the IL-1 receptor.</div>
-                                
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal routing and degradation, operating alongside ERAD</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060090" target="_blank" class="term-link">
                                     GO:0060090
                                 </a>
                             </span>
                             <span class="term-label">molecular adaptor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10854325" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10854325
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tollip, a new component of the IL-1RI pathway, links IRAK to...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0060090" data-r="PMID:10854325" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0060090" data-r="PMID:10854325" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Molecular adaptor activity captures the core TOLLIP role in linking cargo, endosomal membranes, and receptor-signaling proteins.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> molecular adaptor activity is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10854325" target="_blank" class="term-link">
-                                        PMID:10854325
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Tollip, a new component of the IL-1RI pathway, links IRAK to the IL-1 receptor.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal routing and degradation, operating alongside ERAD</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070498" target="_blank" class="term-link">
                                     GO:0070498
                                 </a>
                             </span>
                             <span class="term-label">interleukin-1-mediated signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10854325" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10854325
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tollip, a new component of the IL-1RI pathway, links IRAK to...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0070498" data-r="PMID:10854325" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0070498" data-r="PMID:10854325" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Interleukin-1-mediated signaling pathway is a supported core immune-signaling context for TOLLIP.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> interleukin-1-mediated signaling pathway is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10854325" target="_blank" class="term-link">
-                                        PMID:10854325
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Tollip, a new component of the IL-1RI pathway, links IRAK to the IL-1 receptor.</div>
-                                
+
+                                <div class="support-text">**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells; BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger NF‑κB signaling</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060090" target="_blank" class="term-link">
                                     GO:0060090
                                 </a>
                             </span>
                             <span class="term-label">molecular adaptor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27368102" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27368102
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An ER-Associated Pathway Defines Endosomal Architecture for ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0060090" data-r="PMID:27368102" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0060090" data-r="PMID:27368102" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Molecular adaptor activity captures the core TOLLIP role in linking cargo, endosomal membranes, and receptor-signaling proteins.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> molecular adaptor activity is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27368102" target="_blank" class="term-link">
-                                        PMID:27368102
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">An ER-Associated Pathway Defines Endosomal Architecture for Controlled Cargo Transport.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal routing and degradation, operating alongside ERAD</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019900" target="_blank" class="term-link">
                                     GO:0019900
                                 </a>
                             </span>
                             <span class="term-label">kinase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10854325" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10854325
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tollip, a new component of the IL-1RI pathway, links IRAK to...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0019900" data-r="PMID:10854325" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0019900" data-r="PMID:10854325" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Kinase binding is supported by TOLLIP interactions with IRAK1 and BLK in receptor-proximal signaling control.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> kinase binding is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10854325" target="_blank" class="term-link">
-                                        PMID:10854325
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Tollip, a new component of the IL-1RI pathway, links IRAK to the IL-1 receptor.</div>
-                                
+
+                                <div class="support-text">**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells; BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger NF‑κB signaling</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">BLK binding and phosphorylation promote **dissociation of TOLLIP from IRAK1**, exposing IRAK1 phosphorylation sites (ProST region) and enabling **IRAK1 hyperphosphorylation**, downstream **NF‑κB activation**, and inflammatory cytokine responses</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
                                     GO:0032991
                                 </a>
                             </span>
                             <span class="term-label">protein-containing complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10854325" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10854325
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tollip, a new component of the IL-1RI pathway, links IRAK to...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0032991" data-r="PMID:10854325" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0032991" data-r="PMID:10854325" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein-containing complex is supported because TOLLIP acts in TOM1/clathrin, cargo, IRAK, and receptor-proximal complexes.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein-containing complex is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10854325" target="_blank" class="term-link">
-                                        PMID:10854325
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Tollip, a new component of the IL-1RI pathway, links IRAK to the IL-1 receptor.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells; BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger NF‑κB signaling</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11397809" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11397809
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     IRAK1b, a novel alternative splice variant of interleukin-1 ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:11397809" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:11397809" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11397809" target="_blank" class="term-link">
-                                        PMID:11397809
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2001 Jun 7. IRAK1b, a novel alternative splice variant of interleukin-1 receptor-associated kinase (IRAK), mediates interleukin-1 signaling and has prolonged stability.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6798749
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005576" data-r="Reactome:R-HSA-6798749" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005576" data-r="Reactome:R-HSA-6798749" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Extracellular region is inconsistent with the reviewed intracellular adaptor/endosomal functions of TOLLIP.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> extracellular region overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6798751
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005576" data-r="Reactome:R-HSA-6798751" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005576" data-r="Reactome:R-HSA-6798751" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Extracellular region is inconsistent with the reviewed intracellular adaptor/endosomal functions of TOLLIP.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> extracellular region overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035578" target="_blank" class="term-link">
                                     GO:0035578
                                 </a>
                             </span>
                             <span class="term-label">azurophil granule lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6798751
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0035578" data-r="Reactome:R-HSA-6798751" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0035578" data-r="Reactome:R-HSA-6798751" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Azurophil granule lumen is a context-specific secretory-granule annotation and is not supported as a functional TOLLIP location.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> azurophil granule lumen overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035580" target="_blank" class="term-link">
                                     GO:0035580
                                 </a>
                             </span>
                             <span class="term-label">specific granule lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6798749
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0035580" data-r="Reactome:R-HSA-6798749" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0035580" data-r="Reactome:R-HSA-6798749" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Specific granule lumen is a context-specific secretory-granule annotation and is not supported as a functional TOLLIP location.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> specific granule lumen overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23533145
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     In-depth proteomic analyses of exosomes isolated from expres...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0070062" data-r="PMID:23533145" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0070062" data-r="PMID:23533145" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Extracellular exosome detection does not represent the core intracellular adaptor function of TOLLIP.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> extracellular exosome overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
-                                        PMID:23533145
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2013 Apr 23. In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
-                                
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030855" target="_blank" class="term-link">
                                     GO:0030855
                                 </a>
                             </span>
                             <span class="term-label">epithelial cell differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21492153" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21492153
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Analysis of proteomic changes induced upon cellular differen...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0030855" data-r="PMID:21492153" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0030855" data-r="PMID:21492153" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> epithelial cell differentiation is plausible as a context-specific or secondary TOLLIP-associated annotation, but it is not the most precise core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> epithelial cell differentiation is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R signaling roles.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21492153" target="_blank" class="term-link">
-                                        PMID:21492153
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Analysis of proteomic changes induced upon cellular differentiation of the human intestinal cell line Caco-2.</div>
-                                
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal routing and degradation, operating alongside ERAD</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16412388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16412388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Recruitment of clathrin onto endosomes by the Tom1-Tollip co...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:16412388" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005515" data-r="PMID:16412388" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding, receptor-binding, and kinase-binding terms better capture the mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein binding overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16412388" target="_blank" class="term-link">
-                                        PMID:16412388
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Recruitment of clathrin onto endosomes by the Tom1-Tollip complex.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036010" target="_blank" class="term-link">
                                     GO:0036010
                                 </a>
                             </span>
                             <span class="term-label">protein localization to endosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16412388" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16412388
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Recruitment of clathrin onto endosomes by the Tom1-Tollip co...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0036010" data-r="PMID:16412388" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0036010" data-r="PMID:16412388" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein localization to endosome is supported by the TOLLIP cargo-routing mechanism.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> protein localization to endosome is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16412388" target="_blank" class="term-link">
-                                        PMID:16412388
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Recruitment of clathrin onto endosomes by the Tom1-Tollip complex.</div>
-                                
+
+                                <div class="support-text">**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal routing and degradation, operating alongside ERAD</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070062" target="_blank" class="term-link">
                                     GO:0070062
                                 </a>
                             </span>
                             <span class="term-label">extracellular exosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19056867
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Large-scale proteomics and phosphoproteomics of urinary exos...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0070062" data-r="PMID:19056867" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0070062" data-r="PMID:19056867" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Extracellular exosome detection does not represent the core intracellular adaptor function of TOLLIP.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> extracellular exosome overstates or obscures the supported TOLLIP function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
-                                        PMID:19056867
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2008 Dec 3. Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
-                                
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-446634
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446634" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446634" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal and receptor-signaling compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-446684
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446684" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446684" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal and receptor-signaling compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-446692
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446692" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446692" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal and receptor-signaling compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-446694
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446694" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446694" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal and receptor-signaling compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-446701
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446701" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446701" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal and receptor-signaling compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-446862
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446862" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446862" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal and receptor-signaling compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-446868
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446868" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446868" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal and receptor-signaling compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-446894
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446894" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005829" data-r="Reactome:R-HSA-446894" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal and receptor-signaling compartments.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IC</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11441107" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11441107
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cooperation of Toll-like receptor 2 and 6 for cellular activ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005737" data-r="PMID:11441107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0005737" data-r="PMID:11441107" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytoplasm is the broad cellular compartment for TOLLIP adaptor activity and endosomal trafficking.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> cytoplasm is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11441107" target="_blank" class="term-link">
-                                        PMID:11441107
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Cooperation of Toll-like receptor 2 and 6 for cellular activation by soluble tuberculosis factor and Borrelia burgdorferi outer surface protein A lipoprotein: role of Toll-interacting protein and IL-1 receptor signaling molecules in Toll-like receptor 2 signaling.</div>
-                                
+
+                                <div class="support-text">TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007165" target="_blank" class="term-link">
                                     GO:0007165
                                 </a>
                             </span>
                             <span class="term-label">signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11441107" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11441107
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cooperation of Toll-like receptor 2 and 6 for cellular activ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0007165" data-r="PMID:11441107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0007165" data-r="PMID:11441107" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Generic signal transduction should be refined to the IL-1R/TLR receptor signaling context supported for TOLLIP.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> signal transduction is less precise than the supported TOLLIP mechanism.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070498" target="_blank" class="term-link">
+                                    interleukin-1-mediated signaling pathway
+                                </a>
+                            </span>
+
+                        </div>
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11441107" target="_blank" class="term-link">
-                                        PMID:11441107
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Cooperation of Toll-like receptor 2 and 6 for cellular activation by soluble tuberculosis factor and Borrelia burgdorferi outer surface protein A lipoprotein: role of Toll-interacting protein and IL-1 receptor signaling molecules in Toll-like receptor 2 signaling.</div>
-                                
+
+                                <div class="support-text">**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells; BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger NF‑κB signaling</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035325" target="_blank" class="term-link">
                                     GO:0035325
                                 </a>
                             </span>
                             <span class="term-label">Toll-like receptor binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11441107" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11441107
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cooperation of Toll-like receptor 2 and 6 for cellular activ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0035325" data-r="PMID:11441107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0035325" data-r="PMID:11441107" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Toll-like receptor binding is supported as part of TOLLIP receptor-proximal innate immune signaling regulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Toll-like receptor binding is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate immune signaling function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11441107" target="_blank" class="term-link">
-                                        PMID:11441107
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Cooperation of Toll-like receptor 2 and 6 for cellular activation by soluble tuberculosis factor and Borrelia burgdorferi outer surface protein A lipoprotein: role of Toll-interacting protein and IL-1 receptor signaling molecules in Toll-like receptor 2 signaling.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells; BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger NF‑κB signaling</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016310" target="_blank" class="term-link">
                                     GO:0016310
                                 </a>
                             </span>
                             <span class="term-label">phosphorylation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/1085432" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:1085432
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Malignant lymphoma and rheumatic symptoms.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -5216,871 +6487,1509 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> MISANNOTATION with WRONG PMID: PMID:1085432 is about &#34;Malignant lymphoma and rheumatic symptoms&#34; from 1976 - completely unrelated to TOLLIP! Furthermore, TOLLIP is a signaling adapter protein, NOT a kinase. UniProt states TOLLIP &#34;Inhibits IRAK1 phosphorylation and kinase activity&#34; - it REGULATES kinases, not performs phosphorylation itself.
+                            <strong>Summary:</strong> TOLLIP is phosphorylated by BLK during signaling, but TOLLIP is not a kinase and should not be annotated to phosphorylation as an activity/process it performs.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> TOLLIP is a phosphorylation-regulated adaptor, not an enzyme that catalyzes phosphorylation.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/1085432" target="_blank" class="term-link">
-                                        PMID:1085432
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Malignant lymphoma and rheumatic symptoms.</div>
-                                
+
+                                <div class="support-text">BLK binding and phosphorylation promote **dissociation of TOLLIP from IRAK1**, exposing IRAK1 phosphorylation sites (ProST region) and enabling **IRAK1 hyperphosphorylation**, downstream **NF‑κB activation**, and inflammatory cytokine responses</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045321" target="_blank" class="term-link">
                                     GO:0045321
                                 </a>
                             </span>
                             <span class="term-label">leukocyte activation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11441107" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11441107
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cooperation of Toll-like receptor 2 and 6 for cellular activ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0045321" data-r="PMID:11441107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q9H0E2" data-a="GO:0045321" data-r="PMID:11441107" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> leukocyte activation is plausible as a context-specific or secondary TOLLIP-associated annotation, but it is not the most precise core function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> leukocyte activation is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R signaling roles.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11441107" target="_blank" class="term-link">
-                                        PMID:11441107
-                                    </a>
-                                    
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Cooperation of Toll-like receptor 2 and 6 for cellular activation by soluble tuberculosis factor and Borrelia burgdorferi outer surface protein A lipoprotein: role of Toll-interacting protein and IL-1 receptor signaling molecules in Toll-like receptor 2 signaling.</div>
-                                
+
+                                <div class="support-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells; BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger NF‑κB signaling</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Ubiquitin- and phosphoinositide-directed molecular adaptor activity that routes ubiquitinated or aberrant membrane cargo toward endolysosomal degradation.</h3>
+                <span class="vote-buttons" data-g="Q9H0E2" data-a="FUNCTION: Ubiquitin- and phosphoinositide-directed molecular..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060090" target="_blank" class="term-link">
+                            molecular adaptor activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036010" target="_blank" class="term-link">
+                                protein localization to endosome
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006511" target="_blank" class="term-link">
+                                ubiquitin-dependent protein catabolic process
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                endosome
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005769" target="_blank" class="term-link">
+                                early endosome
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**C2 domain (~central ~130 aa)**: binds **phosphoinositides**; in a 2023 mechanistic study, the C2 domain showed preferential interaction with **PI3P** and **PI(4,5)P2**, consistent with **membrane/endosome targeting** and PI3P-vesicle coupling</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal routing and degradation, operating alongside ERAD</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>CUE-domain ubiquitin-conjugate binding that supports cargo selection and receptor-proximal signaling complex regulation.</h3>
+                <span class="vote-buttons" data-g="Q9H0E2" data-a="FUNCTION: CUE-domain ubiquitin-conjugate binding that suppor..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043130" target="_blank" class="term-link">
+                            ubiquitin binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006511" target="_blank" class="term-link">
+                                ubiquitin-dependent protein catabolic process
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070498" target="_blank" class="term-link">
+                                interleukin-1-mediated signaling pathway
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045087" target="_blank" class="term-link">
+                                innate immune response
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                endosome
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis)</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells; BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger NF‑κB signaling</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">TOLLIP is a **non-enzymatic adaptor** whose primary biochemical capabilities are **specific binding interactions**:</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/1085432" target="_blank" class="term-link">
                             PMID:1085432
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Malignant lymphoma and rheumatic symptoms.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10854325" target="_blank" class="term-link">
                             PMID:10854325
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tollip, a new component of the IL-1RI pathway, links IRAK to the IL-1 receptor.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11397809" target="_blank" class="term-link">
                             PMID:11397809
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">IRAK1b, a novel alternative splice variant of interleukin-1 receptor-associated kinase (IRAK), mediates interleukin-1 signaling and has prolonged stability.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11441107" target="_blank" class="term-link">
                             PMID:11441107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cooperation of Toll-like receptor 2 and 6 for cellular activation by soluble tuberculosis factor and Borrelia burgdorferi outer surface protein A lipoprotein: role of Toll-interacting protein and IL-1 receptor signaling molecules in Toll-like receptor 2 signaling.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14563850" target="_blank" class="term-link">
                             PMID:14563850
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tom1, a VHS domain-containing protein, interacts with tollip, ubiquitin, and clathrin.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15047686" target="_blank" class="term-link">
                             PMID:15047686
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tollip and Tom1 form a complex and recruit ubiquitin-conjugated proteins onto early endosomes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16189514" target="_blank" class="term-link">
                             PMID:16189514
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Towards a proteome-scale map of the human protein-protein interaction network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16412388" target="_blank" class="term-link">
                             PMID:16412388
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Recruitment of clathrin onto endosomes by the Tom1-Tollip complex.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16713569" target="_blank" class="term-link">
                             PMID:16713569
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A protein-protein interaction network for human inherited ataxias and disorders of Purkinje cell degeneration.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19056867" target="_blank" class="term-link">
                             PMID:19056867
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Large-scale proteomics and phosphoproteomics of urinary exosomes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19060904" target="_blank" class="term-link">
                             PMID:19060904
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An empirical framework for binary interactome mapping.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19447967" target="_blank" class="term-link">
                             PMID:19447967
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Shifted Transversal Design smart-pooling for high coverage interactome mapping.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20936779" target="_blank" class="term-link">
                             PMID:20936779
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A human MAP kinase interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21492153" target="_blank" class="term-link">
                             PMID:21492153
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Analysis of proteomic changes induced upon cellular differentiation of the human intestinal cell line Caco-2.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21903422" target="_blank" class="term-link">
                             PMID:21903422
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mapping a dynamic innate immunity protein interaction network regulating type I interferon production.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link">
                             PMID:21988832
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Toward an understanding of the protein interaction network of the human liver.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23533145" target="_blank" class="term-link">
                             PMID:23533145
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in urine.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25042851" target="_blank" class="term-link">
                             PMID:25042851
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Autophagic clearance of polyQ proteins mediated by ubiquitin-Atg8 adaptors of the conserved CUET protein family.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25416956" target="_blank" class="term-link">
                             PMID:25416956
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A proteome-scale map of the human interactome network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25910212" target="_blank" class="term-link">
                             PMID:25910212
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Widespread macromolecular interaction perturbations in human genetic disorders.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26320582" target="_blank" class="term-link">
                             PMID:26320582
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tom1 Modulates Binding of Tollip to Phosphatidylinositol 3-Phosphate via a Coupled Folding and Binding Mechanism.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link">
                             PMID:27107014
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An inter-species protein-protein interaction network across vast evolutionary distance.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27368102" target="_blank" class="term-link">
                             PMID:27368102
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An ER-Associated Pathway Defines Endosomal Architecture for Controlled Cargo Transport.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31263572" target="_blank" class="term-link">
                             PMID:31263572
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dominant TOM1 mutation associated with combined immunodeficiency and autoimmune disease.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31515488" target="_blank" class="term-link">
                             PMID:31515488
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Extensive disruption of protein interactions by genetic variants across the allele frequency spectrum in human populations.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34524948" target="_blank" class="term-link">
                             PMID:34524948
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global Proximity Interactome of the Human Macroautophagy Pathway.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
                             PMID:35271311
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-446634
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">IRAK4 is activated by autophosphorylation</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-446684
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">IRAK2 is phosphorylated downstream of IRAK4 following IL1 receptor activation</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-446692
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">IRAK1 binds to MYD88 within the IL1R complex</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-446694
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">IRAK4 phosphorylates IRAK1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-446701
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">IRAK4-activated IRAK1 autophosphorylates</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-446862
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Hyperphosphorylated IRAK1 associates with TRAF6</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-446868
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Interleukin 1 receptor complex binds Tollip</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-446894
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TRAF6 binding leads to IRAK1:TRAF6 release</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6798749
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Exocytosis of specific granule lumen proteins</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6798751
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Exocytosis of azurophil granule lumen proteins</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research synthesis for TOLLIP</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(TOLLIP-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q9H0E2" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-12T00:13:27.954226'<br />
+end_time: '2026-05-12T00:22:49.573276'<br />
+duration_seconds: 561.62<br />
+template_file: templates/gene_research_go_focused.md<br />
+template_variables:<br />
+  organism: human<br />
+  gene_id: TOLLIP<br />
+  gene_symbol: TOLLIP<br />
+  uniprot_accession: Q9H0E2<br />
+  protein_description: 'RecName: Full=Toll-interacting protein;'<br />
+  gene_info: Name=TOLLIP;<br />
+  organism_full: Homo sapiens (Human).<br />
+  protein_family: Belongs to the tollip family. .<br />
+  protein_domains: C2_dom. (IPR000008); C2_domain_sf. (IPR035892); CUE. (IPR003892);<br />
+    TOLIP_CUE. (IPR041799); Tollip_C2. (IPR037301)<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 23</p>
+<hr />
+<h2 id="question">Question</h2>
+<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9H0E2</li>
+<li><strong>Protein Description:</strong> RecName: Full=Toll-interacting protein;</li>
+<li><strong>Gene Information:</strong> Name=TOLLIP;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the tollip family. .</li>
+<li><strong>Key Domains:</strong> C2_dom. (IPR000008); C2_domain_sf. (IPR035892); CUE. (IPR003892); TOLIP_CUE. (IPR041799); Tollip_C2. (IPR037301)</li>
+</ul>
+<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TOLLIP" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TOLLIP' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TOLLIP</strong> (gene ID: TOLLIP, UniProt: Q9H0E2) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
+<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
+<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
+<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
+<ul>
+<li><strong>UniProt Accession:</strong> Q9H0E2</li>
+<li><strong>Protein Description:</strong> RecName: Full=Toll-interacting protein;</li>
+<li><strong>Gene Information:</strong> Name=TOLLIP;</li>
+<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
+<li><strong>Protein Family:</strong> Belongs to the tollip family. .</li>
+<li><strong>Key Domains:</strong> C2_dom. (IPR000008); C2_domain_sf. (IPR035892); CUE. (IPR003892); TOLIP_CUE. (IPR041799); Tollip_C2. (IPR037301)</li>
+</ul>
+<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
+<ol>
+<li><strong>Check if the gene symbol "TOLLIP" matches the protein description above</strong></li>
+<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
+<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
+<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
+</ol>
+<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
+<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
+- State clearly: "The gene symbol 'TOLLIP' is ambiguous or literature is limited for this specific protein"<br />
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
+- Describe the protein based ONLY on the UniProt information provided above<br />
+- Suggest that the protein function can be inferred from domain/family information</p>
+<h3 id="research-target_1">Research Target:</h3>
+<p>Please provide a comprehensive research report on the gene <strong>TOLLIP</strong> (gene ID: TOLLIP, UniProt: Q9H0E2) in human.</p>
+<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-human-tollip-uniprot-q9h0e2-functional-annotation">Research report: Human <strong>TOLLIP</strong> (UniProt <strong>Q9H0E2</strong>) functional annotation</h2>
+<h3 id="0-target-verification-mandatory">0) Target verification (mandatory)</h3>
+<p>The literature synthesized here is restricted to <strong>human TOLLIP (Toll-interacting protein)</strong>, consistent with UniProt accession <strong>Q9H0E2</strong> and a ~274 aa adaptor protein organized around a <strong>phosphoinositide-binding C2 domain</strong> and a <strong>ubiquitin-binding CUE domain</strong>, with an N-terminal <strong>TOM1-binding domain</strong> and an experimentally mapped <strong>intrinsically disordered region (IDR)</strong> (hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas pages 5-6, baig2024adaptormoleculesmediate pages 8-9). Non-human “TOLLIP” studies exist (e.g., fish) and were not used to make claims about human molecular mechanisms beyond very general conservation context (tian2025fishtollipmanipulates pages 21-22).</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-what-tollip-is">1.1 What TOLLIP is</h4>
+<p>TOLLIP is best understood as a <strong>multifunctional adaptor/regulator</strong> that couples <strong>ubiquitin recognition</strong> and <strong>membrane/endosomal phosphoinositide recognition</strong> to (i) <strong>tuning innate immune receptor signaling</strong> (TLR/IL‑1R pathways) and (ii) <strong>sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation</strong> (baig2024adaptormoleculesmediate pages 8-9, hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas pages 1-2).</p>
+<h4 id="12-domain-architecture-and-domain-defined-functions">1.2 Domain architecture and domain-defined functions</h4>
+<p>Recent primary work provides a high-resolution functional decomposition of TOLLIP:<br />
+- <strong>TBD (TOM1-binding domain; ~aa 1–53)</strong>: supports interaction with <strong>TOM1</strong>, with endosomal machinery including <strong>clathrin</strong>, and participates in recruitment of ubiquitinated cargo to early endosomes (baig2024adaptormoleculesmediate pages 8-9, hayashi2023tollipactsas pages 2-5).<br />
+- <strong>C2 domain (~central ~130 aa)</strong>: binds <strong>phosphoinositides</strong>; in a 2023 mechanistic study, the C2 domain showed preferential interaction with <strong>PI3P</strong> and <strong>PI(4,5)P2</strong>, consistent with <strong>membrane/endosome targeting</strong> and PI3P-vesicle coupling (hayashi2023tollipactsas pages 5-6).<br />
+- <strong>IDR (intrinsically disordered region; mapped in 2023 study as aa 181–229)</strong>: functions as a <strong>misfolding-sensing cargo-recognition module</strong> that can directly bind aberrant proteins (e.g., binding heat-denatured luciferase) and is required for certain lysosomal trafficking functions (hayashi2023tollipactsas pages 5-6, hayashi2023tollipactsas pages 17-18).<br />
+- <strong>CUE domain (C-terminal; mapped as aa 231–274)</strong>: mediates <strong>ubiquitin conjugate binding</strong> and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis) (hayashi2023tollipactsas pages 5-6, baig2024adaptormoleculesmediate pages 8-9).</p>
+<p>A figure-level schematic of this domain organization and a model of PI3P-dependent lysosomal trafficking are shown in Hayashi et al. 2023 (hayashi2023tollipactsas media 03df7429, hayashi2023tollipactsas media aced0de5).</p>
+<table>
+<thead>
+<tr>
+<th>Region (aa boundaries if available)</th>
+<th>Domain/feature</th>
+<th>Key binding partners/ligands</th>
+<th>Main mechanistic role(s)</th>
+<th>Evidence type</th>
+<th>Key citations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1–53</td>
+<td>TBD (TOM1-binding domain)</td>
+<td>TOM1, clathrin, ubiquitin-conjugated cargo</td>
+<td>Recruits TOM1/clathrin-linked endosomal sorting machinery; helps load ubiquitinated cargo onto early endosomes and supports endosome-to-lysosome trafficking</td>
+<td>Domain annotation and interaction mapping from review; mutational/domain-mapping support in primary studies</td>
+<td>(baig2024adaptormoleculesmediate pages 8-9, hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas media 03df7429)</td>
+</tr>
+<tr>
+<td>~53–178 (central ~130 aa)</td>
+<td>C2 domain</td>
+<td>Phosphoinositides, especially PI3P and PI(4,5)P2; membranes/endosomes</td>
+<td>Membrane targeting and anchoring of TOLLIP to PI3P-enriched vesicles/endosomes; required for PI3P-dependent lysosomal trafficking of aberrant membrane cargo; supports localization relevant to TLR/IL-1R trafficking control</td>
+<td>Phospholipid-binding and mutagenesis data; localization assays; review synthesis</td>
+<td>(forneris2025regulationofhost pages 15-19, baig2024adaptormoleculesmediate pages 8-9, hayashi2023tollipactsas pages 5-6, hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas media 03df7429)</td>
+</tr>
+<tr>
+<td>181–229</td>
+<td>IDR (intrinsically disordered region)</td>
+<td>Misfolded/aberrant proteins (e.g., heat-denatured luciferase; aberrant ER membrane cargo such as A53T-HP)</td>
+<td>Misfolding-sensing cargo-recognition module that directly binds aberrant proteins and enables selective lysosomal clearance without bulk ER turnover</td>
+<td>Biochemical binding assays, mutagenesis, disorder prediction, lysosomal trafficking assays</td>
+<td>(hayashi2023tollipactsas pages 5-6, hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas pages 1-2, hayashi2023tollipactsas pages 17-18, hayashi2023tollipactsas media 03df7429)</td>
+</tr>
+<tr>
+<td>231–274</td>
+<td>CUE domain</td>
+<td>Ubiquitin chains/conjugates; IRAK1; TIR domains of IL-1R/TLR2/TLR4; BLK competes for the same interaction motif</td>
+<td>Ubiquitin recognition; contributes to restraint of IRAK1 autophosphorylation in resting cells; links TOLLIP to IL-1R/TLR signaling complexes; supports cargo selection for lysosomal degradation</td>
+<td>Mutagenesis and co-immunoprecipitation in primary studies; review synthesis</td>
+<td>(forneris2025regulationofhost pages 15-19, baig2024adaptormoleculesmediate pages 8-9, hayashi2023tollipactsas pages 5-6, li2023blkpositivelyregulates pages 6-10, li2023blkpositivelyregulates pages 10-15)</td>
+</tr>
+<tr>
+<td>Y76, Y86, Y152</td>
+<td>Regulatory phosphotyrosine sites</td>
+<td>BLK kinase; functionally affect IRAK1 association</td>
+<td>BLK-mediated phosphorylation promotes dissociation of TOLLIP from IRAK1, exposing IRAK1 for hyperphosphorylation and enabling stronger IL-1R/TLR-driven NF-κB signaling and cytokine responses</td>
+<td>Mass spectrometry-supported site identification, kinase assays, interaction assays, signaling assays, mouse genetics</td>
+<td>(li2023blkpositivelyregulates pages 6-10, li2023blkpositivelyregulates pages 10-15, li2023blkpositivelyregulates pages 15-21, li2023blkpositivelyregulates pages 3-6)</td>
+</tr>
+<tr>
+<td>Full-length protein / integrated domain action</td>
+<td>Endosomal–lysosomal cargo adaptor</td>
+<td>Ubiquitinated cargo, TOM1, clathrin, PI3P vesicles, lysosomal/endosomal compartments</td>
+<td>Couples ubiquitinated and/or misfolded cargo to PI3P-dependent lysosomal trafficking; promotes degradation of aberrant ER membrane proteins and contributes to selective autophagy/protein quality control</td>
+<td>Cell-based trafficking assays, KO/knockdown-rescue experiments, ultrastructural localization, review synthesis</td>
+<td>(forneris2025regulationofhost pages 19-23, hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas pages 1-2, hayashi2023tollipactsas pages 17-18, baig2024adaptormoleculesmediate pages 18-19, hayashi2023tollipactsas media aced0de5)</td>
+</tr>
+<tr>
+<td>Full-length protein / integrated domain action</td>
+<td>Innate immune signaling adaptor-regulator</td>
+<td>IRAK1, IL-1R, TLR2, TLR4, MyD88-pathway components, STING</td>
+<td>Generally acts as a brake on IL-1R/TLR signaling in resting or homeostatic contexts by restraining IRAK1 and promoting receptor turnover; can also be switched to permit signaling after BLK-dependent phosphorylation; additionally implicated in STING homeostasis</td>
+<td>Reviews plus mechanistic primary signaling study</td>
+<td>(baig2024adaptormoleculesmediate pages 8-9, tian2025fishtollipmanipulates pages 21-22, li2023blkpositivelyregulates pages 6-10, baig2024adaptormoleculesmediate pages 9-11)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes the experimentally supported domain architecture of human TOLLIP and links each region to its major ligands, trafficking roles, and signaling functions. It is useful as a compact functional annotation anchored to recent mechanistic studies and authoritative reviews.</em></p>
+<h4 id="13-cellular-localization">1.3 Cellular localization</h4>
+<p>TOLLIP’s C2 domain supports association with <strong>PI3P-enriched membranes/vesicles</strong> and <strong>endosomal/lysosomal compartments</strong>, aligning with its roles in endosomal sorting and lysosomal delivery of cargo (hayashi2023tollipactsas pages 5-6, hayashi2023tollipactsas pages 2-5). In the context of aberrant ER membrane cargo, TOLLIP operates at the <strong>ER surface</strong> to capture client proteins and route them into <strong>RAB7/LAMP1-positive endolysosomal compartments</strong> (hayashi2023tollipactsas pages 2-5). A review additionally notes context-dependent translocation (e.g., low-dose LPS driving relocation from lysosomes to mitochondria with ROS consequences), emphasizing that localization can be dynamic under inflammatory conditions (baig2024adaptormoleculesmediate pages 8-9).</p>
+<h3 id="2-recent-developments-and-latest-research-prioritizing-20232024">2) Recent developments and latest research (prioritizing 2023–2024)</h3>
+<h4 id="21-dec-2023-a-phosphorylation-switch-that-converts-tollip-from-a-brake-to-a-permissive-factor-for-tlril1r-signaling">2.1 (Dec 2023) A phosphorylation “switch” that converts TOLLIP from a brake to a permissive factor for TLR/IL‑1R signaling</h4>
+<p>Li et al. (Journal of Cell Biology; published Dec 2023; https://doi.org/10.1083/jcb.202302081) identified <strong>BLK</strong> as a kinase that <strong>phosphorylates TOLLIP</strong> on <strong>Y76, Y86, and Y152</strong> (li2023blkpositivelyregulates pages 6-10). Mechanistically:<br />
+- In resting cells, TOLLIP forms a constitutive complex with <strong>IRAK1</strong> and restrains IRAK1 phosphorylation (li2023blkpositivelyregulates pages 6-10).<br />
+- Upon <strong>IL‑1β stimulation</strong>, BLK is activated, binds the <strong>CUE domain</strong> of TOLLIP (with ~<strong>10-fold higher affinity</strong> than IRAK1), and phosphorylates TOLLIP at Y76/Y86/Y152 (li2023blkpositivelyregulates pages 6-10).<br />
+- BLK binding and phosphorylation promote <strong>dissociation of TOLLIP from IRAK1</strong>, exposing IRAK1 phosphorylation sites (ProST region) and enabling <strong>IRAK1 hyperphosphorylation</strong>, downstream <strong>NF‑κB activation</strong>, and inflammatory cytokine responses (li2023blkpositivelyregulates pages 6-10, li2023blkpositivelyregulates pages 10-15).<br />
+Physiological relevance was supported by in vivo phenotypes where <strong>Blk−/− mice</strong> produced fewer inflammatory cytokines and showed increased resistance to IL‑1β-induced death (li2023blkpositivelyregulates pages 6-10).</p>
+<p>This study reframes TOLLIP not only as a negative regulator but as a <strong>regulated checkpoint node</strong> whose inhibitory complex can be actively dismantled by a receptor-proximal kinase to permit robust signaling.</p>
+<h4 id="22-nov-2023-tollip-as-a-cargo-adaptor-for-selective-lysosomal-degradation-of-aberrant-er-membrane-proteins">2.2 (Nov 2023) TOLLIP as a cargo adaptor for selective lysosomal degradation of aberrant ER membrane proteins</h4>
+<p>Hayashi et al. (The EMBO Journal; published Nov 2023; https://doi.org/10.15252/embj.2023114272) provided a mechanistic model in which TOLLIP is a <strong>cargo-specific adaptor</strong> for the lysosomal removal of <strong>aberrant ER membrane proteins</strong> (hayashi2023tollipactsas pages 1-2).</p>
+<p>Key findings:<br />
+- TOLLIP promotes selective lysosomal degradation of aberrant membrane proteins (including a model A53T-HP substrate and disease mutants of <strong>VAPB</strong> and <strong>Seipin</strong>) (hayashi2023tollipactsas pages 1-2).<br />
+- Cargo recognition requires a <strong>misfolding-sensing IDR</strong> and a <strong>ubiquitin-binding CUE domain</strong>; deletion/mutation of these regions disrupts binding to ubiquitin conjugates and interaction with aberrant cargo (hayashi2023tollipactsas pages 5-6, hayashi2023tollipactsas pages 1-2).<br />
+- The <strong>C2 domain</strong> links TOLLIP to <strong>PI3P-dependent trafficking</strong>, enabling delivery to <strong>endolysosomal</strong> compartments; this pathway is selective for aberrant cargos and does not drive bulk ER turnover (hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas pages 1-2).<br />
+- Functionally, TOLLIP depletion exacerbated ER stress when ERAD was inhibited, suggesting TOLLIP-mediated lysosomal quality control operates <strong>in parallel with ERAD</strong> to safeguard ER proteostasis (hayashi2023tollipactsas pages 1-2).</p>
+<p>This 2023 study expanded TOLLIP’s functional annotation beyond innate immunity into a <strong>direct mechanistic role in ER membrane protein quality control</strong>.</p>
+<h4 id="23-feb-2024-expert-synthesis-tollip-as-a-multitasking-adaptor-coordinating-negative-regulation-and-trafficking">2.3 (Feb 2024) Expert synthesis: TOLLIP as a “multitasking” adaptor coordinating negative regulation and trafficking</h4>
+<p>Baig et al. (Frontiers in Immunology; published Feb 2024; https://doi.org/10.3389/fimmu.2024.1355012) review adaptor molecules that negatively regulate macrophage inflammatory pathways and describe TOLLIP as a <strong>ubiquitously expressed adaptor</strong> that modulates <strong>IL‑1R and TLR2/4 signaling</strong> and interacts directly with TLR2/TLR4 (baig2024adaptormoleculesmediate pages 8-9). The review emphasizes a canonical negative-regulatory role in acute inflammatory signaling—via interactions with IRAKs and receptor TIR domains and via promoting receptor degradation—while noting context-dependence and additional roles in trafficking/autophagy-related processes (baig2024adaptormoleculesmediate pages 8-9, baig2024adaptormoleculesmediate pages 9-11).</p>
+<h3 id="3-current-applications-and-real-world-implementations">3) Current applications and real-world implementations</h3>
+<h4 id="31-clinical-trial-implementation-genotyping-tollip-snps-as-a-candidate-modifier-of-n-acetylcysteine-nac-response">3.1 Clinical trial implementation: genotyping TOLLIP SNPs as a candidate modifier of N-acetylcysteine (NAC) response</h4>
+<p>A completed Phase 1 clinical trial in retinitis pigmentosa, <strong>FIGHT‑RP1</strong> (ClinicalTrials.gov <strong>NCT03063021</strong>; start date <strong>2017-02-15</strong>, completion date <strong>2019-02-11</strong>) tested oral <strong>N‑acetylcysteine (NAC)</strong> and explicitly planned <strong>DNA collection to genotype the same TOLLIP SNPs</strong> previously reported as influencing NAC response in idiopathic pulmonary fibrosis (IPF), as a candidate-gene analysis (NCT03063021 chunk 1). The trial also banks RNA for future transcriptomic studies (NCT03063021 chunk 1). Trial URL: https://clinicaltrials.gov/study/NCT03063021.</p>
+<p>Importantly, this trial does not target TOLLIP directly, but illustrates how TOLLIP <strong>human genetics</strong> can be operationalized as a <strong>therapeutic-response modifier</strong> in an interventional study design (NCT03063021 chunk 1).</p>
+<h4 id="32-translational-disease-associations-targetdisease-knowledgebases">3.2 Translational disease associations (target–disease knowledgebases)</h4>
+<p>Open Targets lists TOLLIP (ENSG00000078902) association evidence across respiratory and other diseases, including <strong>idiopathic pulmonary fibrosis</strong> and <strong>chronic obstructive pulmonary disease</strong>, with disease-association scores (e.g., COPD score ~0.142; IPF score ~0.374 in the returned Open Targets snapshot) (OpenTargets Search: -TOLLIP). While such associations are not mechanistic proof, they highlight settings where TOLLIP biology and/or genetics are considered relevant for human disease prioritization.</p>
+<h3 id="4-expert-opinions-and-analysis-authoritative-sources">4) Expert opinions and analysis (authoritative sources)</h3>
+<h4 id="41-consensus-view-adaptor-integrating-ubiquitin-membranes-and-receptor-signaling">4.1 Consensus view: adaptor integrating ubiquitin, membranes, and receptor signaling</h4>
+<p>The 2024 review frames TOLLIP as a “multitasking” adaptor that links <strong>ubiquitin</strong>, <strong>endosomal trafficking machinery (TOM1/clathrin)</strong>, and <strong>innate immune receptor signaling</strong> to restrain inflammatory outputs, including by limiting IRAK activation and promoting receptor turnover (baig2024adaptormoleculesmediate pages 8-9, baig2024adaptormoleculesmediate pages 9-11). This aligns with the mechanistic picture from 2023 primary studies in which specific TOLLIP domains encode: phosphoinositide-directed localization (C2), ubiquitin recognition (CUE), and client recognition (IDR) (hayashi2023tollipactsas pages 5-6, hayashi2023tollipactsas pages 1-2).</p>
+<h4 id="42-updated-20232024-perspective-negative-regulator-is-accurate-but-incomplete">4.2 Updated 2023–2024 perspective: “negative regulator” is accurate but incomplete</h4>
+<p>Two 2023 studies sharpen (and partially complicate) the traditional “TOLLIP is a negative regulator” label:<br />
+- In TLR/IL‑1R pathways, TOLLIP can function as an inhibitory clamp on IRAK1 in resting cells but is <strong>actively displaced</strong> by BLK after receptor engagement to permit efficient signal propagation—an explicit <strong>regulatory switch</strong> rather than a static inhibitor (li2023blkpositivelyregulates pages 6-10).<br />
+- In proteostasis, TOLLIP is not simply an autophagy receptor; it can act as a <strong>cargo-specific adaptor</strong> for PI3P-dependent lysosomal trafficking of aberrant ER membrane proteins, with domain-level specificity and separability from bulk ER-phagy (hayashi2023tollipactsas pages 1-2, hayashi2023tollipactsas media aced0de5).</p>
+<h3 id="5-relevant-statistics-and-data-points-from-recent-studies">5) Relevant statistics and data points from recent studies</h3>
+<h4 id="51-quantitative-trafficking-readouts-hayashi-et-al-embo-j-2023">5.1 Quantitative trafficking readouts (Hayashi et al., EMBO J 2023)</h4>
+<p>Hayashi et al. quantified endosomal/lysosomal features and lysosomal delivery using operational metrics, including:<br />
+- Definition of “acidic puncta” as mCherry:EGFP intensity ratio <strong>&gt; 1.25</strong> in mCherry‑EGFP cargo assays (hayashi2023tollipactsas pages 17-18).<br />
+- Example reported puncta counts: average <strong>PI3P puncta per cell</strong> changed from <strong>38</strong> (siCtrl) to <strong>33</strong> (siTOLLIP) in one condition set; additional construct-dependent values were reported (e.g., 39 CFP; 36 WT; 37 C2mut; 48 IDRmut; 37 ΔCUE) (hayashi2023tollipactsas pages 17-18).<br />
+- Example <strong>LAMP1 puncta</strong> averages reported across conditions included <strong>50</strong> (siCtrl) vs <strong>33</strong> (siTOLLIP), with partial rescue by WT and differing impacts of mutants (e.g., 32 siTOLLIP+WT; 28 siTOLLIP+C2mut #1; 38 siTOLLIP+IDRmut) (hayashi2023tollipactsas pages 17-18).<br />
+These data support that TOLLIP perturbation measurably affects PI3P/LAMP1-associated trafficking features in cells, consistent with its PI3P-dependent lysosomal routing role (hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas pages 17-18).</p>
+<h4 id="52-sample-sizes-and-quantitative-design-features-li-et-al-jcb-2023">5.2 Sample sizes and quantitative design features (Li et al., JCB 2023)</h4>
+<p>Li et al. report typical experimental replication for signaling outputs, including qPCR with <strong>n=3 technical replicates</strong>, luciferase assays with <strong>n=3 biological replicates</strong>, and ELISA with <strong>n=6 biological replicates</strong>, and they use Kaplan–Meier/log-rank tests for survival analyses in mouse studies (li2023blkpositivelyregulates pages 6-10). While many fold-changes are figure-embedded (not present in the excerpt), key quantitative mechanistic claims include BLK’s ~<strong>10-fold higher affinity</strong> for TOLLIP than IRAK1 in their binding analyses (li2023blkpositivelyregulates pages 6-10).</p>
+<h4 id="53-quantitative-association-signals-open-targets-snapshot">5.3 Quantitative association signals (Open Targets snapshot)</h4>
+<p>Open Targets returned disease-association scores for TOLLIP such as ~<strong>0.374</strong> (idiopathic pulmonary fibrosis) and ~<strong>0.142</strong> (COPD) in the snapshot retrieved here (OpenTargets Search: -TOLLIP). These scores are integrative/knowledgebase-derived rather than a single study statistic, and should be interpreted accordingly.</p>
+<hr />
+<h2 id="mechanistic-functional-annotation-summary-human-tollipq9h0e2">Mechanistic functional annotation summary (human TOLLIP/Q9H0E2)</h2>
+<h3 id="primary-molecular-function">Primary molecular function</h3>
+<p>TOLLIP is a <strong>non-enzymatic adaptor</strong> whose primary biochemical capabilities are <strong>specific binding interactions</strong>:<br />
+1) <strong>Phosphoinositide binding</strong> (C2 domain; PI3P/PI(4,5)P2) that localizes TOLLIP to appropriate membranes/vesicles and enables PI3P-dependent trafficking (hayashi2023tollipactsas pages 5-6). <br />
+2) <strong>Ubiquitin binding</strong> (CUE domain), enabling recognition of ubiquitinated cargo and coupling to degradation pathways; in immune signaling contexts the CUE domain is also implicated in interactions with IRAKs and receptor TIR domains (hayashi2023tollipactsas pages 5-6, baig2024adaptormoleculesmediate pages 8-9).<br />
+3) <strong>Misfolded client recognition</strong> (IDR), supporting selective capture of aberrant proteins for lysosomal trafficking (hayashi2023tollipactsas pages 5-6).</p>
+<h3 id="cellular-sites-of-action">Cellular sites of action</h3>
+<ul>
+<li><strong>Endosomes / PI3P-enriched vesicles and endolysosomes</strong>, supporting receptor/cargo sorting and degradation (hayashi2023tollipactsas pages 5-6, hayashi2023tollipactsas pages 2-5).</li>
+<li><strong>ER surface</strong>, where TOLLIP can recognize aberrant membrane proteins and route them to lysosomes (hayashi2023tollipactsas pages 2-5).</li>
+<li>Potentially dynamic relocalization under inflammatory contexts (e.g., mitochondria translocation described in review synthesis) (baig2024adaptormoleculesmediate pages 8-9).</li>
+</ul>
+<h3 id="major-pathways">Major pathways</h3>
+<ul>
+<li><strong>TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB</strong>: TOLLIP restrains IRAK1 in resting cells; BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger NF‑κB signaling (li2023blkpositivelyregulates pages 6-10, li2023blkpositivelyregulates pages 10-15).</li>
+<li><strong>Endosomal/lysosomal trafficking and protein quality control</strong>: TOLLIP functions as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal routing and degradation, operating alongside ERAD (hayashi2023tollipactsas pages 1-2).</li>
+</ul>
+<hr />
+<h2 id="key-20232024-references-urls-and-dates">Key 2023–2024 references (URLs and dates)</h2>
+<ul>
+<li><strong>Hayashi Y. et al.</strong> “TOLLIP acts as a cargo adaptor to promote lysosomal degradation of aberrant ER membrane proteins.” <em>The EMBO Journal</em> (Nov <strong>2023</strong>). https://doi.org/10.15252/embj.2023114272 (hayashi2023tollipactsas pages 1-2)</li>
+<li><strong>Li W‑W. et al.</strong> “BLK positively regulates TLR/IL‑1R signaling by catalyzing TOLLIP phosphorylation.” <em>The Journal of Cell Biology</em> (Dec <strong>2023</strong>). https://doi.org/10.1083/jcb.202302081 (li2023blkpositivelyregulates pages 6-10)</li>
+<li><strong>Baig M.S. et al.</strong> “Adaptor molecules mediate negative regulation of macrophage inflammatory pathways: a closer look.” <em>Frontiers in Immunology</em> (Feb <strong>2024</strong>). https://doi.org/10.3389/fimmu.2024.1355012 (baig2024adaptormoleculesmediate pages 8-9)</li>
+<li><strong>ClinicalTrials.gov</strong>: <strong>NCT03063021</strong> (FIGHT‑RP1; NAC in retinitis pigmentosa; includes TOLLIP SNP genotyping plan). First posted <strong>2017</strong>; completed <strong>2019</strong>. https://clinicaltrials.gov/study/NCT03063021 (NCT03063021 chunk 1)</li>
+<li><strong>Open Targets Platform</strong> (accessed via tool snapshot): disease–target associations for TOLLIP including IPF/COPD (OpenTargets Search: -TOLLIP)</li>
+</ul>
+<h2 id="notable-evidence-gaps-based-on-retrieved-sources">Notable evidence gaps (based on retrieved sources)</h2>
+<p>Within the retrieved 2023–2024 corpus, explicit human-variant (SNP-level) effect sizes for specific TOLLIP polymorphisms and their mechanistic consequences were not available as full-text evidence; the clinical trial record confirms such polymorphisms are considered actionable for NAC response in IPF, but the underlying genetic association details would require direct access to the cited IPF pharmacogenetic studies (NCT03063021 chunk 1).</p>
+<p>References</p>
+<ol>
+<li>
+<p>(hayashi2023tollipactsas pages 2-5): Yuki Hayashi, Sho Takatori, Waleed Y Warsame, Taisuke Tomita, Takao Fujisawa, and Hidenori Ichijo. Tollip acts as a cargo adaptor to promote lysosomal degradation of aberrant er membrane proteins. The EMBO Journal, Nov 2023. URL: https://doi.org/10.15252/embj.2023114272, doi:10.15252/embj.2023114272. This article has 25 citations.</p>
+</li>
+<li>
+<p>(hayashi2023tollipactsas pages 5-6): Yuki Hayashi, Sho Takatori, Waleed Y Warsame, Taisuke Tomita, Takao Fujisawa, and Hidenori Ichijo. Tollip acts as a cargo adaptor to promote lysosomal degradation of aberrant er membrane proteins. The EMBO Journal, Nov 2023. URL: https://doi.org/10.15252/embj.2023114272, doi:10.15252/embj.2023114272. This article has 25 citations.</p>
+</li>
+<li>
+<p>(baig2024adaptormoleculesmediate pages 8-9): Mirza S. Baig, Spyridoula Barmpoutsi, Shreya Bharti, Andreas Weigert, Nik Hirani, Rajat Atre, Rakhi Khabiya, Rahul Sharma, Shivmuni Sarup, and Rajkumar Savai. Adaptor molecules mediate negative regulation of macrophage inflammatory pathways: a closer look. Frontiers in Immunology, Feb 2024. URL: https://doi.org/10.3389/fimmu.2024.1355012, doi:10.3389/fimmu.2024.1355012. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(tian2025fishtollipmanipulates pages 21-22): Meng-Ze Tian, Yang-Yang Wang, Bao-jie Cui, Xiao Xu, Chu-Jing Zhou, Can Zhang, Zhuo-Cong Li, Meng-Qian Hong, Na Xu, Dan-Dan Chen, Long-Feng Lu, and Shun Li. Fish tollip manipulates atg5 for autophagic degradation of sting to attenuate antiviral interferon responses. PLOS Pathogens, 21:e1013512, Sep 2025. URL: https://doi.org/10.1371/journal.ppat.1013512, doi:10.1371/journal.ppat.1013512. This article has 1 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hayashi2023tollipactsas pages 1-2): Yuki Hayashi, Sho Takatori, Waleed Y Warsame, Taisuke Tomita, Takao Fujisawa, and Hidenori Ichijo. Tollip acts as a cargo adaptor to promote lysosomal degradation of aberrant er membrane proteins. The EMBO Journal, Nov 2023. URL: https://doi.org/10.15252/embj.2023114272, doi:10.15252/embj.2023114272. This article has 25 citations.</p>
+</li>
+<li>
+<p>(hayashi2023tollipactsas pages 17-18): Yuki Hayashi, Sho Takatori, Waleed Y Warsame, Taisuke Tomita, Takao Fujisawa, and Hidenori Ichijo. Tollip acts as a cargo adaptor to promote lysosomal degradation of aberrant er membrane proteins. The EMBO Journal, Nov 2023. URL: https://doi.org/10.15252/embj.2023114272, doi:10.15252/embj.2023114272. This article has 25 citations.</p>
+</li>
+<li>
+<p>(hayashi2023tollipactsas media 03df7429): Yuki Hayashi, Sho Takatori, Waleed Y Warsame, Taisuke Tomita, Takao Fujisawa, and Hidenori Ichijo. Tollip acts as a cargo adaptor to promote lysosomal degradation of aberrant er membrane proteins. The EMBO Journal, Nov 2023. URL: https://doi.org/10.15252/embj.2023114272, doi:10.15252/embj.2023114272. This article has 25 citations.</p>
+</li>
+<li>
+<p>(hayashi2023tollipactsas media aced0de5): Yuki Hayashi, Sho Takatori, Waleed Y Warsame, Taisuke Tomita, Takao Fujisawa, and Hidenori Ichijo. Tollip acts as a cargo adaptor to promote lysosomal degradation of aberrant er membrane proteins. The EMBO Journal, Nov 2023. URL: https://doi.org/10.15252/embj.2023114272, doi:10.15252/embj.2023114272. This article has 25 citations.</p>
+</li>
+<li>
+<p>(forneris2025regulationofhost pages 15-19): P Forneris. Regulation of host immune responses by toll-interacting protein during citrobacter rodentium infection. Unknown journal, 2025.</p>
+</li>
+<li>
+<p>(li2023blkpositivelyregulates pages 6-10): Wei-Wei Li, Xu-Xu Fan, Zhi-Sheng Xu, Zi-Xiang Zhu, Zhao-Yu Zhu, Xue-Jing Cao, Dan-Shi Pei, Yi-Zhuo Wang, Ji-Yan Zhang, Yan-Yi Wang, and Hai-Xue Zheng. Blk positively regulates tlr/il-1r signaling by catalyzing tollip phosphorylation. The Journal of Cell Biology, Dec 2023. URL: https://doi.org/10.1083/jcb.202302081, doi:10.1083/jcb.202302081. This article has 4 citations.</p>
+</li>
+<li>
+<p>(li2023blkpositivelyregulates pages 10-15): Wei-Wei Li, Xu-Xu Fan, Zhi-Sheng Xu, Zi-Xiang Zhu, Zhao-Yu Zhu, Xue-Jing Cao, Dan-Shi Pei, Yi-Zhuo Wang, Ji-Yan Zhang, Yan-Yi Wang, and Hai-Xue Zheng. Blk positively regulates tlr/il-1r signaling by catalyzing tollip phosphorylation. The Journal of Cell Biology, Dec 2023. URL: https://doi.org/10.1083/jcb.202302081, doi:10.1083/jcb.202302081. This article has 4 citations.</p>
+</li>
+<li>
+<p>(li2023blkpositivelyregulates pages 15-21): Wei-Wei Li, Xu-Xu Fan, Zhi-Sheng Xu, Zi-Xiang Zhu, Zhao-Yu Zhu, Xue-Jing Cao, Dan-Shi Pei, Yi-Zhuo Wang, Ji-Yan Zhang, Yan-Yi Wang, and Hai-Xue Zheng. Blk positively regulates tlr/il-1r signaling by catalyzing tollip phosphorylation. The Journal of Cell Biology, Dec 2023. URL: https://doi.org/10.1083/jcb.202302081, doi:10.1083/jcb.202302081. This article has 4 citations.</p>
+</li>
+<li>
+<p>(li2023blkpositivelyregulates pages 3-6): Wei-Wei Li, Xu-Xu Fan, Zhi-Sheng Xu, Zi-Xiang Zhu, Zhao-Yu Zhu, Xue-Jing Cao, Dan-Shi Pei, Yi-Zhuo Wang, Ji-Yan Zhang, Yan-Yi Wang, and Hai-Xue Zheng. Blk positively regulates tlr/il-1r signaling by catalyzing tollip phosphorylation. The Journal of Cell Biology, Dec 2023. URL: https://doi.org/10.1083/jcb.202302081, doi:10.1083/jcb.202302081. This article has 4 citations.</p>
+</li>
+<li>
+<p>(forneris2025regulationofhost pages 19-23): P Forneris. Regulation of host immune responses by toll-interacting protein during citrobacter rodentium infection. Unknown journal, 2025.</p>
+</li>
+<li>
+<p>(baig2024adaptormoleculesmediate pages 18-19): Mirza S. Baig, Spyridoula Barmpoutsi, Shreya Bharti, Andreas Weigert, Nik Hirani, Rajat Atre, Rakhi Khabiya, Rahul Sharma, Shivmuni Sarup, and Rajkumar Savai. Adaptor molecules mediate negative regulation of macrophage inflammatory pathways: a closer look. Frontiers in Immunology, Feb 2024. URL: https://doi.org/10.3389/fimmu.2024.1355012, doi:10.3389/fimmu.2024.1355012. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(baig2024adaptormoleculesmediate pages 9-11): Mirza S. Baig, Spyridoula Barmpoutsi, Shreya Bharti, Andreas Weigert, Nik Hirani, Rajat Atre, Rakhi Khabiya, Rahul Sharma, Shivmuni Sarup, and Rajkumar Savai. Adaptor molecules mediate negative regulation of macrophage inflammatory pathways: a closer look. Frontiers in Immunology, Feb 2024. URL: https://doi.org/10.3389/fimmu.2024.1355012, doi:10.3389/fimmu.2024.1355012. This article has 7 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(NCT03063021 chunk 1):  The FIGHT-RP1 Study. Johns Hopkins University. 2017. ClinicalTrials.gov Identifier: NCT03063021</p>
+</li>
+<li>
+<p>(OpenTargets Search: -TOLLIP): Open Targets Query (-TOLLIP, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>tian2025fishtollipmanipulates pages 21-22</li>
+<li>hayashi2023tollipactsas pages 5-6</li>
+<li>hayashi2023tollipactsas pages 2-5</li>
+<li>baig2024adaptormoleculesmediate pages 8-9</li>
+<li>li2023blkpositivelyregulates pages 6-10</li>
+<li>hayashi2023tollipactsas pages 1-2</li>
+<li>hayashi2023tollipactsas pages 17-18</li>
+<li>forneris2025regulationofhost pages 15-19</li>
+<li>li2023blkpositivelyregulates pages 10-15</li>
+<li>li2023blkpositivelyregulates pages 15-21</li>
+<li>li2023blkpositivelyregulates pages 3-6</li>
+<li>forneris2025regulationofhost pages 19-23</li>
+<li>baig2024adaptormoleculesmediate pages 18-19</li>
+<li>baig2024adaptormoleculesmediate pages 9-11</li>
+<li>https://doi.org/10.1083/jcb.202302081</li>
+<li>https://doi.org/10.15252/embj.2023114272</li>
+<li>https://doi.org/10.3389/fimmu.2024.1355012</li>
+<li>https://clinicaltrials.gov/study/NCT03063021.</li>
+<li>https://clinicaltrials.gov/study/NCT03063021</li>
+<li>https://doi.org/10.15252/embj.2023114272,</li>
+<li>https://doi.org/10.3389/fimmu.2024.1355012,</li>
+<li>https://doi.org/10.1371/journal.ppat.1013512,</li>
+<li>https://doi.org/10.1083/jcb.202302081,</li>
+</ol>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -6092,953 +8001,1647 @@
                 <pre><code>id: Q9H0E2
 gene_symbol: TOLLIP
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: &#39;TODO: Add description for TOLLIP&#39;
+description: &#39;TOLLIP encodes Toll-interacting protein, a non-enzymatic ubiquitin/phosphoinositide-binding
+  adaptor that links endosomal membranes, TOM1/clathrin-associated trafficking, and TLR/IL-1 receptor
+  signaling. Its core roles are CUE-domain ubiquitin recognition, C2-domain membrane/endosome targeting,
+  PI3P-dependent endolysosomal routing of ubiquitinated or aberrant cargo, and regulated restraint of
+  IRAK-dependent innate immune signaling.&#39;
 alternative_products:
-  - id: Q9H0E2-1
-    name: &#39;1&#39;
-  - id: Q9H0E2-2
-    name: &#39;2&#39;
+- id: Q9H0E2-1
+  name: &#39;1&#39;
+- id: Q9H0E2-2
+  name: &#39;2&#39;
 existing_annotations:
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0006511
-      label: ubiquitin-dependent protein catabolic process
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0031624
-      label: ubiquitin conjugating enzyme binding
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0043130
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Cytoplasm is the broad cellular compartment for TOLLIP adaptor activity and endosomal
+      trafficking.
+    action: ACCEPT
+    reason: cytoplasm is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0006511
+    label: ubiquitin-dependent protein catabolic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Ubiquitin-dependent protein catabolic process is supported by TOLLIP-mediated routing
+      of ubiquitinated or aberrant cargo to endolysosomal degradation.
+    action: ACCEPT
+    reason: ubiquitin-dependent protein catabolic process is supported as part of TOLLIP adaptor,
+      endosomal cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD&#39;
+- term:
+    id: GO:0031624
+    label: ubiquitin conjugating enzyme binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: The evidence supports CUE-domain recognition of ubiquitin conjugates rather than a
+      specific ubiquitin-conjugating enzyme binding function.
+    action: MODIFY
+    reason: ubiquitin conjugating enzyme binding is less precise than the supported TOLLIP
+      mechanism.
+    proposed_replacement_terms:
+    - id: GO:0043130
       label: ubiquitin binding
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0002376
-      label: immune system process
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000044
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005768
-      label: endosome
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000044
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005769
-      label: early endosome
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000044
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0006914
-      label: autophagy
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0006954
-      label: inflammatory response
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0043130
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0043130
+    label: ubiquitin binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Ubiquitin binding is a core CUE-domain molecular function of TOLLIP.
+    action: ACCEPT
+    reason: ubiquitin binding is supported as part of TOLLIP adaptor, endosomal cargo-routing, or
+      innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+- term:
+    id: GO:0002376
+    label: immune system process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: immune system process is plausible as a context-specific or secondary TOLLIP-associated
+      annotation, but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: immune system process is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R
+      signaling roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling&#39;
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Cytoplasm is the broad cellular compartment for TOLLIP adaptor activity and endosomal
+      trafficking.
+    action: ACCEPT
+    reason: cytoplasm is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005768
+    label: endosome
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Endosome localization is central to TOLLIP PI3P-dependent cargo routing.
+    action: ACCEPT
+    reason: endosome is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD&#39;
+- term:
+    id: GO:0005769
+    label: early endosome
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Early endosome localization is supported by TOLLIP coupling of PI3P vesicles to cargo
+      trafficking.
+    action: ACCEPT
+    reason: early endosome is supported as part of TOLLIP adaptor, endosomal cargo-routing, or
+      innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD&#39;
+- term:
+    id: GO:0006914
+    label: autophagy
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: autophagy is plausible as a context-specific or secondary TOLLIP-associated annotation,
+      but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: autophagy is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R signaling
+      roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD&#39;
+- term:
+    id: GO:0006954
+    label: inflammatory response
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: inflammatory response is plausible as a context-specific or secondary TOLLIP-associated
+      annotation, but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: inflammatory response is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R
+      signaling roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling&#39;
+- term:
+    id: GO:0043130
+    label: ubiquitin binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Ubiquitin binding is a core CUE-domain molecular function of TOLLIP.
+    action: ACCEPT
+    reason: ubiquitin binding is supported as part of TOLLIP adaptor, endosomal cargo-routing, or
+      innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+- term:
+    id: GO:0045087
+    label: innate immune response
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: Innate immune response is supported through TOLLIP regulation of TLR/IL-1R signaling
+      outputs.
+    action: ACCEPT
+    reason: innate immune response is supported as part of TOLLIP adaptor, endosomal cargo-routing,
+      or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:14563850
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16189514
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16713569
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19060904
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19447967
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20936779
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21903422
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21988832
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25042851
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25910212
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:27107014
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31515488
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32814053
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:34524948
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35271311
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005150
+    label: interleukin-1, type I receptor binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Interleukin-1 type I receptor binding is supported as part of the IL-1R/TLR signaling
+      adaptor-regulator role.
+    action: ACCEPT
+    reason: interleukin-1, type I receptor binding is supported as part of TOLLIP adaptor, endosomal
+      cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling&#39;
+- term:
+    id: GO:0016604
+    label: nuclear body
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: nuclear body is plausible as a context-specific or secondary TOLLIP-associated
+      annotation, but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: nuclear body is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R signaling
+      roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD&#39;
+- term:
+    id: GO:0031624
+    label: ubiquitin conjugating enzyme binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: The evidence supports CUE-domain recognition of ubiquitin conjugates rather than a
+      specific ubiquitin-conjugating enzyme binding function.
+    action: MODIFY
+    reason: ubiquitin conjugating enzyme binding is less precise than the supported TOLLIP
+      mechanism.
+    proposed_replacement_terms:
+    - id: GO:0043130
       label: ubiquitin binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0045087
-      label: innate immune response
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:14563850
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:14563850
-          supporting_text: 2003 Oct 15. Tom1, a VHS domain-containing protein, 
-            interacts with tollip, ubiquitin, and clathrin.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:16189514
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:16189514
-          supporting_text: Towards a proteome-scale map of the human 
-            protein-protein interaction network.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:16713569
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:16713569
-          supporting_text: A protein-protein interaction network for human 
-            inherited ataxias and disorders of Purkinje cell degeneration.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:19060904
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:19060904
-          supporting_text: An empirical framework for binary interactome 
-            mapping.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:19447967
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:19447967
-          supporting_text: Shifted Transversal Design smart-pooling for high 
-            coverage interactome mapping.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:20936779
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20936779
-          supporting_text: A human MAP kinase interactome.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:21903422
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:21903422
-          supporting_text: 2011 Sep 8. Mapping a dynamic innate immunity protein
-            interaction network regulating type I interferon production.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:21988832
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:21988832
-          supporting_text: Toward an understanding of the protein interaction 
-            network of the human liver.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:25042851
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:25042851
-          supporting_text: Jul 18. Autophagic clearance of polyQ proteins 
-            mediated by ubiquitin-Atg8 adaptors of the conserved CUET protein 
-            family.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:25416956
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:25416956
-          supporting_text: A proteome-scale map of the human interactome 
-            network.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:25910212
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:25910212
-          supporting_text: Widespread macromolecular interaction perturbations 
-            in human genetic disorders.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:27107014
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:27107014
-          supporting_text: An inter-species protein-protein interaction network 
-            across vast evolutionary distance.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:31515488
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31515488
-          supporting_text: Extensive disruption of protein interactions by 
-            genetic variants across the allele frequency spectrum in human 
-            populations.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:32296183
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32296183
-          supporting_text: Apr 8. A reference map of the human binary protein 
-            interactome.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:32814053
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32814053
-          supporting_text: Interactome Mapping Provides a Network of 
-            Neurodegenerative Disease Proteins and Uncovers Widespread Protein 
-            Aggregation in Affected Brains.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:33961781
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:33961781
-          supporting_text: 2021 May 6. Dual proteome-scale networks reveal 
-            cell-specific remodeling of the human interactome.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:34524948
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:34524948
-          supporting_text: 2021 Sep 15. Global Proximity Interactome of the 
-            Human Macroautophagy Pathway.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:35271311
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:35271311
-          supporting_text: &#39;2022 Mar 11. OpenCell: Endogenous tagging for the cartography
-            of human cellular organization.&#39;
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:40205054
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:40205054
-          supporting_text: Apr 9. Multimodal cell maps as a foundation for 
-            structural and functional genomics.
-  - term:
-      id: GO:0005150
-      label: interleukin-1, type I receptor binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0016604
-      label: nuclear body
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0031624
-      label: ubiquitin conjugating enzyme binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0031625
-      label: ubiquitin protein ligase binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0032183
-      label: SUMO binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0032991
-      label: protein-containing complex
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0033235
-      label: positive regulation of protein sumoylation
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0048471
-      label: perinuclear region of cytoplasm
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0070498
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0031625
+    label: ubiquitin protein ligase binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Ubiquitin protein ligase binding is not the main supported activity; the reviewed
+      evidence emphasizes ubiquitin conjugate binding and adaptor function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: ubiquitin protein ligase binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0032183
+    label: SUMO binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: SUMO binding is not supported by the Falcon synthesis as a core or well-grounded TOLLIP
+      function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: SUMO binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+- term:
+    id: GO:0032991
+    label: protein-containing complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Protein-containing complex is supported because TOLLIP acts in TOM1/clathrin, cargo,
+      IRAK, and receptor-proximal complexes.
+    action: ACCEPT
+    reason: protein-containing complex is supported as part of TOLLIP adaptor, endosomal
+      cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling&#39;
+- term:
+    id: GO:0033235
+    label: positive regulation of protein sumoylation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Positive regulation of protein sumoylation is not supported as a TOLLIP core function
+      in the reviewed evidence.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: positive regulation of protein sumoylation overstates or obscures the supported TOLLIP
+      function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+- term:
+    id: GO:0048471
+    label: perinuclear region of cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: perinuclear region of cytoplasm is plausible as a context-specific or secondary
+      TOLLIP-associated annotation, but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: perinuclear region of cytoplasm is secondary to TOLLIP ubiquitin/membrane adaptor and
+      TLR/IL-1R signaling roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD&#39;
+- term:
+    id: GO:0070498
+    label: interleukin-1-mediated signaling pathway
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Interleukin-1-mediated signaling pathway is a supported core immune-signaling context
+      for TOLLIP.
+    action: ACCEPT
+    reason: interleukin-1-mediated signaling pathway is supported as part of TOLLIP adaptor,
+      endosomal cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling&#39;
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:26320582
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31263572
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:15047686
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0019897
+    label: extrinsic component of plasma membrane
+  evidence_type: IC
+  original_reference_id: PMID:10854325
+  review:
+    summary: extrinsic component of plasma membrane is plausible as a context-specific or secondary
+      TOLLIP-associated annotation, but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: extrinsic component of plasma membrane is secondary to TOLLIP ubiquitin/membrane adaptor
+      and TLR/IL-1R signaling roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD&#39;
+- term:
+    id: GO:0060090
+    label: molecular adaptor activity
+  evidence_type: IDA
+  original_reference_id: PMID:10854325
+  review:
+    summary: Molecular adaptor activity captures the core TOLLIP role in linking cargo, endosomal
+      membranes, and receptor-signaling proteins.
+    action: ACCEPT
+    reason: molecular adaptor activity is supported as part of TOLLIP adaptor, endosomal
+      cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD&#39;
+- term:
+    id: GO:0070498
+    label: interleukin-1-mediated signaling pathway
+  evidence_type: IDA
+  original_reference_id: PMID:10854325
+  review:
+    summary: Interleukin-1-mediated signaling pathway is a supported core immune-signaling context
+      for TOLLIP.
+    action: ACCEPT
+    reason: interleukin-1-mediated signaling pathway is supported as part of TOLLIP adaptor,
+      endosomal cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling&#39;
+- term:
+    id: GO:0060090
+    label: molecular adaptor activity
+  evidence_type: IDA
+  original_reference_id: PMID:27368102
+  review:
+    summary: Molecular adaptor activity captures the core TOLLIP role in linking cargo, endosomal
+      membranes, and receptor-signaling proteins.
+    action: ACCEPT
+    reason: molecular adaptor activity is supported as part of TOLLIP adaptor, endosomal
+      cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD&#39;
+- term:
+    id: GO:0019900
+    label: kinase binding
+  evidence_type: IPI
+  original_reference_id: PMID:10854325
+  review:
+    summary: Kinase binding is supported by TOLLIP interactions with IRAK1 and BLK in
+      receptor-proximal signaling control.
+    action: ACCEPT
+    reason: kinase binding is supported as part of TOLLIP adaptor, endosomal cargo-routing, or
+      innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling&#39;
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: BLK binding and phosphorylation promote **dissociation of TOLLIP from
+        IRAK1**, exposing IRAK1 phosphorylation sites (ProST region) and enabling **IRAK1
+        hyperphosphorylation**, downstream **NF‑κB activation**, and inflammatory cytokine responses
+- term:
+    id: GO:0032991
+    label: protein-containing complex
+  evidence_type: IDA
+  original_reference_id: PMID:10854325
+  review:
+    summary: Protein-containing complex is supported because TOLLIP acts in TOM1/clathrin, cargo,
+      IRAK, and receptor-proximal complexes.
+    action: ACCEPT
+    reason: protein-containing complex is supported as part of TOLLIP adaptor, endosomal
+      cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:11397809
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798749
+  review:
+    summary: Extracellular region is inconsistent with the reviewed intracellular adaptor/endosomal
+      functions of TOLLIP.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: extracellular region overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798751
+  review:
+    summary: Extracellular region is inconsistent with the reviewed intracellular adaptor/endosomal
+      functions of TOLLIP.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: extracellular region overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0035578
+    label: azurophil granule lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798751
+  review:
+    summary: Azurophil granule lumen is a context-specific secretory-granule annotation and is not
+      supported as a functional TOLLIP location.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: azurophil granule lumen overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0035580
+    label: specific granule lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798749
+  review:
+    summary: Specific granule lumen is a context-specific secretory-granule annotation and is not
+      supported as a functional TOLLIP location.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: specific granule lumen overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:23533145
+  review:
+    summary: Extracellular exosome detection does not represent the core intracellular adaptor
+      function of TOLLIP.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: extracellular exosome overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0030855
+    label: epithelial cell differentiation
+  evidence_type: IEP
+  original_reference_id: PMID:21492153
+  review:
+    summary: epithelial cell differentiation is plausible as a context-specific or secondary
+      TOLLIP-associated annotation, but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: epithelial cell differentiation is secondary to TOLLIP ubiquitin/membrane adaptor and
+      TLR/IL-1R signaling roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD&#39;
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16412388
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)&#39;
+- term:
+    id: GO:0036010
+    label: protein localization to endosome
+  evidence_type: IDA
+  original_reference_id: PMID:16412388
+  review:
+    summary: Protein localization to endosome is supported by the TOLLIP cargo-routing mechanism.
+    action: ACCEPT
+    reason: protein localization to endosome is supported as part of TOLLIP adaptor, endosomal
+      cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD&#39;
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:19056867
+  review:
+    summary: Extracellular exosome detection does not represent the core intracellular adaptor
+      function of TOLLIP.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: extracellular exosome overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446634
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446684
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446692
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446694
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446701
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446862
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446868
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446894
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IC
+  original_reference_id: PMID:11441107
+  review:
+    summary: Cytoplasm is the broad cellular compartment for TOLLIP adaptor activity and endosomal
+      trafficking.
+    action: ACCEPT
+    reason: cytoplasm is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0007165
+    label: signal transduction
+  evidence_type: IPI
+  original_reference_id: PMID:11441107
+  review:
+    summary: Generic signal transduction should be refined to the IL-1R/TLR receptor signaling
+      context supported for TOLLIP.
+    action: MODIFY
+    reason: signal transduction is less precise than the supported TOLLIP mechanism.
+    proposed_replacement_terms:
+    - id: GO:0070498
       label: interleukin-1-mediated signaling pathway
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: IDA
-    original_reference_id: GO_REF:0000052
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:26320582
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:26320582
-          supporting_text: 2015 Aug 27. Tom1 Modulates Binding of Tollip to 
-            Phosphatidylinositol 3-Phosphate via a Coupled Folding and Binding 
-            Mechanism.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:31263572
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31263572
-          supporting_text: Dominant TOM1 mutation associated with combined 
-            immunodeficiency and autoimmune disease.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:15047686
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:15047686
-          supporting_text: 2004 Mar 26. Tollip and Tom1 form a complex and 
-            recruit ubiquitin-conjugated proteins onto early endosomes.
-  - term:
-      id: GO:0019897
-      label: extrinsic component of plasma membrane
-    evidence_type: IC
-    original_reference_id: PMID:10854325
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:10854325
-          supporting_text: Tollip, a new component of the IL-1RI pathway, links 
-            IRAK to the IL-1 receptor.
-  - term:
-      id: GO:0060090
-      label: molecular adaptor activity
-    evidence_type: IDA
-    original_reference_id: PMID:10854325
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:10854325
-          supporting_text: Tollip, a new component of the IL-1RI pathway, links 
-            IRAK to the IL-1 receptor.
-  - term:
-      id: GO:0070498
-      label: interleukin-1-mediated signaling pathway
-    evidence_type: IDA
-    original_reference_id: PMID:10854325
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:10854325
-          supporting_text: Tollip, a new component of the IL-1RI pathway, links 
-            IRAK to the IL-1 receptor.
-  - term:
-      id: GO:0060090
-      label: molecular adaptor activity
-    evidence_type: IDA
-    original_reference_id: PMID:27368102
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:27368102
-          supporting_text: An ER-Associated Pathway Defines Endosomal 
-            Architecture for Controlled Cargo Transport.
-  - term:
-      id: GO:0019900
-      label: kinase binding
-    evidence_type: IPI
-    original_reference_id: PMID:10854325
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:10854325
-          supporting_text: Tollip, a new component of the IL-1RI pathway, links 
-            IRAK to the IL-1 receptor.
-  - term:
-      id: GO:0032991
-      label: protein-containing complex
-    evidence_type: IDA
-    original_reference_id: PMID:10854325
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:10854325
-          supporting_text: Tollip, a new component of the IL-1RI pathway, links 
-            IRAK to the IL-1 receptor.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:11397809
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:11397809
-          supporting_text: 2001 Jun 7. IRAK1b, a novel alternative splice 
-            variant of interleukin-1 receptor-associated kinase (IRAK), mediates
-            interleukin-1 signaling and has prolonged stability.
-  - term:
-      id: GO:0005576
-      label: extracellular region
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-6798749
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005576
-      label: extracellular region
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-6798751
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0035578
-      label: azurophil granule lumen
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-6798751
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0035580
-      label: specific granule lumen
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-6798749
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0070062
-      label: extracellular exosome
-    evidence_type: HDA
-    original_reference_id: PMID:23533145
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:23533145
-          supporting_text: 2013 Apr 23. In-depth proteomic analyses of exosomes 
-            isolated from expressed prostatic secretions in urine.
-  - term:
-      id: GO:0030855
-      label: epithelial cell differentiation
-    evidence_type: IEP
-    original_reference_id: PMID:21492153
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:21492153
-          supporting_text: Analysis of proteomic changes induced upon cellular 
-            differentiation of the human intestinal cell line Caco-2.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:16412388
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:16412388
-          supporting_text: Recruitment of clathrin onto endosomes by the 
-            Tom1-Tollip complex.
-  - term:
-      id: GO:0036010
-      label: protein localization to endosome
-    evidence_type: IDA
-    original_reference_id: PMID:16412388
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:16412388
-          supporting_text: Recruitment of clathrin onto endosomes by the 
-            Tom1-Tollip complex.
-  - term:
-      id: GO:0070062
-      label: extracellular exosome
-    evidence_type: HDA
-    original_reference_id: PMID:19056867
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:19056867
-          supporting_text: 2008 Dec 3. Large-scale proteomics and 
-            phosphoproteomics of urinary exosomes.
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446634
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446684
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446692
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446694
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446701
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446862
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446868
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446894
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IC
-    original_reference_id: PMID:11441107
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:11441107
-          supporting_text: &#39;Cooperation of Toll-like receptor 2 and 6 for cellular
-            activation by soluble tuberculosis factor and Borrelia burgdorferi outer
-            surface protein A lipoprotein: role of Toll-interacting protein and IL-1
-            receptor signaling molecules in Toll-like receptor 2 signaling.&#39;
-  - term:
-      id: GO:0007165
-      label: signal transduction
-    evidence_type: IPI
-    original_reference_id: PMID:11441107
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:11441107
-          supporting_text: &#39;Cooperation of Toll-like receptor 2 and 6 for cellular
-            activation by soluble tuberculosis factor and Borrelia burgdorferi outer
-            surface protein A lipoprotein: role of Toll-interacting protein and IL-1
-            receptor signaling molecules in Toll-like receptor 2 signaling.&#39;
-  - term:
-      id: GO:0035325
-      label: Toll-like receptor binding
-    evidence_type: IPI
-    original_reference_id: PMID:11441107
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:11441107
-          supporting_text: &#39;Cooperation of Toll-like receptor 2 and 6 for cellular
-            activation by soluble tuberculosis factor and Borrelia burgdorferi outer
-            surface protein A lipoprotein: role of Toll-interacting protein and IL-1
-            receptor signaling molecules in Toll-like receptor 2 signaling.&#39;
-  - term:
-      id: GO:0016310
-      label: phosphorylation
-    evidence_type: IDA
-    original_reference_id: PMID:1085432
-    review:
-      summary: &gt;-
-        MISANNOTATION with WRONG PMID: PMID:1085432 is about &#34;Malignant lymphoma and
-        rheumatic symptoms&#34; from 1976 - completely unrelated to TOLLIP! Furthermore,
-        TOLLIP is a signaling adapter protein, NOT a kinase. UniProt states TOLLIP
-        &#34;Inhibits IRAK1 phosphorylation and kinase activity&#34; - it REGULATES kinases,
-        not performs phosphorylation itself.
-      action: REMOVE
-      supported_by:
-        - reference_id: PMID:1085432
-          supporting_text: Malignant lymphoma and rheumatic symptoms.
-  - term:
-      id: GO:0045321
-      label: leukocyte activation
-    evidence_type: NAS
-    original_reference_id: PMID:11441107
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:11441107
-          supporting_text: &#39;Cooperation of Toll-like receptor 2 and 6 for cellular
-            activation by soluble tuberculosis factor and Borrelia burgdorferi outer
-            surface protein A lipoprotein: role of Toll-interacting protein and IL-1
-            receptor signaling molecules in Toll-like receptor 2 signaling.&#39;
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling&#39;
+- term:
+    id: GO:0035325
+    label: Toll-like receptor binding
+  evidence_type: IPI
+  original_reference_id: PMID:11441107
+  review:
+    summary: Toll-like receptor binding is supported as part of TOLLIP receptor-proximal innate
+      immune signaling regulation.
+    action: ACCEPT
+    reason: Toll-like receptor binding is supported as part of TOLLIP adaptor, endosomal
+      cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling&#39;
+- term:
+    id: GO:0016310
+    label: phosphorylation
+  evidence_type: IDA
+  original_reference_id: PMID:1085432
+  review:
+    summary: TOLLIP is phosphorylated by BLK during signaling, but TOLLIP is not a kinase and should
+      not be annotated to phosphorylation as an activity/process it performs.
+    action: REMOVE
+    reason: TOLLIP is a phosphorylation-regulated adaptor, not an enzyme that catalyzes
+      phosphorylation.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: BLK binding and phosphorylation promote **dissociation of TOLLIP from
+        IRAK1**, exposing IRAK1 phosphorylation sites (ProST region) and enabling **IRAK1
+        hyperphosphorylation**, downstream **NF‑κB activation**, and inflammatory cytokine responses
+- term:
+    id: GO:0045321
+    label: leukocyte activation
+  evidence_type: NAS
+  original_reference_id: PMID:11441107
+  review:
+    summary: leukocyte activation is plausible as a context-specific or secondary TOLLIP-associated
+      annotation, but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: leukocyte activation is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R
+      signaling roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: &#39;**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling&#39;
 references:
-  - id: GO_REF:0000002
-    title: Gene Ontology annotation through association of InterPro records with
-      GO terms
-    findings: []
-  - id: GO_REF:0000033
-    title: Annotation inferences using phylogenetic trees
-    findings: []
-  - id: GO_REF:0000043
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword 
-      mapping
-    findings: []
-  - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt
-    findings: []
-  - id: GO_REF:0000052
-    title: Gene Ontology annotation based on curation of immunofluorescence data
-    findings: []
-  - id: GO_REF:0000107
-    title: Automatic transfer of experimentally verified manual GO annotation 
-      data to orthologs using Ensembl Compara
-    findings: []
-  - id: PMID:1085432
-    title: Malignant lymphoma and rheumatic symptoms.
-    findings: []
-  - id: PMID:10854325
-    title: Tollip, a new component of the IL-1RI pathway, links IRAK to the IL-1
-      receptor.
-    findings: []
-  - id: PMID:11397809
-    title: IRAK1b, a novel alternative splice variant of interleukin-1 
-      receptor-associated kinase (IRAK), mediates interleukin-1 signaling and 
-      has prolonged stability.
-    findings: []
-  - id: PMID:11441107
-    title: &#39;Cooperation of Toll-like receptor 2 and 6 for cellular activation by soluble
-      tuberculosis factor and Borrelia burgdorferi outer surface protein A lipoprotein:
-      role of Toll-interacting protein and IL-1 receptor signaling molecules in Toll-like
-      receptor 2 signaling.&#39;
-    findings: []
-  - id: PMID:14563850
-    title: Tom1, a VHS domain-containing protein, interacts with tollip, 
-      ubiquitin, and clathrin.
-    findings: []
-  - id: PMID:15047686
-    title: Tollip and Tom1 form a complex and recruit ubiquitin-conjugated 
-      proteins onto early endosomes.
-    findings: []
-  - id: PMID:16189514
-    title: Towards a proteome-scale map of the human protein-protein interaction
-      network.
-    findings: []
-  - id: PMID:16412388
-    title: Recruitment of clathrin onto endosomes by the Tom1-Tollip complex.
-    findings: []
-  - id: PMID:16713569
-    title: A protein-protein interaction network for human inherited ataxias and
-      disorders of Purkinje cell degeneration.
-    findings: []
-  - id: PMID:19056867
-    title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
-    findings: []
-  - id: PMID:19060904
-    title: An empirical framework for binary interactome mapping.
-    findings: []
-  - id: PMID:19447967
-    title: Shifted Transversal Design smart-pooling for high coverage 
-      interactome mapping.
-    findings: []
-  - id: PMID:20936779
-    title: A human MAP kinase interactome.
-    findings: []
-  - id: PMID:21492153
-    title: Analysis of proteomic changes induced upon cellular differentiation 
-      of the human intestinal cell line Caco-2.
-    findings: []
-  - id: PMID:21903422
-    title: Mapping a dynamic innate immunity protein interaction network 
-      regulating type I interferon production.
-    findings: []
-  - id: PMID:21988832
-    title: Toward an understanding of the protein interaction network of the 
-      human liver.
-    findings: []
-  - id: PMID:23533145
-    title: In-depth proteomic analyses of exosomes isolated from expressed 
-      prostatic secretions in urine.
-    findings: []
-  - id: PMID:25042851
-    title: Autophagic clearance of polyQ proteins mediated by ubiquitin-Atg8 
-      adaptors of the conserved CUET protein family.
-    findings: []
-  - id: PMID:25416956
-    title: A proteome-scale map of the human interactome network.
-    findings: []
-  - id: PMID:25910212
-    title: Widespread macromolecular interaction perturbations in human genetic 
-      disorders.
-    findings: []
-  - id: PMID:26320582
-    title: Tom1 Modulates Binding of Tollip to Phosphatidylinositol 3-Phosphate 
-      via a Coupled Folding and Binding Mechanism.
-    findings: []
-  - id: PMID:27107014
-    title: An inter-species protein-protein interaction network across vast 
-      evolutionary distance.
-    findings: []
-  - id: PMID:27368102
-    title: An ER-Associated Pathway Defines Endosomal Architecture for 
-      Controlled Cargo Transport.
-    findings: []
-  - id: PMID:31263572
-    title: Dominant TOM1 mutation associated with combined immunodeficiency and 
-      autoimmune disease.
-    findings: []
-  - id: PMID:31515488
-    title: Extensive disruption of protein interactions by genetic variants 
-      across the allele frequency spectrum in human populations.
-    findings: []
-  - id: PMID:32296183
-    title: A reference map of the human binary protein interactome.
-    findings: []
-  - id: PMID:32814053
-    title: Interactome Mapping Provides a Network of Neurodegenerative Disease 
-      Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.
-    findings: []
-  - id: PMID:33961781
-    title: Dual proteome-scale networks reveal cell-specific remodeling of the 
-      human interactome.
-    findings: []
-  - id: PMID:34524948
-    title: Global Proximity Interactome of the Human Macroautophagy Pathway.
-    findings: []
-  - id: PMID:35271311
-    title: &#39;OpenCell: Endogenous tagging for the cartography of human cellular organization.&#39;
-    findings: []
-  - id: PMID:40205054
-    title: Multimodal cell maps as a foundation for structural and functional 
-      genomics.
-    findings: []
-  - id: Reactome:R-HSA-446634
-    title: IRAK4 is activated by autophosphorylation
-    findings: []
-  - id: Reactome:R-HSA-446684
-    title: IRAK2 is phosphorylated downstream of IRAK4 following IL1 receptor 
-      activation
-    findings: []
-  - id: Reactome:R-HSA-446692
-    title: IRAK1 binds to MYD88 within the IL1R complex
-    findings: []
-  - id: Reactome:R-HSA-446694
-    title: IRAK4 phosphorylates IRAK1
-    findings: []
-  - id: Reactome:R-HSA-446701
-    title: IRAK4-activated IRAK1 autophosphorylates
-    findings: []
-  - id: Reactome:R-HSA-446862
-    title: Hyperphosphorylated IRAK1 associates with TRAF6
-    findings: []
-  - id: Reactome:R-HSA-446868
-    title: The Interleukin 1 receptor complex binds Tollip
-    findings: []
-  - id: Reactome:R-HSA-446894
-    title: TRAF6 binding leads to IRAK1:TRAF6 release
-    findings: []
-  - id: Reactome:R-HSA-6798749
-    title: Exocytosis of specific granule lumen proteins
-    findings: []
-  - id: Reactome:R-HSA-6798751
-    title: Exocytosis of azurophil granule lumen proteins
-    findings: []
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000043
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to orthologs using
+    Ensembl Compara
+  findings: []
+- id: PMID:1085432
+  title: Malignant lymphoma and rheumatic symptoms.
+  findings: []
+- id: PMID:10854325
+  title: Tollip, a new component of the IL-1RI pathway, links IRAK to the IL-1 receptor.
+  findings: []
+- id: PMID:11397809
+  title: IRAK1b, a novel alternative splice variant of interleukin-1 receptor-associated kinase
+    (IRAK), mediates interleukin-1 signaling and has prolonged stability.
+  findings: []
+- id: PMID:11441107
+  title: &#39;Cooperation of Toll-like receptor 2 and 6 for cellular activation by soluble tuberculosis factor
+    and Borrelia burgdorferi outer surface protein A lipoprotein: role of Toll-interacting protein and
+    IL-1 receptor signaling molecules in Toll-like receptor 2 signaling.&#39;
+  findings: []
+- id: PMID:14563850
+  title: Tom1, a VHS domain-containing protein, interacts with tollip, ubiquitin, and clathrin.
+  findings: []
+- id: PMID:15047686
+  title: Tollip and Tom1 form a complex and recruit ubiquitin-conjugated proteins onto early
+    endosomes.
+  findings: []
+- id: PMID:16189514
+  title: Towards a proteome-scale map of the human protein-protein interaction network.
+  findings: []
+- id: PMID:16412388
+  title: Recruitment of clathrin onto endosomes by the Tom1-Tollip complex.
+  findings: []
+- id: PMID:16713569
+  title: A protein-protein interaction network for human inherited ataxias and disorders of Purkinje
+    cell degeneration.
+  findings: []
+- id: PMID:19056867
+  title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
+  findings: []
+- id: PMID:19060904
+  title: An empirical framework for binary interactome mapping.
+  findings: []
+- id: PMID:19447967
+  title: Shifted Transversal Design smart-pooling for high coverage interactome mapping.
+  findings: []
+- id: PMID:20936779
+  title: A human MAP kinase interactome.
+  findings: []
+- id: PMID:21492153
+  title: Analysis of proteomic changes induced upon cellular differentiation of the human intestinal
+    cell line Caco-2.
+  findings: []
+- id: PMID:21903422
+  title: Mapping a dynamic innate immunity protein interaction network regulating type I interferon
+    production.
+  findings: []
+- id: PMID:21988832
+  title: Toward an understanding of the protein interaction network of the human liver.
+  findings: []
+- id: PMID:23533145
+  title: In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in
+    urine.
+  findings: []
+- id: PMID:25042851
+  title: Autophagic clearance of polyQ proteins mediated by ubiquitin-Atg8 adaptors of the conserved
+    CUET protein family.
+  findings: []
+- id: PMID:25416956
+  title: A proteome-scale map of the human interactome network.
+  findings: []
+- id: PMID:25910212
+  title: Widespread macromolecular interaction perturbations in human genetic disorders.
+  findings: []
+- id: PMID:26320582
+  title: Tom1 Modulates Binding of Tollip to Phosphatidylinositol 3-Phosphate via a Coupled Folding
+    and Binding Mechanism.
+  findings: []
+- id: PMID:27107014
+  title: An inter-species protein-protein interaction network across vast evolutionary distance.
+  findings: []
+- id: PMID:27368102
+  title: An ER-Associated Pathway Defines Endosomal Architecture for Controlled Cargo Transport.
+  findings: []
+- id: PMID:31263572
+  title: Dominant TOM1 mutation associated with combined immunodeficiency and autoimmune disease.
+  findings: []
+- id: PMID:31515488
+  title: Extensive disruption of protein interactions by genetic variants across the allele
+    frequency spectrum in human populations.
+  findings: []
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+- id: PMID:32814053
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers
+    Widespread Protein Aggregation in Affected Brains.
+  findings: []
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
+  findings: []
+- id: PMID:34524948
+  title: Global Proximity Interactome of the Human Macroautophagy Pathway.
+  findings: []
+- id: PMID:35271311
+  title: &#39;OpenCell: Endogenous tagging for the cartography of human cellular organization.&#39;
+  findings: []
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+- id: Reactome:R-HSA-446634
+  title: IRAK4 is activated by autophosphorylation
+  findings: []
+- id: Reactome:R-HSA-446684
+  title: IRAK2 is phosphorylated downstream of IRAK4 following IL1 receptor activation
+  findings: []
+- id: Reactome:R-HSA-446692
+  title: IRAK1 binds to MYD88 within the IL1R complex
+  findings: []
+- id: Reactome:R-HSA-446694
+  title: IRAK4 phosphorylates IRAK1
+  findings: []
+- id: Reactome:R-HSA-446701
+  title: IRAK4-activated IRAK1 autophosphorylates
+  findings: []
+- id: Reactome:R-HSA-446862
+  title: Hyperphosphorylated IRAK1 associates with TRAF6
+  findings: []
+- id: Reactome:R-HSA-446868
+  title: The Interleukin 1 receptor complex binds Tollip
+  findings: []
+- id: Reactome:R-HSA-446894
+  title: TRAF6 binding leads to IRAK1:TRAF6 release
+  findings: []
+- id: Reactome:R-HSA-6798749
+  title: Exocytosis of specific granule lumen proteins
+  findings: []
+- id: Reactome:R-HSA-6798751
+  title: Exocytosis of azurophil granule lumen proteins
+  findings: []
+- id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+  title: Falcon deep research synthesis for TOLLIP
+  findings: []
+core_functions:
+- description: Ubiquitin- and phosphoinositide-directed molecular adaptor activity that routes
+    ubiquitinated or aberrant membrane cargo toward endolysosomal degradation.
+  molecular_function:
+    id: GO:0060090
+    label: molecular adaptor activity
+  directly_involved_in:
+  - id: GO:0036010
+    label: protein localization to endosome
+  - id: GO:0006511
+    label: ubiquitin-dependent protein catabolic process
+  locations:
+  - id: GO:0005768
+    label: endosome
+  - id: GO:0005769
+    label: early endosome
+  - id: GO:0005737
+    label: cytoplasm
+  supported_by:
+  - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+    supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+      couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+      (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+      **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**
+  - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+    supporting_text: &#39;**C2 domain (~central ~130 aa)**: binds **phosphoinositides**; in a 2023 mechanistic
+      study, the C2 domain showed preferential interaction with **PI3P** and **PI(4,5)P2**, consistent
+      with **membrane/endosome targeting** and PI3P-vesicle coupling&#39;
+  - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+    supporting_text: &#39;**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+      as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+      routing and degradation, operating alongside ERAD&#39;
+- description: CUE-domain ubiquitin-conjugate binding that supports cargo selection and
+    receptor-proximal signaling complex regulation.
+  molecular_function:
+    id: GO:0043130
+    label: ubiquitin binding
+  directly_involved_in:
+  - id: GO:0006511
+    label: ubiquitin-dependent protein catabolic process
+  - id: GO:0070498
+    label: interleukin-1-mediated signaling pathway
+  - id: GO:0045087
+    label: innate immune response
+  locations:
+  - id: GO:0005768
+    label: endosome
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+    supporting_text: &#39;**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+      binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+      IRAK and receptor TIR domains in review synthesis)&#39;
+  - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+    supporting_text: &#39;**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+      BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+      NF‑κB signaling&#39;
+  - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+    supporting_text: &#39;TOLLIP is a **non-enzymatic adaptor** whose primary biochemical capabilities are
+      **specific binding interactions**:&#39;
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/TOLLIP/TOLLIP-ai-review.yaml
+++ b/genes/human/TOLLIP/TOLLIP-ai-review.yaml
@@ -1,943 +1,1637 @@
 id: Q9H0E2
 gene_symbol: TOLLIP
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for TOLLIP'
+description: 'TOLLIP encodes Toll-interacting protein, a non-enzymatic ubiquitin/phosphoinositide-binding
+  adaptor that links endosomal membranes, TOM1/clathrin-associated trafficking, and TLR/IL-1 receptor
+  signaling. Its core roles are CUE-domain ubiquitin recognition, C2-domain membrane/endosome targeting,
+  PI3P-dependent endolysosomal routing of ubiquitinated or aberrant cargo, and regulated restraint of
+  IRAK-dependent innate immune signaling.'
 alternative_products:
-  - id: Q9H0E2-1
-    name: '1'
-  - id: Q9H0E2-2
-    name: '2'
+- id: Q9H0E2-1
+  name: '1'
+- id: Q9H0E2-2
+  name: '2'
 existing_annotations:
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0006511
-      label: ubiquitin-dependent protein catabolic process
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0031624
-      label: ubiquitin conjugating enzyme binding
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0043130
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Cytoplasm is the broad cellular compartment for TOLLIP adaptor activity and endosomal
+      trafficking.
+    action: ACCEPT
+    reason: cytoplasm is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0006511
+    label: ubiquitin-dependent protein catabolic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Ubiquitin-dependent protein catabolic process is supported by TOLLIP-mediated routing
+      of ubiquitinated or aberrant cargo to endolysosomal degradation.
+    action: ACCEPT
+    reason: ubiquitin-dependent protein catabolic process is supported as part of TOLLIP adaptor,
+      endosomal cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD'
+- term:
+    id: GO:0031624
+    label: ubiquitin conjugating enzyme binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: The evidence supports CUE-domain recognition of ubiquitin conjugates rather than a
+      specific ubiquitin-conjugating enzyme binding function.
+    action: MODIFY
+    reason: ubiquitin conjugating enzyme binding is less precise than the supported TOLLIP
+      mechanism.
+    proposed_replacement_terms:
+    - id: GO:0043130
       label: ubiquitin binding
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0002376
-      label: immune system process
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000044
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005768
-      label: endosome
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000044
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005769
-      label: early endosome
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000044
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0006914
-      label: autophagy
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0006954
-      label: inflammatory response
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0043130
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0043130
+    label: ubiquitin binding
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Ubiquitin binding is a core CUE-domain molecular function of TOLLIP.
+    action: ACCEPT
+    reason: ubiquitin binding is supported as part of TOLLIP adaptor, endosomal cargo-routing, or
+      innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+- term:
+    id: GO:0002376
+    label: immune system process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: immune system process is plausible as a context-specific or secondary TOLLIP-associated
+      annotation, but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: immune system process is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R
+      signaling roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling'
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Cytoplasm is the broad cellular compartment for TOLLIP adaptor activity and endosomal
+      trafficking.
+    action: ACCEPT
+    reason: cytoplasm is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005768
+    label: endosome
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Endosome localization is central to TOLLIP PI3P-dependent cargo routing.
+    action: ACCEPT
+    reason: endosome is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD'
+- term:
+    id: GO:0005769
+    label: early endosome
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Early endosome localization is supported by TOLLIP coupling of PI3P vesicles to cargo
+      trafficking.
+    action: ACCEPT
+    reason: early endosome is supported as part of TOLLIP adaptor, endosomal cargo-routing, or
+      innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD'
+- term:
+    id: GO:0006914
+    label: autophagy
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: autophagy is plausible as a context-specific or secondary TOLLIP-associated annotation,
+      but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: autophagy is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R signaling
+      roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD'
+- term:
+    id: GO:0006954
+    label: inflammatory response
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: inflammatory response is plausible as a context-specific or secondary TOLLIP-associated
+      annotation, but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: inflammatory response is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R
+      signaling roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling'
+- term:
+    id: GO:0043130
+    label: ubiquitin binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Ubiquitin binding is a core CUE-domain molecular function of TOLLIP.
+    action: ACCEPT
+    reason: ubiquitin binding is supported as part of TOLLIP adaptor, endosomal cargo-routing, or
+      innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+- term:
+    id: GO:0045087
+    label: innate immune response
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: Innate immune response is supported through TOLLIP regulation of TLR/IL-1R signaling
+      outputs.
+    action: ACCEPT
+    reason: innate immune response is supported as part of TOLLIP adaptor, endosomal cargo-routing,
+      or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:14563850
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16189514
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16713569
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19060904
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:19447967
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:20936779
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21903422
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21988832
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25042851
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25416956
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:25910212
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:27107014
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31515488
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32814053
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:34524948
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35271311
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005150
+    label: interleukin-1, type I receptor binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Interleukin-1 type I receptor binding is supported as part of the IL-1R/TLR signaling
+      adaptor-regulator role.
+    action: ACCEPT
+    reason: interleukin-1, type I receptor binding is supported as part of TOLLIP adaptor, endosomal
+      cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling'
+- term:
+    id: GO:0016604
+    label: nuclear body
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: nuclear body is plausible as a context-specific or secondary TOLLIP-associated
+      annotation, but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: nuclear body is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R signaling
+      roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD'
+- term:
+    id: GO:0031624
+    label: ubiquitin conjugating enzyme binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: The evidence supports CUE-domain recognition of ubiquitin conjugates rather than a
+      specific ubiquitin-conjugating enzyme binding function.
+    action: MODIFY
+    reason: ubiquitin conjugating enzyme binding is less precise than the supported TOLLIP
+      mechanism.
+    proposed_replacement_terms:
+    - id: GO:0043130
       label: ubiquitin binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0045087
-      label: innate immune response
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:14563850
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:14563850
-          supporting_text: 2003 Oct 15. Tom1, a VHS domain-containing protein, 
-            interacts with tollip, ubiquitin, and clathrin.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:16189514
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:16189514
-          supporting_text: Towards a proteome-scale map of the human 
-            protein-protein interaction network.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:16713569
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:16713569
-          supporting_text: A protein-protein interaction network for human 
-            inherited ataxias and disorders of Purkinje cell degeneration.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:19060904
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:19060904
-          supporting_text: An empirical framework for binary interactome 
-            mapping.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:19447967
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:19447967
-          supporting_text: Shifted Transversal Design smart-pooling for high 
-            coverage interactome mapping.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:20936779
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20936779
-          supporting_text: A human MAP kinase interactome.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:21903422
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:21903422
-          supporting_text: 2011 Sep 8. Mapping a dynamic innate immunity protein
-            interaction network regulating type I interferon production.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:21988832
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:21988832
-          supporting_text: Toward an understanding of the protein interaction 
-            network of the human liver.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:25042851
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:25042851
-          supporting_text: Jul 18. Autophagic clearance of polyQ proteins 
-            mediated by ubiquitin-Atg8 adaptors of the conserved CUET protein 
-            family.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:25416956
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:25416956
-          supporting_text: A proteome-scale map of the human interactome 
-            network.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:25910212
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:25910212
-          supporting_text: Widespread macromolecular interaction perturbations 
-            in human genetic disorders.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:27107014
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:27107014
-          supporting_text: An inter-species protein-protein interaction network 
-            across vast evolutionary distance.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:31515488
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31515488
-          supporting_text: Extensive disruption of protein interactions by 
-            genetic variants across the allele frequency spectrum in human 
-            populations.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:32296183
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32296183
-          supporting_text: Apr 8. A reference map of the human binary protein 
-            interactome.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:32814053
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32814053
-          supporting_text: Interactome Mapping Provides a Network of 
-            Neurodegenerative Disease Proteins and Uncovers Widespread Protein 
-            Aggregation in Affected Brains.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:33961781
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:33961781
-          supporting_text: 2021 May 6. Dual proteome-scale networks reveal 
-            cell-specific remodeling of the human interactome.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:34524948
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:34524948
-          supporting_text: 2021 Sep 15. Global Proximity Interactome of the 
-            Human Macroautophagy Pathway.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:35271311
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:35271311
-          supporting_text: '2022 Mar 11. OpenCell: Endogenous tagging for the cartography
-            of human cellular organization.'
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:40205054
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:40205054
-          supporting_text: Apr 9. Multimodal cell maps as a foundation for 
-            structural and functional genomics.
-  - term:
-      id: GO:0005150
-      label: interleukin-1, type I receptor binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0016604
-      label: nuclear body
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0031624
-      label: ubiquitin conjugating enzyme binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0031625
-      label: ubiquitin protein ligase binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0032183
-      label: SUMO binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0032991
-      label: protein-containing complex
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0033235
-      label: positive regulation of protein sumoylation
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0048471
-      label: perinuclear region of cytoplasm
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0070498
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0031625
+    label: ubiquitin protein ligase binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Ubiquitin protein ligase binding is not the main supported activity; the reviewed
+      evidence emphasizes ubiquitin conjugate binding and adaptor function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: ubiquitin protein ligase binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0032183
+    label: SUMO binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: SUMO binding is not supported by the Falcon synthesis as a core or well-grounded TOLLIP
+      function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: SUMO binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+- term:
+    id: GO:0032991
+    label: protein-containing complex
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Protein-containing complex is supported because TOLLIP acts in TOM1/clathrin, cargo,
+      IRAK, and receptor-proximal complexes.
+    action: ACCEPT
+    reason: protein-containing complex is supported as part of TOLLIP adaptor, endosomal
+      cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling'
+- term:
+    id: GO:0033235
+    label: positive regulation of protein sumoylation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Positive regulation of protein sumoylation is not supported as a TOLLIP core function
+      in the reviewed evidence.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: positive regulation of protein sumoylation overstates or obscures the supported TOLLIP
+      function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+- term:
+    id: GO:0048471
+    label: perinuclear region of cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: perinuclear region of cytoplasm is plausible as a context-specific or secondary
+      TOLLIP-associated annotation, but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: perinuclear region of cytoplasm is secondary to TOLLIP ubiquitin/membrane adaptor and
+      TLR/IL-1R signaling roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD'
+- term:
+    id: GO:0070498
+    label: interleukin-1-mediated signaling pathway
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000107
+  review:
+    summary: Interleukin-1-mediated signaling pathway is a supported core immune-signaling context
+      for TOLLIP.
+    action: ACCEPT
+    reason: interleukin-1-mediated signaling pathway is supported as part of TOLLIP adaptor,
+      endosomal cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling'
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:26320582
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31263572
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:15047686
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0019897
+    label: extrinsic component of plasma membrane
+  evidence_type: IC
+  original_reference_id: PMID:10854325
+  review:
+    summary: extrinsic component of plasma membrane is plausible as a context-specific or secondary
+      TOLLIP-associated annotation, but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: extrinsic component of plasma membrane is secondary to TOLLIP ubiquitin/membrane adaptor
+      and TLR/IL-1R signaling roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD'
+- term:
+    id: GO:0060090
+    label: molecular adaptor activity
+  evidence_type: IDA
+  original_reference_id: PMID:10854325
+  review:
+    summary: Molecular adaptor activity captures the core TOLLIP role in linking cargo, endosomal
+      membranes, and receptor-signaling proteins.
+    action: ACCEPT
+    reason: molecular adaptor activity is supported as part of TOLLIP adaptor, endosomal
+      cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD'
+- term:
+    id: GO:0070498
+    label: interleukin-1-mediated signaling pathway
+  evidence_type: IDA
+  original_reference_id: PMID:10854325
+  review:
+    summary: Interleukin-1-mediated signaling pathway is a supported core immune-signaling context
+      for TOLLIP.
+    action: ACCEPT
+    reason: interleukin-1-mediated signaling pathway is supported as part of TOLLIP adaptor,
+      endosomal cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling'
+- term:
+    id: GO:0060090
+    label: molecular adaptor activity
+  evidence_type: IDA
+  original_reference_id: PMID:27368102
+  review:
+    summary: Molecular adaptor activity captures the core TOLLIP role in linking cargo, endosomal
+      membranes, and receptor-signaling proteins.
+    action: ACCEPT
+    reason: molecular adaptor activity is supported as part of TOLLIP adaptor, endosomal
+      cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD'
+- term:
+    id: GO:0019900
+    label: kinase binding
+  evidence_type: IPI
+  original_reference_id: PMID:10854325
+  review:
+    summary: Kinase binding is supported by TOLLIP interactions with IRAK1 and BLK in
+      receptor-proximal signaling control.
+    action: ACCEPT
+    reason: kinase binding is supported as part of TOLLIP adaptor, endosomal cargo-routing, or
+      innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling'
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: BLK binding and phosphorylation promote **dissociation of TOLLIP from
+        IRAK1**, exposing IRAK1 phosphorylation sites (ProST region) and enabling **IRAK1
+        hyperphosphorylation**, downstream **NF‑κB activation**, and inflammatory cytokine responses
+- term:
+    id: GO:0032991
+    label: protein-containing complex
+  evidence_type: IDA
+  original_reference_id: PMID:10854325
+  review:
+    summary: Protein-containing complex is supported because TOLLIP acts in TOM1/clathrin, cargo,
+      IRAK, and receptor-proximal complexes.
+    action: ACCEPT
+    reason: protein-containing complex is supported as part of TOLLIP adaptor, endosomal
+      cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:11397809
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798749
+  review:
+    summary: Extracellular region is inconsistent with the reviewed intracellular adaptor/endosomal
+      functions of TOLLIP.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: extracellular region overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005576
+    label: extracellular region
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798751
+  review:
+    summary: Extracellular region is inconsistent with the reviewed intracellular adaptor/endosomal
+      functions of TOLLIP.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: extracellular region overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0035578
+    label: azurophil granule lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798751
+  review:
+    summary: Azurophil granule lumen is a context-specific secretory-granule annotation and is not
+      supported as a functional TOLLIP location.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: azurophil granule lumen overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0035580
+    label: specific granule lumen
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-6798749
+  review:
+    summary: Specific granule lumen is a context-specific secretory-granule annotation and is not
+      supported as a functional TOLLIP location.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: specific granule lumen overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:23533145
+  review:
+    summary: Extracellular exosome detection does not represent the core intracellular adaptor
+      function of TOLLIP.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: extracellular exosome overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0030855
+    label: epithelial cell differentiation
+  evidence_type: IEP
+  original_reference_id: PMID:21492153
+  review:
+    summary: epithelial cell differentiation is plausible as a context-specific or secondary
+      TOLLIP-associated annotation, but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: epithelial cell differentiation is secondary to TOLLIP ubiquitin/membrane adaptor and
+      TLR/IL-1R signaling roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD'
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:16412388
+  review:
+    summary: Protein binding is too generic for TOLLIP; specific adaptor, ubiquitin-binding,
+      receptor-binding, and kinase-binding terms better capture the mechanism.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: protein binding overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+        binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+        IRAK and receptor TIR domains in review synthesis)'
+- term:
+    id: GO:0036010
+    label: protein localization to endosome
+  evidence_type: IDA
+  original_reference_id: PMID:16412388
+  review:
+    summary: Protein localization to endosome is supported by the TOLLIP cargo-routing mechanism.
+    action: ACCEPT
+    reason: protein localization to endosome is supported as part of TOLLIP adaptor, endosomal
+      cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+        as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+        routing and degradation, operating alongside ERAD'
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0070062
+    label: extracellular exosome
+  evidence_type: HDA
+  original_reference_id: PMID:19056867
+  review:
+    summary: Extracellular exosome detection does not represent the core intracellular adaptor
+      function of TOLLIP.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: extracellular exosome overstates or obscures the supported TOLLIP function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446634
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446684
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446692
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446694
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446701
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446862
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446868
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-446894
+  review:
+    summary: Cytosol is consistent with TOLLIP acting as a soluble adaptor recruited to endosomal
+      and receptor-signaling compartments.
+    action: ACCEPT
+    reason: cytosol is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IC
+  original_reference_id: PMID:11441107
+  review:
+    summary: Cytoplasm is the broad cellular compartment for TOLLIP adaptor activity and endosomal
+      trafficking.
+    action: ACCEPT
+    reason: cytoplasm is supported as part of TOLLIP adaptor, endosomal cargo-routing, or innate
+      immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP’s C2 domain supports association with **PI3P-enriched
+        membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in
+        endosomal sorting and lysosomal delivery of cargo
+- term:
+    id: GO:0007165
+    label: signal transduction
+  evidence_type: IPI
+  original_reference_id: PMID:11441107
+  review:
+    summary: Generic signal transduction should be refined to the IL-1R/TLR receptor signaling
+      context supported for TOLLIP.
+    action: MODIFY
+    reason: signal transduction is less precise than the supported TOLLIP mechanism.
+    proposed_replacement_terms:
+    - id: GO:0070498
       label: interleukin-1-mediated signaling pathway
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000107
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: IDA
-    original_reference_id: GO_REF:0000052
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:26320582
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:26320582
-          supporting_text: 2015 Aug 27. Tom1 Modulates Binding of Tollip to 
-            Phosphatidylinositol 3-Phosphate via a Coupled Folding and Binding 
-            Mechanism.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:31263572
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31263572
-          supporting_text: Dominant TOM1 mutation associated with combined 
-            immunodeficiency and autoimmune disease.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:15047686
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:15047686
-          supporting_text: 2004 Mar 26. Tollip and Tom1 form a complex and 
-            recruit ubiquitin-conjugated proteins onto early endosomes.
-  - term:
-      id: GO:0019897
-      label: extrinsic component of plasma membrane
-    evidence_type: IC
-    original_reference_id: PMID:10854325
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:10854325
-          supporting_text: Tollip, a new component of the IL-1RI pathway, links 
-            IRAK to the IL-1 receptor.
-  - term:
-      id: GO:0060090
-      label: molecular adaptor activity
-    evidence_type: IDA
-    original_reference_id: PMID:10854325
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:10854325
-          supporting_text: Tollip, a new component of the IL-1RI pathway, links 
-            IRAK to the IL-1 receptor.
-  - term:
-      id: GO:0070498
-      label: interleukin-1-mediated signaling pathway
-    evidence_type: IDA
-    original_reference_id: PMID:10854325
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:10854325
-          supporting_text: Tollip, a new component of the IL-1RI pathway, links 
-            IRAK to the IL-1 receptor.
-  - term:
-      id: GO:0060090
-      label: molecular adaptor activity
-    evidence_type: IDA
-    original_reference_id: PMID:27368102
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:27368102
-          supporting_text: An ER-Associated Pathway Defines Endosomal 
-            Architecture for Controlled Cargo Transport.
-  - term:
-      id: GO:0019900
-      label: kinase binding
-    evidence_type: IPI
-    original_reference_id: PMID:10854325
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:10854325
-          supporting_text: Tollip, a new component of the IL-1RI pathway, links 
-            IRAK to the IL-1 receptor.
-  - term:
-      id: GO:0032991
-      label: protein-containing complex
-    evidence_type: IDA
-    original_reference_id: PMID:10854325
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:10854325
-          supporting_text: Tollip, a new component of the IL-1RI pathway, links 
-            IRAK to the IL-1 receptor.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:11397809
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:11397809
-          supporting_text: 2001 Jun 7. IRAK1b, a novel alternative splice 
-            variant of interleukin-1 receptor-associated kinase (IRAK), mediates
-            interleukin-1 signaling and has prolonged stability.
-  - term:
-      id: GO:0005576
-      label: extracellular region
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-6798749
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005576
-      label: extracellular region
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-6798751
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0035578
-      label: azurophil granule lumen
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-6798751
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0035580
-      label: specific granule lumen
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-6798749
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0070062
-      label: extracellular exosome
-    evidence_type: HDA
-    original_reference_id: PMID:23533145
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:23533145
-          supporting_text: 2013 Apr 23. In-depth proteomic analyses of exosomes 
-            isolated from expressed prostatic secretions in urine.
-  - term:
-      id: GO:0030855
-      label: epithelial cell differentiation
-    evidence_type: IEP
-    original_reference_id: PMID:21492153
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:21492153
-          supporting_text: Analysis of proteomic changes induced upon cellular 
-            differentiation of the human intestinal cell line Caco-2.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:16412388
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:16412388
-          supporting_text: Recruitment of clathrin onto endosomes by the 
-            Tom1-Tollip complex.
-  - term:
-      id: GO:0036010
-      label: protein localization to endosome
-    evidence_type: IDA
-    original_reference_id: PMID:16412388
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:16412388
-          supporting_text: Recruitment of clathrin onto endosomes by the 
-            Tom1-Tollip complex.
-  - term:
-      id: GO:0070062
-      label: extracellular exosome
-    evidence_type: HDA
-    original_reference_id: PMID:19056867
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:19056867
-          supporting_text: 2008 Dec 3. Large-scale proteomics and 
-            phosphoproteomics of urinary exosomes.
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446634
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446684
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446692
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446694
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446701
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446862
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446868
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-446894
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IC
-    original_reference_id: PMID:11441107
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:11441107
-          supporting_text: 'Cooperation of Toll-like receptor 2 and 6 for cellular
-            activation by soluble tuberculosis factor and Borrelia burgdorferi outer
-            surface protein A lipoprotein: role of Toll-interacting protein and IL-1
-            receptor signaling molecules in Toll-like receptor 2 signaling.'
-  - term:
-      id: GO:0007165
-      label: signal transduction
-    evidence_type: IPI
-    original_reference_id: PMID:11441107
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:11441107
-          supporting_text: 'Cooperation of Toll-like receptor 2 and 6 for cellular
-            activation by soluble tuberculosis factor and Borrelia burgdorferi outer
-            surface protein A lipoprotein: role of Toll-interacting protein and IL-1
-            receptor signaling molecules in Toll-like receptor 2 signaling.'
-  - term:
-      id: GO:0035325
-      label: Toll-like receptor binding
-    evidence_type: IPI
-    original_reference_id: PMID:11441107
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:11441107
-          supporting_text: 'Cooperation of Toll-like receptor 2 and 6 for cellular
-            activation by soluble tuberculosis factor and Borrelia burgdorferi outer
-            surface protein A lipoprotein: role of Toll-interacting protein and IL-1
-            receptor signaling molecules in Toll-like receptor 2 signaling.'
-  - term:
-      id: GO:0016310
-      label: phosphorylation
-    evidence_type: IDA
-    original_reference_id: PMID:1085432
-    review:
-      summary: >-
-        MISANNOTATION with WRONG PMID: PMID:1085432 is about "Malignant lymphoma and
-        rheumatic symptoms" from 1976 - completely unrelated to TOLLIP! Furthermore,
-        TOLLIP is a signaling adapter protein, NOT a kinase. UniProt states TOLLIP
-        "Inhibits IRAK1 phosphorylation and kinase activity" - it REGULATES kinases,
-        not performs phosphorylation itself.
-      action: REMOVE
-      supported_by:
-        - reference_id: PMID:1085432
-          supporting_text: Malignant lymphoma and rheumatic symptoms.
-  - term:
-      id: GO:0045321
-      label: leukocyte activation
-    evidence_type: NAS
-    original_reference_id: PMID:11441107
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:11441107
-          supporting_text: 'Cooperation of Toll-like receptor 2 and 6 for cellular
-            activation by soluble tuberculosis factor and Borrelia burgdorferi outer
-            surface protein A lipoprotein: role of Toll-interacting protein and IL-1
-            receptor signaling molecules in Toll-like receptor 2 signaling.'
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling'
+- term:
+    id: GO:0035325
+    label: Toll-like receptor binding
+  evidence_type: IPI
+  original_reference_id: PMID:11441107
+  review:
+    summary: Toll-like receptor binding is supported as part of TOLLIP receptor-proximal innate
+      immune signaling regulation.
+    action: ACCEPT
+    reason: Toll-like receptor binding is supported as part of TOLLIP adaptor, endosomal
+      cargo-routing, or innate immune signaling function.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling'
+- term:
+    id: GO:0016310
+    label: phosphorylation
+  evidence_type: IDA
+  original_reference_id: PMID:1085432
+  review:
+    summary: TOLLIP is phosphorylated by BLK during signaling, but TOLLIP is not a kinase and should
+      not be annotated to phosphorylation as an activity/process it performs.
+    action: REMOVE
+    reason: TOLLIP is a phosphorylation-regulated adaptor, not an enzyme that catalyzes
+      phosphorylation.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: BLK binding and phosphorylation promote **dissociation of TOLLIP from
+        IRAK1**, exposing IRAK1 phosphorylation sites (ProST region) and enabling **IRAK1
+        hyperphosphorylation**, downstream **NF‑κB activation**, and inflammatory cytokine responses
+- term:
+    id: GO:0045321
+    label: leukocyte activation
+  evidence_type: NAS
+  original_reference_id: PMID:11441107
+  review:
+    summary: leukocyte activation is plausible as a context-specific or secondary TOLLIP-associated
+      annotation, but it is not the most precise core function.
+    action: KEEP_AS_NON_CORE
+    reason: leukocyte activation is secondary to TOLLIP ubiquitin/membrane adaptor and TLR/IL-1R
+      signaling roles.
+    supported_by:
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+        couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+        (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+        **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal
+        degradation**
+    - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+      supporting_text: '**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+        BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+        NF‑κB signaling'
 references:
-  - id: GO_REF:0000002
-    title: Gene Ontology annotation through association of InterPro records with
-      GO terms
-    findings: []
-  - id: GO_REF:0000033
-    title: Annotation inferences using phylogenetic trees
-    findings: []
-  - id: GO_REF:0000043
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword 
-      mapping
-    findings: []
-  - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt
-    findings: []
-  - id: GO_REF:0000052
-    title: Gene Ontology annotation based on curation of immunofluorescence data
-    findings: []
-  - id: GO_REF:0000107
-    title: Automatic transfer of experimentally verified manual GO annotation 
-      data to orthologs using Ensembl Compara
-    findings: []
-  - id: PMID:1085432
-    title: Malignant lymphoma and rheumatic symptoms.
-    findings: []
-  - id: PMID:10854325
-    title: Tollip, a new component of the IL-1RI pathway, links IRAK to the IL-1
-      receptor.
-    findings: []
-  - id: PMID:11397809
-    title: IRAK1b, a novel alternative splice variant of interleukin-1 
-      receptor-associated kinase (IRAK), mediates interleukin-1 signaling and 
-      has prolonged stability.
-    findings: []
-  - id: PMID:11441107
-    title: 'Cooperation of Toll-like receptor 2 and 6 for cellular activation by soluble
-      tuberculosis factor and Borrelia burgdorferi outer surface protein A lipoprotein:
-      role of Toll-interacting protein and IL-1 receptor signaling molecules in Toll-like
-      receptor 2 signaling.'
-    findings: []
-  - id: PMID:14563850
-    title: Tom1, a VHS domain-containing protein, interacts with tollip, 
-      ubiquitin, and clathrin.
-    findings: []
-  - id: PMID:15047686
-    title: Tollip and Tom1 form a complex and recruit ubiquitin-conjugated 
-      proteins onto early endosomes.
-    findings: []
-  - id: PMID:16189514
-    title: Towards a proteome-scale map of the human protein-protein interaction
-      network.
-    findings: []
-  - id: PMID:16412388
-    title: Recruitment of clathrin onto endosomes by the Tom1-Tollip complex.
-    findings: []
-  - id: PMID:16713569
-    title: A protein-protein interaction network for human inherited ataxias and
-      disorders of Purkinje cell degeneration.
-    findings: []
-  - id: PMID:19056867
-    title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
-    findings: []
-  - id: PMID:19060904
-    title: An empirical framework for binary interactome mapping.
-    findings: []
-  - id: PMID:19447967
-    title: Shifted Transversal Design smart-pooling for high coverage 
-      interactome mapping.
-    findings: []
-  - id: PMID:20936779
-    title: A human MAP kinase interactome.
-    findings: []
-  - id: PMID:21492153
-    title: Analysis of proteomic changes induced upon cellular differentiation 
-      of the human intestinal cell line Caco-2.
-    findings: []
-  - id: PMID:21903422
-    title: Mapping a dynamic innate immunity protein interaction network 
-      regulating type I interferon production.
-    findings: []
-  - id: PMID:21988832
-    title: Toward an understanding of the protein interaction network of the 
-      human liver.
-    findings: []
-  - id: PMID:23533145
-    title: In-depth proteomic analyses of exosomes isolated from expressed 
-      prostatic secretions in urine.
-    findings: []
-  - id: PMID:25042851
-    title: Autophagic clearance of polyQ proteins mediated by ubiquitin-Atg8 
-      adaptors of the conserved CUET protein family.
-    findings: []
-  - id: PMID:25416956
-    title: A proteome-scale map of the human interactome network.
-    findings: []
-  - id: PMID:25910212
-    title: Widespread macromolecular interaction perturbations in human genetic 
-      disorders.
-    findings: []
-  - id: PMID:26320582
-    title: Tom1 Modulates Binding of Tollip to Phosphatidylinositol 3-Phosphate 
-      via a Coupled Folding and Binding Mechanism.
-    findings: []
-  - id: PMID:27107014
-    title: An inter-species protein-protein interaction network across vast 
-      evolutionary distance.
-    findings: []
-  - id: PMID:27368102
-    title: An ER-Associated Pathway Defines Endosomal Architecture for 
-      Controlled Cargo Transport.
-    findings: []
-  - id: PMID:31263572
-    title: Dominant TOM1 mutation associated with combined immunodeficiency and 
-      autoimmune disease.
-    findings: []
-  - id: PMID:31515488
-    title: Extensive disruption of protein interactions by genetic variants 
-      across the allele frequency spectrum in human populations.
-    findings: []
-  - id: PMID:32296183
-    title: A reference map of the human binary protein interactome.
-    findings: []
-  - id: PMID:32814053
-    title: Interactome Mapping Provides a Network of Neurodegenerative Disease 
-      Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.
-    findings: []
-  - id: PMID:33961781
-    title: Dual proteome-scale networks reveal cell-specific remodeling of the 
-      human interactome.
-    findings: []
-  - id: PMID:34524948
-    title: Global Proximity Interactome of the Human Macroautophagy Pathway.
-    findings: []
-  - id: PMID:35271311
-    title: 'OpenCell: Endogenous tagging for the cartography of human cellular organization.'
-    findings: []
-  - id: PMID:40205054
-    title: Multimodal cell maps as a foundation for structural and functional 
-      genomics.
-    findings: []
-  - id: Reactome:R-HSA-446634
-    title: IRAK4 is activated by autophosphorylation
-    findings: []
-  - id: Reactome:R-HSA-446684
-    title: IRAK2 is phosphorylated downstream of IRAK4 following IL1 receptor 
-      activation
-    findings: []
-  - id: Reactome:R-HSA-446692
-    title: IRAK1 binds to MYD88 within the IL1R complex
-    findings: []
-  - id: Reactome:R-HSA-446694
-    title: IRAK4 phosphorylates IRAK1
-    findings: []
-  - id: Reactome:R-HSA-446701
-    title: IRAK4-activated IRAK1 autophosphorylates
-    findings: []
-  - id: Reactome:R-HSA-446862
-    title: Hyperphosphorylated IRAK1 associates with TRAF6
-    findings: []
-  - id: Reactome:R-HSA-446868
-    title: The Interleukin 1 receptor complex binds Tollip
-    findings: []
-  - id: Reactome:R-HSA-446894
-    title: TRAF6 binding leads to IRAK1:TRAF6 release
-    findings: []
-  - id: Reactome:R-HSA-6798749
-    title: Exocytosis of specific granule lumen proteins
-    findings: []
-  - id: Reactome:R-HSA-6798751
-    title: Exocytosis of azurophil granule lumen proteins
-    findings: []
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000043
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000107
+  title: Automatic transfer of experimentally verified manual GO annotation data to orthologs using
+    Ensembl Compara
+  findings: []
+- id: PMID:1085432
+  title: Malignant lymphoma and rheumatic symptoms.
+  findings: []
+- id: PMID:10854325
+  title: Tollip, a new component of the IL-1RI pathway, links IRAK to the IL-1 receptor.
+  findings: []
+- id: PMID:11397809
+  title: IRAK1b, a novel alternative splice variant of interleukin-1 receptor-associated kinase
+    (IRAK), mediates interleukin-1 signaling and has prolonged stability.
+  findings: []
+- id: PMID:11441107
+  title: 'Cooperation of Toll-like receptor 2 and 6 for cellular activation by soluble tuberculosis factor
+    and Borrelia burgdorferi outer surface protein A lipoprotein: role of Toll-interacting protein and
+    IL-1 receptor signaling molecules in Toll-like receptor 2 signaling.'
+  findings: []
+- id: PMID:14563850
+  title: Tom1, a VHS domain-containing protein, interacts with tollip, ubiquitin, and clathrin.
+  findings: []
+- id: PMID:15047686
+  title: Tollip and Tom1 form a complex and recruit ubiquitin-conjugated proteins onto early
+    endosomes.
+  findings: []
+- id: PMID:16189514
+  title: Towards a proteome-scale map of the human protein-protein interaction network.
+  findings: []
+- id: PMID:16412388
+  title: Recruitment of clathrin onto endosomes by the Tom1-Tollip complex.
+  findings: []
+- id: PMID:16713569
+  title: A protein-protein interaction network for human inherited ataxias and disorders of Purkinje
+    cell degeneration.
+  findings: []
+- id: PMID:19056867
+  title: Large-scale proteomics and phosphoproteomics of urinary exosomes.
+  findings: []
+- id: PMID:19060904
+  title: An empirical framework for binary interactome mapping.
+  findings: []
+- id: PMID:19447967
+  title: Shifted Transversal Design smart-pooling for high coverage interactome mapping.
+  findings: []
+- id: PMID:20936779
+  title: A human MAP kinase interactome.
+  findings: []
+- id: PMID:21492153
+  title: Analysis of proteomic changes induced upon cellular differentiation of the human intestinal
+    cell line Caco-2.
+  findings: []
+- id: PMID:21903422
+  title: Mapping a dynamic innate immunity protein interaction network regulating type I interferon
+    production.
+  findings: []
+- id: PMID:21988832
+  title: Toward an understanding of the protein interaction network of the human liver.
+  findings: []
+- id: PMID:23533145
+  title: In-depth proteomic analyses of exosomes isolated from expressed prostatic secretions in
+    urine.
+  findings: []
+- id: PMID:25042851
+  title: Autophagic clearance of polyQ proteins mediated by ubiquitin-Atg8 adaptors of the conserved
+    CUET protein family.
+  findings: []
+- id: PMID:25416956
+  title: A proteome-scale map of the human interactome network.
+  findings: []
+- id: PMID:25910212
+  title: Widespread macromolecular interaction perturbations in human genetic disorders.
+  findings: []
+- id: PMID:26320582
+  title: Tom1 Modulates Binding of Tollip to Phosphatidylinositol 3-Phosphate via a Coupled Folding
+    and Binding Mechanism.
+  findings: []
+- id: PMID:27107014
+  title: An inter-species protein-protein interaction network across vast evolutionary distance.
+  findings: []
+- id: PMID:27368102
+  title: An ER-Associated Pathway Defines Endosomal Architecture for Controlled Cargo Transport.
+  findings: []
+- id: PMID:31263572
+  title: Dominant TOM1 mutation associated with combined immunodeficiency and autoimmune disease.
+  findings: []
+- id: PMID:31515488
+  title: Extensive disruption of protein interactions by genetic variants across the allele
+    frequency spectrum in human populations.
+  findings: []
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+- id: PMID:32814053
+  title: Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers
+    Widespread Protein Aggregation in Affected Brains.
+  findings: []
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
+  findings: []
+- id: PMID:34524948
+  title: Global Proximity Interactome of the Human Macroautophagy Pathway.
+  findings: []
+- id: PMID:35271311
+  title: 'OpenCell: Endogenous tagging for the cartography of human cellular organization.'
+  findings: []
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+- id: Reactome:R-HSA-446634
+  title: IRAK4 is activated by autophosphorylation
+  findings: []
+- id: Reactome:R-HSA-446684
+  title: IRAK2 is phosphorylated downstream of IRAK4 following IL1 receptor activation
+  findings: []
+- id: Reactome:R-HSA-446692
+  title: IRAK1 binds to MYD88 within the IL1R complex
+  findings: []
+- id: Reactome:R-HSA-446694
+  title: IRAK4 phosphorylates IRAK1
+  findings: []
+- id: Reactome:R-HSA-446701
+  title: IRAK4-activated IRAK1 autophosphorylates
+  findings: []
+- id: Reactome:R-HSA-446862
+  title: Hyperphosphorylated IRAK1 associates with TRAF6
+  findings: []
+- id: Reactome:R-HSA-446868
+  title: The Interleukin 1 receptor complex binds Tollip
+  findings: []
+- id: Reactome:R-HSA-446894
+  title: TRAF6 binding leads to IRAK1:TRAF6 release
+  findings: []
+- id: Reactome:R-HSA-6798749
+  title: Exocytosis of specific granule lumen proteins
+  findings: []
+- id: Reactome:R-HSA-6798751
+  title: Exocytosis of azurophil granule lumen proteins
+  findings: []
+- id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+  title: Falcon deep research synthesis for TOLLIP
+  findings: []
+core_functions:
+- description: Ubiquitin- and phosphoinositide-directed molecular adaptor activity that routes
+    ubiquitinated or aberrant membrane cargo toward endolysosomal degradation.
+  molecular_function:
+    id: GO:0060090
+    label: molecular adaptor activity
+  directly_involved_in:
+  - id: GO:0036010
+    label: protein localization to endosome
+  - id: GO:0006511
+    label: ubiquitin-dependent protein catabolic process
+  locations:
+  - id: GO:0005768
+    label: endosome
+  - id: GO:0005769
+    label: early endosome
+  - id: GO:0005737
+    label: cytoplasm
+  supported_by:
+  - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+    supporting_text: TOLLIP is best understood as a **multifunctional adaptor/regulator** that
+      couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to
+      (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii)
+      **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation**
+  - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+    supporting_text: '**C2 domain (~central ~130 aa)**: binds **phosphoinositides**; in a 2023 mechanistic
+      study, the C2 domain showed preferential interaction with **PI3P** and **PI(4,5)P2**, consistent
+      with **membrane/endosome targeting** and PI3P-vesicle coupling'
+  - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+    supporting_text: '**Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions
+      as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal
+      routing and degradation, operating alongside ERAD'
+- description: CUE-domain ubiquitin-conjugate binding that supports cargo selection and
+    receptor-proximal signaling complex regulation.
+  molecular_function:
+    id: GO:0043130
+    label: ubiquitin binding
+  directly_involved_in:
+  - id: GO:0006511
+    label: ubiquitin-dependent protein catabolic process
+  - id: GO:0070498
+    label: interleukin-1-mediated signaling pathway
+  - id: GO:0045087
+    label: innate immune response
+  locations:
+  - id: GO:0005768
+    label: endosome
+  - id: GO:0005829
+    label: cytosol
+  supported_by:
+  - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+    supporting_text: '**CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate
+      binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g.,
+      IRAK and receptor TIR domains in review synthesis)'
+  - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+    supporting_text: '**TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells;
+      BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger
+      NF‑κB signaling'
+  - reference_id: file:human/TOLLIP/TOLLIP-deep-research-falcon.md
+    supporting_text: 'TOLLIP is a **non-enzymatic adaptor** whose primary biochemical capabilities are
+      **specific binding interactions**:'
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []

--- a/genes/human/TOLLIP/TOLLIP-deep-research-falcon.md
+++ b/genes/human/TOLLIP/TOLLIP-deep-research-falcon.md
@@ -1,0 +1,325 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-12T00:13:27.954226'
+end_time: '2026-05-12T00:22:49.573276'
+duration_seconds: 561.62
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: human
+  gene_id: TOLLIP
+  gene_symbol: TOLLIP
+  uniprot_accession: Q9H0E2
+  protein_description: 'RecName: Full=Toll-interacting protein;'
+  gene_info: Name=TOLLIP;
+  organism_full: Homo sapiens (Human).
+  protein_family: Belongs to the tollip family. .
+  protein_domains: C2_dom. (IPR000008); C2_domain_sf. (IPR035892); CUE. (IPR003892);
+    TOLIP_CUE. (IPR041799); Tollip_C2. (IPR037301)
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 23
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9H0E2
+- **Protein Description:** RecName: Full=Toll-interacting protein;
+- **Gene Information:** Name=TOLLIP;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the tollip family. .
+- **Key Domains:** C2_dom. (IPR000008); C2_domain_sf. (IPR035892); CUE. (IPR003892); TOLIP_CUE. (IPR041799); Tollip_C2. (IPR037301)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TOLLIP" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TOLLIP' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TOLLIP** (gene ID: TOLLIP, UniProt: Q9H0E2) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q9H0E2
+- **Protein Description:** RecName: Full=Toll-interacting protein;
+- **Gene Information:** Name=TOLLIP;
+- **Organism (full):** Homo sapiens (Human).
+- **Protein Family:** Belongs to the tollip family. .
+- **Key Domains:** C2_dom. (IPR000008); C2_domain_sf. (IPR035892); CUE. (IPR003892); TOLIP_CUE. (IPR041799); Tollip_C2. (IPR037301)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "TOLLIP" matches the protein description above**
+2. **Verify the organism is correct:** Homo sapiens (Human).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'TOLLIP' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **TOLLIP** (gene ID: TOLLIP, UniProt: Q9H0E2) in human.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: Human **TOLLIP** (UniProt **Q9H0E2**) functional annotation
+
+### 0) Target verification (mandatory)
+The literature synthesized here is restricted to **human TOLLIP (Toll-interacting protein)**, consistent with UniProt accession **Q9H0E2** and a ~274 aa adaptor protein organized around a **phosphoinositide-binding C2 domain** and a **ubiquitin-binding CUE domain**, with an N-terminal **TOM1-binding domain** and an experimentally mapped **intrinsically disordered region (IDR)** (hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas pages 5-6, baig2024adaptormoleculesmediate pages 8-9). Non-human “TOLLIP” studies exist (e.g., fish) and were not used to make claims about human molecular mechanisms beyond very general conservation context (tian2025fishtollipmanipulates pages 21-22).
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 What TOLLIP is
+TOLLIP is best understood as a **multifunctional adaptor/regulator** that couples **ubiquitin recognition** and **membrane/endosomal phosphoinositide recognition** to (i) **tuning innate immune receptor signaling** (TLR/IL‑1R pathways) and (ii) **sorting/trafficking of ubiquitinated or aberrant proteins toward endolysosomal degradation** (baig2024adaptormoleculesmediate pages 8-9, hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas pages 1-2).
+
+#### 1.2 Domain architecture and domain-defined functions
+Recent primary work provides a high-resolution functional decomposition of TOLLIP:
+- **TBD (TOM1-binding domain; ~aa 1–53)**: supports interaction with **TOM1**, with endosomal machinery including **clathrin**, and participates in recruitment of ubiquitinated cargo to early endosomes (baig2024adaptormoleculesmediate pages 8-9, hayashi2023tollipactsas pages 2-5).
+- **C2 domain (~central ~130 aa)**: binds **phosphoinositides**; in a 2023 mechanistic study, the C2 domain showed preferential interaction with **PI3P** and **PI(4,5)P2**, consistent with **membrane/endosome targeting** and PI3P-vesicle coupling (hayashi2023tollipactsas pages 5-6).
+- **IDR (intrinsically disordered region; mapped in 2023 study as aa 181–229)**: functions as a **misfolding-sensing cargo-recognition module** that can directly bind aberrant proteins (e.g., binding heat-denatured luciferase) and is required for certain lysosomal trafficking functions (hayashi2023tollipactsas pages 5-6, hayashi2023tollipactsas pages 17-18).
+- **CUE domain (C-terminal; mapped as aa 231–274)**: mediates **ubiquitin conjugate binding** and is also implicated in receptor-proximal innate immune pathway interactions (e.g., IRAK and receptor TIR domains in review synthesis) (hayashi2023tollipactsas pages 5-6, baig2024adaptormoleculesmediate pages 8-9).
+
+A figure-level schematic of this domain organization and a model of PI3P-dependent lysosomal trafficking are shown in Hayashi et al. 2023 (hayashi2023tollipactsas media 03df7429, hayashi2023tollipactsas media aced0de5).
+
+| Region (aa boundaries if available) | Domain/feature | Key binding partners/ligands | Main mechanistic role(s) | Evidence type | Key citations |
+|---|---|---|---|---|---|
+| 1–53 | TBD (TOM1-binding domain) | TOM1, clathrin, ubiquitin-conjugated cargo | Recruits TOM1/clathrin-linked endosomal sorting machinery; helps load ubiquitinated cargo onto early endosomes and supports endosome-to-lysosome trafficking | Domain annotation and interaction mapping from review; mutational/domain-mapping support in primary studies | (baig2024adaptormoleculesmediate pages 8-9, hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas media 03df7429) |
+| ~53–178 (central ~130 aa) | C2 domain | Phosphoinositides, especially PI3P and PI(4,5)P2; membranes/endosomes | Membrane targeting and anchoring of TOLLIP to PI3P-enriched vesicles/endosomes; required for PI3P-dependent lysosomal trafficking of aberrant membrane cargo; supports localization relevant to TLR/IL-1R trafficking control | Phospholipid-binding and mutagenesis data; localization assays; review synthesis | (forneris2025regulationofhost pages 15-19, baig2024adaptormoleculesmediate pages 8-9, hayashi2023tollipactsas pages 5-6, hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas media 03df7429) |
+| 181–229 | IDR (intrinsically disordered region) | Misfolded/aberrant proteins (e.g., heat-denatured luciferase; aberrant ER membrane cargo such as A53T-HP) | Misfolding-sensing cargo-recognition module that directly binds aberrant proteins and enables selective lysosomal clearance without bulk ER turnover | Biochemical binding assays, mutagenesis, disorder prediction, lysosomal trafficking assays | (hayashi2023tollipactsas pages 5-6, hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas pages 1-2, hayashi2023tollipactsas pages 17-18, hayashi2023tollipactsas media 03df7429) |
+| 231–274 | CUE domain | Ubiquitin chains/conjugates; IRAK1; TIR domains of IL-1R/TLR2/TLR4; BLK competes for the same interaction motif | Ubiquitin recognition; contributes to restraint of IRAK1 autophosphorylation in resting cells; links TOLLIP to IL-1R/TLR signaling complexes; supports cargo selection for lysosomal degradation | Mutagenesis and co-immunoprecipitation in primary studies; review synthesis | (forneris2025regulationofhost pages 15-19, baig2024adaptormoleculesmediate pages 8-9, hayashi2023tollipactsas pages 5-6, li2023blkpositivelyregulates pages 6-10, li2023blkpositivelyregulates pages 10-15) |
+| Y76, Y86, Y152 | Regulatory phosphotyrosine sites | BLK kinase; functionally affect IRAK1 association | BLK-mediated phosphorylation promotes dissociation of TOLLIP from IRAK1, exposing IRAK1 for hyperphosphorylation and enabling stronger IL-1R/TLR-driven NF-κB signaling and cytokine responses | Mass spectrometry-supported site identification, kinase assays, interaction assays, signaling assays, mouse genetics | (li2023blkpositivelyregulates pages 6-10, li2023blkpositivelyregulates pages 10-15, li2023blkpositivelyregulates pages 15-21, li2023blkpositivelyregulates pages 3-6) |
+| Full-length protein / integrated domain action | Endosomal–lysosomal cargo adaptor | Ubiquitinated cargo, TOM1, clathrin, PI3P vesicles, lysosomal/endosomal compartments | Couples ubiquitinated and/or misfolded cargo to PI3P-dependent lysosomal trafficking; promotes degradation of aberrant ER membrane proteins and contributes to selective autophagy/protein quality control | Cell-based trafficking assays, KO/knockdown-rescue experiments, ultrastructural localization, review synthesis | (forneris2025regulationofhost pages 19-23, hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas pages 1-2, hayashi2023tollipactsas pages 17-18, baig2024adaptormoleculesmediate pages 18-19, hayashi2023tollipactsas media aced0de5) |
+| Full-length protein / integrated domain action | Innate immune signaling adaptor-regulator | IRAK1, IL-1R, TLR2, TLR4, MyD88-pathway components, STING | Generally acts as a brake on IL-1R/TLR signaling in resting or homeostatic contexts by restraining IRAK1 and promoting receptor turnover; can also be switched to permit signaling after BLK-dependent phosphorylation; additionally implicated in STING homeostasis | Reviews plus mechanistic primary signaling study | (baig2024adaptormoleculesmediate pages 8-9, tian2025fishtollipmanipulates pages 21-22, li2023blkpositivelyregulates pages 6-10, baig2024adaptormoleculesmediate pages 9-11) |
+
+
+*Table: This table summarizes the experimentally supported domain architecture of human TOLLIP and links each region to its major ligands, trafficking roles, and signaling functions. It is useful as a compact functional annotation anchored to recent mechanistic studies and authoritative reviews.*
+
+#### 1.3 Cellular localization
+TOLLIP’s C2 domain supports association with **PI3P-enriched membranes/vesicles** and **endosomal/lysosomal compartments**, aligning with its roles in endosomal sorting and lysosomal delivery of cargo (hayashi2023tollipactsas pages 5-6, hayashi2023tollipactsas pages 2-5). In the context of aberrant ER membrane cargo, TOLLIP operates at the **ER surface** to capture client proteins and route them into **RAB7/LAMP1-positive endolysosomal compartments** (hayashi2023tollipactsas pages 2-5). A review additionally notes context-dependent translocation (e.g., low-dose LPS driving relocation from lysosomes to mitochondria with ROS consequences), emphasizing that localization can be dynamic under inflammatory conditions (baig2024adaptormoleculesmediate pages 8-9).
+
+### 2) Recent developments and latest research (prioritizing 2023–2024)
+
+#### 2.1 (Dec 2023) A phosphorylation “switch” that converts TOLLIP from a brake to a permissive factor for TLR/IL‑1R signaling
+Li et al. (Journal of Cell Biology; published Dec 2023; https://doi.org/10.1083/jcb.202302081) identified **BLK** as a kinase that **phosphorylates TOLLIP** on **Y76, Y86, and Y152** (li2023blkpositivelyregulates pages 6-10). Mechanistically:
+- In resting cells, TOLLIP forms a constitutive complex with **IRAK1** and restrains IRAK1 phosphorylation (li2023blkpositivelyregulates pages 6-10).
+- Upon **IL‑1β stimulation**, BLK is activated, binds the **CUE domain** of TOLLIP (with ~**10-fold higher affinity** than IRAK1), and phosphorylates TOLLIP at Y76/Y86/Y152 (li2023blkpositivelyregulates pages 6-10).
+- BLK binding and phosphorylation promote **dissociation of TOLLIP from IRAK1**, exposing IRAK1 phosphorylation sites (ProST region) and enabling **IRAK1 hyperphosphorylation**, downstream **NF‑κB activation**, and inflammatory cytokine responses (li2023blkpositivelyregulates pages 6-10, li2023blkpositivelyregulates pages 10-15).
+Physiological relevance was supported by in vivo phenotypes where **Blk−/− mice** produced fewer inflammatory cytokines and showed increased resistance to IL‑1β-induced death (li2023blkpositivelyregulates pages 6-10).
+
+This study reframes TOLLIP not only as a negative regulator but as a **regulated checkpoint node** whose inhibitory complex can be actively dismantled by a receptor-proximal kinase to permit robust signaling.
+
+#### 2.2 (Nov 2023) TOLLIP as a cargo adaptor for selective lysosomal degradation of aberrant ER membrane proteins
+Hayashi et al. (The EMBO Journal; published Nov 2023; https://doi.org/10.15252/embj.2023114272) provided a mechanistic model in which TOLLIP is a **cargo-specific adaptor** for the lysosomal removal of **aberrant ER membrane proteins** (hayashi2023tollipactsas pages 1-2).
+
+Key findings:
+- TOLLIP promotes selective lysosomal degradation of aberrant membrane proteins (including a model A53T-HP substrate and disease mutants of **VAPB** and **Seipin**) (hayashi2023tollipactsas pages 1-2).
+- Cargo recognition requires a **misfolding-sensing IDR** and a **ubiquitin-binding CUE domain**; deletion/mutation of these regions disrupts binding to ubiquitin conjugates and interaction with aberrant cargo (hayashi2023tollipactsas pages 5-6, hayashi2023tollipactsas pages 1-2).
+- The **C2 domain** links TOLLIP to **PI3P-dependent trafficking**, enabling delivery to **endolysosomal** compartments; this pathway is selective for aberrant cargos and does not drive bulk ER turnover (hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas pages 1-2).
+- Functionally, TOLLIP depletion exacerbated ER stress when ERAD was inhibited, suggesting TOLLIP-mediated lysosomal quality control operates **in parallel with ERAD** to safeguard ER proteostasis (hayashi2023tollipactsas pages 1-2).
+
+This 2023 study expanded TOLLIP’s functional annotation beyond innate immunity into a **direct mechanistic role in ER membrane protein quality control**.
+
+#### 2.3 (Feb 2024) Expert synthesis: TOLLIP as a “multitasking” adaptor coordinating negative regulation and trafficking
+Baig et al. (Frontiers in Immunology; published Feb 2024; https://doi.org/10.3389/fimmu.2024.1355012) review adaptor molecules that negatively regulate macrophage inflammatory pathways and describe TOLLIP as a **ubiquitously expressed adaptor** that modulates **IL‑1R and TLR2/4 signaling** and interacts directly with TLR2/TLR4 (baig2024adaptormoleculesmediate pages 8-9). The review emphasizes a canonical negative-regulatory role in acute inflammatory signaling—via interactions with IRAKs and receptor TIR domains and via promoting receptor degradation—while noting context-dependence and additional roles in trafficking/autophagy-related processes (baig2024adaptormoleculesmediate pages 8-9, baig2024adaptormoleculesmediate pages 9-11).
+
+### 3) Current applications and real-world implementations
+
+#### 3.1 Clinical trial implementation: genotyping TOLLIP SNPs as a candidate modifier of N-acetylcysteine (NAC) response
+A completed Phase 1 clinical trial in retinitis pigmentosa, **FIGHT‑RP1** (ClinicalTrials.gov **NCT03063021**; start date **2017-02-15**, completion date **2019-02-11**) tested oral **N‑acetylcysteine (NAC)** and explicitly planned **DNA collection to genotype the same TOLLIP SNPs** previously reported as influencing NAC response in idiopathic pulmonary fibrosis (IPF), as a candidate-gene analysis (NCT03063021 chunk 1). The trial also banks RNA for future transcriptomic studies (NCT03063021 chunk 1). Trial URL: https://clinicaltrials.gov/study/NCT03063021.
+
+Importantly, this trial does not target TOLLIP directly, but illustrates how TOLLIP **human genetics** can be operationalized as a **therapeutic-response modifier** in an interventional study design (NCT03063021 chunk 1).
+
+#### 3.2 Translational disease associations (target–disease knowledgebases)
+Open Targets lists TOLLIP (ENSG00000078902) association evidence across respiratory and other diseases, including **idiopathic pulmonary fibrosis** and **chronic obstructive pulmonary disease**, with disease-association scores (e.g., COPD score ~0.142; IPF score ~0.374 in the returned Open Targets snapshot) (OpenTargets Search: -TOLLIP). While such associations are not mechanistic proof, they highlight settings where TOLLIP biology and/or genetics are considered relevant for human disease prioritization.
+
+### 4) Expert opinions and analysis (authoritative sources)
+
+#### 4.1 Consensus view: adaptor integrating ubiquitin, membranes, and receptor signaling
+The 2024 review frames TOLLIP as a “multitasking” adaptor that links **ubiquitin**, **endosomal trafficking machinery (TOM1/clathrin)**, and **innate immune receptor signaling** to restrain inflammatory outputs, including by limiting IRAK activation and promoting receptor turnover (baig2024adaptormoleculesmediate pages 8-9, baig2024adaptormoleculesmediate pages 9-11). This aligns with the mechanistic picture from 2023 primary studies in which specific TOLLIP domains encode: phosphoinositide-directed localization (C2), ubiquitin recognition (CUE), and client recognition (IDR) (hayashi2023tollipactsas pages 5-6, hayashi2023tollipactsas pages 1-2).
+
+#### 4.2 Updated 2023–2024 perspective: “negative regulator” is accurate but incomplete
+Two 2023 studies sharpen (and partially complicate) the traditional “TOLLIP is a negative regulator” label:
+- In TLR/IL‑1R pathways, TOLLIP can function as an inhibitory clamp on IRAK1 in resting cells but is **actively displaced** by BLK after receptor engagement to permit efficient signal propagation—an explicit **regulatory switch** rather than a static inhibitor (li2023blkpositivelyregulates pages 6-10).
+- In proteostasis, TOLLIP is not simply an autophagy receptor; it can act as a **cargo-specific adaptor** for PI3P-dependent lysosomal trafficking of aberrant ER membrane proteins, with domain-level specificity and separability from bulk ER-phagy (hayashi2023tollipactsas pages 1-2, hayashi2023tollipactsas media aced0de5).
+
+### 5) Relevant statistics and data points from recent studies
+
+#### 5.1 Quantitative trafficking readouts (Hayashi et al., EMBO J 2023)
+Hayashi et al. quantified endosomal/lysosomal features and lysosomal delivery using operational metrics, including:
+- Definition of “acidic puncta” as mCherry:EGFP intensity ratio **> 1.25** in mCherry‑EGFP cargo assays (hayashi2023tollipactsas pages 17-18).
+- Example reported puncta counts: average **PI3P puncta per cell** changed from **38** (siCtrl) to **33** (siTOLLIP) in one condition set; additional construct-dependent values were reported (e.g., 39 CFP; 36 WT; 37 C2mut; 48 IDRmut; 37 ΔCUE) (hayashi2023tollipactsas pages 17-18).
+- Example **LAMP1 puncta** averages reported across conditions included **50** (siCtrl) vs **33** (siTOLLIP), with partial rescue by WT and differing impacts of mutants (e.g., 32 siTOLLIP+WT; 28 siTOLLIP+C2mut #1; 38 siTOLLIP+IDRmut) (hayashi2023tollipactsas pages 17-18).
+These data support that TOLLIP perturbation measurably affects PI3P/LAMP1-associated trafficking features in cells, consistent with its PI3P-dependent lysosomal routing role (hayashi2023tollipactsas pages 2-5, hayashi2023tollipactsas pages 17-18).
+
+#### 5.2 Sample sizes and quantitative design features (Li et al., JCB 2023)
+Li et al. report typical experimental replication for signaling outputs, including qPCR with **n=3 technical replicates**, luciferase assays with **n=3 biological replicates**, and ELISA with **n=6 biological replicates**, and they use Kaplan–Meier/log-rank tests for survival analyses in mouse studies (li2023blkpositivelyregulates pages 6-10). While many fold-changes are figure-embedded (not present in the excerpt), key quantitative mechanistic claims include BLK’s ~**10-fold higher affinity** for TOLLIP than IRAK1 in their binding analyses (li2023blkpositivelyregulates pages 6-10).
+
+#### 5.3 Quantitative association signals (Open Targets snapshot)
+Open Targets returned disease-association scores for TOLLIP such as ~**0.374** (idiopathic pulmonary fibrosis) and ~**0.142** (COPD) in the snapshot retrieved here (OpenTargets Search: -TOLLIP). These scores are integrative/knowledgebase-derived rather than a single study statistic, and should be interpreted accordingly.
+
+---
+
+## Mechanistic functional annotation summary (human TOLLIP/Q9H0E2)
+
+### Primary molecular function
+TOLLIP is a **non-enzymatic adaptor** whose primary biochemical capabilities are **specific binding interactions**:
+1) **Phosphoinositide binding** (C2 domain; PI3P/PI(4,5)P2) that localizes TOLLIP to appropriate membranes/vesicles and enables PI3P-dependent trafficking (hayashi2023tollipactsas pages 5-6).
+2) **Ubiquitin binding** (CUE domain), enabling recognition of ubiquitinated cargo and coupling to degradation pathways; in immune signaling contexts the CUE domain is also implicated in interactions with IRAKs and receptor TIR domains (hayashi2023tollipactsas pages 5-6, baig2024adaptormoleculesmediate pages 8-9).
+3) **Misfolded client recognition** (IDR), supporting selective capture of aberrant proteins for lysosomal trafficking (hayashi2023tollipactsas pages 5-6).
+
+### Cellular sites of action
+- **Endosomes / PI3P-enriched vesicles and endolysosomes**, supporting receptor/cargo sorting and degradation (hayashi2023tollipactsas pages 5-6, hayashi2023tollipactsas pages 2-5).
+- **ER surface**, where TOLLIP can recognize aberrant membrane proteins and route them to lysosomes (hayashi2023tollipactsas pages 2-5).
+- Potentially dynamic relocalization under inflammatory contexts (e.g., mitochondria translocation described in review synthesis) (baig2024adaptormoleculesmediate pages 8-9).
+
+### Major pathways
+- **TLR/IL‑1R → Myddosome/IRAK1 → NF‑κB**: TOLLIP restrains IRAK1 in resting cells; BLK-mediated phosphorylation on Y76/Y86/Y152 releases IRAK1 for hyperphosphorylation and stronger NF‑κB signaling (li2023blkpositivelyregulates pages 6-10, li2023blkpositivelyregulates pages 10-15).
+- **Endosomal/lysosomal trafficking and protein quality control**: TOLLIP functions as a cargo adaptor linking aberrant/ubiquitinated membrane proteins to PI3P-dependent lysosomal routing and degradation, operating alongside ERAD (hayashi2023tollipactsas pages 1-2).
+
+---
+
+## Key 2023–2024 references (URLs and dates)
+- **Hayashi Y. et al.** “TOLLIP acts as a cargo adaptor to promote lysosomal degradation of aberrant ER membrane proteins.” *The EMBO Journal* (Nov **2023**). https://doi.org/10.15252/embj.2023114272 (hayashi2023tollipactsas pages 1-2)
+- **Li W‑W. et al.** “BLK positively regulates TLR/IL‑1R signaling by catalyzing TOLLIP phosphorylation.” *The Journal of Cell Biology* (Dec **2023**). https://doi.org/10.1083/jcb.202302081 (li2023blkpositivelyregulates pages 6-10)
+- **Baig M.S. et al.** “Adaptor molecules mediate negative regulation of macrophage inflammatory pathways: a closer look.” *Frontiers in Immunology* (Feb **2024**). https://doi.org/10.3389/fimmu.2024.1355012 (baig2024adaptormoleculesmediate pages 8-9)
+- **ClinicalTrials.gov**: **NCT03063021** (FIGHT‑RP1; NAC in retinitis pigmentosa; includes TOLLIP SNP genotyping plan). First posted **2017**; completed **2019**. https://clinicaltrials.gov/study/NCT03063021 (NCT03063021 chunk 1)
+- **Open Targets Platform** (accessed via tool snapshot): disease–target associations for TOLLIP including IPF/COPD (OpenTargets Search: -TOLLIP)
+
+## Notable evidence gaps (based on retrieved sources)
+Within the retrieved 2023–2024 corpus, explicit human-variant (SNP-level) effect sizes for specific TOLLIP polymorphisms and their mechanistic consequences were not available as full-text evidence; the clinical trial record confirms such polymorphisms are considered actionable for NAC response in IPF, but the underlying genetic association details would require direct access to the cited IPF pharmacogenetic studies (NCT03063021 chunk 1).
+
+References
+
+1. (hayashi2023tollipactsas pages 2-5): Yuki Hayashi, Sho Takatori, Waleed Y Warsame, Taisuke Tomita, Takao Fujisawa, and Hidenori Ichijo. Tollip acts as a cargo adaptor to promote lysosomal degradation of aberrant er membrane proteins. The EMBO Journal, Nov 2023. URL: https://doi.org/10.15252/embj.2023114272, doi:10.15252/embj.2023114272. This article has 25 citations.
+
+2. (hayashi2023tollipactsas pages 5-6): Yuki Hayashi, Sho Takatori, Waleed Y Warsame, Taisuke Tomita, Takao Fujisawa, and Hidenori Ichijo. Tollip acts as a cargo adaptor to promote lysosomal degradation of aberrant er membrane proteins. The EMBO Journal, Nov 2023. URL: https://doi.org/10.15252/embj.2023114272, doi:10.15252/embj.2023114272. This article has 25 citations.
+
+3. (baig2024adaptormoleculesmediate pages 8-9): Mirza S. Baig, Spyridoula Barmpoutsi, Shreya Bharti, Andreas Weigert, Nik Hirani, Rajat Atre, Rakhi Khabiya, Rahul Sharma, Shivmuni Sarup, and Rajkumar Savai. Adaptor molecules mediate negative regulation of macrophage inflammatory pathways: a closer look. Frontiers in Immunology, Feb 2024. URL: https://doi.org/10.3389/fimmu.2024.1355012, doi:10.3389/fimmu.2024.1355012. This article has 7 citations and is from a peer-reviewed journal.
+
+4. (tian2025fishtollipmanipulates pages 21-22): Meng-Ze Tian, Yang-Yang Wang, Bao-jie Cui, Xiao Xu, Chu-Jing Zhou, Can Zhang, Zhuo-Cong Li, Meng-Qian Hong, Na Xu, Dan-Dan Chen, Long-Feng Lu, and Shun Li. Fish tollip manipulates atg5 for autophagic degradation of sting to attenuate antiviral interferon responses. PLOS Pathogens, 21:e1013512, Sep 2025. URL: https://doi.org/10.1371/journal.ppat.1013512, doi:10.1371/journal.ppat.1013512. This article has 1 citations and is from a highest quality peer-reviewed journal.
+
+5. (hayashi2023tollipactsas pages 1-2): Yuki Hayashi, Sho Takatori, Waleed Y Warsame, Taisuke Tomita, Takao Fujisawa, and Hidenori Ichijo. Tollip acts as a cargo adaptor to promote lysosomal degradation of aberrant er membrane proteins. The EMBO Journal, Nov 2023. URL: https://doi.org/10.15252/embj.2023114272, doi:10.15252/embj.2023114272. This article has 25 citations.
+
+6. (hayashi2023tollipactsas pages 17-18): Yuki Hayashi, Sho Takatori, Waleed Y Warsame, Taisuke Tomita, Takao Fujisawa, and Hidenori Ichijo. Tollip acts as a cargo adaptor to promote lysosomal degradation of aberrant er membrane proteins. The EMBO Journal, Nov 2023. URL: https://doi.org/10.15252/embj.2023114272, doi:10.15252/embj.2023114272. This article has 25 citations.
+
+7. (hayashi2023tollipactsas media 03df7429): Yuki Hayashi, Sho Takatori, Waleed Y Warsame, Taisuke Tomita, Takao Fujisawa, and Hidenori Ichijo. Tollip acts as a cargo adaptor to promote lysosomal degradation of aberrant er membrane proteins. The EMBO Journal, Nov 2023. URL: https://doi.org/10.15252/embj.2023114272, doi:10.15252/embj.2023114272. This article has 25 citations.
+
+8. (hayashi2023tollipactsas media aced0de5): Yuki Hayashi, Sho Takatori, Waleed Y Warsame, Taisuke Tomita, Takao Fujisawa, and Hidenori Ichijo. Tollip acts as a cargo adaptor to promote lysosomal degradation of aberrant er membrane proteins. The EMBO Journal, Nov 2023. URL: https://doi.org/10.15252/embj.2023114272, doi:10.15252/embj.2023114272. This article has 25 citations.
+
+9. (forneris2025regulationofhost pages 15-19): P Forneris. Regulation of host immune responses by toll-interacting protein during citrobacter rodentium infection. Unknown journal, 2025.
+
+10. (li2023blkpositivelyregulates pages 6-10): Wei-Wei Li, Xu-Xu Fan, Zhi-Sheng Xu, Zi-Xiang Zhu, Zhao-Yu Zhu, Xue-Jing Cao, Dan-Shi Pei, Yi-Zhuo Wang, Ji-Yan Zhang, Yan-Yi Wang, and Hai-Xue Zheng. Blk positively regulates tlr/il-1r signaling by catalyzing tollip phosphorylation. The Journal of Cell Biology, Dec 2023. URL: https://doi.org/10.1083/jcb.202302081, doi:10.1083/jcb.202302081. This article has 4 citations.
+
+11. (li2023blkpositivelyregulates pages 10-15): Wei-Wei Li, Xu-Xu Fan, Zhi-Sheng Xu, Zi-Xiang Zhu, Zhao-Yu Zhu, Xue-Jing Cao, Dan-Shi Pei, Yi-Zhuo Wang, Ji-Yan Zhang, Yan-Yi Wang, and Hai-Xue Zheng. Blk positively regulates tlr/il-1r signaling by catalyzing tollip phosphorylation. The Journal of Cell Biology, Dec 2023. URL: https://doi.org/10.1083/jcb.202302081, doi:10.1083/jcb.202302081. This article has 4 citations.
+
+12. (li2023blkpositivelyregulates pages 15-21): Wei-Wei Li, Xu-Xu Fan, Zhi-Sheng Xu, Zi-Xiang Zhu, Zhao-Yu Zhu, Xue-Jing Cao, Dan-Shi Pei, Yi-Zhuo Wang, Ji-Yan Zhang, Yan-Yi Wang, and Hai-Xue Zheng. Blk positively regulates tlr/il-1r signaling by catalyzing tollip phosphorylation. The Journal of Cell Biology, Dec 2023. URL: https://doi.org/10.1083/jcb.202302081, doi:10.1083/jcb.202302081. This article has 4 citations.
+
+13. (li2023blkpositivelyregulates pages 3-6): Wei-Wei Li, Xu-Xu Fan, Zhi-Sheng Xu, Zi-Xiang Zhu, Zhao-Yu Zhu, Xue-Jing Cao, Dan-Shi Pei, Yi-Zhuo Wang, Ji-Yan Zhang, Yan-Yi Wang, and Hai-Xue Zheng. Blk positively regulates tlr/il-1r signaling by catalyzing tollip phosphorylation. The Journal of Cell Biology, Dec 2023. URL: https://doi.org/10.1083/jcb.202302081, doi:10.1083/jcb.202302081. This article has 4 citations.
+
+14. (forneris2025regulationofhost pages 19-23): P Forneris. Regulation of host immune responses by toll-interacting protein during citrobacter rodentium infection. Unknown journal, 2025.
+
+15. (baig2024adaptormoleculesmediate pages 18-19): Mirza S. Baig, Spyridoula Barmpoutsi, Shreya Bharti, Andreas Weigert, Nik Hirani, Rajat Atre, Rakhi Khabiya, Rahul Sharma, Shivmuni Sarup, and Rajkumar Savai. Adaptor molecules mediate negative regulation of macrophage inflammatory pathways: a closer look. Frontiers in Immunology, Feb 2024. URL: https://doi.org/10.3389/fimmu.2024.1355012, doi:10.3389/fimmu.2024.1355012. This article has 7 citations and is from a peer-reviewed journal.
+
+16. (baig2024adaptormoleculesmediate pages 9-11): Mirza S. Baig, Spyridoula Barmpoutsi, Shreya Bharti, Andreas Weigert, Nik Hirani, Rajat Atre, Rakhi Khabiya, Rahul Sharma, Shivmuni Sarup, and Rajkumar Savai. Adaptor molecules mediate negative regulation of macrophage inflammatory pathways: a closer look. Frontiers in Immunology, Feb 2024. URL: https://doi.org/10.3389/fimmu.2024.1355012, doi:10.3389/fimmu.2024.1355012. This article has 7 citations and is from a peer-reviewed journal.
+
+17. (NCT03063021 chunk 1):  The FIGHT-RP1 Study. Johns Hopkins University. 2017. ClinicalTrials.gov Identifier: NCT03063021
+
+18. (OpenTargets Search: -TOLLIP): Open Targets Query (-TOLLIP, 5 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+## Citations
+
+1. tian2025fishtollipmanipulates pages 21-22
+2. hayashi2023tollipactsas pages 5-6
+3. hayashi2023tollipactsas pages 2-5
+4. baig2024adaptormoleculesmediate pages 8-9
+5. li2023blkpositivelyregulates pages 6-10
+6. hayashi2023tollipactsas pages 1-2
+7. hayashi2023tollipactsas pages 17-18
+8. forneris2025regulationofhost pages 15-19
+9. li2023blkpositivelyregulates pages 10-15
+10. li2023blkpositivelyregulates pages 15-21
+11. li2023blkpositivelyregulates pages 3-6
+12. forneris2025regulationofhost pages 19-23
+13. baig2024adaptormoleculesmediate pages 18-19
+14. baig2024adaptormoleculesmediate pages 9-11
+15. https://doi.org/10.1083/jcb.202302081
+16. https://doi.org/10.15252/embj.2023114272
+17. https://doi.org/10.3389/fimmu.2024.1355012
+18. https://clinicaltrials.gov/study/NCT03063021.
+19. https://clinicaltrials.gov/study/NCT03063021
+20. https://doi.org/10.15252/embj.2023114272,
+21. https://doi.org/10.3389/fimmu.2024.1355012,
+22. https://doi.org/10.1371/journal.ppat.1013512,
+23. https://doi.org/10.1083/jcb.202302081,


### PR DESCRIPTION
## Summary

- Add Falcon deep research reports for human TOLLIP, PICK1, and RUNX3.
- Complete the corresponding review YAMLs with curated action decisions, evidence-backed summaries, core functions, and Falcon references.
- Render updated HTML review pages for the three genes.

## Validation

- `just validate human TOLLIP`
- `just validate human PICK1`
- `just validate human RUNX3`
- `uv run python scripts/validate_deep_research.py genes/human/TOLLIP/TOLLIP-deep-research-falcon.md genes/human/PICK1/PICK1-deep-research-falcon.md genes/human/RUNX3/RUNX3-deep-research-falcon.md`
- supporting-text audit over 420 local file/PMID-backed snippets
- `git diff --check`