### PR TITLE
Add Falcon review for PIK3C3

### DIFF
--- a/genes/human/PIK3C3/PIK3C3-ai-review.html
+++ b/genes/human/PIK3C3/PIK3C3-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>PIK3C3</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q8NEB9" target="_blank" class="term-link">
                         Q8NEB9
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-in-progress">
-                    IN PROGRESS
+                <span class="status-badge status-draft">
+                    DRAFT
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>PIK3C3 encodes VPS34, the catalytic lipid kinase of class III phosphatidylinositol 3-kinase complexes. VPS34 generates phosphatidylinositol 3-phosphate (PI3P) on endomembranes and operates in two main Beclin 1-containing assemblies: PI3KC3-C1 with ATG14 for autophagosome initiation and PI3KC3-C2 with UVRAG for endosomal sorting and later autophagy-associated trafficking. In the proteostasis-network context, the autophagy-initiation complex and macroautophagy are the central core claims, whereas endosomal trafficking and cytokinesis are supported but contextual extensions of the same VPS34 PI3P-generating biology.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,267 +758,495 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytoplasm is a broad but directionally compatible localization for a cytoplasmic vesicle-associated lipid kinase.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 is best localized to specific autophagy and endosomal membranes/complexes; cytoplasm is retained only as a broad contextual cellular-component annotation.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Midbody {ECO:0000269|PubMed:20208530}. Late endosome {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome {ECO:0000305|PubMed:14617358}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">As component of the PI3K complex I localized to pre-autophagosome structures. As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0016020" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0016020" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Membrane is too broad for PIK3C3 localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The evidence supports specific endomembrane contexts, especially phagophore/autophagosome and endosomal membranes, rather than a generic membrane annotation.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Midbody {ECO:0000269|PubMed:20208530}. Late endosome {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome {ECO:0000305|PubMed:14617358}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">As component of the PI3K complex I localized to pre-autophagosome structures. As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048015" target="_blank" class="term-link">
                                     GO:0048015
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol-mediated signaling</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0048015" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0048015" data-r="GO_REF:0000033" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Phosphatidylinositol-mediated signaling is directionally related but too broad for VPS34.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The direct process output of PIK3C3 is PI3P biosynthesis, with downstream effects in autophagosome formation and endosomal organization; the signaling parent term blurs that specificity.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036092" target="_blank" class="term-link">
+                                    phosphatidylinositol-3-phosphate biosynthetic process
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol 3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 is described as **exclusively catalyzing PI3P production from phosphatidylinositol (PI) in vitro and in vivo**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006897" target="_blank" class="term-link">
                                     GO:0006897
                                 </a>
                             </span>
                             <span class="term-label">endocytosis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0006897" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0006897" data-r="GO_REF:0000033" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Endocytosis is supported only as a contextual trafficking role.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 participates in endosomal PI3P-dependent trafficking and maturation, but endocytosis itself is too broad; endosome organization or early-to-late endosome transport better captures the supported role.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007032" target="_blank" class="term-link">
+                                    endosome organization
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045022" target="_blank" class="term-link">
+                                    early endosome to late endosome transport
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 activity is strongly tied to **endosomal PI3P pools** that define **early endosome identity** and sorting, and PI3P serves as a platform for downstream trafficking and maturation processes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000425" target="_blank" class="term-link">
                                     GO:0000425
                                 </a>
                             </span>
                             <span class="term-label">pexophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0000425" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0000425" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Pexophagy is a selective-autophagy overextension for PIK3C3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 is core for canonical autophagy initiation and can support selective autophagy generally, but this row does not provide human evidence for a specific pexophagy role.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
+                                    macroautophagy
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
                                     GO:0005768
                                 </a>
                             </span>
                             <span class="term-label">endosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1030,64 +1258,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PIK3C3 is active on endosomal membranes as part of the UVRAG-containing PI3KC3-C2 complex. This localization is well supported but is contextual relative to the core PN autophagy-initiation case.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Human VPS34 participates in a type II class III PI3K complex dedicated to endosomal sorting and later autophagy-associated trafficking. That role is real, but it is not the central PN framing for this gene.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/40442316" target="_blank" class="term-link">
                                         PMID:40442316
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation.</div>
-                                
+
+                                <div class="support-text">The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation5–7.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 activity is strongly tied to **endosomal PI3P pools** that define **early endosome identity** and sorting, and PI3P serves as a platform for downstream trafficking and maturation processes.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000045" target="_blank" class="term-link">
                                     GO:0000045
                                 </a>
                             </span>
                             <span class="term-label">autophagosome assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1099,64 +1338,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Core PN function. VPS34 is required for autophagosome assembly through the autophagy-initiating PI3KC3-C1 complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This is the central autophagy-complex biology for PIK3C3. VPS34-derived PI3P is required for autophagosome formation, and human PI3KC3-C1 is now structurally defined as an autophagy core complex.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33637724" target="_blank" class="term-link">
                                         PMID:33637724
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.</div>
-                                
+
+                                <div class="support-text">This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016303" target="_blank" class="term-link">
                                     GO:0016303
                                 </a>
                             </span>
                             <span class="term-label">1-phosphatidylinositol-3-kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1168,64 +1418,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Core molecular function. PIK3C3/VPS34 is the class III lipid kinase that phosphorylates phosphatidylinositol to generate PI3P.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct biochemical work established the substrate specificity of human VPS34, and this specific lipid kinase activity remains the most precise MF term for the gene product.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7628435" target="_blank" class="term-link">
                                         PMID:7628435
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol 3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 is described as **exclusively catalyzing PI3P production from phosphatidylinositol (PI) in vitro and in vivo**</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036092" target="_blank" class="term-link">
                                     GO:0036092
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol-3-phosphate biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1237,64 +1509,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Core process output of VPS34 catalytic activity. PIK3C3 generates PI3P for autophagosome biogenesis and related membrane-trafficking pathways.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PI3P synthesis is the direct biochemical consequence of VPS34 activity and is the process-level claim that best captures the shared output of the type I and type II class III PI3K complexes.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33637724" target="_blank" class="term-link">
                                         PMID:33637724
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.</div>
-                                
+
+                                <div class="support-text">This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol 3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034271" target="_blank" class="term-link">
                                     GO:0034271
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol 3-kinase complex, class III, type I</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1306,64 +1589,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Core PN complex membership. PIK3C3 is the catalytic subunit of PI3KC3-C1, the ATG14-containing class III PI3K complex that initiates autophagy.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The type I complex is the core autophagy-initiation complex for VPS34 and is the key PN-driven complex call that was previously missing locally.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/40442316" target="_blank" class="term-link">
                                         PMID:40442316
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase VPS15 and the regulatory subunits BECN1 and ATG14.</div>
-                                
+
+                                <div class="support-text">PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase VPS15 and the regulatory subunits BECN1 and ATG14</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034272" target="_blank" class="term-link">
                                     GO:0034272
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol 3-kinase complex, class III, type II</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1375,64 +1669,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> PIK3C3 also participates in PI3KC3-C2, the UVRAG-containing class III PI3K complex linked to endosomal sorting and later autophagy-associated trafficking. This is supported but is contextual relative to the core PN autophagy-initiation case.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Type II complex membership is well established, but the primary PN-focused role for PIK3C3 is the autophagy-initiation complex PI3KC3-C1 rather than the broader trafficking context.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/40442316" target="_blank" class="term-link">
                                         PMID:40442316
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation.</div>
-                                
+
+                                <div class="support-text">The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation5–7.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
                                     GO:0000407
                                 </a>
                             </span>
                             <span class="term-label">phagophore assembly site</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1444,111 +1749,142 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Core localization for the autophagy-initiation role of PIK3C3. VPS34 acts at the phagophore assembly site as part of PI3KC3-C1.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This term is consistent with the type I complex call and captures the localization at which VPS34-derived PI3P seeds early autophagosome biogenesis.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/40442316" target="_blank" class="term-link">
                                         PMID:40442316
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">All forms of canonical autophagy, bulk and selective, are initiated upon the recruitment and activation of the FIP200 protein4 and the class III phosphatidylinositol 3-OH kinase complex I (PI3KC3-C1)5–7.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005777" target="_blank" class="term-link">
                                     GO:0005777
                                 </a>
                             </span>
                             <span class="term-label">peroxisome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005777" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005777" data-r="GO_REF:0000033" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Peroxisome localization is not supported for PIK3C3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> A pexophagy-related inference does not justify localizing PIK3C3 to the peroxisome; curated locations place VPS34 at midbody, late endosome, cytoplasmic vesicle/autophagosome, and pre-autophagosome/endosome contexts.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Midbody {ECO:0000269|PubMed:20208530}. Late endosome {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome {ECO:0000305|PubMed:14617358}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">As component of the PI3K complex I localized to pre-autophagosome structures. As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000045" target="_blank" class="term-link">
                                     GO:0000045
                                 </a>
                             </span>
                             <span class="term-label">autophagosome assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1560,64 +1896,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Duplicate automated annotation for a reviewed core function. VPS34 is required for autophagosome assembly.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The multi-source IEA is consistent with direct human evidence and the reviewed IBA/IDA annotations for the autophagy-initiation complex.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33637724" target="_blank" class="term-link">
                                         PMID:33637724
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.</div>
-                                
+
+                                <div class="support-text">This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004672" target="_blank" class="term-link">
                                     GO:0004672
                                 </a>
                             </span>
                             <span class="term-label">protein kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-remove">
@@ -1629,111 +1976,142 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This annotation is categorically wrong. PIK3C3 is a phosphatidylinositol 3-kinase, not a protein kinase.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Direct biochemical evidence shows that VPS34 phosphorylates phosphatidylinositol rather than protein substrates. This is the wrong enzyme class, not a merely imprecise parent term, and the correct molecular function is already captured by accepted 1-phosphatidylinositol-3-kinase activity annotations elsewhere in the review.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7628435" target="_blank" class="term-link">
                                         PMID:7628435
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007032" target="_blank" class="term-link">
                                     GO:0007032
                                 </a>
                             </span>
                             <span class="term-label">endosome organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0007032" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0007032" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Endosome organization is a supported non-core PIK3C3 process.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3-derived PI3P helps define endosomal identity and trafficking, especially in the UVRAG-containing type II complex, but the central reviewed function remains class III PI3K activity in autophagy initiation.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 activity is strongly tied to **endosomal PI3P pools** that define **early endosome identity** and sorting, and PI3P serves as a platform for downstream trafficking and maturation processes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
                                     GO:0016236
                                 </a>
                             </span>
                             <span class="term-label">macroautophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1745,111 +2123,161 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Core PN process. VPS34 is required for macroautophagy through PI3KC3-C1 mediated PI3P generation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Conserved automated transfer is consistent with direct mammalian evidence that class III PI3K activity is required for macroautophagy.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10625637" target="_blank" class="term-link">
                                         PMID:10625637
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Transfection of a specific class III PI3K antisense oligonucleotide greatly inhibited the rate of macroautophagy.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016485" target="_blank" class="term-link">
                                     GO:0016485
                                 </a>
                             </span>
                             <span class="term-label">protein processing</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0016485" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0016485" data-r="GO_REF:0000107" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein processing is too generic for the supported trafficking role.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Human and review evidence support PI3P-dependent endocytic membrane traffic, phagosome maturation, autophagy, and lysosome-directed trafficking rather than protein processing as a molecularly informative process.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045022" target="_blank" class="term-link">
+                                    early endosome to late endosome transport
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007032" target="_blank" class="term-link">
+                                    endosome organization
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16467569" target="_blank" class="term-link">
+                                        PMID:16467569
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">By contrast, class III PI 3-kinases mainly mediate receptor-independent trafficking events, which mostly are related to endocytic membrane traffic, phagosome maturation and autophagy.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035032" target="_blank" class="term-link">
                                     GO:0035032
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol 3-kinase complex, class III</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -1861,562 +2289,953 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic class III complex membership is true but underspecified for human PIK3C3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Human VPS34 participates in both ATG14-containing PI3KC3-C1 and UVRAG-containing PI3KC3-C2. The type-specific complex terms preserve the autophagy-versus-trafficking split that matters for conservative curation.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034271" target="_blank" class="term-link">
                                     phosphatidylinositol 3-kinase complex, class III, type I
                                 </a>
                             </span>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034272" target="_blank" class="term-link">
                                     phosphatidylinositol 3-kinase complex, class III, type II
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/40442316" target="_blank" class="term-link">
                                         PMID:40442316
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation.</div>
-                                
+
+                                <div class="support-text">The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation5–7.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042149" target="_blank" class="term-link">
                                     GO:0042149
                                 </a>
                             </span>
                             <span class="term-label">cellular response to glucose starvation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0042149" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0042149" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Glucose starvation response is a contextual autophagy input, not the core PIK3C3 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Starvation stimulates VPS34-dependent autophagy and PI3P production, but the reviewed core function is the lipid kinase/autophagy-initiation activity rather than the stimulus-response term itself.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
+                                    macroautophagy
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25327288" target="_blank" class="term-link">
+                                        PMID:25327288
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIK-III acutely inhibits autophagy and de novo lipidation of LC3, and leads to the stabilization of autophagy substrates.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043201" target="_blank" class="term-link">
                                     GO:0043201
                                 </a>
                             </span>
                             <span class="term-label">response to L-leucine</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0043201" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0043201" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Response to L-leucine is a nutrient-response overextension for PIK3C3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 participates in nutrient-sensitive autophagy pathways, but this specific amino-acid response is not the direct activity or best-supported process for the gene product.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
+                                    macroautophagy
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043491" target="_blank" class="term-link">
                                     GO:0043491
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol 3-kinase/protein kinase B signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0043491" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0043491" data-r="GO_REF:0000107" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> PI3K/AKT signal transduction conflates VPS34 with class I PI3K signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3/VPS34 is a class III PI3K that produces PI3P from PI and should not be annotated to the class I PI3K/AKT pathway without direct evidence.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol 3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 is described as **exclusively catalyzing PI3P production from phosphatidylinositol (PI) in vitro and in vivo**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045335" target="_blank" class="term-link">
                                     GO:0045335
                                 </a>
                             </span>
                             <span class="term-label">phagocytic vesicle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0045335" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0045335" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Phagocytic vesicle is a supported but non-core trafficking context.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Class III PI3Ks participate in phagosome maturation and endocytic membrane traffic, but this is contextual relative to the core VPS34 lipid kinase/autophagy initiation function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16467569" target="_blank" class="term-link">
+                                        PMID:16467569
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">By contrast, class III PI 3-kinases mainly mediate receptor-independent trafficking events, which mostly are related to endocytic membrane traffic, phagosome maturation and autophagy.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048488" target="_blank" class="term-link">
                                     GO:0048488
                                 </a>
                             </span>
                             <span class="term-label">synaptic vesicle endocytosis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0048488" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0048488" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Synaptic vesicle endocytosis is an over-specific inference from a general endosomal role.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 supports endosomal PI3P-dependent trafficking, but the reviewed evidence here does not establish a synaptic-vesicle-specific function.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007032" target="_blank" class="term-link">
+                                    endosome organization
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 activity is strongly tied to **endosomal PI3P pools** that define **early endosome identity** and sorting, and PI3P serves as a platform for downstream trafficking and maturation processes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098794" target="_blank" class="term-link">
                                     GO:0098794
                                 </a>
                             </span>
                             <span class="term-label">postsynapse</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0098794" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0098794" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Postsynapse localization is not established as a reviewed PIK3C3 localization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The available human/Falcon evidence supports endosomal, autophagic, and midbody contexts; synapse-specific localization is not part of the core or well-supported contextual function.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Midbody {ECO:0000269|PubMed:20208530}. Late endosome {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome {ECO:0000305|PubMed:14617358}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">As component of the PI3K complex I localized to pre-autophagosome structures. As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098830" target="_blank" class="term-link">
                                     GO:0098830
                                 </a>
                             </span>
                             <span class="term-label">presynaptic endosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0098830" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0098830" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Presynaptic endosome is too specific for the evidence used here.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Endosomal PI3P biology is supported, but this annotation narrows the localization to a neuronal presynaptic compartment without direct evidence in the reviewed record.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 activity is strongly tied to **endosomal PI3P pools** that define **early endosome identity** and sorting, and PI3P serves as a platform for downstream trafficking and maturation processes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098845" target="_blank" class="term-link">
                                     GO:0098845
                                 </a>
                             </span>
                             <span class="term-label">postsynaptic endosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0098845" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0098845" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Postsynaptic endosome is too specific for the evidence used here.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Endosomal PI3P biology is supported, but this annotation narrows the localization to a neuronal postsynaptic compartment without direct evidence in the reviewed record.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 activity is strongly tied to **endosomal PI3P pools** that define **early endosome identity** and sorting, and PI3P serves as a platform for downstream trafficking and maturation processes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098978" target="_blank" class="term-link">
                                     GO:0098978
                                 </a>
                             </span>
                             <span class="term-label">glutamatergic synapse</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0098978" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0098978" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Glutamatergic synapse localization is an unsupported specialization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 has supported endosomal and autophagy-related localizations; the reviewed evidence does not establish a glutamatergic synapse location.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Midbody {ECO:0000269|PubMed:20208530}. Late endosome {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome {ECO:0000305|PubMed:14617358}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">As component of the PI3K complex I localized to pre-autophagosome structures. As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0098982" target="_blank" class="term-link">
                                     GO:0098982
                                 </a>
                             </span>
                             <span class="term-label">GABA-ergic synapse</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0098982" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0098982" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> GABA-ergic synapse localization is an unsupported specialization.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 has supported endosomal and autophagy-related localizations; the reviewed evidence does not establish a GABA-ergic synapse location.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Midbody {ECO:0000269|PubMed:20208530}. Late endosome {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome {ECO:0000305|PubMed:14617358}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">As component of the PI3K complex I localized to pre-autophagosome structures. As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19050071" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19050071
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2428,57 +3247,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20142477" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20142477
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2490,57 +3309,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20562859" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20562859
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2552,57 +3371,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21062745" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21062745
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2614,57 +3433,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22493499" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22493499
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2676,57 +3495,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23316280" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23316280
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2738,57 +3557,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23332761" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23332761
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2800,57 +3619,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23364696" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23364696
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2862,57 +3681,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23954414" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23954414
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2924,57 +3743,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24034250" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24034250
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2986,57 +3805,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24056303" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24056303
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3048,57 +3867,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24472739" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24472739
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3110,57 +3929,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24785657" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24785657
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3172,57 +3991,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24849286" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24849286
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3234,57 +4053,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25490155" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25490155
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3296,57 +4115,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25594178" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25594178
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3358,57 +4177,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26496610" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26496610
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3420,57 +4239,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26783301" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26783301
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3482,57 +4301,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3544,57 +4363,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33422265" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33422265
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3606,57 +4425,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3668,57 +4487,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34386498" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34386498
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3730,57 +4549,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34524948" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34524948
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3792,57 +4611,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35271311
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -3854,140 +4673,213 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005770" target="_blank" class="term-link">
                                     GO:0005770
                                 </a>
                             </span>
                             <span class="term-label">late endosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005770" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005770" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Late endosome is a supported contextual localization for PIK3C3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Late-endosome localization and endosomal trafficking are supported, especially through the type II complex, but are contextual relative to the core autophagy-initiation function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Midbody {ECO:0000269|PubMed:20208530}. Late endosome {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome {ECO:0000305|PubMed:14617358}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 activity is strongly tied to **endosomal PI3P pools** that define **early endosome identity** and sorting, and PI3P serves as a platform for downstream trafficking and maturation processes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005776" target="_blank" class="term-link">
                                     GO:0005776
                                 </a>
                             </span>
                             <span class="term-label">autophagosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005776" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005776" data-r="GO_REF:0000044" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Autophagosome localization is supported for PIK3C3 autophagy biology.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 acts in autophagosome biogenesis through PI3KC3-C1 and is curated as associated with cytoplasmic vesicle/autophagosome and pre-autophagosome structures.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Midbody {ECO:0000269|PubMed:20208530}. Late endosome {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome {ECO:0000305|PubMed:14617358}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">As component of the PI3K complex I localized to pre-autophagosome structures. As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016301" target="_blank" class="term-link">
                                     GO:0016301
                                 </a>
                             </span>
                             <span class="term-label">kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3999,75 +4891,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Generic kinase activity is too broad here. The reviewed molecular function for PIK3C3 should be the specific class III phosphatidylinositol 3-kinase activity term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Human VPS34 is a lipid kinase acting on phosphatidylinositol rather than a generic kinase activity in the GO-review sense. The specific MF term is available and better matches the direct biochemistry.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016303" target="_blank" class="term-link">
                                     1-phosphatidylinositol-3-kinase activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7628435" target="_blank" class="term-link">
                                         PMID:7628435
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016303" target="_blank" class="term-link">
                                     GO:0016303
                                 </a>
                             </span>
                             <span class="term-label">1-phosphatidylinositol-3-kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4079,64 +4971,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Automated duplicate of the reviewed core molecular function for PIK3C3. VPS34 is the class III phosphatidylinositol 3-kinase.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The automated call is consistent with the direct biochemical literature and with the accepted curated annotations for this gene.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7628435" target="_blank" class="term-link">
                                         PMID:7628435
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol 3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 is described as **exclusively catalyzing PI3P production from phosphatidylinositol (PI) in vitro and in vivo**</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016773" target="_blank" class="term-link">
                                     GO:0016773
                                 </a>
                             </span>
                             <span class="term-label">phosphotransferase activity, alcohol group as acceptor</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -4148,122 +5062,142 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This broad phosphotransferase term is less informative than the specific class III phosphatidylinositol 3-kinase activity term that is available for PIK3C3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Human VPS34 has well-defined lipid-substrate specificity, so the specific GO molecular function should replace this high-level transferase term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016303" target="_blank" class="term-link">
                                     1-phosphatidylinositol-3-kinase activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7628435" target="_blank" class="term-link">
                                         PMID:7628435
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030496" target="_blank" class="term-link">
                                     GO:0030496
                                 </a>
                             </span>
                             <span class="term-label">midbody</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0030496" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0030496" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Midbody localization is a supported non-core cytokinesis context.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Human PIK3C3 has experimental midbody localization and a PI3P-dependent cytokinesis role, but this is not the main conserved function emphasized for this review.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Midbody {ECO:0000269|PubMed:20208530}. Late endosome {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome {ECO:0000305|PubMed:14617358}.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036092" target="_blank" class="term-link">
                                     GO:0036092
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol-3-phosphate biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4275,64 +5209,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Automated duplicate of a reviewed core process. VPS34-driven PI3P generation is the central biochemical output of PIK3C3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This specific process term correctly captures the immediate product of VPS34 catalytic activity and is preferable to broader phosphoinositide biosynthesis labels.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33637724" target="_blank" class="term-link">
                                         PMID:33637724
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.</div>
-                                
+
+                                <div class="support-text">This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol 3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046854" target="_blank" class="term-link">
                                     GO:0046854
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol phosphate biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -4344,144 +5289,183 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The process is directionally correct but too broad. For PIK3C3 the literature supports the specific PI3P biosynthetic process term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Human VPS34 is specifically responsible for generating phosphatidylinositol 3-phosphate rather than phosphatidylinositol phosphates in general.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036092" target="_blank" class="term-link">
                                     phosphatidylinositol-3-phosphate biosynthetic process
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33637724" target="_blank" class="term-link">
                                         PMID:33637724
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.</div>
-                                
+
+                                <div class="support-text">This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006622" target="_blank" class="term-link">
                                     GO:0006622
                                 </a>
                             </span>
                             <span class="term-label">protein targeting to lysosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16467569" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16467569
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0006622" data-r="PMID:16467569" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0006622" data-r="PMID:16467569" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein targeting to lysosome is a contextual trafficking assignment.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The accessible review evidence supports class III PI3K roles in endocytic membrane traffic, phagosome maturation, and autophagy; a more informative term is endosome organization or early-to-late endosome transport.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007032" target="_blank" class="term-link">
+                                    endosome organization
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045022" target="_blank" class="term-link">
+                                    early endosome to late endosome transport
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16467569" target="_blank" class="term-link">
+                                        PMID:16467569
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">By contrast, class III PI 3-kinases mainly mediate receptor-independent trafficking events, which mostly are related to endocytic membrane traffic, phagosome maturation and autophagy.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010506" target="_blank" class="term-link">
                                     GO:0010506
                                 </a>
                             </span>
                             <span class="term-label">regulation of autophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16799551" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16799551
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Autophagic and tumour suppressor activity of a novel Beclin1...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -4493,86 +5477,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> This study supports PIK3C3 participation in macroautophagy, but classifying VPS34 itself as a regulator is too indirect. The gene product is part of the executing PI3KC3 complex.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> PIK3C3 is not merely upstream of autophagy in this context; it is a core catalytic component of the autophagy machinery. The process annotation should therefore be macroautophagy rather than regulation of autophagy.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
                                     macroautophagy
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10625637" target="_blank" class="term-link">
                                         PMID:10625637
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Transfection of a specific class III PI3K antisense oligonucleotide greatly inhibited the rate of macroautophagy.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
                                     GO:0016236
                                 </a>
                             </span>
                             <span class="term-label">macroautophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40442316" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40442316
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure and activation of the human autophagy-initiating U...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4584,75 +5568,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Core PN process assignment. Human structural and mechanistic work places PIK3C3 in the autophagy-initiating PI3KC3-C1 complex required for macroautophagy.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The human literature now directly frames PI3KC3-C1 as an autophagy core complex, which supports macroautophagy as a central process annotation for PIK3C3.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/40442316" target="_blank" class="term-link">
                                         PMID:40442316
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">All forms of canonical autophagy, bulk and selective, are initiated upon the recruitment and activation of the FIP200 protein4 and the class III phosphatidylinositol 3-OH kinase complex I (PI3KC3-C1)5–7.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016241" target="_blank" class="term-link">
                                     GO:0016241
                                 </a>
                             </span>
                             <span class="term-label">regulation of macroautophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10625637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10625637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Distinct classes of phosphatidylinositol 3&#39;-kinases are invo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -4664,86 +5659,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The underlying result supports macroautophagy itself rather than a purely regulatory role. PIK3C3 is required for the process.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> In this experiment class III PI3K activity is necessary for macroautophagy, so the process term is more appropriate than a regulation term for PIK3C3.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
                                     macroautophagy
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10625637" target="_blank" class="term-link">
                                         PMID:10625637
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Transfection of a specific class III PI3K antisense oligonucleotide greatly inhibited the rate of macroautophagy.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036092" target="_blank" class="term-link">
                                     GO:0036092
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol-3-phosphate biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/8999962" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:8999962
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Characterization of p150, an adaptor protein for the human p...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4755,75 +5750,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reviewed core process assignment. Human VPS34/p150 complex activity is part of the specific PI3P-producing pathway.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Across the human literature, VPS34 activity is consistently tied to PI3P generation rather than a generic phosphoinositide biosynthetic role.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/10625637" target="_blank" class="term-link">
                                         PMID:10625637
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">an increase in the class III PI3K product (phosphatidylinositol 3-phosphate), either by feeding cells with a synthetic lipid or by overexpressing the p150 adaptor, stimulates macroautophagy.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol 3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045022" target="_blank" class="term-link">
                                     GO:0045022
                                 </a>
                             </span>
                             <span class="term-label">early endosome to late endosome transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14617358" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14617358
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human VPS34 and p150 are Rab7 interacting partners.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4835,390 +5841,557 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Human VPS34/p150 participates in Rab7-linked endosomal trafficking. This is supported but is contextual relative to the core PN autophagy role.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The late-endosomal transport function is directly supported in human cells, but it should be kept distinct from the autophagy-initiation complex that defines the core PN case for PIK3C3.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14617358" target="_blank" class="term-link">
                                         PMID:14617358
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The hVPS34/p150 complex colocalized with rab7 on late endosomes and hVPS34 activity was dependent on nucleotide cycling of rab7.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 activity is strongly tied to **endosomal PI3P pools** that define **early endosome identity** and sorting, and PI3P serves as a platform for downstream trafficking and maturation processes.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097352" target="_blank" class="term-link">
                                     GO:0097352
                                 </a>
                             </span>
                             <span class="term-label">autophagosome maturation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10625637" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10625637
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Distinct classes of phosphatidylinositol 3&#39;-kinases are invo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0097352" data-r="PMID:10625637" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0097352" data-r="PMID:10625637" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Autophagosome maturation is supported as part of the core autophagy role.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Older macroautophagy evidence and newer VPS34 complex evidence support PIK3C3-dependent PI3P production in autophagosome formation and maturation.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/10625637" target="_blank" class="term-link">
+                                        PMID:10625637
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Transfection of a specific class III PI3K antisense oligonucleotide greatly inhibited the rate of macroautophagy.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
                                     GO:0016236
                                 </a>
                             </span>
                             <span class="term-label">macroautophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1632852
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0016236" data-r="Reactome:R-HSA-1632852" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0016236" data-r="Reactome:R-HSA-1632852" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Macroautophagy is a core PIK3C3 process.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Reactome and literature synthesis support PIK3C3/VPS34 as the catalytic component of the class III PI3K complex needed for early autophagy.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:reactome/R-HSA-5672012.md
+
+                                </span>
+
+                                <div class="support-text">PIK3C3 (VPS34), the catalytic component of this complex, is a class III phosphatidylinositol 3-kinase that phosphorylates phosphatidylinositol (PI) producing phosphatidylinositol 3-phosphate (PI3P).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016303" target="_blank" class="term-link">
                                     GO:0016303
                                 </a>
                             </span>
                             <span class="term-label">1-phosphatidylinositol-3-kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5672012
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0016303" data-r="Reactome:R-HSA-5672012" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0016303" data-r="Reactome:R-HSA-5672012" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The Reactome TAS row correctly captures the core VPS34 lipid kinase activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3/VPS34 is the catalytic class III PI3K that phosphorylates phosphatidylinositol to produce PI3P.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:reactome/R-HSA-5672012.md
+
+                                </span>
+
+                                <div class="support-text">PIK3C3 (VPS34), the catalytic component of this complex, is a class III phosphatidylinositol 3-kinase that phosphorylates phosphatidylinositol (PI) producing phosphatidylinositol 3-phosphate (PI3P).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol 3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 is described as **exclusively catalyzing PI3P production from phosphatidylinositol (PI) in vitro and in vivo**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016303" target="_blank" class="term-link">
                                     GO:0016303
                                 </a>
                             </span>
                             <span class="term-label">1-phosphatidylinositol-3-kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6798174
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0016303" data-r="Reactome:R-HSA-6798174" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0016303" data-r="Reactome:R-HSA-6798174" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The Reactome TAS row correctly captures the core VPS34 lipid kinase activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3/VPS34 is the catalytic class III PI3K that phosphorylates phosphatidylinositol to produce PI3P.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol 3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 is described as **exclusively catalyzing PI3P production from phosphatidylinositol (PI) in vitro and in vivo**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17307798" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17307798
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005886" data-r="PMID:17307798" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005886" data-r="PMID:17307798" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Plasma membrane localization could not be reviewed from accessible evidence.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The cited PMID is not present in the local publication cache, and the Falcon/UniProt evidence reviewed here supports endosomal/autophagic and midbody contexts rather than a clear plasma-membrane localization.
+                        </div>
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045954" target="_blank" class="term-link">
                                     GO:0045954
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of natural killer cell mediated cytotoxicity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17307798" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17307798
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0045954" data-r="PMID:17307798" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0045954" data-r="PMID:17307798" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Natural killer cell-mediated cytotoxicity could not be reviewed from accessible evidence.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The cited PMID is not present in the local publication cache, and the Falcon report does not cover this immune-cell phenotype sufficiently to decide whether the process annotation should be retained.
+                        </div>
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0052742" target="_blank" class="term-link">
                                     GO:0052742
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7628435" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7628435
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A human phosphatidylinositol 3-kinase complex related to the...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -5230,86 +6403,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The activity is valid but too general. Human VPS34 should be annotated to the specific 1-phosphatidylinositol-3-kinase activity term.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The original biochemical characterization resolved the substrate and the 3-position specificity, so the narrower MF term is warranted.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016303" target="_blank" class="term-link">
                                     1-phosphatidylinositol-3-kinase activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7628435" target="_blank" class="term-link">
                                         PMID:7628435
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016303" target="_blank" class="term-link">
                                     GO:0016303
                                 </a>
                             </span>
                             <span class="term-label">1-phosphatidylinositol-3-kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25327288" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25327288
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Selective VPS34 inhibitor blocks autophagy and uncovers a ro...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5321,133 +6494,177 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Reviewed core molecular function. Later chemical-genetic work is fully consistent with VPS34 as the relevant class III PI3 kinase.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This term matches the established biochemical function of PIK3C3 and is consistent with selective VPS34 inhibition experiments in human systems.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25327288" target="_blank" class="term-link">
                                         PMID:25327288
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PIK-III is a selective inhibitor of VPS34 that binds a unique hydrophobic pocket not present in related kinases such as PI(3)Kα.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol 3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 is described as **exclusively catalyzing PI3P production from phosphatidylinositol (PI) in vitro and in vivo**</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1903061" target="_blank" class="term-link">
                                     GO:1903061
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of protein lipidation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25327288" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25327288
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Selective VPS34 inhibitor blocks autophagy and uncovers a ro...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:1903061" data-r="PMID:25327288" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:1903061" data-r="PMID:25327288" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Positive regulation of protein lipidation is supported as a non-core autophagy pathway effect.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Selective VPS34 inhibition blocks de novo LC3 lipidation, supporting an upstream positive role in LC3 lipidation during autophagy, but the direct core function remains PI3P synthesis.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25327288" target="_blank" class="term-link">
+                                        PMID:25327288
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIK-III acutely inhibits autophagy and de novo lipidation of LC3, and leads to the stabilization of autophagy substrates.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30767700" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30767700
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -5459,115 +6676,119 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044829" target="_blank" class="term-link">
                                     GO:0044829
                                 </a>
                             </span>
                             <span class="term-label">host-mediated activation of viral genome replication</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34320401" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34320401
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0044829" data-r="PMID:34320401" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0044829" data-r="PMID:34320401" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Viral genome replication activation could not be confidently reviewed from accessible evidence.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The cited PMID is not present in the local publication cache. Falcon evidence supports a PIK3C3 role in Ebola virus entry via endocytic trafficking, but that is not the same as host-mediated activation of viral genome replication.
+                        </div>
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000045" target="_blank" class="term-link">
                                     GO:0000045
                                 </a>
                             </span>
                             <span class="term-label">autophagosome assembly</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33637724" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33637724
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     VPS34 K29/K48 branched ubiquitination governed by UBE3C and ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -5579,75 +6800,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Direct human evidence for a core PN process. VPS34 abundance and regulation affect autophagosome formation.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This study explicitly ties VPS34-controlled PI3P production to autophagosome formation and maturation, which is central to the reviewed biology of PIK3C3.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/33637724" target="_blank" class="term-link">
                                         PMID:33637724
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.</div>
-                                
+
+                                <div class="support-text">This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046854" target="_blank" class="term-link">
                                     GO:0046854
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol phosphate biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7628435" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7628435
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A human phosphatidylinositol 3-kinase complex related to the...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -5659,86 +6891,86 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The biochemical direction is correct but the term is too broad. The human enzyme characterized here specifically supports PI3P biosynthesis.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The original paper established the specific phosphatidylinositol 3-kinase activity of human VPS34, which is more precisely captured by the PI3P biosynthetic process term.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036092" target="_blank" class="term-link">
                                     phosphatidylinositol-3-phosphate biosynthetic process
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7628435" target="_blank" class="term-link">
                                         PMID:7628435
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33473107" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33473107
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -5750,57 +6982,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28890335" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28890335
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -5812,57 +7044,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31806350" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31806350
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -5874,57 +7106,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032465" target="_blank" class="term-link">
                                     GO:0032465
                                 </a>
                             </span>
                             <span class="term-label">regulation of cytokinesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20208530" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20208530
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PtdIns(3)P controls cytokinesis through KIF13A-mediated recr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -5936,75 +7168,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Human PIK3C3 contributes to cytokinesis through a PI3P-dependent midbody pathway. This role is supported but is contextual relative to the core PN autophagy case.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The cytokinesis phenotype is convincing, but it reflects a contextual deployment of VPS34 PI3P biology rather than the primary autophagy-focused role being curated here.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20208530" target="_blank" class="term-link">
                                         PMID:20208530
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Depletion of the VPS34 or Beclin 1 subunits of PI(3)K-III causes cytokinesis arrest and an increased number of binucleate and multinucleate cells, in a similar manner to the depletion of FYVE-CENT, KIF13A or TTC19.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28479384" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28479384
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -6016,57 +7248,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22095288" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22095288
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -6078,57 +7310,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006914" target="_blank" class="term-link">
                                     GO:0006914
                                 </a>
                             </span>
                             <span class="term-label">autophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25327288" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25327288
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Selective VPS34 inhibitor blocks autophagy and uncovers a ro...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -6140,191 +7372,252 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The biology is correct but the process term is too general. For PIK3C3 the literature supports macroautophagy specifically.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> VPS34 inhibition in this study blocks the canonical autophagy pathway tracked by LC3 lipidation and autophagy-substrate turnover, which is better captured as macroautophagy.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
                                     macroautophagy
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25327288" target="_blank" class="term-link">
                                         PMID:25327288
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PIK-III acutely inhibits autophagy and de novo lipidation of LC3, and leads to the stabilization of autophagy substrates.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044754" target="_blank" class="term-link">
                                     GO:0044754
                                 </a>
                             </span>
                             <span class="term-label">autolysosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25327288" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25327288
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Selective VPS34 inhibitor blocks autophagy and uncovers a ro...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0044754" data-r="PMID:25327288" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0044754" data-r="PMID:25327288" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Autolysosome localization is over-annotated from an inhibitor/substrate study.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The cited inhibitor study supports VPS34-dependent autophagy and NCOA4/ferritin delivery to autolysosomes, but it does not directly place PIK3C3 itself in the autolysosome.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005776" target="_blank" class="term-link">
+                                    autophagosome
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
+                                    macroautophagy
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25327288" target="_blank" class="term-link">
+                                        PMID:25327288
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">NCOA4 directly binds ferritin heavy chain-1 (FTH1) to target the iron-binding ferritin complex with a relative molecular mass of 450,000 to autolysosomes following starvation or iron depletion.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030670" target="_blank" class="term-link">
                                     GO:0030670
                                 </a>
                             </span>
                             <span class="term-label">phagocytic vesicle membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6798174
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0030670" data-r="Reactome:R-HSA-6798174" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0030670" data-r="Reactome:R-HSA-6798174" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Phagocytic vesicle membrane is a supported but non-core trafficking context.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Class III PI3Ks are linked to phagosome maturation and endocytic membrane traffic; this contextual membrane role should not displace the core autophagy-initiation complex function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16467569" target="_blank" class="term-link">
+                                        PMID:16467569
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">By contrast, class III PI 3-kinases mainly mediate receptor-independent trafficking events, which mostly are related to endocytic membrane traffic, phagosome maturation and autophagy.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032465" target="_blank" class="term-link">
                                     GO:0032465
                                 </a>
                             </span>
                             <span class="term-label">regulation of cytokinesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20643123" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20643123
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A phosphatidylinositol 3-kinase class III sub-complex contai...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6336,64 +7629,64 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Supported contextual role for a UVRAG/BIF-1-containing PI3K-III subcomplex in cytokinesis. This remains outside the core PN autophagy framing.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The human data support a real cytokinesis role for a VPS34-containing complex, but the review should keep this separate from the central autophagy-initiation assignment.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20643123" target="_blank" class="term-link">
                                         PMID:20643123
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">High-content microscopy-based assays combined with siRNA-mediated depletion of individual subunits indicated that a specific sub-complex containing VPS15, VPS34, Beclin 1, UVRAG and BIF-1 regulates both receptor degradation and cytokinesis, whereas ATG14L, a PI3K-III subunit involved in autophagy, is not required.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
                                     GO:0016236
                                 </a>
                             </span>
                             <span class="term-label">macroautophagy</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -6405,64 +7698,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Conservative orthology-supported duplicate of a core process assignment. Macroautophagy is appropriate for human PIK3C3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This transfer is consistent with direct human evidence for VPS34 in the autophagy-initiating PI3KC3-C1 complex.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/40442316" target="_blank" class="term-link">
                                         PMID:40442316
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">All forms of canonical autophagy, bulk and selective, are initiated upon the recruitment and activation of the FIP200 protein4 and the class III phosphatidylinositol 3-OH kinase complex I (PI3KC3-C1)5–7.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035032" target="_blank" class="term-link">
                                     GO:0035032
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol 3-kinase complex, class III</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -6474,152 +7778,196 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> The generic class III PI3K complex term is true but underspecified for human PIK3C3. The literature supports explicit type I and type II complex membership.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> For this gene, the main curatorial distinction is between the autophagy-initiating PI3KC3-C1/type I complex and the contextual endosomal PI3KC3-C2/type II complex.
                         </div>
-                        
-                        
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034271" target="_blank" class="term-link">
                                     phosphatidylinositol 3-kinase complex, class III, type I
                                 </a>
                             </span>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034272" target="_blank" class="term-link">
                                     phosphatidylinositol 3-kinase complex, class III, type II
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/40442316" target="_blank" class="term-link">
                                         PMID:40442316
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase VPS15 and the regulatory subunits BECN1 and ATG14.</div>
-                                
+
+                                <div class="support-text">PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase VPS15 and the regulatory subunits BECN1 and ATG14</div>
+
                             </div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/40442316" target="_blank" class="term-link">
                                         PMID:40442316
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation.</div>
-                                
+
+                                <div class="support-text">The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation5–7.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042149" target="_blank" class="term-link">
                                     GO:0042149
                                 </a>
                             </span>
                             <span class="term-label">cellular response to glucose starvation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0042149" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0042149" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Glucose starvation response is a contextual autophagy input, not the core PIK3C3 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Starvation-dependent autophagy is a supported context for VPS34 action, but the direct conserved role is PI3P production in autophagy and endosomal pathways.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
+                                    macroautophagy
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25327288" target="_blank" class="term-link">
+                                        PMID:25327288
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PIK-III acutely inhibits autophagy and de novo lipidation of LC3, and leads to the stabilization of autophagy substrates.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23878393" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23878393
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -6631,184 +7979,204 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016020" target="_blank" class="term-link">
                                     GO:0016020
                                 </a>
                             </span>
                             <span class="term-label">membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19946888
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Defining the membrane proteome of NK cells.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-remove">
-                            REMOVE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0016020" data-r="PMID:19946888" data-act="REMOVE">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0016020" data-r="PMID:19946888" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This broad membrane localization call is not reliable enough for manual retention. The source is large-scale membrane proteomics with many transiently associated proteins.
+                            <strong>Summary:</strong> Broad membrane association from large-scale proteomics is weak and uninformative for PIK3C3.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> The paper does not establish a specific or stable membrane localization for PIK3C3 beyond broad proteomic association, so this annotation is too weak and uninformative to retain.
+                            <strong>Reason:</strong> PIK3C3 is a cytosolic/peripheral lipid kinase recruited to autophagy and endosomal membranes, so generic membrane association is not entirely wrong, but this broad HDA row is not specific enough for the reviewed function.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
                                         PMID:19946888
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The remaining species were largely involved in cellular processes and molecular functions that could be predicted to be transiently associated with membranes.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005930" target="_blank" class="term-link">
                                     GO:0005930
                                 </a>
                             </span>
                             <span class="term-label">axoneme</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005930" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005930" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Axoneme localization is supported only by similarity and is non-core.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records a ciliary axoneme localization by similarity, but the reviewed human core function is VPS34 lipid kinase activity in autophagy/endosomal complexes.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Also localizes to discrete punctae along the ciliary axoneme and to the base of the ciliary axoneme (By similarity).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19270696" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19270696
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -6820,57 +8188,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14617358" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14617358
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human VPS34 and p150 are Rab7 interacting partners.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -6882,57 +8250,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005770" target="_blank" class="term-link">
                                     GO:0005770
                                 </a>
                             </span>
                             <span class="term-label">late endosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14617358" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14617358
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human VPS34 and p150 are Rab7 interacting partners.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -6944,75 +8312,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Supported contextual localization. Human VPS34/p150 colocalizes with Rab7 on late endosomes.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The localization is directly supported in human cells, but it belongs to the contextual endosomal-trafficking side of PIK3C3 biology rather than the core PN autophagy claim.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14617358" target="_blank" class="term-link">
                                         PMID:14617358
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The hVPS34/p150 complex colocalized with rab7 on late endosomes and hVPS34 activity was dependent on nucleotide cycling of rab7.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045022" target="_blank" class="term-link">
                                     GO:0045022
                                 </a>
                             </span>
                             <span class="term-label">early endosome to late endosome transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14617358" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14617358
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human VPS34 and p150 are Rab7 interacting partners.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -7024,733 +8392,1416 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Contextual trafficking role supported by human Rab7/VPS34 data. Appropriate to retain as non-core.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This transport function is part of the broader endosomal deployment of VPS34 PI3P signaling and should remain separate from the core macroautophagy-focused curation.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/14617358" target="_blank" class="term-link">
                                         PMID:14617358
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The data identify rab7 as an important regulator of late endosomal hVPS34 function and link rab7 to the regulation of phosphatidylinositol 3&#39;-kinase cycling between early and late endosomes.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 activity is strongly tied to **endosomal PI3P pools** that define **early endosome identity** and sorting, and PI3P serves as a platform for downstream trafficking and maturation processes.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-109699
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-109699" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-109699" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and endosomal membranes; the cytosol rows are retained as non-core pathway context rather than precise localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1632857
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-1632857" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-1632857" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and endosomal membranes; the cytosol rows are retained as non-core pathway context rather than precise localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1675939
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-1675939" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-1675939" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and endosomal membranes; the cytosol rows are retained as non-core pathway context rather than precise localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1675961
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-1675961" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-1675961" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and endosomal membranes; the cytosol rows are retained as non-core pathway context rather than precise localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1676024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-1676024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-1676024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and endosomal membranes; the cytosol rows are retained as non-core pathway context rather than precise localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-188002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-188002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-188002" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and endosomal membranes; the cytosol rows are retained as non-core pathway context rather than precise localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5672012
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-5672012" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-5672012" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and endosomal membranes; the cytosol rows are retained as non-core pathway context rather than precise localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5678313
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-5678313" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-5678313" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and endosomal membranes; the cytosol rows are retained as non-core pathway context rather than precise localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5678315
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-5678315" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-5678315" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and endosomal membranes; the cytosol rows are retained as non-core pathway context rather than precise localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5679205
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-5679205" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-5679205" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and endosomal membranes; the cytosol rows are retained as non-core pathway context rather than precise localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5679266
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-5679266" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-5679266" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and endosomal membranes; the cytosol rows are retained as non-core pathway context rather than precise localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5682385
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-5682385" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-5682385" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and endosomal membranes; the cytosol rows are retained as non-core pathway context rather than precise localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9755359
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-9755359" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-9755359" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and endosomal membranes; the cytosol rows are retained as non-core pathway context rather than precise localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9921171
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-9921171" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q8NEB9" data-a="GO:0005829" data-r="Reactome:R-HSA-9921171" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and endosomal membranes; the cytosol rows are retained as non-core pathway context rather than precise localization.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
+                                    phagophore assembly site
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005768" target="_blank" class="term-link">
+                                    endosome
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016303" target="_blank" class="term-link">
                                     GO:0016303
                                 </a>
                             </span>
                             <span class="term-label">1-phosphatidylinositol-3-kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20208530" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20208530
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PtdIns(3)P controls cytokinesis through KIF13A-mediated recr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -7762,75 +9813,97 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Contextual cytokinesis paper, but the molecular function assignment itself is core and remains correct for PIK3C3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Even though this paper focuses on cytokinesis, it does so through the catalytic PI3P-generating activity of the class III PI3K complex.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7628435" target="_blank" class="term-link">
                                         PMID:7628435
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol 3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 is described as **exclusively catalyzing PI3P production from phosphatidylinositol (PI) in vitro and in vivo**</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030496" target="_blank" class="term-link">
                                     GO:0030496
                                 </a>
                             </span>
                             <span class="term-label">midbody</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20208530" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20208530
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PtdIns(3)P controls cytokinesis through KIF13A-mediated recr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -7842,75 +9915,75 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Midbody association is part of a supported cytokinesis-specific context for VPS34 biology and should not be treated as core PN localization.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> The cytokinesis paper supports a midbody-linked PI3P pathway, but this is a contextual deployment of VPS34 rather than the primary autophagy localization used for core-function synthesis.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20208530" target="_blank" class="term-link">
                                         PMID:20208530
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">We show that PtdIns(3)P localizes to the midbody during cytokinesis and recruits a centrosomal protein, FYVE-CENT (ZFYVE26), and its binding partner TTC19, which in turn interacts with CHMP4B, an endosomal sorting complex required for transport (ESCRT)-III subunit implicated in the abscission step of cytokinesis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16417406" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16417406
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -7922,57 +9995,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7504174" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7504174
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TODO: Fetch title
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -7984,57 +10057,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Protein binding is too generic to serve as an informative molecular-function annotation for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex, localization, or process terms.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Per project convention, `protein binding` should not be retained when it does not convey a specific molecular function. For PIK3C3, these interaction data inform complex membership and contextual pathway roles rather than a standalone MF annotation.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016303" target="_blank" class="term-link">
                                     GO:0016303
                                 </a>
                             </span>
                             <span class="term-label">1-phosphatidylinositol-3-kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7628435" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7628435
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A human phosphatidylinositol 3-kinase complex related to the...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -8046,50 +10119,72 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Literature-traceable duplicate of the reviewed core molecular function. Human VPS34 is the phosphatidylinositol 3-kinase.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> This term directly reflects the original biochemical characterization of the human enzyme and should be retained.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/7628435" target="_blank" class="term-link">
                                         PMID:7628435
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.</div>
-                                
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol 3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">VPS34 is described as **exclusively catalyzing PI3P production from phosphatidylinositol (PI) in vitro and in vivo**</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
+
+
     <div class="section">
         <h2 class="section-title">Core Functions</h2>
-        
+
         <div class="core-function-card">
-            
+
             <div style="display: flex; justify-content: space-between; align-items: center;">
                 <h3>PIK3C3/VPS34 is the catalytic lipid kinase of the ATG14-containing class III PI3K complex that generates PI3P at early autophagy membranes to drive phagophore formation and autophagosome assembly during macroautophagy.</h3>
                 <span class="vote-buttons" data-g="Q8NEB9" data-a="FUNCTION: PIK3C3/VPS34 is the catalytic lipid kinase of the ..." data-r="" data-act="CORE_FUNCTION">
@@ -8097,10 +10192,10 @@
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
             </div>
-            
+
 
             <div class="core-function-terms">
-                
+
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
@@ -8109,51 +10204,63 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Directly Involved In:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036092" target="_blank" class="term-link">
                                 phosphatidylinositol-3-phosphate biosynthetic process
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000045" target="_blank" class="term-link">
                                 autophagosome assembly
                             </a>
                         </span>
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016236" target="_blank" class="term-link">
                                 macroautophagy
                             </a>
                         </span>
-                        
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097352" target="_blank" class="term-link">
+                                autophagosome maturation
+                            </a>
+                        </span>
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">Cellular Locations:</div>
                     <div class="function-annotations">
-                        
+
                         <span class="badge">
                             <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000407" target="_blank" class="term-link">
                                 phagophore assembly site
                             </a>
                         </span>
-                        
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005776" target="_blank" class="term-link">
+                                autophagosome
+                            </a>
+                        </span>
+
                     </div>
                 </div>
-                
 
-                
+
+
                 <div class="function-term-group">
                     <div class="function-term-label">In Complex:</div>
                     <span class="badge">
@@ -8162,1191 +10269,1543 @@
                         </a>
                     </span>
                 </div>
-                
 
-                
+
+
             </div>
 
-            
+
             <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
                 <strong>Supporting Evidence:</strong>
                 <ul class="findings-list">
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7628435" target="_blank" class="term-link">
                                 PMID:7628435
                             </a>
-                            
+
                         </span>
-                        
+
                         <div class="finding-text">PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.</div>
-                        
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40442316" target="_blank" class="term-link">
                                 PMID:40442316
                             </a>
-                            
+
                         </span>
-                        
-                        <div class="finding-text">PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase VPS15 and the regulatory subunits BECN1 and ATG14.</div>
-                        
+
+                        <div class="finding-text">PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase VPS15 and the regulatory subunits BECN1 and ATG14</div>
+
                     </li>
-                    
+
                     <li class="finding-item">
                         <span class="reference-id">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33637724" target="_blank" class="term-link">
                                 PMID:33637724
                             </a>
-                            
+
                         </span>
-                        
-                        <div class="finding-text">This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.</div>
-                        
+
+                        <div class="finding-text">This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation</div>
+
                     </li>
-                    
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol 3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis.</div>
+
+                    </li>
+
                 </ul>
             </div>
-            
-        </div>
-        
-    </div>
-    
 
-    
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
                             GO_REF:0000024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10625637" target="_blank" class="term-link">
                             PMID:10625637
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Distinct classes of phosphatidylinositol 3&#39;-kinases are involved in signaling pathways that control macroautophagy in HT-29 cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14617358" target="_blank" class="term-link">
                             PMID:14617358
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human VPS34 and p150 are Rab7 interacting partners.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16417406" target="_blank" class="term-link">
                             PMID:16417406
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16467569" target="_blank" class="term-link">
                             PMID:16467569
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16799551" target="_blank" class="term-link">
                             PMID:16799551
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Autophagic and tumour suppressor activity of a novel Beclin1-binding protein UVRAG.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17307798" target="_blank" class="term-link">
                             PMID:17307798
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19050071" target="_blank" class="term-link">
                             PMID:19050071
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19270696" target="_blank" class="term-link">
                             PMID:19270696
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19946888" target="_blank" class="term-link">
                             PMID:19946888
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Defining the membrane proteome of NK cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20142477" target="_blank" class="term-link">
                             PMID:20142477
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20208530" target="_blank" class="term-link">
                             PMID:20208530
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PtdIns(3)P controls cytokinesis through KIF13A-mediated recruitment of FYVE-CENT to the midbody.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20562859" target="_blank" class="term-link">
                             PMID:20562859
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20643123" target="_blank" class="term-link">
                             PMID:20643123
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A phosphatidylinositol 3-kinase class III sub-complex containing VPS15, VPS34, Beclin 1, UVRAG and BIF-1 regulates cytokinesis and degradative endocytic traffic.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21062745" target="_blank" class="term-link">
                             PMID:21062745
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22095288" target="_blank" class="term-link">
                             PMID:22095288
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22493499" target="_blank" class="term-link">
                             PMID:22493499
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23316280" target="_blank" class="term-link">
                             PMID:23316280
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23332761" target="_blank" class="term-link">
                             PMID:23332761
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23364696" target="_blank" class="term-link">
                             PMID:23364696
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23878393" target="_blank" class="term-link">
                             PMID:23878393
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23954414" target="_blank" class="term-link">
                             PMID:23954414
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24034250" target="_blank" class="term-link">
                             PMID:24034250
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24056303" target="_blank" class="term-link">
                             PMID:24056303
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24472739" target="_blank" class="term-link">
                             PMID:24472739
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24785657" target="_blank" class="term-link">
                             PMID:24785657
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24849286" target="_blank" class="term-link">
                             PMID:24849286
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25327288" target="_blank" class="term-link">
                             PMID:25327288
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Selective VPS34 inhibitor blocks autophagy and uncovers a role for NCOA4 in ferritin degradation and iron homeostasis in vivo.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25490155" target="_blank" class="term-link">
                             PMID:25490155
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25594178" target="_blank" class="term-link">
                             PMID:25594178
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26496610" target="_blank" class="term-link">
                             PMID:26496610
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26783301" target="_blank" class="term-link">
                             PMID:26783301
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28479384" target="_blank" class="term-link">
                             PMID:28479384
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28890335" target="_blank" class="term-link">
                             PMID:28890335
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30767700" target="_blank" class="term-link">
                             PMID:30767700
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31806350" target="_blank" class="term-link">
                             PMID:31806350
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33422265" target="_blank" class="term-link">
                             PMID:33422265
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33473107" target="_blank" class="term-link">
                             PMID:33473107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33637724" target="_blank" class="term-link">
                             PMID:33637724
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">VPS34 K29/K48 branched ubiquitination governed by UBE3C and TRABID regulates autophagy, proteostasis and liver metabolism.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34320401" target="_blank" class="term-link">
                             PMID:34320401
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34386498" target="_blank" class="term-link">
                             PMID:34386498
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34524948" target="_blank" class="term-link">
                             PMID:34524948
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
                             PMID:35271311
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40442316" target="_blank" class="term-link">
                             PMID:40442316
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structure and activation of the human autophagy-initiating ULK1C:PI3KC3-C1 supercomplex.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/7504174" target="_blank" class="term-link">
                             PMID:7504174
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/7628435" target="_blank" class="term-link">
                             PMID:7628435
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A human phosphatidylinositol 3-kinase complex related to the yeast Vps34p-Vps15p protein sorting system.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/8999962" target="_blank" class="term-link">
                             PMID:8999962
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Characterization of p150, an adaptor protein for the human phosphatidylinositol (PtdIns) 3-kinase. Substrate presentation by phosphatidylinositol transfer protein to the p150.Ptdins 3-kinase complex.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-109699
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1632852
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Macroautophagy</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1632857
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1675939
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1675961
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1676024
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-188002
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5672012
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Beclin-1 complex phosphorylates PtdIns</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5678313
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5678315
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5679205
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5679266
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5682385
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6798174
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9755359
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9921171
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research synthesis for PIK3C3</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIK3C3/PIK3C3-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt record for human PIK3C3</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:reactome/R-HSA-5672012.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Reactome autophagy initiation event containing PIK3C3</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
     <div class="section">
         <h2 class="section-title">📚 Additional Documentation</h2>
-        
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIK3C3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q8NEB9" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-12T07:20:13.222491'<br />
+end_time: '2026-05-12T07:27:33.020845'<br />
+duration_seconds: 439.8<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 28</p>
+<hr />
+<h2 id="question">Question</h2>
+<p>Perform concise GO-focused deep research on the human PIK3C3 gene (UniProt Q8NEB9; phosphatidylinositol 3-kinase catalytic subunit type 3/Vps34). Summarize the core molecular function, major biological processes, cellular locations, key experimental evidence, and any GO annotation caveats. Include PMID or DOI citations where available, and keep the report focused for gene annotation review.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<p>Perform concise GO-focused deep research on the human PIK3C3 gene (UniProt Q8NEB9; phosphatidylinositol 3-kinase catalytic subunit type 3/Vps34). Summarize the core molecular function, major biological processes, cellular locations, key experimental evidence, and any GO annotation caveats. Include PMID or DOI citations where available, and keep the report focused for gene annotation review.</p>
+<h2 id="go-focused-gene-annotation-research-report-human-pik3c3-vps34-uniprot-q8neb9">GO-focused gene annotation research report: human <strong>PIK3C3</strong> (VPS34) (UniProt Q8NEB9)</h2>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<p><strong>Gene/protein</strong>: Human <strong>PIK3C3</strong> encodes <strong>VPS34</strong>, the <em>class III phosphatidylinositol 3-kinase</em> catalytic subunit that produces <strong>phosphatidylinositol 3-phosphate (PI3P)</strong>. In the most authoritative recent pharmacology-focused synthesis, VPS34 is described as <strong>exclusively catalyzing PI3P production from phosphatidylinositol (PI) in vitro and in vivo</strong>—a key point for GO molecular function specificity (i.e., not generating PIP3 from PI(4,5)P2 as class I PI3Ks do). (burke2023beyondpi3kstargeting pages 22-23)</p>
+<p><strong>GO-relevant biochemical reaction</strong> (MF + BP):<br />
+- Substrate/product specificity for curation: <strong>PI → PI3P</strong> (phosphatidylinositol 3-phosphate biosynthesis) as the defining catalytic activity of VPS34. (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 1-2)</p>
+<p><strong>Complex architecture and nomenclature</strong> (GO CC + context for BP): VPS34 functions as a subunit of two <strong>distinct tetrameric complexes</strong>:<br />
+- <strong>PI3KC3 Complex I (PI3KC3-C1)</strong>: VPS34 (<strong>PIK3C3</strong>) + <strong>VPS15 (PIK3R4)</strong> + <strong>BECN1</strong> + <strong>ATG14</strong>. This complex is classically associated with <strong>autophagy initiation/autophagosome nucleation</strong>. (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 1-2, chau2024thecellularadaptor pages 1-2)<br />
+- <strong>PI3KC3 Complex II (PI3KC3-C2)</strong>: VPS34 (<strong>PIK3C3</strong>) + <strong>VPS15 (PIK3R4)</strong> + <strong>BECN1</strong> + <strong>UVRAG</strong>, classically associated with <strong>endocytic sorting/endosome maturation</strong> and related trafficking. (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 1-2)</p>
+<p><strong>Key regulators frequently relevant to annotation context</strong>:<br />
+- <strong>NRBF2</strong>: described as an activator of <strong>Complex I</strong> (and thus relevant when annotating autophagy-initiation-linked PI3P production). (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 12-12)<br />
+- <strong>Rubicon (RUBCN)</strong>: described as a Complex-II-associated regulator that can modulate autophagy stages and endocytic roles in a context-dependent manner; it contributes to why Complex I vs II should be separated in annotation where possible. (lee2024regulatorymechanismsgoverning pages 12-12)</p>
+<h3 id="2-core-go-molecular-function-mf-what-vps34-does">2) Core GO Molecular Function (MF): what VPS34 does</h3>
+<p><strong>Core MF statement for PIK3C3</strong>: VPS34 is the catalytic subunit of class III PI3K and <strong>produces PI3P from PI</strong>, with major sources emphasizing the <strong>exclusivity</strong> of this reaction for VPS34 in vivo/in vitro among class III PI3Ks. (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 1-2)</p>
+<p><strong>Complex requirement for activity</strong>: VPS34 activity depends on its complex context; notably <strong>VPS15/PIK3R4 is described as required for VPS34 activity</strong>, reinforcing that MF evidence often comes from complex-level biochemistry/structural studies rather than isolated VPS34. (lee2024regulatorymechanismsgoverning pages 1-2)</p>
+<h3 id="3-major-go-biological-processes-bp-autophagy-and-endocytosis-centered-roles">3) Major GO Biological Processes (BP): autophagy and endocytosis-centered roles</h3>
+<h4 id="31-autophagy-initiation-autophagosome-nucleation-canonical-macroautophagy">3.1 Autophagy initiation / autophagosome nucleation (canonical macroautophagy)</h4>
+<ul>
+<li>Multiple sources converge on the model that <strong>Complex I (ATG14-containing)</strong> is the <strong>autophagy initiation</strong> VPS34 complex, generating PI3P to recruit downstream PI3P-binding effectors (including WIPI proteins) to early autophagic membranes. (lee2024regulatorymechanismsgoverning pages 1-2, lee2024regulatorymechanismsgoverning pages 12-12)</li>
+<li>In an experimentally grounded signaling study (STING/autophagy), PI3P is described as a key product that <strong>recruits ATG12–ATG5–ATG16L1 via WIPI2 to target LC3 to the phagophore</strong>, consistent with a canonical pathway in which VPS34-derived PI3P supports phagophore maturation steps. (wan2023stingdirectlyrecruits pages 1-2)</li>
+</ul>
+<h4 id="32-endocytic-trafficking-endosomal-identity-and-endolysosomal-maturation">3.2 Endocytic trafficking, endosomal identity, and endolysosomal maturation</h4>
+<ul>
+<li>VPS34 activity is strongly tied to <strong>endosomal PI3P pools</strong> that define <strong>early endosome identity</strong> and sorting, and PI3P serves as a platform for downstream trafficking and maturation processes. (thibault2023targetingclassiiiiii pages 8-10, swamynathan2024dietaryprooxidanttherapy pages 8-9)</li>
+<li>A recent 2024 <em>Science</em> study provides direct phenotype-level support consistent with an endosomal identity role: both a selective VPS34 inhibitor (<strong>VPS34-IN1</strong>) and an oxidative intervention (<strong>MSB</strong>) produce endosomal defects alongside a reduction in PI3P-reporter puncta (GFP-2xFYVE), and CRISPR targeting of VPS34 phenocopies these effects. This supports annotating VPS34 to <strong>PI3P-dependent endosomal organization/trafficking</strong> processes. (swamynathan2024dietaryprooxidanttherapy pages 8-9)</li>
+</ul>
+<h3 id="4-go-cellular-component-cc-where-vps34-acts">4) GO Cellular Component (CC): where VPS34 acts</h3>
+<p><strong>Complex-level CC annotations (high confidence)</strong>:<br />
+- <strong>PI3KC3-C1 (Complex I)</strong> and <strong>PI3KC3-C2 (Complex II)</strong> as distinct cellular components/complexes are directly supported by recent authoritative reviews describing their tetrameric composition and functional distinctness. (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 1-2)</p>
+<p><strong>Membrane compartments</strong> (context-dependent localization):<br />
+- <strong>ER-linked autophagy initiation sites / phagophore assembly sites</strong>: Evidence that Complex I is functionally tied to ER-associated initiation emerges from work showing that factors can promote <strong>ATG14 targeting to the ER</strong> and enhance PI3KC3-C1 activity, supporting ER/phagophore-associated CC assignments for the autophagy-initiation complex. (chau2024thecellularadaptor pages 1-2)<br />
+- <strong>Early endosomes</strong>: A recent <em>Science</em> study reports that VPS34 perturbation reduces PI3P reporter puncta and yields vacuoles retaining early-endosome markers (e.g., Rab5 association) while lacking lysosomal marker LAMP1 in the tested context, consistent with a key VPS34 role at early endosomal membranes. (swamynathan2024dietaryprooxidanttherapy pages 8-9)<br />
+- <strong>Endosomes and endosome–lysosome interface</strong>: Complex composition is described as directing VPS34 to endosome-linked vs phagophore-linked functions, and VPS34-dependent PI3P is connected to later fusion/maturation events involving late endosomes/lysosomes in trafficking-centric models. (wible2024unexpectedinhibitionof pages 1-3, thibault2023targetingclassiiiiii pages 8-10)</p>
+<h3 id="5-key-experimental-evidence-selected-go-curation-relevant">5) Key experimental evidence (selected, GO-curation-relevant)</h3>
+<h4 id="51-pi3p-reporter-depletion-and-endosomal-phenotypes-2024">5.1 PI3P reporter depletion and endosomal phenotypes (2024)</h4>
+<ul>
+<li><strong>Swamynathan et al., Science (Oct 2024; DOI: 10.1126/science.adk9167; URL: https://doi.org/10.1126/science.adk9167)</strong>: Demonstrates that an oxidative agent (MSB) functionally antagonizes VPS34 and phenocopies VPS34 inhibition, sharply reducing PI3P reporter puncta (GFP-2xFYVE) and producing endosome identity defects; NAC reverses MSB effects consistent with oxidative inactivation rather than simple competitive inhibition. This is strong support for <strong>PI3P biosynthesis</strong> and <strong>endosomal organization</strong> functions at the cellular level. (swamynathan2024dietaryprooxidanttherapy pages 8-9, swamynathan2024dietaryprooxidanttherapy pages 1-3)</li>
+</ul>
+<h4 id="52-genetic-inhibitor-evidence-tying-vps34-to-endosomal-trafficking-during-viral-entry-2024-quantitative">5.2 Genetic + inhibitor evidence tying VPS34 to endosomal trafficking during viral entry (2024; quantitative)</h4>
+<ul>
+<li><strong>Gong et al., PLoS Pathogens (Aug 2024; DOI: 10.1371/journal.ppat.1012444; URL: https://doi.org/10.1371/journal.ppat.1012444)</strong>: Shows VPS34/PIK3C3 is required for <strong>Ebola virus entry</strong> via endocytic trafficking. Quantitatively, <strong>VPS34-IN-1</strong> inhibits EBOV infection with <strong>IC50 = 371 nM</strong> (EBOVΔVP30-EGFP model) and <strong>IC50 = 405 nM</strong> (authentic EBOV), and a <strong>kinase-dead PIK3C3 D761A</strong> does not complement PIK3C3 KO. These results link <strong>VPS34 kinase activity</strong> to <strong>endosomal maturation/trafficking to NPC1-positive endolysosomal compartments</strong>. (gong2024genomewidecrisprcas9screen pages 7-10)</li>
+</ul>
+<h4 id="53-autophagy-independent-pi3p-dependent-membrane-phenotypes-2024">5.3 Autophagy-independent PI3P-dependent membrane phenotypes (2024)</h4>
+<ul>
+<li><strong>Wible et al., Cell Death &amp; Disease (Jan 2024; DOI: 10.1038/s41419-024-06423-0; URL: https://doi.org/10.1038/s41419-024-06423-0)</strong>: Reports that a vacuolation phenotype can <strong>rely on the PIK3C3 complex and PI(3)P production but not on autophagy per se</strong>, supporting VPS34 assignment to endolysosomal organization/volume control processes that are distinct from canonical macroautophagy readouts. (wible2024unexpectedinhibitionof pages 1-3)</li>
+</ul>
+<h4 id="54-noncanonical-autophagy-route-bypassing-pik3c3-2023-caveat">5.4 Noncanonical autophagy route bypassing PIK3C3 (2023; caveat)</h4>
+<ul>
+<li><strong>Wan et al., EMBO Journal (Mar 2023; DOI: 10.15252/embj.2022112387; URL: https://doi.org/10.15252/embj.2022112387)</strong>: Shows <strong>STING-induced autophagy requires WIPI2 but not the PIK3C3 complex</strong>, an important warning against blanket annotation of PIK3C3 as required for all forms of autophagosome formation/LC3 lipidation. (wan2023stingdirectlyrecruits pages 1-2)</li>
+</ul>
+<h3 id="6-go-annotation-caveats-and-curation-guidance-for-review">6) GO annotation caveats and curation guidance (for review)</h3>
+<ol>
+<li>
+<p><strong>Avoid class I PI3K conflation</strong>: VPS34 produces <strong>PI3P from PI</strong>, not PIP3 from PI(4,5)P2; MF terms should reflect PI3P biosynthesis rather than PI(3,4,5)P3-linked signaling. (burke2023beyondpi3kstargeting pages 22-23)</p>
+</li>
+<li>
+<p><strong>Complex-specific annotation is preferred</strong>: When evidence indicates autophagy initiation, it is most consistent with <strong>Complex I (ATG14; NRBF2-activated)</strong>; when evidence indicates endocytic sorting/viral entry/early endosome identity, it is most consistent with <strong>Complex II (UVRAG)</strong> and shared core subunits. Consider annotating to both BP terms only when evidence supports both, or qualifying via complex context. (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 1-2, thibault2023targetingclassiiiiii pages 8-10)</p>
+</li>
+<li>
+<p><strong>Noncanonical autophagy can be VPS34-independent</strong>: STING-induced autophagy provides a clear example that autophagy-related phenotypes can occur without PIK3C3 dependency; phenotype-only studies should not automatically imply direct PIK3C3 participation in all autophagy initiation contexts. (wan2023stingdirectlyrecruits pages 1-2)</p>
+</li>
+<li>
+<p><strong>Endosomal PI3P roles can masquerade as ‘autophagy’ phenotypes</strong>: PI3P-dependent vacuolation and endolysosomal swelling can depend on PIK3C3 but be <strong>autophagy-independent</strong>, affecting inference of BP terms from morphology alone. (wible2024unexpectedinhibitionof pages 1-3)</p>
+</li>
+<li>
+<p><strong>Phenotype interpretation (KO vs kinase-dead; compensatory PI3P)</strong>: A synthesis focused on PI3K targeting highlights that VPS34 has roles that can be complicated by scaffolding/complex-level effects, differences between genetic knockout and catalytic inactivation, and potential compensatory PI3P sources in specific contexts; this argues for prioritizing direct biochemical/kinase-activity evidence (IDAs/IMP with catalytic mutants) for MF/BP assertions. (thibault2023targetingclassiiiiii pages 8-10)</p>
+</li>
+</ol>
+<h3 id="7-recent-developments-and-real-world-applications-20232024">7) Recent developments and real-world applications (2023–2024)</h3>
+<ul>
+<li>
+<p><strong>Therapeutic targeting/redox pharmacology</strong>: A high-impact 2024 <em>Science</em> paper identifies an oxidative dietary compound (MSB) as functionally antagonizing VPS34 by <strong>oxidation of key cysteines</strong>, tying VPS34 to endosomal identity/sorting and suggesting redox-sensitive control points relevant to drug development and disease models. (Oct 2024; https://doi.org/10.1126/science.adk9167). (swamynathan2024dietaryprooxidanttherapy pages 1-3, swamynathan2024dietaryprooxidanttherapy pages 8-9)</p>
+</li>
+<li>
+<p><strong>Antiviral host-factor targeting</strong>: A 2024 <em>PLOS Pathogens</em> study provides quantitative inhibitor potency (sub-micromolar IC50s) and genetic validation of kinase activity requirement for EBOV entry, supporting VPS34 as a potential host-directed antiviral target specifically through endocytic/endolysosomal trafficking mechanisms. (Aug 2024; https://doi.org/10.1371/journal.ppat.1012444). (gong2024genomewidecrisprcas9screen pages 7-10)</p>
+</li>
+<li>
+<p><strong>Expert synthesis of complex biology and druggability</strong>: A widely cited 2023 <em>Nature Reviews Drug Discovery</em> review emphasizes VPS34’s catalytic specificity and clear complex partitioning (C1 vs C2), supporting precise GO MF/CC curation and motivating use of complex-aware annotations. (Nov 2023; https://doi.org/10.1038/s41573-022-00582-5). (burke2023beyondpi3kstargeting pages 22-23)</p>
+</li>
+</ul>
+<h3 id="8-go-focused-evidence-summary-table">8) GO-focused evidence summary table</h3>
+<table>
+<thead>
+<tr>
+<th>GO aspect</th>
+<th>Proposed GO concept / term label</th>
+<th>Evidence summary</th>
+<th>Key complex context</th>
+<th>Representative experimental evidence types</th>
+<th>Citations</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>MF</td>
+<td>Phosphatidylinositol 3-kinase activity; phosphatidylinositol-3-phosphate biosynthetic process</td>
+<td>Human VPS34/PIK3C3 is the class III PI3K catalytic subunit that converts phosphatidylinositol (PI) to PI3P, with recent reviews emphasizing this as its defining enzymatic activity and distinguishing it from class I PI3Ks.</td>
+<td>Shared catalytic core in both Complex I and II with VPS15/PIK3R4 and BECN1; VPS15 is required for full VPS34 activity.</td>
+<td>Biochemical/structural studies; kinase inhibition; PI3P-effector recruitment analyses.</td>
+<td>Burke et al., <em>Nat Rev Drug Discov</em> (Nov 2023), DOI: 10.1038/s41573-022-00582-5, https://doi.org/10.1038/s41573-022-00582-5 (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 1-2)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>Macroautophagy initiation / autophagosome nucleation</td>
+<td>VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis.</td>
+<td>Complex I: PIK3C3-VPS15-BECN1-ATG14; activated by NRBF2 and regulated by ULK1-linked inputs.</td>
+<td>Complex reconstitution/structural studies; localization of ATG14 puncta; PI3P-dependent effector recruitment.</td>
+<td>Lee et al., <em>Biomol Ther</em> (Oct 2024), DOI: 10.4062/biomolther.2024.094, https://doi.org/10.4062/biomolther.2024.094 (lee2024regulatorymechanismsgoverning pages 12-12, lee2024regulatorymechanismsgoverning pages 6-7)</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>PI3KC3-C1 autophagy initiation complex; ER/phagophore assembly site / omegasome-associated membrane</td>
+<td>PI3KC3-C1 is targeted to ER-linked autophagy initiation sites, and ATG14-directed ER localization promotes autophagic vacuole formation.</td>
+<td>Complex I with ATG14 as specifying subunit; GULP1 can enhance ATG14 targeting to ER and stimulate PI3KC3-C1 activity.</td>
+<td>ER localization microscopy; autophagic vacuole analysis; modulation of ATG14 targeting.</td>
+<td>Chau et al., <em>Cell Mol Life Sci</em> (Jul 2024), DOI: 10.1007/s00018-024-05351-8, https://doi.org/10.1007/s00018-024-05351-8 (chau2024thecellularadaptor pages 1-2)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>Endocytic trafficking / early endosome organization</td>
+<td>VPS34 activity is required to maintain PI3P-positive early endosome identity, and oxidative or pharmacologic VPS34 inhibition depletes PI3P and disrupts endosomal sorting.</td>
+<td>Most consistent with endosomal VPS34 complexes, especially Complex II-linked endocytic function; shared VPS34-VPS15-BECN1 core.</td>
+<td>GFP-2xFYVE PI3P reporter loss; CRISPR targeting; VPS34-IN1; live-cell vacuolization imaging.</td>
+<td>Swamynathan et al., <em>Science</em> (Oct 2024), DOI: 10.1126/science.adk9167, https://doi.org/10.1126/science.adk9167 (swamynathan2024dietaryprooxidanttherapy pages 8-9, swamynathan2024dietaryprooxidanttherapy pages 1-3)</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>Early endosome</td>
+<td>PI3P reporter depletion, Rab5-associated vacuoles, and loss of normal endosomal identity after VPS34 perturbation support localization/function at early endosomal membranes.</td>
+<td>Endosomal VPS34 complexes; Rab5-dependent recruitment of hVPS34/p150 noted in review-level mechanistic summaries.</td>
+<td>PI3P reporter imaging; Rab5 colocalization; inhibitor phenocopy; CRISPR knockout.</td>
+<td>Swamynathan et al., <em>Science</em> (Oct 2024), DOI: 10.1126/science.adk9167, https://doi.org/10.1126/science.adk9167; Lee et al., <em>Biomol Ther</em> (Oct 2024), DOI: 10.4062/biomolther.2024.094, https://doi.org/10.4062/biomolther.2024.094 (swamynathan2024dietaryprooxidanttherapy pages 8-9, lee2024regulatorymechanismsgoverning pages 12-12)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>Endosome maturation / endolysosomal trafficking</td>
+<td>VPS34 kinase activity is necessary for trafficking cargo/virions into NPC1-positive endolysosomal compartments, supporting a role in endosomal maturation and membrane traffic beyond canonical autophagy.</td>
+<td>Functional emphasis on endocytic VPS34 activity; Complex II is the main endocytic sorting complex in current models.</td>
+<td>KO/rescue with kinase-dead mutant; selective inhibitor; confocal colocalization with NPC1; viral entry assays.</td>
+<td>Gong et al., <em>PLoS Pathog</em> (Aug 2024), DOI: 10.1371/journal.ppat.1012444, https://doi.org/10.1371/journal.ppat.1012444; VPS34-IN-1 IC50 = 371 nM for EBOVΔVP30-EGFP and 405 nM for authentic EBOV (gong2024genomewidecrisprcas9screen pages 7-10)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>Regulation of autophagy-independent endolysosomal membrane organization</td>
+<td>Some VPS34-dependent PI3P phenotypes reflect endolysosomal control rather than autophagy itself, since vacuolation can require the PIK3C3 complex and PI3P but occur independently of autophagy per se.</td>
+<td>Shared VPS34 complex with context-dependent adaptor usage; not uniquely attributable to Complex I.</td>
+<td>Pharmacologic perturbation; PI3P dependence tests; endolysosomal morphology assays.</td>
+<td>Wible et al., <em>Cell Death &amp; Disease</em> (Jan 2024), DOI: 10.1038/s41419-024-06423-0, https://doi.org/10.1038/s41419-024-06423-0 (wible2024unexpectedinhibitionof pages 1-3)</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>Endosome/lysosome fusion pathway; autophagosome-endolysosome interface</td>
+<td>VPS34 participates in pathways linking PI3P-positive autophagic/endosomal membranes to later Rab7-dependent fusion with late endosomes and lysosomes.</td>
+<td>Complex composition helps determine whether VPS34 acts at phagophore-associated or endosomal membranes; UVRAG/Rubicon-linked contexts are especially relevant downstream.</td>
+<td>Membrane-trafficking studies; inhibitor phenotypes; pathway reconstruction from imaging and genetics.</td>
+<td>Wible et al., <em>Cell Death &amp; Disease</em> (Jan 2024), DOI: 10.1038/s41419-024-06423-0, https://doi.org/10.1038/s41419-024-06423-0; Thibault et al., <em>Cancers</em> (Jan 2023), DOI: 10.3390/cancers15030784, https://doi.org/10.3390/cancers15030784 (wible2024unexpectedinhibitionof pages 1-3, thibault2023targetingclassiiiiii pages 8-10)</td>
+</tr>
+<tr>
+<td>CC/BP caveat</td>
+<td>Context-specific: not all LC3 lipidation/autophagosome formation is VPS34-dependent</td>
+<td>STING-induced autophagy can require WIPI2 but not the PIK3C3 complex, so annotations for autophagosome formation should avoid overgeneralizing VPS34 dependence to all noncanonical autophagy pathways.</td>
+<td>Canonical autophagy uses Complex I; this caveat applies to noncanonical STING-driven LC3 lipidation/autophagosome formation.</td>
+<td>Genetic pathway dissection; VPS34 inhibitor insensitivity in STING context; WIPI2 dependency tests.</td>
+<td>Wan et al., <em>EMBO J</em> (Mar 2023), DOI: 10.15252/embj.2022112387, https://doi.org/10.15252/embj.2022112387 (wan2023stingdirectlyrecruits pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes GO-relevant molecular function, biological process, and cellular component evidence for human PIK3C3/VPS34, with emphasis on complex-specific context and annotation caveats. It also includes the key quantitative antiviral statistic from Gong 2024 for VPS34-IN-1.</em></p>
+<p>References</p>
+<ol>
+<li>
+<p>(burke2023beyondpi3kstargeting pages 22-23): John E Burke, Joanna Catherine Caprio Triscott, Brooke M Emerling, and Gerald R V Hammond. Beyond pi3ks: targeting phosphoinositide kinases in disease. Nature Reviews. Drug Discovery, 22:357-386, Nov 2023. URL: https://doi.org/10.1038/s41573-022-00582-5, doi:10.1038/s41573-022-00582-5. This article has 157 citations.</p>
+</li>
+<li>
+<p>(lee2024regulatorymechanismsgoverning pages 1-2): Yongook Lee, Nguyen Minh Tuan, Gi Jeong Lee, Boram Kim, Jung Ho Park, and Chang Hoon Lee. Regulatory mechanisms governing the autophagy-initiating vps34 complex and its inhibitors. Biomolecules &amp; Therapeutics, 32:723-735, Oct 2024. URL: https://doi.org/10.4062/biomolther.2024.094, doi:10.4062/biomolther.2024.094. This article has 16 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(chau2024thecellularadaptor pages 1-2): Dennis Dik-Long Chau, Zhicheng Yu, Wai Wa Ray Chan, Zhai Yuqi, Raymond Chuen Chung Chang, Jacky Chi Ki Ngo, Ho Yin Edwin Chan, and Kwok-Fai Lau. The cellular adaptor gulp1 interacts with atg14 to potentiate autophagy and app processing. Cellular and Molecular Life Sciences: CMLS, Jul 2024. URL: https://doi.org/10.1007/s00018-024-05351-8, doi:10.1007/s00018-024-05351-8. This article has 6 citations.</p>
+</li>
+<li>
+<p>(lee2024regulatorymechanismsgoverning pages 12-12): Yongook Lee, Nguyen Minh Tuan, Gi Jeong Lee, Boram Kim, Jung Ho Park, and Chang Hoon Lee. Regulatory mechanisms governing the autophagy-initiating vps34 complex and its inhibitors. Biomolecules &amp; Therapeutics, 32:723-735, Oct 2024. URL: https://doi.org/10.4062/biomolther.2024.094, doi:10.4062/biomolther.2024.094. This article has 16 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wan2023stingdirectlyrecruits pages 1-2): Wei Wan, Chuying Qian, Qian Wang, Jin Li, Hongtao Zhang, Lei Wang, Maomao Pu, Yewei Huang, Zhengfu He, Tianhua Zhou, Han‐Ming Shen, and Wei Liu. Sting directly recruits wipi2 for autophagosome formation during sting‐induced autophagy. The EMBO Journal, Mar 2023. URL: https://doi.org/10.15252/embj.2022112387, doi:10.15252/embj.2022112387. This article has 71 citations.</p>
+</li>
+<li>
+<p>(thibault2023targetingclassiiiiii pages 8-10): Benoît Thibault, Fernanda Ramos-Delgado, and Julie Guillermet-Guibert. Targeting class i-ii-iii pi3ks in cancer therapy: recent advances in tumor biology and preclinical research. Cancers, 15:784, Jan 2023. URL: https://doi.org/10.3390/cancers15030784, doi:10.3390/cancers15030784. This article has 36 citations.</p>
+</li>
+<li>
+<p>(swamynathan2024dietaryprooxidanttherapy pages 8-9): Manojit M. Swamynathan, Shan Kuang, Kaitlin E. Watrud, Mary R. Doherty, Charlotte Gineste, Grinu Mathew, Grace Q. Gong, Hilary Cox, Eileen Cheng, David Reiss, Jude Kendall, Diya Ghosh, Colleen R. Reczek, Xiang Zhao, Tali Herzka, Saulė Špokaitė, Antoine N. Dessus, Seung Tea Kim, Olaf Klingbeil, Juan Liu, Dawid G. Nowak, Habeeb Alsudani, Tse-Luen Wee, Youngkyu Park, Francesca Minicozzi, Keith Rivera, Ana S. Almeida, Kenneth Chang, Ram P. Chakrabarty, John E. Wilkinson, Phyllis A. Gimotty, Sarah D. Diermeier, Mikala Egeblad, Christopher R. Vakoc, Jason W. Locasale, Navdeep S. Chandel, Tobias Janowitz, James B. Hicks, Michael Wigler, Darryl J. Pappin, Roger L. Williams, Paolo Cifani, David A. Tuveson, Jocelyn Laporte, and Lloyd C. Trotman. Dietary pro-oxidant therapy by a vitamin k precursor targets pi 3-kinase vps34 function. Science, Oct 2024. URL: https://doi.org/10.1126/science.adk9167, doi:10.1126/science.adk9167. This article has 41 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wible2024unexpectedinhibitionof pages 1-3): Daric J. Wible, Zalak Parikh, Eun Jeong Cho, Miao-Der Chen, Collene R. Jeter, Somshuvra Mukhopadhyay, Kevin N. Dalby, Shankar Varadarajan, and Shawn B. Bratton. Unexpected inhibition of the lipid kinase pikfyve reveals an epistatic role for p38 mapks in endolysosomal fission and volume control. Cell Death &amp; Disease, Jan 2024. URL: https://doi.org/10.1038/s41419-024-06423-0, doi:10.1038/s41419-024-06423-0. This article has 19 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(swamynathan2024dietaryprooxidanttherapy pages 1-3): Manojit M. Swamynathan, Shan Kuang, Kaitlin E. Watrud, Mary R. Doherty, Charlotte Gineste, Grinu Mathew, Grace Q. Gong, Hilary Cox, Eileen Cheng, David Reiss, Jude Kendall, Diya Ghosh, Colleen R. Reczek, Xiang Zhao, Tali Herzka, Saulė Špokaitė, Antoine N. Dessus, Seung Tea Kim, Olaf Klingbeil, Juan Liu, Dawid G. Nowak, Habeeb Alsudani, Tse-Luen Wee, Youngkyu Park, Francesca Minicozzi, Keith Rivera, Ana S. Almeida, Kenneth Chang, Ram P. Chakrabarty, John E. Wilkinson, Phyllis A. Gimotty, Sarah D. Diermeier, Mikala Egeblad, Christopher R. Vakoc, Jason W. Locasale, Navdeep S. Chandel, Tobias Janowitz, James B. Hicks, Michael Wigler, Darryl J. Pappin, Roger L. Williams, Paolo Cifani, David A. Tuveson, Jocelyn Laporte, and Lloyd C. Trotman. Dietary pro-oxidant therapy by a vitamin k precursor targets pi 3-kinase vps34 function. Science, Oct 2024. URL: https://doi.org/10.1126/science.adk9167, doi:10.1126/science.adk9167. This article has 41 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gong2024genomewidecrisprcas9screen pages 7-10): Mingli Gong, Cheng Peng, Chen Yang, Zhenhua Wang, Hongwu Qian, Xue Hu, Peng Zhou, Chao Shan, and Qiang Ding. Genome-wide crispr/cas9 screen identifies slc39a9 and pik3c3 as crucial entry factors for ebola virus infection. PLOS Pathogens, 20:e1012444, Aug 2024. URL: https://doi.org/10.1371/journal.ppat.1012444, doi:10.1371/journal.ppat.1012444. This article has 12 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(lee2024regulatorymechanismsgoverning pages 6-7): Yongook Lee, Nguyen Minh Tuan, Gi Jeong Lee, Boram Kim, Jung Ho Park, and Chang Hoon Lee. Regulatory mechanisms governing the autophagy-initiating vps34 complex and its inhibitors. Biomolecules &amp; Therapeutics, 32:723-735, Oct 2024. URL: https://doi.org/10.4062/biomolther.2024.094, doi:10.4062/biomolther.2024.094. This article has 16 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>lee2024regulatorymechanismsgoverning pages 12-12</li>
+<li>lee2024regulatorymechanismsgoverning pages 1-2</li>
+<li>wan2023stingdirectlyrecruits pages 1-2</li>
+<li>swamynathan2024dietaryprooxidanttherapy pages 8-9</li>
+<li>chau2024thecellularadaptor pages 1-2</li>
+<li>wible2024unexpectedinhibitionof pages 1-3</li>
+<li>thibault2023targetingclassiiiiii pages 8-10</li>
+<li>swamynathan2024dietaryprooxidanttherapy pages 1-3</li>
+<li>lee2024regulatorymechanismsgoverning pages 6-7</li>
+<li>https://doi.org/10.1126/science.adk9167</li>
+<li>https://doi.org/10.1371/journal.ppat.1012444</li>
+<li>https://doi.org/10.1038/s41419-024-06423-0</li>
+<li>https://doi.org/10.15252/embj.2022112387</li>
+<li>https://doi.org/10.1038/s41573-022-00582-5</li>
+<li>https://doi.org/10.4062/biomolther.2024.094</li>
+<li>https://doi.org/10.1007/s00018-024-05351-8</li>
+<li>https://doi.org/10.1126/science.adk9167;</li>
+<li>https://doi.org/10.1371/journal.ppat.1012444;</li>
+<li>https://doi.org/10.1038/s41419-024-06423-0;</li>
+<li>https://doi.org/10.3390/cancers15030784</li>
+<li>https://doi.org/10.1038/s41573-022-00582-5,</li>
+<li>https://doi.org/10.4062/biomolther.2024.094,</li>
+<li>https://doi.org/10.1007/s00018-024-05351-8,</li>
+<li>https://doi.org/10.15252/embj.2022112387,</li>
+<li>https://doi.org/10.3390/cancers15030784,</li>
+<li>https://doi.org/10.1126/science.adk9167,</li>
+<li>https://doi.org/10.1038/s41419-024-06423-0,</li>
+<li>https://doi.org/10.1371/journal.ppat.1012444,</li>
+</ol>
+            </div>
+        </details>
+
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -9370,9 +11829,9 @@
 </ul>
             </div>
         </details>
-        
+
     </div>
-    
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -9384,20 +11843,17 @@
                 <pre><code>id: Q8NEB9
 gene_symbol: PIK3C3
 product_type: PROTEIN
-status: IN_PROGRESS
+status: DRAFT
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: &gt;-
-  PIK3C3 encodes VPS34, the catalytic lipid kinase of class III
-  phosphatidylinositol 3-kinase complexes. VPS34 generates
-  phosphatidylinositol 3-phosphate (PI3P) on endomembranes and operates in two
-  main Beclin 1-containing assemblies: PI3KC3-C1 with ATG14 for autophagosome
-  initiation and PI3KC3-C2 with UVRAG for endosomal sorting and later
-  autophagy-associated trafficking. In the proteostasis-network context, the
-  autophagy-initiation complex and macroautophagy are the central core claims,
-  whereas endosomal trafficking and cytokinesis are supported but contextual
-  extensions of the same VPS34 PI3P-generating biology.
+description: &#39;PIK3C3 encodes VPS34, the catalytic lipid kinase of class III phosphatidylinositol 3-kinase
+  complexes. VPS34 generates phosphatidylinositol 3-phosphate (PI3P) on endomembranes and operates in
+  two main Beclin 1-containing assemblies: PI3KC3-C1 with ATG14 for autophagosome initiation and PI3KC3-C2
+  with UVRAG for endosomal sorting and later autophagy-associated trafficking. In the proteostasis-network
+  context, the autophagy-initiation complex and macroautophagy are the central core claims, whereas endosomal
+  trafficking and cytokinesis are supported but contextual extensions of the same VPS34 PI3P-generating
+  biology.&#39;
 existing_annotations:
 - term:
     id: GO:0005737
@@ -9405,1261 +11861,2149 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Cytoplasm is a broad but directionally compatible localization for a cytoplasmic
+      vesicle-associated lipid kinase.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 is best localized to specific autophagy and endosomal membranes/complexes;
+      cytoplasm is retained only as a broad contextual cellular-component annotation.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: As component of the PI3K complex I localized to pre-autophagosome structures.
+        As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).
 - term:
     id: GO:0016020
     label: membrane
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Membrane is too broad for PIK3C3 localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The evidence supports specific endomembrane contexts, especially
+      phagophore/autophagosome and endosomal membranes, rather than a generic membrane annotation.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: As component of the PI3K complex I localized to pre-autophagosome structures.
+        As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).
 - term:
     id: GO:0048015
     label: phosphatidylinositol-mediated signaling
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Phosphatidylinositol-mediated signaling is directionally related but too broad for
+      VPS34.
+    action: MODIFY
+    reason: The direct process output of PIK3C3 is PI3P biosynthesis, with downstream effects in
+      autophagosome formation and endosomal organization; the signaling parent term blurs that
+      specificity.
+    proposed_replacement_terms:
+    - id: GO:0036092
+      label: phosphatidylinositol-3-phosphate biosynthetic process
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:0006897
     label: endocytosis
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Endocytosis is supported only as a contextual trafficking role.
+    action: MODIFY
+    reason: PIK3C3 participates in endosomal PI3P-dependent trafficking and maturation, but
+      endocytosis itself is too broad; endosome organization or early-to-late endosome transport
+      better captures the supported role.
+    proposed_replacement_terms:
+    - id: GO:0007032
+      label: endosome organization
+    - id: GO:0045022
+      label: early endosome to late endosome transport
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0000425
     label: pexophagy
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Pexophagy is a selective-autophagy overextension for PIK3C3.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3C3 is core for canonical autophagy initiation and can support selective autophagy
+      generally, but this row does not provide human evidence for a specific pexophagy role.
+    proposed_replacement_terms:
+    - id: GO:0016236
+      label: macroautophagy
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0005768
     label: endosome
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &gt;-
-      PIK3C3 is active on endosomal membranes as part of the UVRAG-containing
-      PI3KC3-C2 complex. This localization is well supported but is contextual
-      relative to the core PN autophagy-initiation case.
+    summary: PIK3C3 is active on endosomal membranes as part of the UVRAG-containing PI3KC3-C2
+      complex. This localization is well supported but is contextual relative to the core PN
+      autophagy-initiation case.
     action: KEEP_AS_NON_CORE
-    reason: &gt;-
-      Human VPS34 participates in a type II class III PI3K complex dedicated to
-      endosomal sorting and later autophagy-associated trafficking. That role
-      is real, but it is not the central PN framing for this gene.
+    reason: Human VPS34 participates in a type II class III PI3K complex dedicated to endosomal
+      sorting and later autophagy-associated trafficking. That role is real, but it is not the
+      central PN framing for this gene.
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation.
+    - reference_id: PMID:40442316
+      supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal
+        sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy
+        initiation5–7.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0000045
     label: autophagosome assembly
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &gt;-
-      Core PN function. VPS34 is required for autophagosome assembly through
-      the autophagy-initiating PI3KC3-C1 complex.
+    summary: Core PN function. VPS34 is required for autophagosome assembly through the
+      autophagy-initiating PI3KC3-C1 complex.
     action: ACCEPT
-    reason: &gt;-
-      This is the central autophagy-complex biology for PIK3C3. VPS34-derived
-      PI3P is required for autophagosome formation, and human PI3KC3-C1 is now
-      structurally defined as an autophagy core complex.
+    reason: This is the central autophagy-complex biology for PIK3C3. VPS34-derived PI3P is required
+      for autophagosome formation, and human PI3KC3-C1 is now structurally defined as an autophagy
+      core complex.
     supported_by:
-      - reference_id: PMID:33637724
-        supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.
+    - reference_id: PMID:33637724
+      supporting_text: This complex catalyzes the production of PI3P and is required for both bulk
+        and selective types of autophagy by controlling both autophagosome formation and maturation
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0016303
     label: 1-phosphatidylinositol-3-kinase activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &gt;-
-      Core molecular function. PIK3C3/VPS34 is the class III lipid kinase that
-      phosphorylates phosphatidylinositol to generate PI3P.
+    summary: Core molecular function. PIK3C3/VPS34 is the class III lipid kinase that phosphorylates
+      phosphatidylinositol to generate PI3P.
     action: ACCEPT
-    reason: &gt;-
-      Direct biochemical work established the substrate specificity of human
-      VPS34, and this specific lipid kinase activity remains the most precise MF
-      term for the gene product.
+    reason: Direct biochemical work established the substrate specificity of human VPS34, and this
+      specific lipid kinase activity remains the most precise MF term for the gene product.
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:0036092
     label: phosphatidylinositol-3-phosphate biosynthetic process
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &gt;-
-      Core process output of VPS34 catalytic activity. PIK3C3 generates PI3P for
+    summary: Core process output of VPS34 catalytic activity. PIK3C3 generates PI3P for
       autophagosome biogenesis and related membrane-trafficking pathways.
     action: ACCEPT
-    reason: &gt;-
-      PI3P synthesis is the direct biochemical consequence of VPS34 activity and
-      is the process-level claim that best captures the shared output of the
-      type I and type II class III PI3K complexes.
+    reason: PI3P synthesis is the direct biochemical consequence of VPS34 activity and is the
+      process-level claim that best captures the shared output of the type I and type II class III
+      PI3K complexes.
     supported_by:
-      - reference_id: PMID:33637724
-        supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.
+    - reference_id: PMID:33637724
+      supporting_text: This complex catalyzes the production of PI3P and is required for both bulk
+        and selective types of autophagy by controlling both autophagosome formation and maturation
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
 - term:
     id: GO:0034271
     label: phosphatidylinositol 3-kinase complex, class III, type I
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &gt;-
-      Core PN complex membership. PIK3C3 is the catalytic subunit of PI3KC3-C1,
-      the ATG14-containing class III PI3K complex that initiates autophagy.
+    summary: Core PN complex membership. PIK3C3 is the catalytic subunit of PI3KC3-C1, the
+      ATG14-containing class III PI3K complex that initiates autophagy.
     action: ACCEPT
-    reason: &gt;-
-      The type I complex is the core autophagy-initiation complex for VPS34 and
-      is the key PN-driven complex call that was previously missing locally.
+    reason: The type I complex is the core autophagy-initiation complex for VPS34 and is the key
+      PN-driven complex call that was previously missing locally.
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase VPS15 and the regulatory subunits BECN1 and ATG14.
+    - reference_id: PMID:40442316
+      supporting_text: PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase
+        VPS15 and the regulatory subunits BECN1 and ATG14
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
 - term:
     id: GO:0034272
     label: phosphatidylinositol 3-kinase complex, class III, type II
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &gt;-
-      PIK3C3 also participates in PI3KC3-C2, the UVRAG-containing class III PI3K
-      complex linked to endosomal sorting and later autophagy-associated
-      trafficking. This is supported but is contextual relative to the core PN
-      autophagy-initiation case.
+    summary: PIK3C3 also participates in PI3KC3-C2, the UVRAG-containing class III PI3K complex
+      linked to endosomal sorting and later autophagy-associated trafficking. This is supported but
+      is contextual relative to the core PN autophagy-initiation case.
     action: KEEP_AS_NON_CORE
-    reason: &gt;-
-      Type II complex membership is well established, but the primary PN-focused
-      role for PIK3C3 is the autophagy-initiation complex PI3KC3-C1 rather than
-      the broader trafficking context.
+    reason: Type II complex membership is well established, but the primary PN-focused role for
+      PIK3C3 is the autophagy-initiation complex PI3KC3-C1 rather than the broader trafficking
+      context.
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation.
+    - reference_id: PMID:40442316
+      supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal
+        sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy
+        initiation5–7.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
 - term:
     id: GO:0000407
     label: phagophore assembly site
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &gt;-
-      Core localization for the autophagy-initiation role of PIK3C3. VPS34 acts
-      at the phagophore assembly site as part of PI3KC3-C1.
+    summary: Core localization for the autophagy-initiation role of PIK3C3. VPS34 acts at the
+      phagophore assembly site as part of PI3KC3-C1.
     action: ACCEPT
-    reason: &gt;-
-      This term is consistent with the type I complex call and captures the
-      localization at which VPS34-derived PI3P seeds early autophagosome
-      biogenesis.
+    reason: This term is consistent with the type I complex call and captures the localization at
+      which VPS34-derived PI3P seeds early autophagosome biogenesis.
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: All forms of canonical autophagy, bulk and selective, are initiated upon the recruitment and activation of the FIP200 protein4 and the class III phosphatidylinositol 3-OH kinase complex I (PI3KC3-C1)5–7.
+    - reference_id: PMID:40442316
+      supporting_text: All forms of canonical autophagy, bulk and selective, are initiated upon the
+        recruitment and activation of the FIP200 protein4 and the class III phosphatidylinositol
+        3-OH kinase complex I (PI3KC3-C1)5–7.
 - term:
     id: GO:0005777
     label: peroxisome
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Peroxisome localization is not supported for PIK3C3.
+    action: REMOVE
+    reason: A pexophagy-related inference does not justify localizing PIK3C3 to the peroxisome;
+      curated locations place VPS34 at midbody, late endosome, cytoplasmic vesicle/autophagosome,
+      and pre-autophagosome/endosome contexts.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: As component of the PI3K complex I localized to pre-autophagosome structures.
+        As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).
 - term:
     id: GO:0000045
     label: autophagosome assembly
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &gt;-
-      Duplicate automated annotation for a reviewed core function. VPS34 is
-      required for autophagosome assembly.
+    summary: Duplicate automated annotation for a reviewed core function. VPS34 is required for
+      autophagosome assembly.
     action: ACCEPT
-    reason: &gt;-
-      The multi-source IEA is consistent with direct human evidence and the
-      reviewed IBA/IDA annotations for the autophagy-initiation complex.
+    reason: The multi-source IEA is consistent with direct human evidence and the reviewed IBA/IDA
+      annotations for the autophagy-initiation complex.
     supported_by:
-      - reference_id: PMID:33637724
-        supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.
+    - reference_id: PMID:33637724
+      supporting_text: This complex catalyzes the production of PI3P and is required for both bulk
+        and selective types of autophagy by controlling both autophagosome formation and maturation
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0004672
     label: protein kinase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &gt;-
-      This annotation is categorically wrong. PIK3C3 is a
-      phosphatidylinositol 3-kinase, not a protein kinase.
+    summary: This annotation is categorically wrong. PIK3C3 is a phosphatidylinositol 3-kinase, not
+      a protein kinase.
     action: REMOVE
-    reason: &gt;-
-      Direct biochemical evidence shows that VPS34 phosphorylates
-      phosphatidylinositol rather than protein substrates. This is the wrong
-      enzyme class, not a merely imprecise parent term, and the correct
-      molecular function is already captured by accepted
-      1-phosphatidylinositol-3-kinase activity annotations elsewhere in the
-      review.
+    reason: Direct biochemical evidence shows that VPS34 phosphorylates phosphatidylinositol rather
+      than protein substrates. This is the wrong enzyme class, not a merely imprecise parent term,
+      and the correct molecular function is already captured by accepted
+      1-phosphatidylinositol-3-kinase activity annotations elsewhere in the review.
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
 - term:
     id: GO:0007032
     label: endosome organization
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Endosome organization is a supported non-core PIK3C3 process.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3-derived PI3P helps define endosomal identity and trafficking, especially in the
+      UVRAG-containing type II complex, but the central reviewed function remains class III PI3K
+      activity in autophagy initiation.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0016236
     label: macroautophagy
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &gt;-
-      Core PN process. VPS34 is required for macroautophagy through PI3KC3-C1
-      mediated PI3P generation.
+    summary: Core PN process. VPS34 is required for macroautophagy through PI3KC3-C1 mediated PI3P
+      generation.
     action: ACCEPT
-    reason: &gt;-
-      Conserved automated transfer is consistent with direct mammalian evidence
-      that class III PI3K activity is required for macroautophagy.
+    reason: Conserved automated transfer is consistent with direct mammalian evidence that class III
+      PI3K activity is required for macroautophagy.
     supported_by:
-      - reference_id: PMID:10625637
-        supporting_text: Transfection of a specific class III PI3K antisense oligonucleotide greatly inhibited the rate of macroautophagy.
+    - reference_id: PMID:10625637
+      supporting_text: Transfection of a specific class III PI3K antisense oligonucleotide greatly
+        inhibited the rate of macroautophagy.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0016485
     label: protein processing
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Protein processing is too generic for the supported trafficking role.
+    action: MODIFY
+    reason: Human and review evidence support PI3P-dependent endocytic membrane traffic, phagosome
+      maturation, autophagy, and lysosome-directed trafficking rather than protein processing as a
+      molecularly informative process.
+    proposed_replacement_terms:
+    - id: GO:0045022
+      label: early endosome to late endosome transport
+    - id: GO:0007032
+      label: endosome organization
+    supported_by:
+    - reference_id: PMID:16467569
+      supporting_text: By contrast, class III PI 3-kinases mainly mediate receptor-independent
+        trafficking events, which mostly are related to endocytic membrane traffic, phagosome
+        maturation and autophagy.
 - term:
     id: GO:0035032
     label: phosphatidylinositol 3-kinase complex, class III
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &gt;-
-      Generic class III complex membership is true but underspecified for human
-      PIK3C3.
+    summary: Generic class III complex membership is true but underspecified for human PIK3C3.
     action: MODIFY
-    reason: &gt;-
-      Human VPS34 participates in both ATG14-containing PI3KC3-C1 and
-      UVRAG-containing PI3KC3-C2. The type-specific complex terms preserve the
-      autophagy-versus-trafficking split that matters for conservative curation.
+    reason: Human VPS34 participates in both ATG14-containing PI3KC3-C1 and UVRAG-containing
+      PI3KC3-C2. The type-specific complex terms preserve the autophagy-versus-trafficking split
+      that matters for conservative curation.
     proposed_replacement_terms:
-      - id: GO:0034271
-        label: phosphatidylinositol 3-kinase complex, class III, type I
-      - id: GO:0034272
-        label: phosphatidylinositol 3-kinase complex, class III, type II
+    - id: GO:0034271
+      label: phosphatidylinositol 3-kinase complex, class III, type I
+    - id: GO:0034272
+      label: phosphatidylinositol 3-kinase complex, class III, type II
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation.
+    - reference_id: PMID:40442316
+      supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal
+        sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy
+        initiation5–7.
 - term:
     id: GO:0042149
     label: cellular response to glucose starvation
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Glucose starvation response is a contextual autophagy input, not the core PIK3C3
+      function.
+    action: KEEP_AS_NON_CORE
+    reason: Starvation stimulates VPS34-dependent autophagy and PI3P production, but the reviewed
+      core function is the lipid kinase/autophagy-initiation activity rather than the
+      stimulus-response term itself.
+    proposed_replacement_terms:
+    - id: GO:0016236
+      label: macroautophagy
+    supported_by:
+    - reference_id: PMID:25327288
+      supporting_text: PIK-III acutely inhibits autophagy and de novo lipidation of LC3, and leads
+        to the stabilization of autophagy substrates.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0043201
     label: response to L-leucine
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Response to L-leucine is a nutrient-response overextension for PIK3C3.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3C3 participates in nutrient-sensitive autophagy pathways, but this specific
+      amino-acid response is not the direct activity or best-supported process for the gene product.
+    proposed_replacement_terms:
+    - id: GO:0016236
+      label: macroautophagy
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0043491
     label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: PI3K/AKT signal transduction conflates VPS34 with class I PI3K signaling.
+    action: REMOVE
+    reason: PIK3C3/VPS34 is a class III PI3K that produces PI3P from PI and should not be annotated
+      to the class I PI3K/AKT pathway without direct evidence.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:0045335
     label: phagocytic vesicle
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Phagocytic vesicle is a supported but non-core trafficking context.
+    action: KEEP_AS_NON_CORE
+    reason: Class III PI3Ks participate in phagosome maturation and endocytic membrane traffic, but
+      this is contextual relative to the core VPS34 lipid kinase/autophagy initiation function.
+    supported_by:
+    - reference_id: PMID:16467569
+      supporting_text: By contrast, class III PI 3-kinases mainly mediate receptor-independent
+        trafficking events, which mostly are related to endocytic membrane traffic, phagosome
+        maturation and autophagy.
 - term:
     id: GO:0048488
     label: synaptic vesicle endocytosis
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Synaptic vesicle endocytosis is an over-specific inference from a general endosomal
+      role.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3C3 supports endosomal PI3P-dependent trafficking, but the reviewed evidence here
+      does not establish a synaptic-vesicle-specific function.
+    proposed_replacement_terms:
+    - id: GO:0007032
+      label: endosome organization
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0098794
     label: postsynapse
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Postsynapse localization is not established as a reviewed PIK3C3 localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The available human/Falcon evidence supports endosomal, autophagic, and midbody
+      contexts; synapse-specific localization is not part of the core or well-supported contextual
+      function.
+    proposed_replacement_terms:
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: As component of the PI3K complex I localized to pre-autophagosome structures.
+        As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).
 - term:
     id: GO:0098830
     label: presynaptic endosome
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Presynaptic endosome is too specific for the evidence used here.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Endosomal PI3P biology is supported, but this annotation narrows the localization to a
+      neuronal presynaptic compartment without direct evidence in the reviewed record.
+    proposed_replacement_terms:
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0098845
     label: postsynaptic endosome
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Postsynaptic endosome is too specific for the evidence used here.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Endosomal PI3P biology is supported, but this annotation narrows the localization to a
+      neuronal postsynaptic compartment without direct evidence in the reviewed record.
+    proposed_replacement_terms:
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0098978
     label: glutamatergic synapse
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Glutamatergic synapse localization is an unsupported specialization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3C3 has supported endosomal and autophagy-related localizations; the reviewed
+      evidence does not establish a glutamatergic synapse location.
+    proposed_replacement_terms:
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: As component of the PI3K complex I localized to pre-autophagosome structures.
+        As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).
 - term:
     id: GO:0098982
     label: GABA-ergic synapse
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: GABA-ergic synapse localization is an unsupported specialization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3C3 has supported endosomal and autophagy-related localizations; the reviewed
+      evidence does not establish a GABA-ergic synapse location.
+    proposed_replacement_terms:
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: As component of the PI3K complex I localized to pre-autophagosome structures.
+        As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19050071
-  review: &amp;protein_binding_overannotated
-    summary: &gt;-
-      Protein binding is too generic to serve as an informative
-      molecular-function annotation for PIK3C3. Interaction-derived biology is
-      captured elsewhere through specific complex, localization, or process
-      terms.
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
     action: MARK_AS_OVER_ANNOTATED
-    reason: &gt;-
-      Per project convention, `protein binding` should not be retained when it
-      does not convey a specific molecular function. For PIK3C3, these
-      interaction data inform complex membership and contextual pathway roles
-      rather than a standalone MF annotation.
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:20142477
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:20562859
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:21062745
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:22493499
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23316280
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23332761
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23364696
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23954414
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24034250
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24056303
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24472739
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24785657
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24849286
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25490155
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25594178
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:26496610
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:26783301
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:28514442
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:33422265
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:33961781
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:34386498
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:34524948
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:35271311
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005770
     label: late endosome
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Late endosome is a supported contextual localization for PIK3C3.
+    action: KEEP_AS_NON_CORE
+    reason: Late-endosome localization and endosomal trafficking are supported, especially through
+      the type II complex, but are contextual relative to the core autophagy-initiation function.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0005776
     label: autophagosome
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Autophagosome localization is supported for PIK3C3 autophagy biology.
+    action: ACCEPT
+    reason: PIK3C3 acts in autophagosome biogenesis through PI3KC3-C1 and is curated as associated
+      with cytoplasmic vesicle/autophagosome and pre-autophagosome structures.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: As component of the PI3K complex I localized to pre-autophagosome structures.
+        As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0016301
     label: kinase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &gt;-
-      Generic kinase activity is too broad here. The reviewed molecular function
-      for PIK3C3 should be the specific class III phosphatidylinositol 3-kinase
-      activity term.
+    summary: Generic kinase activity is too broad here. The reviewed molecular function for PIK3C3
+      should be the specific class III phosphatidylinositol 3-kinase activity term.
     action: MODIFY
-    reason: &gt;-
-      Human VPS34 is a lipid kinase acting on phosphatidylinositol rather than a
-      generic kinase activity in the GO-review sense. The specific MF term is
-      available and better matches the direct biochemistry.
+    reason: Human VPS34 is a lipid kinase acting on phosphatidylinositol rather than a generic
+      kinase activity in the GO-review sense. The specific MF term is available and better matches
+      the direct biochemistry.
     proposed_replacement_terms:
-      - id: GO:0016303
-        label: 1-phosphatidylinositol-3-kinase activity
+    - id: GO:0016303
+      label: 1-phosphatidylinositol-3-kinase activity
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
 - term:
     id: GO:0016303
     label: 1-phosphatidylinositol-3-kinase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &gt;-
-      Automated duplicate of the reviewed core molecular function for PIK3C3.
-      VPS34 is the class III phosphatidylinositol 3-kinase.
+    summary: Automated duplicate of the reviewed core molecular function for PIK3C3. VPS34 is the
+      class III phosphatidylinositol 3-kinase.
     action: ACCEPT
-    reason: &gt;-
-      The automated call is consistent with the direct biochemical literature
-      and with the accepted curated annotations for this gene.
+    reason: The automated call is consistent with the direct biochemical literature and with the
+      accepted curated annotations for this gene.
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:0016773
     label: phosphotransferase activity, alcohol group as acceptor
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &gt;-
-      This broad phosphotransferase term is less informative than the specific
-      class III phosphatidylinositol 3-kinase activity term that is available
-      for PIK3C3.
+    summary: This broad phosphotransferase term is less informative than the specific class III
+      phosphatidylinositol 3-kinase activity term that is available for PIK3C3.
     action: MODIFY
-    reason: &gt;-
-      Human VPS34 has well-defined lipid-substrate specificity, so the specific
-      GO molecular function should replace this high-level transferase term.
+    reason: Human VPS34 has well-defined lipid-substrate specificity, so the specific GO molecular
+      function should replace this high-level transferase term.
     proposed_replacement_terms:
-      - id: GO:0016303
-        label: 1-phosphatidylinositol-3-kinase activity
+    - id: GO:0016303
+      label: 1-phosphatidylinositol-3-kinase activity
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
 - term:
     id: GO:0030496
     label: midbody
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Midbody localization is a supported non-core cytokinesis context.
+    action: KEEP_AS_NON_CORE
+    reason: Human PIK3C3 has experimental midbody localization and a PI3P-dependent cytokinesis
+      role, but this is not the main conserved function emphasized for this review.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
 - term:
     id: GO:0036092
     label: phosphatidylinositol-3-phosphate biosynthetic process
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &gt;-
-      Automated duplicate of a reviewed core process. VPS34-driven PI3P
-      generation is the central biochemical output of PIK3C3.
+    summary: Automated duplicate of a reviewed core process. VPS34-driven PI3P generation is the
+      central biochemical output of PIK3C3.
     action: ACCEPT
-    reason: &gt;-
-      This specific process term correctly captures the immediate product of
-      VPS34 catalytic activity and is preferable to broader phosphoinositide
-      biosynthesis labels.
+    reason: This specific process term correctly captures the immediate product of VPS34 catalytic
+      activity and is preferable to broader phosphoinositide biosynthesis labels.
     supported_by:
-      - reference_id: PMID:33637724
-        supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.
+    - reference_id: PMID:33637724
+      supporting_text: This complex catalyzes the production of PI3P and is required for both bulk
+        and selective types of autophagy by controlling both autophagosome formation and maturation
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
 - term:
     id: GO:0046854
     label: phosphatidylinositol phosphate biosynthetic process
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: &gt;-
-      The process is directionally correct but too broad. For PIK3C3 the
-      literature supports the specific PI3P biosynthetic process term.
+    summary: The process is directionally correct but too broad. For PIK3C3 the literature supports
+      the specific PI3P biosynthetic process term.
     action: MODIFY
-    reason: &gt;-
-      Human VPS34 is specifically responsible for generating
-      phosphatidylinositol 3-phosphate rather than phosphatidylinositol
-      phosphates in general.
+    reason: Human VPS34 is specifically responsible for generating phosphatidylinositol 3-phosphate
+      rather than phosphatidylinositol phosphates in general.
     proposed_replacement_terms:
-      - id: GO:0036092
-        label: phosphatidylinositol-3-phosphate biosynthetic process
+    - id: GO:0036092
+      label: phosphatidylinositol-3-phosphate biosynthetic process
     supported_by:
-      - reference_id: PMID:33637724
-        supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.
+    - reference_id: PMID:33637724
+      supporting_text: This complex catalyzes the production of PI3P and is required for both bulk
+        and selective types of autophagy by controlling both autophagosome formation and maturation
 - term:
     id: GO:0006622
     label: protein targeting to lysosome
   evidence_type: NAS
   original_reference_id: PMID:16467569
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Protein targeting to lysosome is a contextual trafficking assignment.
+    action: MODIFY
+    reason: The accessible review evidence supports class III PI3K roles in endocytic membrane
+      traffic, phagosome maturation, and autophagy; a more informative term is endosome organization
+      or early-to-late endosome transport.
+    proposed_replacement_terms:
+    - id: GO:0007032
+      label: endosome organization
+    - id: GO:0045022
+      label: early endosome to late endosome transport
+    supported_by:
+    - reference_id: PMID:16467569
+      supporting_text: By contrast, class III PI 3-kinases mainly mediate receptor-independent
+        trafficking events, which mostly are related to endocytic membrane traffic, phagosome
+        maturation and autophagy.
 - term:
     id: GO:0010506
     label: regulation of autophagy
   evidence_type: IDA
   original_reference_id: PMID:16799551
   review:
-    summary: &gt;-
-      This study supports PIK3C3 participation in macroautophagy, but
-      classifying VPS34 itself as a regulator is too indirect. The gene product
-      is part of the executing PI3KC3 complex.
+    summary: This study supports PIK3C3 participation in macroautophagy, but classifying VPS34
+      itself as a regulator is too indirect. The gene product is part of the executing PI3KC3
+      complex.
     action: MODIFY
-    reason: &gt;-
-      PIK3C3 is not merely upstream of autophagy in this context; it is a core
-      catalytic component of the autophagy machinery. The process annotation
-      should therefore be macroautophagy rather than regulation of autophagy.
+    reason: PIK3C3 is not merely upstream of autophagy in this context; it is a core catalytic
+      component of the autophagy machinery. The process annotation should therefore be
+      macroautophagy rather than regulation of autophagy.
     proposed_replacement_terms:
-      - id: GO:0016236
-        label: macroautophagy
+    - id: GO:0016236
+      label: macroautophagy
     supported_by:
-      - reference_id: PMID:10625637
-        supporting_text: Transfection of a specific class III PI3K antisense oligonucleotide greatly inhibited the rate of macroautophagy.
+    - reference_id: PMID:10625637
+      supporting_text: Transfection of a specific class III PI3K antisense oligonucleotide greatly
+        inhibited the rate of macroautophagy.
 - term:
     id: GO:0016236
     label: macroautophagy
   evidence_type: NAS
   original_reference_id: PMID:40442316
   review:
-    summary: &gt;-
-      Core PN process assignment. Human structural and mechanistic work places
-      PIK3C3 in the autophagy-initiating PI3KC3-C1 complex required for
-      macroautophagy.
+    summary: Core PN process assignment. Human structural and mechanistic work places PIK3C3 in the
+      autophagy-initiating PI3KC3-C1 complex required for macroautophagy.
     action: ACCEPT
-    reason: &gt;-
-      The human literature now directly frames PI3KC3-C1 as an autophagy core
-      complex, which supports macroautophagy as a central process annotation for
-      PIK3C3.
+    reason: The human literature now directly frames PI3KC3-C1 as an autophagy core complex, which
+      supports macroautophagy as a central process annotation for PIK3C3.
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: All forms of canonical autophagy, bulk and selective, are initiated upon the recruitment and activation of the FIP200 protein4 and the class III phosphatidylinositol 3-OH kinase complex I (PI3KC3-C1)5–7.
+    - reference_id: PMID:40442316
+      supporting_text: All forms of canonical autophagy, bulk and selective, are initiated upon the
+        recruitment and activation of the FIP200 protein4 and the class III phosphatidylinositol
+        3-OH kinase complex I (PI3KC3-C1)5–7.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0016241
     label: regulation of macroautophagy
   evidence_type: IDA
   original_reference_id: PMID:10625637
   review:
-    summary: &gt;-
-      The underlying result supports macroautophagy itself rather than a purely
-      regulatory role. PIK3C3 is required for the process.
+    summary: The underlying result supports macroautophagy itself rather than a purely regulatory
+      role. PIK3C3 is required for the process.
     action: MODIFY
-    reason: &gt;-
-      In this experiment class III PI3K activity is necessary for
-      macroautophagy, so the process term is more appropriate than a regulation
-      term for PIK3C3.
+    reason: In this experiment class III PI3K activity is necessary for macroautophagy, so the
+      process term is more appropriate than a regulation term for PIK3C3.
     proposed_replacement_terms:
-      - id: GO:0016236
-        label: macroautophagy
+    - id: GO:0016236
+      label: macroautophagy
     supported_by:
-      - reference_id: PMID:10625637
-        supporting_text: Transfection of a specific class III PI3K antisense oligonucleotide greatly inhibited the rate of macroautophagy.
+    - reference_id: PMID:10625637
+      supporting_text: Transfection of a specific class III PI3K antisense oligonucleotide greatly
+        inhibited the rate of macroautophagy.
 - term:
     id: GO:0036092
     label: phosphatidylinositol-3-phosphate biosynthetic process
   evidence_type: IDA
   original_reference_id: PMID:8999962
   review:
-    summary: &gt;-
-      Reviewed core process assignment. Human VPS34/p150 complex activity is
-      part of the specific PI3P-producing pathway.
+    summary: Reviewed core process assignment. Human VPS34/p150 complex activity is part of the
+      specific PI3P-producing pathway.
     action: ACCEPT
-    reason: &gt;-
-      Across the human literature, VPS34 activity is consistently tied to PI3P
-      generation rather than a generic phosphoinositide biosynthetic role.
+    reason: Across the human literature, VPS34 activity is consistently tied to PI3P generation
+      rather than a generic phosphoinositide biosynthetic role.
     supported_by:
-      - reference_id: PMID:10625637
-        supporting_text: an increase in the class III PI3K product (phosphatidylinositol 3-phosphate), either by feeding cells with a synthetic lipid or by overexpressing the p150 adaptor, stimulates macroautophagy.
+    - reference_id: PMID:10625637
+      supporting_text: an increase in the class III PI3K product (phosphatidylinositol 3-phosphate),
+        either by feeding cells with a synthetic lipid or by overexpressing the p150 adaptor,
+        stimulates macroautophagy.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
 - term:
     id: GO:0045022
     label: early endosome to late endosome transport
   evidence_type: IDA
   original_reference_id: PMID:14617358
   review:
-    summary: &gt;-
-      Human VPS34/p150 participates in Rab7-linked endosomal trafficking. This
-      is supported but is contextual relative to the core PN autophagy role.
+    summary: Human VPS34/p150 participates in Rab7-linked endosomal trafficking. This is supported
+      but is contextual relative to the core PN autophagy role.
     action: KEEP_AS_NON_CORE
-    reason: &gt;-
-      The late-endosomal transport function is directly supported in human
-      cells, but it should be kept distinct from the autophagy-initiation
-      complex that defines the core PN case for PIK3C3.
+    reason: The late-endosomal transport function is directly supported in human cells, but it
+      should be kept distinct from the autophagy-initiation complex that defines the core PN case
+      for PIK3C3.
     supported_by:
-      - reference_id: PMID:14617358
-        supporting_text: The hVPS34/p150 complex colocalized with rab7 on late endosomes and hVPS34 activity was dependent on nucleotide cycling of rab7.
+    - reference_id: PMID:14617358
+      supporting_text: The hVPS34/p150 complex colocalized with rab7 on late endosomes and hVPS34
+        activity was dependent on nucleotide cycling of rab7.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0097352
     label: autophagosome maturation
   evidence_type: IDA
   original_reference_id: PMID:10625637
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Autophagosome maturation is supported as part of the core autophagy role.
+    action: ACCEPT
+    reason: Older macroautophagy evidence and newer VPS34 complex evidence support PIK3C3-dependent
+      PI3P production in autophagosome formation and maturation.
+    supported_by:
+    - reference_id: PMID:10625637
+      supporting_text: Transfection of a specific class III PI3K antisense oligonucleotide greatly
+        inhibited the rate of macroautophagy.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0016236
     label: macroautophagy
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-1632852
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Macroautophagy is a core PIK3C3 process.
+    action: ACCEPT
+    reason: Reactome and literature synthesis support PIK3C3/VPS34 as the catalytic component of the
+      class III PI3K complex needed for early autophagy.
+    supported_by:
+    - reference_id: file:reactome/R-HSA-5672012.md
+      supporting_text: PIK3C3 (VPS34), the catalytic component of this complex, is a class III
+        phosphatidylinositol 3-kinase that phosphorylates phosphatidylinositol (PI) producing
+        phosphatidylinositol 3-phosphate (PI3P).
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0016303
     label: 1-phosphatidylinositol-3-kinase activity
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5672012
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: The Reactome TAS row correctly captures the core VPS34 lipid kinase activity.
+    action: ACCEPT
+    reason: PIK3C3/VPS34 is the catalytic class III PI3K that phosphorylates phosphatidylinositol to
+      produce PI3P.
+    supported_by:
+    - reference_id: file:reactome/R-HSA-5672012.md
+      supporting_text: PIK3C3 (VPS34), the catalytic component of this complex, is a class III
+        phosphatidylinositol 3-kinase that phosphorylates phosphatidylinositol (PI) producing
+        phosphatidylinositol 3-phosphate (PI3P).
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:0016303
     label: 1-phosphatidylinositol-3-kinase activity
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6798174
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: The Reactome TAS row correctly captures the core VPS34 lipid kinase activity.
+    action: ACCEPT
+    reason: PIK3C3/VPS34 is the catalytic class III PI3K that phosphorylates phosphatidylinositol to
+      produce PI3P.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: IDA
   original_reference_id: PMID:17307798
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Plasma membrane localization could not be reviewed from accessible evidence.
+    action: UNDECIDED
+    reason: The cited PMID is not present in the local publication cache, and the Falcon/UniProt
+      evidence reviewed here supports endosomal/autophagic and midbody contexts rather than a clear
+      plasma-membrane localization.
 - term:
     id: GO:0045954
     label: positive regulation of natural killer cell mediated cytotoxicity
   evidence_type: IMP
   original_reference_id: PMID:17307798
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Natural killer cell-mediated cytotoxicity could not be reviewed from accessible
+      evidence.
+    action: UNDECIDED
+    reason: The cited PMID is not present in the local publication cache, and the Falcon report does
+      not cover this immune-cell phenotype sufficiently to decide whether the process annotation
+      should be retained.
 - term:
     id: GO:0052742
     label: phosphatidylinositol kinase activity
   evidence_type: IDA
   original_reference_id: PMID:7628435
   review:
-    summary: &gt;-
-      The activity is valid but too general. Human VPS34 should be annotated to
-      the specific 1-phosphatidylinositol-3-kinase activity term.
+    summary: The activity is valid but too general. Human VPS34 should be annotated to the specific
+      1-phosphatidylinositol-3-kinase activity term.
     action: MODIFY
-    reason: &gt;-
-      The original biochemical characterization resolved the substrate and the
-      3-position specificity, so the narrower MF term is warranted.
+    reason: The original biochemical characterization resolved the substrate and the 3-position
+      specificity, so the narrower MF term is warranted.
     proposed_replacement_terms:
-      - id: GO:0016303
-        label: 1-phosphatidylinositol-3-kinase activity
+    - id: GO:0016303
+      label: 1-phosphatidylinositol-3-kinase activity
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
 - term:
     id: GO:0016303
     label: 1-phosphatidylinositol-3-kinase activity
   evidence_type: IDA
   original_reference_id: PMID:25327288
   review:
-    summary: &gt;-
-      Reviewed core molecular function. Later chemical-genetic work is fully
-      consistent with VPS34 as the relevant class III PI3 kinase.
+    summary: Reviewed core molecular function. Later chemical-genetic work is fully consistent with
+      VPS34 as the relevant class III PI3 kinase.
     action: ACCEPT
-    reason: &gt;-
-      This term matches the established biochemical function of PIK3C3 and is
-      consistent with selective VPS34 inhibition experiments in human systems.
+    reason: This term matches the established biochemical function of PIK3C3 and is consistent with
+      selective VPS34 inhibition experiments in human systems.
     supported_by:
-      - reference_id: PMID:25327288
-        supporting_text: PIK-III is a selective inhibitor of VPS34 that binds a unique hydrophobic pocket not present in related kinases such as PI(3)Kα.
+    - reference_id: PMID:25327288
+      supporting_text: PIK-III is a selective inhibitor of VPS34 that binds a unique hydrophobic
+        pocket not present in related kinases such as PI(3)Kα.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:1903061
     label: positive regulation of protein lipidation
   evidence_type: IMP
   original_reference_id: PMID:25327288
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Positive regulation of protein lipidation is supported as a non-core autophagy pathway
+      effect.
+    action: KEEP_AS_NON_CORE
+    reason: Selective VPS34 inhibition blocks de novo LC3 lipidation, supporting an upstream
+      positive role in LC3 lipidation during autophagy, but the direct core function remains PI3P
+      synthesis.
+    supported_by:
+    - reference_id: PMID:25327288
+      supporting_text: PIK-III acutely inhibits autophagy and de novo lipidation of LC3, and leads
+        to the stabilization of autophagy substrates.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:30767700
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0044829
     label: host-mediated activation of viral genome replication
   evidence_type: IDA
   original_reference_id: PMID:34320401
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Viral genome replication activation could not be confidently reviewed from accessible
+      evidence.
+    action: UNDECIDED
+    reason: The cited PMID is not present in the local publication cache. Falcon evidence supports a
+      PIK3C3 role in Ebola virus entry via endocytic trafficking, but that is not the same as
+      host-mediated activation of viral genome replication.
 - term:
     id: GO:0000045
     label: autophagosome assembly
   evidence_type: IDA
   original_reference_id: PMID:33637724
   review:
-    summary: &gt;-
-      Direct human evidence for a core PN process. VPS34 abundance and
-      regulation affect autophagosome formation.
+    summary: Direct human evidence for a core PN process. VPS34 abundance and regulation affect
+      autophagosome formation.
     action: ACCEPT
-    reason: &gt;-
-      This study explicitly ties VPS34-controlled PI3P production to
-      autophagosome formation and maturation, which is central to the reviewed
-      biology of PIK3C3.
+    reason: This study explicitly ties VPS34-controlled PI3P production to autophagosome formation
+      and maturation, which is central to the reviewed biology of PIK3C3.
     supported_by:
-      - reference_id: PMID:33637724
-        supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.
+    - reference_id: PMID:33637724
+      supporting_text: This complex catalyzes the production of PI3P and is required for both bulk
+        and selective types of autophagy by controlling both autophagosome formation and maturation
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0046854
     label: phosphatidylinositol phosphate biosynthetic process
   evidence_type: IDA
   original_reference_id: PMID:7628435
   review:
-    summary: &gt;-
-      The biochemical direction is correct but the term is too broad. The human
-      enzyme characterized here specifically supports PI3P biosynthesis.
+    summary: The biochemical direction is correct but the term is too broad. The human enzyme
+      characterized here specifically supports PI3P biosynthesis.
     action: MODIFY
-    reason: &gt;-
-      The original paper established the specific phosphatidylinositol
-      3-kinase activity of human VPS34, which is more precisely captured by the
-      PI3P biosynthetic process term.
+    reason: The original paper established the specific phosphatidylinositol 3-kinase activity of
+      human VPS34, which is more precisely captured by the PI3P biosynthetic process term.
     proposed_replacement_terms:
-      - id: GO:0036092
-        label: phosphatidylinositol-3-phosphate biosynthetic process
+    - id: GO:0036092
+      label: phosphatidylinositol-3-phosphate biosynthetic process
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:33473107
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:28890335
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:31806350
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0032465
     label: regulation of cytokinesis
   evidence_type: IMP
   original_reference_id: PMID:20208530
   review:
-    summary: &gt;-
-      Human PIK3C3 contributes to cytokinesis through a PI3P-dependent midbody
-      pathway. This role is supported but is contextual relative to the core PN
-      autophagy case.
+    summary: Human PIK3C3 contributes to cytokinesis through a PI3P-dependent midbody pathway. This
+      role is supported but is contextual relative to the core PN autophagy case.
     action: KEEP_AS_NON_CORE
-    reason: &gt;-
-      The cytokinesis phenotype is convincing, but it reflects a contextual
-      deployment of VPS34 PI3P biology rather than the primary autophagy-focused
-      role being curated here.
+    reason: The cytokinesis phenotype is convincing, but it reflects a contextual deployment of
+      VPS34 PI3P biology rather than the primary autophagy-focused role being curated here.
     supported_by:
-      - reference_id: PMID:20208530
-        supporting_text: Depletion of the VPS34 or Beclin 1 subunits of PI(3)K-III causes cytokinesis arrest and an increased number of binucleate and multinucleate cells, in a similar manner to the depletion of FYVE-CENT, KIF13A or TTC19.
+    - reference_id: PMID:20208530
+      supporting_text: Depletion of the VPS34 or Beclin 1 subunits of PI(3)K-III causes cytokinesis
+        arrest and an increased number of binucleate and multinucleate cells, in a similar manner to
+        the depletion of FYVE-CENT, KIF13A or TTC19.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:28479384
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:22095288
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0006914
     label: autophagy
   evidence_type: IMP
   original_reference_id: PMID:25327288
   review:
-    summary: &gt;-
-      The biology is correct but the process term is too general. For PIK3C3
-      the literature supports macroautophagy specifically.
+    summary: The biology is correct but the process term is too general. For PIK3C3 the literature
+      supports macroautophagy specifically.
     action: MODIFY
-    reason: &gt;-
-      VPS34 inhibition in this study blocks the canonical autophagy pathway
-      tracked by LC3 lipidation and autophagy-substrate turnover, which is
-      better captured as macroautophagy.
+    reason: VPS34 inhibition in this study blocks the canonical autophagy pathway tracked by LC3
+      lipidation and autophagy-substrate turnover, which is better captured as macroautophagy.
     proposed_replacement_terms:
-      - id: GO:0016236
-        label: macroautophagy
+    - id: GO:0016236
+      label: macroautophagy
     supported_by:
-      - reference_id: PMID:25327288
-        supporting_text: PIK-III acutely inhibits autophagy and de novo lipidation of LC3, and leads to the stabilization of autophagy substrates.
+    - reference_id: PMID:25327288
+      supporting_text: PIK-III acutely inhibits autophagy and de novo lipidation of LC3, and leads
+        to the stabilization of autophagy substrates.
 - term:
     id: GO:0044754
     label: autolysosome
   evidence_type: IDA
   original_reference_id: PMID:25327288
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Autolysosome localization is over-annotated from an inhibitor/substrate study.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The cited inhibitor study supports VPS34-dependent autophagy and NCOA4/ferritin delivery
+      to autolysosomes, but it does not directly place PIK3C3 itself in the autolysosome.
+    proposed_replacement_terms:
+    - id: GO:0005776
+      label: autophagosome
+    - id: GO:0016236
+      label: macroautophagy
+    supported_by:
+    - reference_id: PMID:25327288
+      supporting_text: NCOA4 directly binds ferritin heavy chain-1 (FTH1) to target the iron-binding
+        ferritin complex with a relative molecular mass of 450,000 to autolysosomes following
+        starvation or iron depletion.
 - term:
     id: GO:0030670
     label: phagocytic vesicle membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6798174
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Phagocytic vesicle membrane is a supported but non-core trafficking context.
+    action: KEEP_AS_NON_CORE
+    reason: Class III PI3Ks are linked to phagosome maturation and endocytic membrane traffic; this
+      contextual membrane role should not displace the core autophagy-initiation complex function.
+    supported_by:
+    - reference_id: PMID:16467569
+      supporting_text: By contrast, class III PI 3-kinases mainly mediate receptor-independent
+        trafficking events, which mostly are related to endocytic membrane traffic, phagosome
+        maturation and autophagy.
 - term:
     id: GO:0032465
     label: regulation of cytokinesis
   evidence_type: IMP
   original_reference_id: PMID:20643123
   review:
-    summary: &gt;-
-      Supported contextual role for a UVRAG/BIF-1-containing PI3K-III subcomplex
-      in cytokinesis. This remains outside the core PN autophagy framing.
+    summary: Supported contextual role for a UVRAG/BIF-1-containing PI3K-III subcomplex in
+      cytokinesis. This remains outside the core PN autophagy framing.
     action: KEEP_AS_NON_CORE
-    reason: &gt;-
-      The human data support a real cytokinesis role for a VPS34-containing
-      complex, but the review should keep this separate from the central
-      autophagy-initiation assignment.
+    reason: The human data support a real cytokinesis role for a VPS34-containing complex, but the
+      review should keep this separate from the central autophagy-initiation assignment.
     supported_by:
-      - reference_id: PMID:20643123
-        supporting_text: High-content microscopy-based assays combined with siRNA-mediated depletion of individual subunits indicated that a specific sub-complex containing VPS15, VPS34, Beclin 1, UVRAG and BIF-1 regulates both receptor degradation and cytokinesis, whereas ATG14L, a PI3K-III subunit involved in autophagy, is not required.
+    - reference_id: PMID:20643123
+      supporting_text: High-content microscopy-based assays combined with siRNA-mediated depletion
+        of individual subunits indicated that a specific sub-complex containing VPS15, VPS34, Beclin
+        1, UVRAG and BIF-1 regulates both receptor degradation and cytokinesis, whereas ATG14L, a
+        PI3K-III subunit involved in autophagy, is not required.
 - term:
     id: GO:0016236
     label: macroautophagy
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: &gt;-
-      Conservative orthology-supported duplicate of a core process assignment.
-      Macroautophagy is appropriate for human PIK3C3.
+    summary: Conservative orthology-supported duplicate of a core process assignment. Macroautophagy
+      is appropriate for human PIK3C3.
     action: ACCEPT
-    reason: &gt;-
-      This transfer is consistent with direct human evidence for VPS34 in the
+    reason: This transfer is consistent with direct human evidence for VPS34 in the
       autophagy-initiating PI3KC3-C1 complex.
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: All forms of canonical autophagy, bulk and selective, are initiated upon the recruitment and activation of the FIP200 protein4 and the class III phosphatidylinositol 3-OH kinase complex I (PI3KC3-C1)5–7.
+    - reference_id: PMID:40442316
+      supporting_text: All forms of canonical autophagy, bulk and selective, are initiated upon the
+        recruitment and activation of the FIP200 protein4 and the class III phosphatidylinositol
+        3-OH kinase complex I (PI3KC3-C1)5–7.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0035032
     label: phosphatidylinositol 3-kinase complex, class III
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: &gt;-
-      The generic class III PI3K complex term is true but underspecified for
-      human PIK3C3. The literature supports explicit type I and type II complex
-      membership.
+    summary: The generic class III PI3K complex term is true but underspecified for human PIK3C3.
+      The literature supports explicit type I and type II complex membership.
     action: MODIFY
-    reason: &gt;-
-      For this gene, the main curatorial distinction is between the
-      autophagy-initiating PI3KC3-C1/type I complex and the contextual
-      endosomal PI3KC3-C2/type II complex.
+    reason: For this gene, the main curatorial distinction is between the autophagy-initiating
+      PI3KC3-C1/type I complex and the contextual endosomal PI3KC3-C2/type II complex.
     proposed_replacement_terms:
-      - id: GO:0034271
-        label: phosphatidylinositol 3-kinase complex, class III, type I
-      - id: GO:0034272
-        label: phosphatidylinositol 3-kinase complex, class III, type II
+    - id: GO:0034271
+      label: phosphatidylinositol 3-kinase complex, class III, type I
+    - id: GO:0034272
+      label: phosphatidylinositol 3-kinase complex, class III, type II
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase VPS15 and the regulatory subunits BECN1 and ATG14.
-      - reference_id: PMID:40442316
-        supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation.
+    - reference_id: PMID:40442316
+      supporting_text: PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase
+        VPS15 and the regulatory subunits BECN1 and ATG14
+    - reference_id: PMID:40442316
+      supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal
+        sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy
+        initiation5–7.
 - term:
     id: GO:0042149
     label: cellular response to glucose starvation
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Glucose starvation response is a contextual autophagy input, not the core PIK3C3
+      function.
+    action: KEEP_AS_NON_CORE
+    reason: Starvation-dependent autophagy is a supported context for VPS34 action, but the direct
+      conserved role is PI3P production in autophagy and endosomal pathways.
+    proposed_replacement_terms:
+    - id: GO:0016236
+      label: macroautophagy
+    supported_by:
+    - reference_id: PMID:25327288
+      supporting_text: PIK-III acutely inhibits autophagy and de novo lipidation of LC3, and leads
+        to the stabilization of autophagy substrates.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23878393
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0016020
     label: membrane
   evidence_type: HDA
   original_reference_id: PMID:19946888
   review:
-    summary: &gt;-
-      This broad membrane localization call is not reliable enough for manual
-      retention. The source is large-scale membrane proteomics with many
-      transiently associated proteins.
-    action: REMOVE
-    reason: &gt;-
-      The paper does not establish a specific or stable membrane localization
-      for PIK3C3 beyond broad proteomic association, so this annotation is too
-      weak and uninformative to retain.
+    summary: Broad membrane association from large-scale proteomics is weak and uninformative for
+      PIK3C3.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3C3 is a cytosolic/peripheral lipid kinase recruited to autophagy and endosomal
+      membranes, so generic membrane association is not entirely wrong, but this broad HDA row is
+      not specific enough for the reviewed function.
     supported_by:
-      - reference_id: PMID:19946888
-        supporting_text: The remaining species were largely involved in cellular processes and molecular functions that could be predicted to be transiently associated with membranes.
+    - reference_id: PMID:19946888
+      supporting_text: The remaining species were largely involved in cellular processes and
+        molecular functions that could be predicted to be transiently associated with membranes.
 - term:
     id: GO:0005930
     label: axoneme
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Axoneme localization is supported only by similarity and is non-core.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records a ciliary axoneme localization by similarity, but the reviewed human
+      core function is VPS34 lipid kinase activity in autophagy/endosomal complexes.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Also localizes to discrete punctae along the ciliary axoneme and to the base
+        of the ciliary axoneme (By similarity).
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19270696
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:14617358
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005770
     label: late endosome
   evidence_type: IDA
   original_reference_id: PMID:14617358
   review:
-    summary: &gt;-
-      Supported contextual localization. Human VPS34/p150 colocalizes with Rab7
-      on late endosomes.
+    summary: Supported contextual localization. Human VPS34/p150 colocalizes with Rab7 on late
+      endosomes.
     action: KEEP_AS_NON_CORE
-    reason: &gt;-
-      The localization is directly supported in human cells, but it belongs to
-      the contextual endosomal-trafficking side of PIK3C3 biology rather than
-      the core PN autophagy claim.
+    reason: The localization is directly supported in human cells, but it belongs to the contextual
+      endosomal-trafficking side of PIK3C3 biology rather than the core PN autophagy claim.
     supported_by:
-      - reference_id: PMID:14617358
-        supporting_text: The hVPS34/p150 complex colocalized with rab7 on late endosomes and hVPS34 activity was dependent on nucleotide cycling of rab7.
+    - reference_id: PMID:14617358
+      supporting_text: The hVPS34/p150 complex colocalized with rab7 on late endosomes and hVPS34
+        activity was dependent on nucleotide cycling of rab7.
 - term:
     id: GO:0045022
     label: early endosome to late endosome transport
   evidence_type: IMP
   original_reference_id: PMID:14617358
   review:
-    summary: &gt;-
-      Contextual trafficking role supported by human Rab7/VPS34 data.
-      Appropriate to retain as non-core.
+    summary: Contextual trafficking role supported by human Rab7/VPS34 data. Appropriate to retain
+      as non-core.
     action: KEEP_AS_NON_CORE
-    reason: &gt;-
-      This transport function is part of the broader endosomal deployment of
-      VPS34 PI3P signaling and should remain separate from the core
-      macroautophagy-focused curation.
+    reason: This transport function is part of the broader endosomal deployment of VPS34 PI3P
+      signaling and should remain separate from the core macroautophagy-focused curation.
     supported_by:
-      - reference_id: PMID:14617358
-        supporting_text: The data identify rab7 as an important regulator of late endosomal hVPS34 function and link rab7 to the regulation of phosphatidylinositol 3&#39;-kinase cycling between early and late endosomes.
+    - reference_id: PMID:14617358
+      supporting_text: The data identify rab7 as an important regulator of late endosomal hVPS34
+        function and link rab7 to the regulation of phosphatidylinositol 3&#39;-kinase cycling between
+        early and late endosomes.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-109699
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-1632857
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-1675939
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-1675961
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-1676024
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-188002
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5672012
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5678313
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5678315
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5679205
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5679266
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5682385
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9755359
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9921171
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.&#39;
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: &#39;**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.&#39;
 - term:
     id: GO:0016303
     label: 1-phosphatidylinositol-3-kinase activity
   evidence_type: IMP
   original_reference_id: PMID:20208530
   review:
-    summary: &gt;-
-      Contextual cytokinesis paper, but the molecular function assignment itself
-      is core and remains correct for PIK3C3.
+    summary: Contextual cytokinesis paper, but the molecular function assignment itself is core and
+      remains correct for PIK3C3.
     action: ACCEPT
-    reason: &gt;-
-      Even though this paper focuses on cytokinesis, it does so through the
-      catalytic PI3P-generating activity of the class III PI3K complex.
+    reason: Even though this paper focuses on cytokinesis, it does so through the catalytic
+      PI3P-generating activity of the class III PI3K complex.
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:0030496
     label: midbody
   evidence_type: IDA
   original_reference_id: PMID:20208530
   review:
-    summary: &gt;-
-      Midbody association is part of a supported cytokinesis-specific context
-      for VPS34 biology and should not be treated as core PN localization.
+    summary: Midbody association is part of a supported cytokinesis-specific context for VPS34
+      biology and should not be treated as core PN localization.
     action: KEEP_AS_NON_CORE
-    reason: &gt;-
-      The cytokinesis paper supports a midbody-linked PI3P pathway, but this is
-      a contextual deployment of VPS34 rather than the primary autophagy
-      localization used for core-function synthesis.
+    reason: The cytokinesis paper supports a midbody-linked PI3P pathway, but this is a contextual
+      deployment of VPS34 rather than the primary autophagy localization used for core-function
+      synthesis.
     supported_by:
-      - reference_id: PMID:20208530
-        supporting_text: We show that PtdIns(3)P localizes to the midbody during cytokinesis and recruits a centrosomal protein, FYVE-CENT (ZFYVE26), and its binding partner TTC19, which in turn interacts with CHMP4B, an endosomal sorting complex required for transport (ESCRT)-III subunit implicated in the abscission step of cytokinesis.
+    - reference_id: PMID:20208530
+      supporting_text: We show that PtdIns(3)P localizes to the midbody during cytokinesis and
+        recruits a centrosomal protein, FYVE-CENT (ZFYVE26), and its binding partner TTC19, which in
+        turn interacts with CHMP4B, an endosomal sorting complex required for transport (ESCRT)-III
+        subunit implicated in the abscission step of cytokinesis.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16417406
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:7504174
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0016303
     label: 1-phosphatidylinositol-3-kinase activity
   evidence_type: TAS
   original_reference_id: PMID:7628435
   review:
-    summary: &gt;-
-      Literature-traceable duplicate of the reviewed core molecular function.
-      Human VPS34 is the phosphatidylinositol 3-kinase.
+    summary: Literature-traceable duplicate of the reviewed core molecular function. Human VPS34 is
+      the phosphatidylinositol 3-kinase.
     action: ACCEPT
-    reason: &gt;-
-      This term directly reflects the original biochemical characterization of
-      the human enzyme and should be retained.
+    reason: This term directly reflects the original biochemical characterization of the human
+      enzyme and should be retained.
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
 - id: GO_REF:0000024
-  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by
+    curator judgment of sequence similarity
   findings: []
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -10668,7 +14012,8 @@ references:
   title: &#39;TODO: Fetch title&#39;
   findings: []
 - id: GO_REF:0000107
-  title: Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara
+  title: Automatic transfer of experimentally verified manual GO annotation data to orthologs using
+    Ensembl Compara
   findings: []
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
@@ -10677,7 +14022,8 @@ references:
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:10625637
-  title: Distinct classes of phosphatidylinositol 3&#39;-kinases are involved in signaling pathways that control macroautophagy in HT-29 cells.
+  title: Distinct classes of phosphatidylinositol 3&#39;-kinases are involved in signaling pathways that
+    control macroautophagy in HT-29 cells.
   findings: []
 - id: PMID:14617358
   title: Human VPS34 and p150 are Rab7 interacting partners.
@@ -10707,13 +14053,15 @@ references:
   title: &#39;TODO: Fetch title&#39;
   findings: []
 - id: PMID:20208530
-  title: PtdIns(3)P controls cytokinesis through KIF13A-mediated recruitment of FYVE-CENT to the midbody.
+  title: PtdIns(3)P controls cytokinesis through KIF13A-mediated recruitment of FYVE-CENT to the
+    midbody.
   findings: []
 - id: PMID:20562859
   title: &#39;TODO: Fetch title&#39;
   findings: []
 - id: PMID:20643123
-  title: A phosphatidylinositol 3-kinase class III sub-complex containing VPS15, VPS34, Beclin 1, UVRAG and BIF-1 regulates cytokinesis and degradative endocytic traffic.
+  title: A phosphatidylinositol 3-kinase class III sub-complex containing VPS15, VPS34, Beclin 1,
+    UVRAG and BIF-1 regulates cytokinesis and degradative endocytic traffic.
   findings: []
 - id: PMID:21062745
   title: &#39;TODO: Fetch title&#39;
@@ -10755,7 +14103,8 @@ references:
   title: &#39;TODO: Fetch title&#39;
   findings: []
 - id: PMID:25327288
-  title: Selective VPS34 inhibitor blocks autophagy and uncovers a role for NCOA4 in ferritin degradation and iron homeostasis in vivo.
+  title: Selective VPS34 inhibitor blocks autophagy and uncovers a role for NCOA4 in ferritin
+    degradation and iron homeostasis in vivo.
   findings: []
 - id: PMID:25490155
   title: &#39;TODO: Fetch title&#39;
@@ -10791,7 +14140,8 @@ references:
   title: &#39;TODO: Fetch title&#39;
   findings: []
 - id: PMID:33637724
-  title: VPS34 K29/K48 branched ubiquitination governed by UBE3C and TRABID regulates autophagy, proteostasis and liver metabolism.
+  title: VPS34 K29/K48 branched ubiquitination governed by UBE3C and TRABID regulates autophagy,
+    proteostasis and liver metabolism.
   findings: []
 - id: PMID:33961781
   title: &#39;TODO: Fetch title&#39;
@@ -10815,10 +14165,13 @@ references:
   title: &#39;TODO: Fetch title&#39;
   findings: []
 - id: PMID:7628435
-  title: A human phosphatidylinositol 3-kinase complex related to the yeast Vps34p-Vps15p protein sorting system.
+  title: A human phosphatidylinositol 3-kinase complex related to the yeast Vps34p-Vps15p protein
+    sorting system.
   findings: []
 - id: PMID:8999962
-  title: Characterization of p150, an adaptor protein for the human phosphatidylinositol (PtdIns) 3-kinase. Substrate presentation by phosphatidylinositol transfer protein to the p150.Ptdins 3-kinase complex.
+  title: Characterization of p150, an adaptor protein for the human phosphatidylinositol (PtdIns)
+    3-kinase. Substrate presentation by phosphatidylinositol transfer protein to the p150.Ptdins
+    3-kinase complex.
   findings: []
 - id: Reactome:R-HSA-109699
   title: &#39;TODO: Fetch title&#39;
@@ -10868,42 +14221,65 @@ references:
 - id: Reactome:R-HSA-9921171
   title: &#39;TODO: Fetch title&#39;
   findings: []
+- id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+  title: Falcon deep research synthesis for PIK3C3
+  findings: []
+- id: file:human/PIK3C3/PIK3C3-uniprot.txt
+  title: UniProt record for human PIK3C3
+  findings: []
+- id: file:reactome/R-HSA-5672012.md
+  title: Reactome autophagy initiation event containing PIK3C3
+  findings: []
 core_functions:
-  - molecular_function:
-      id: GO:0016303
-      label: 1-phosphatidylinositol-3-kinase activity
-    description: &gt;-
-      PIK3C3/VPS34 is the catalytic lipid kinase of the ATG14-containing class
-      III PI3K complex that generates PI3P at early autophagy membranes to
-      drive phagophore formation and autophagosome assembly during
-      macroautophagy.
-    directly_involved_in:
-      - id: GO:0036092
-        label: phosphatidylinositol-3-phosphate biosynthetic process
-      - id: GO:0000045
-        label: autophagosome assembly
-      - id: GO:0016236
-        label: macroautophagy
-    locations:
-      - id: GO:0000407
-        label: phagophore assembly site
-    in_complex:
-      id: GO:0034271
-      label: phosphatidylinositol 3-kinase complex, class III, type I
-    supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
-      - reference_id: PMID:40442316
-        supporting_text: PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase VPS15 and the regulatory subunits BECN1 and ATG14.
-      - reference_id: PMID:33637724
-        supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.
+- molecular_function:
+    id: GO:0016303
+    label: 1-phosphatidylinositol-3-kinase activity
+  description: PIK3C3/VPS34 is the catalytic lipid kinase of the ATG14-containing class III PI3K
+    complex that generates PI3P at early autophagy membranes to drive phagophore formation and
+    autophagosome assembly during macroautophagy.
+  directly_involved_in:
+  - id: GO:0036092
+    label: phosphatidylinositol-3-phosphate biosynthetic process
+  - id: GO:0000045
+    label: autophagosome assembly
+  - id: GO:0016236
+    label: macroautophagy
+  - id: GO:0097352
+    label: autophagosome maturation
+  locations:
+  - id: GO:0000407
+    label: phagophore assembly site
+  - id: GO:0005776
+    label: autophagosome
+  in_complex:
+    id: GO:0034271
+    label: phosphatidylinositol 3-kinase complex, class III, type I
+  supported_by:
+  - reference_id: PMID:7628435
+    supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not
+      PtdIns4P or PtdIns(4,5)P2.
+  - reference_id: PMID:40442316
+    supporting_text: PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase
+      VPS15 and the regulatory subunits BECN1 and ATG14
+  - reference_id: PMID:33637724
+    supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and
+      selective types of autophagy by controlling both autophagosome formation and maturation
+  - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+    supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+      3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+  - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+    supporting_text: &#39;**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+      + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.&#39;
+  - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+    supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+      membranes, supporting autophagosome initiation and early biogenesis.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/PIK3C3/PIK3C3-ai-review.yaml
+++ b/genes/human/PIK3C3/PIK3C3-ai-review.yaml
@@ -1,20 +1,17 @@
 id: Q8NEB9
 gene_symbol: PIK3C3
 product_type: PROTEIN
-status: IN_PROGRESS
+status: DRAFT
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: >-
-  PIK3C3 encodes VPS34, the catalytic lipid kinase of class III
-  phosphatidylinositol 3-kinase complexes. VPS34 generates
-  phosphatidylinositol 3-phosphate (PI3P) on endomembranes and operates in two
-  main Beclin 1-containing assemblies: PI3KC3-C1 with ATG14 for autophagosome
-  initiation and PI3KC3-C2 with UVRAG for endosomal sorting and later
-  autophagy-associated trafficking. In the proteostasis-network context, the
-  autophagy-initiation complex and macroautophagy are the central core claims,
-  whereas endosomal trafficking and cytokinesis are supported but contextual
-  extensions of the same VPS34 PI3P-generating biology.
+description: 'PIK3C3 encodes VPS34, the catalytic lipid kinase of class III phosphatidylinositol 3-kinase
+  complexes. VPS34 generates phosphatidylinositol 3-phosphate (PI3P) on endomembranes and operates in
+  two main Beclin 1-containing assemblies: PI3KC3-C1 with ATG14 for autophagosome initiation and PI3KC3-C2
+  with UVRAG for endosomal sorting and later autophagy-associated trafficking. In the proteostasis-network
+  context, the autophagy-initiation complex and macroautophagy are the central core claims, whereas endosomal
+  trafficking and cytokinesis are supported but contextual extensions of the same VPS34 PI3P-generating
+  biology.'
 existing_annotations:
 - term:
     id: GO:0005737
@@ -22,1261 +19,2149 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Cytoplasm is a broad but directionally compatible localization for a cytoplasmic
+      vesicle-associated lipid kinase.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 is best localized to specific autophagy and endosomal membranes/complexes;
+      cytoplasm is retained only as a broad contextual cellular-component annotation.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: As component of the PI3K complex I localized to pre-autophagosome structures.
+        As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).
 - term:
     id: GO:0016020
     label: membrane
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Membrane is too broad for PIK3C3 localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The evidence supports specific endomembrane contexts, especially
+      phagophore/autophagosome and endosomal membranes, rather than a generic membrane annotation.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: As component of the PI3K complex I localized to pre-autophagosome structures.
+        As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).
 - term:
     id: GO:0048015
     label: phosphatidylinositol-mediated signaling
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Phosphatidylinositol-mediated signaling is directionally related but too broad for
+      VPS34.
+    action: MODIFY
+    reason: The direct process output of PIK3C3 is PI3P biosynthesis, with downstream effects in
+      autophagosome formation and endosomal organization; the signaling parent term blurs that
+      specificity.
+    proposed_replacement_terms:
+    - id: GO:0036092
+      label: phosphatidylinositol-3-phosphate biosynthetic process
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:0006897
     label: endocytosis
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Endocytosis is supported only as a contextual trafficking role.
+    action: MODIFY
+    reason: PIK3C3 participates in endosomal PI3P-dependent trafficking and maturation, but
+      endocytosis itself is too broad; endosome organization or early-to-late endosome transport
+      better captures the supported role.
+    proposed_replacement_terms:
+    - id: GO:0007032
+      label: endosome organization
+    - id: GO:0045022
+      label: early endosome to late endosome transport
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0000425
     label: pexophagy
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Pexophagy is a selective-autophagy overextension for PIK3C3.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3C3 is core for canonical autophagy initiation and can support selective autophagy
+      generally, but this row does not provide human evidence for a specific pexophagy role.
+    proposed_replacement_terms:
+    - id: GO:0016236
+      label: macroautophagy
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0005768
     label: endosome
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: >-
-      PIK3C3 is active on endosomal membranes as part of the UVRAG-containing
-      PI3KC3-C2 complex. This localization is well supported but is contextual
-      relative to the core PN autophagy-initiation case.
+    summary: PIK3C3 is active on endosomal membranes as part of the UVRAG-containing PI3KC3-C2
+      complex. This localization is well supported but is contextual relative to the core PN
+      autophagy-initiation case.
     action: KEEP_AS_NON_CORE
-    reason: >-
-      Human VPS34 participates in a type II class III PI3K complex dedicated to
-      endosomal sorting and later autophagy-associated trafficking. That role
-      is real, but it is not the central PN framing for this gene.
+    reason: Human VPS34 participates in a type II class III PI3K complex dedicated to endosomal
+      sorting and later autophagy-associated trafficking. That role is real, but it is not the
+      central PN framing for this gene.
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation.
+    - reference_id: PMID:40442316
+      supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal
+        sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy
+        initiation5–7.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0000045
     label: autophagosome assembly
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: >-
-      Core PN function. VPS34 is required for autophagosome assembly through
-      the autophagy-initiating PI3KC3-C1 complex.
+    summary: Core PN function. VPS34 is required for autophagosome assembly through the
+      autophagy-initiating PI3KC3-C1 complex.
     action: ACCEPT
-    reason: >-
-      This is the central autophagy-complex biology for PIK3C3. VPS34-derived
-      PI3P is required for autophagosome formation, and human PI3KC3-C1 is now
-      structurally defined as an autophagy core complex.
+    reason: This is the central autophagy-complex biology for PIK3C3. VPS34-derived PI3P is required
+      for autophagosome formation, and human PI3KC3-C1 is now structurally defined as an autophagy
+      core complex.
     supported_by:
-      - reference_id: PMID:33637724
-        supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.
+    - reference_id: PMID:33637724
+      supporting_text: This complex catalyzes the production of PI3P and is required for both bulk
+        and selective types of autophagy by controlling both autophagosome formation and maturation
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0016303
     label: 1-phosphatidylinositol-3-kinase activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: >-
-      Core molecular function. PIK3C3/VPS34 is the class III lipid kinase that
-      phosphorylates phosphatidylinositol to generate PI3P.
+    summary: Core molecular function. PIK3C3/VPS34 is the class III lipid kinase that phosphorylates
+      phosphatidylinositol to generate PI3P.
     action: ACCEPT
-    reason: >-
-      Direct biochemical work established the substrate specificity of human
-      VPS34, and this specific lipid kinase activity remains the most precise MF
-      term for the gene product.
+    reason: Direct biochemical work established the substrate specificity of human VPS34, and this
+      specific lipid kinase activity remains the most precise MF term for the gene product.
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:0036092
     label: phosphatidylinositol-3-phosphate biosynthetic process
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: >-
-      Core process output of VPS34 catalytic activity. PIK3C3 generates PI3P for
+    summary: Core process output of VPS34 catalytic activity. PIK3C3 generates PI3P for
       autophagosome biogenesis and related membrane-trafficking pathways.
     action: ACCEPT
-    reason: >-
-      PI3P synthesis is the direct biochemical consequence of VPS34 activity and
-      is the process-level claim that best captures the shared output of the
-      type I and type II class III PI3K complexes.
+    reason: PI3P synthesis is the direct biochemical consequence of VPS34 activity and is the
+      process-level claim that best captures the shared output of the type I and type II class III
+      PI3K complexes.
     supported_by:
-      - reference_id: PMID:33637724
-        supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.
+    - reference_id: PMID:33637724
+      supporting_text: This complex catalyzes the production of PI3P and is required for both bulk
+        and selective types of autophagy by controlling both autophagosome formation and maturation
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
 - term:
     id: GO:0034271
     label: phosphatidylinositol 3-kinase complex, class III, type I
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: >-
-      Core PN complex membership. PIK3C3 is the catalytic subunit of PI3KC3-C1,
-      the ATG14-containing class III PI3K complex that initiates autophagy.
+    summary: Core PN complex membership. PIK3C3 is the catalytic subunit of PI3KC3-C1, the
+      ATG14-containing class III PI3K complex that initiates autophagy.
     action: ACCEPT
-    reason: >-
-      The type I complex is the core autophagy-initiation complex for VPS34 and
-      is the key PN-driven complex call that was previously missing locally.
+    reason: The type I complex is the core autophagy-initiation complex for VPS34 and is the key
+      PN-driven complex call that was previously missing locally.
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase VPS15 and the regulatory subunits BECN1 and ATG14.
+    - reference_id: PMID:40442316
+      supporting_text: PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase
+        VPS15 and the regulatory subunits BECN1 and ATG14
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
 - term:
     id: GO:0034272
     label: phosphatidylinositol 3-kinase complex, class III, type II
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: >-
-      PIK3C3 also participates in PI3KC3-C2, the UVRAG-containing class III PI3K
-      complex linked to endosomal sorting and later autophagy-associated
-      trafficking. This is supported but is contextual relative to the core PN
-      autophagy-initiation case.
+    summary: PIK3C3 also participates in PI3KC3-C2, the UVRAG-containing class III PI3K complex
+      linked to endosomal sorting and later autophagy-associated trafficking. This is supported but
+      is contextual relative to the core PN autophagy-initiation case.
     action: KEEP_AS_NON_CORE
-    reason: >-
-      Type II complex membership is well established, but the primary PN-focused
-      role for PIK3C3 is the autophagy-initiation complex PI3KC3-C1 rather than
-      the broader trafficking context.
+    reason: Type II complex membership is well established, but the primary PN-focused role for
+      PIK3C3 is the autophagy-initiation complex PI3KC3-C1 rather than the broader trafficking
+      context.
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation.
+    - reference_id: PMID:40442316
+      supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal
+        sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy
+        initiation5–7.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
 - term:
     id: GO:0000407
     label: phagophore assembly site
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: >-
-      Core localization for the autophagy-initiation role of PIK3C3. VPS34 acts
-      at the phagophore assembly site as part of PI3KC3-C1.
+    summary: Core localization for the autophagy-initiation role of PIK3C3. VPS34 acts at the
+      phagophore assembly site as part of PI3KC3-C1.
     action: ACCEPT
-    reason: >-
-      This term is consistent with the type I complex call and captures the
-      localization at which VPS34-derived PI3P seeds early autophagosome
-      biogenesis.
+    reason: This term is consistent with the type I complex call and captures the localization at
+      which VPS34-derived PI3P seeds early autophagosome biogenesis.
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: All forms of canonical autophagy, bulk and selective, are initiated upon the recruitment and activation of the FIP200 protein4 and the class III phosphatidylinositol 3-OH kinase complex I (PI3KC3-C1)5–7.
+    - reference_id: PMID:40442316
+      supporting_text: All forms of canonical autophagy, bulk and selective, are initiated upon the
+        recruitment and activation of the FIP200 protein4 and the class III phosphatidylinositol
+        3-OH kinase complex I (PI3KC3-C1)5–7.
 - term:
     id: GO:0005777
     label: peroxisome
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Peroxisome localization is not supported for PIK3C3.
+    action: REMOVE
+    reason: A pexophagy-related inference does not justify localizing PIK3C3 to the peroxisome;
+      curated locations place VPS34 at midbody, late endosome, cytoplasmic vesicle/autophagosome,
+      and pre-autophagosome/endosome contexts.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: As component of the PI3K complex I localized to pre-autophagosome structures.
+        As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).
 - term:
     id: GO:0000045
     label: autophagosome assembly
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: >-
-      Duplicate automated annotation for a reviewed core function. VPS34 is
-      required for autophagosome assembly.
+    summary: Duplicate automated annotation for a reviewed core function. VPS34 is required for
+      autophagosome assembly.
     action: ACCEPT
-    reason: >-
-      The multi-source IEA is consistent with direct human evidence and the
-      reviewed IBA/IDA annotations for the autophagy-initiation complex.
+    reason: The multi-source IEA is consistent with direct human evidence and the reviewed IBA/IDA
+      annotations for the autophagy-initiation complex.
     supported_by:
-      - reference_id: PMID:33637724
-        supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.
+    - reference_id: PMID:33637724
+      supporting_text: This complex catalyzes the production of PI3P and is required for both bulk
+        and selective types of autophagy by controlling both autophagosome formation and maturation
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0004672
     label: protein kinase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: >-
-      This annotation is categorically wrong. PIK3C3 is a
-      phosphatidylinositol 3-kinase, not a protein kinase.
+    summary: This annotation is categorically wrong. PIK3C3 is a phosphatidylinositol 3-kinase, not
+      a protein kinase.
     action: REMOVE
-    reason: >-
-      Direct biochemical evidence shows that VPS34 phosphorylates
-      phosphatidylinositol rather than protein substrates. This is the wrong
-      enzyme class, not a merely imprecise parent term, and the correct
-      molecular function is already captured by accepted
-      1-phosphatidylinositol-3-kinase activity annotations elsewhere in the
-      review.
+    reason: Direct biochemical evidence shows that VPS34 phosphorylates phosphatidylinositol rather
+      than protein substrates. This is the wrong enzyme class, not a merely imprecise parent term,
+      and the correct molecular function is already captured by accepted
+      1-phosphatidylinositol-3-kinase activity annotations elsewhere in the review.
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
 - term:
     id: GO:0007032
     label: endosome organization
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Endosome organization is a supported non-core PIK3C3 process.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3-derived PI3P helps define endosomal identity and trafficking, especially in the
+      UVRAG-containing type II complex, but the central reviewed function remains class III PI3K
+      activity in autophagy initiation.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0016236
     label: macroautophagy
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: >-
-      Core PN process. VPS34 is required for macroautophagy through PI3KC3-C1
-      mediated PI3P generation.
+    summary: Core PN process. VPS34 is required for macroautophagy through PI3KC3-C1 mediated PI3P
+      generation.
     action: ACCEPT
-    reason: >-
-      Conserved automated transfer is consistent with direct mammalian evidence
-      that class III PI3K activity is required for macroautophagy.
+    reason: Conserved automated transfer is consistent with direct mammalian evidence that class III
+      PI3K activity is required for macroautophagy.
     supported_by:
-      - reference_id: PMID:10625637
-        supporting_text: Transfection of a specific class III PI3K antisense oligonucleotide greatly inhibited the rate of macroautophagy.
+    - reference_id: PMID:10625637
+      supporting_text: Transfection of a specific class III PI3K antisense oligonucleotide greatly
+        inhibited the rate of macroautophagy.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0016485
     label: protein processing
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein processing is too generic for the supported trafficking role.
+    action: MODIFY
+    reason: Human and review evidence support PI3P-dependent endocytic membrane traffic, phagosome
+      maturation, autophagy, and lysosome-directed trafficking rather than protein processing as a
+      molecularly informative process.
+    proposed_replacement_terms:
+    - id: GO:0045022
+      label: early endosome to late endosome transport
+    - id: GO:0007032
+      label: endosome organization
+    supported_by:
+    - reference_id: PMID:16467569
+      supporting_text: By contrast, class III PI 3-kinases mainly mediate receptor-independent
+        trafficking events, which mostly are related to endocytic membrane traffic, phagosome
+        maturation and autophagy.
 - term:
     id: GO:0035032
     label: phosphatidylinositol 3-kinase complex, class III
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: >-
-      Generic class III complex membership is true but underspecified for human
-      PIK3C3.
+    summary: Generic class III complex membership is true but underspecified for human PIK3C3.
     action: MODIFY
-    reason: >-
-      Human VPS34 participates in both ATG14-containing PI3KC3-C1 and
-      UVRAG-containing PI3KC3-C2. The type-specific complex terms preserve the
-      autophagy-versus-trafficking split that matters for conservative curation.
+    reason: Human VPS34 participates in both ATG14-containing PI3KC3-C1 and UVRAG-containing
+      PI3KC3-C2. The type-specific complex terms preserve the autophagy-versus-trafficking split
+      that matters for conservative curation.
     proposed_replacement_terms:
-      - id: GO:0034271
-        label: phosphatidylinositol 3-kinase complex, class III, type I
-      - id: GO:0034272
-        label: phosphatidylinositol 3-kinase complex, class III, type II
+    - id: GO:0034271
+      label: phosphatidylinositol 3-kinase complex, class III, type I
+    - id: GO:0034272
+      label: phosphatidylinositol 3-kinase complex, class III, type II
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation.
+    - reference_id: PMID:40442316
+      supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal
+        sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy
+        initiation5–7.
 - term:
     id: GO:0042149
     label: cellular response to glucose starvation
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Glucose starvation response is a contextual autophagy input, not the core PIK3C3
+      function.
+    action: KEEP_AS_NON_CORE
+    reason: Starvation stimulates VPS34-dependent autophagy and PI3P production, but the reviewed
+      core function is the lipid kinase/autophagy-initiation activity rather than the
+      stimulus-response term itself.
+    proposed_replacement_terms:
+    - id: GO:0016236
+      label: macroautophagy
+    supported_by:
+    - reference_id: PMID:25327288
+      supporting_text: PIK-III acutely inhibits autophagy and de novo lipidation of LC3, and leads
+        to the stabilization of autophagy substrates.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0043201
     label: response to L-leucine
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Response to L-leucine is a nutrient-response overextension for PIK3C3.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3C3 participates in nutrient-sensitive autophagy pathways, but this specific
+      amino-acid response is not the direct activity or best-supported process for the gene product.
+    proposed_replacement_terms:
+    - id: GO:0016236
+      label: macroautophagy
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0043491
     label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: PI3K/AKT signal transduction conflates VPS34 with class I PI3K signaling.
+    action: REMOVE
+    reason: PIK3C3/VPS34 is a class III PI3K that produces PI3P from PI and should not be annotated
+      to the class I PI3K/AKT pathway without direct evidence.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:0045335
     label: phagocytic vesicle
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Phagocytic vesicle is a supported but non-core trafficking context.
+    action: KEEP_AS_NON_CORE
+    reason: Class III PI3Ks participate in phagosome maturation and endocytic membrane traffic, but
+      this is contextual relative to the core VPS34 lipid kinase/autophagy initiation function.
+    supported_by:
+    - reference_id: PMID:16467569
+      supporting_text: By contrast, class III PI 3-kinases mainly mediate receptor-independent
+        trafficking events, which mostly are related to endocytic membrane traffic, phagosome
+        maturation and autophagy.
 - term:
     id: GO:0048488
     label: synaptic vesicle endocytosis
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Synaptic vesicle endocytosis is an over-specific inference from a general endosomal
+      role.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3C3 supports endosomal PI3P-dependent trafficking, but the reviewed evidence here
+      does not establish a synaptic-vesicle-specific function.
+    proposed_replacement_terms:
+    - id: GO:0007032
+      label: endosome organization
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0098794
     label: postsynapse
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Postsynapse localization is not established as a reviewed PIK3C3 localization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The available human/Falcon evidence supports endosomal, autophagic, and midbody
+      contexts; synapse-specific localization is not part of the core or well-supported contextual
+      function.
+    proposed_replacement_terms:
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: As component of the PI3K complex I localized to pre-autophagosome structures.
+        As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).
 - term:
     id: GO:0098830
     label: presynaptic endosome
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Presynaptic endosome is too specific for the evidence used here.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Endosomal PI3P biology is supported, but this annotation narrows the localization to a
+      neuronal presynaptic compartment without direct evidence in the reviewed record.
+    proposed_replacement_terms:
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0098845
     label: postsynaptic endosome
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Postsynaptic endosome is too specific for the evidence used here.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Endosomal PI3P biology is supported, but this annotation narrows the localization to a
+      neuronal postsynaptic compartment without direct evidence in the reviewed record.
+    proposed_replacement_terms:
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0098978
     label: glutamatergic synapse
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Glutamatergic synapse localization is an unsupported specialization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3C3 has supported endosomal and autophagy-related localizations; the reviewed
+      evidence does not establish a glutamatergic synapse location.
+    proposed_replacement_terms:
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: As component of the PI3K complex I localized to pre-autophagosome structures.
+        As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).
 - term:
     id: GO:0098982
     label: GABA-ergic synapse
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: GABA-ergic synapse localization is an unsupported specialization.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3C3 has supported endosomal and autophagy-related localizations; the reviewed
+      evidence does not establish a GABA-ergic synapse location.
+    proposed_replacement_terms:
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: As component of the PI3K complex I localized to pre-autophagosome structures.
+        As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19050071
-  review: &protein_binding_overannotated
-    summary: >-
-      Protein binding is too generic to serve as an informative
-      molecular-function annotation for PIK3C3. Interaction-derived biology is
-      captured elsewhere through specific complex, localization, or process
-      terms.
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
     action: MARK_AS_OVER_ANNOTATED
-    reason: >-
-      Per project convention, `protein binding` should not be retained when it
-      does not convey a specific molecular function. For PIK3C3, these
-      interaction data inform complex membership and contextual pathway roles
-      rather than a standalone MF annotation.
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:20142477
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:20562859
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:21062745
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:22493499
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23316280
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23332761
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23364696
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23954414
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24034250
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24056303
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24472739
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24785657
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24849286
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25490155
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25594178
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:26496610
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:26783301
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:28514442
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:33422265
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:33961781
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:34386498
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:34524948
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:35271311
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005770
     label: late endosome
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Late endosome is a supported contextual localization for PIK3C3.
+    action: KEEP_AS_NON_CORE
+    reason: Late-endosome localization and endosomal trafficking are supported, especially through
+      the type II complex, but are contextual relative to the core autophagy-initiation function.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0005776
     label: autophagosome
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Autophagosome localization is supported for PIK3C3 autophagy biology.
+    action: ACCEPT
+    reason: PIK3C3 acts in autophagosome biogenesis through PI3KC3-C1 and is curated as associated
+      with cytoplasmic vesicle/autophagosome and pre-autophagosome structures.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: As component of the PI3K complex I localized to pre-autophagosome structures.
+        As component of the PI3K complex II localized predominantly to endosomes (PubMed:14617358).
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0016301
     label: kinase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: >-
-      Generic kinase activity is too broad here. The reviewed molecular function
-      for PIK3C3 should be the specific class III phosphatidylinositol 3-kinase
-      activity term.
+    summary: Generic kinase activity is too broad here. The reviewed molecular function for PIK3C3
+      should be the specific class III phosphatidylinositol 3-kinase activity term.
     action: MODIFY
-    reason: >-
-      Human VPS34 is a lipid kinase acting on phosphatidylinositol rather than a
-      generic kinase activity in the GO-review sense. The specific MF term is
-      available and better matches the direct biochemistry.
+    reason: Human VPS34 is a lipid kinase acting on phosphatidylinositol rather than a generic
+      kinase activity in the GO-review sense. The specific MF term is available and better matches
+      the direct biochemistry.
     proposed_replacement_terms:
-      - id: GO:0016303
-        label: 1-phosphatidylinositol-3-kinase activity
+    - id: GO:0016303
+      label: 1-phosphatidylinositol-3-kinase activity
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
 - term:
     id: GO:0016303
     label: 1-phosphatidylinositol-3-kinase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: >-
-      Automated duplicate of the reviewed core molecular function for PIK3C3.
-      VPS34 is the class III phosphatidylinositol 3-kinase.
+    summary: Automated duplicate of the reviewed core molecular function for PIK3C3. VPS34 is the
+      class III phosphatidylinositol 3-kinase.
     action: ACCEPT
-    reason: >-
-      The automated call is consistent with the direct biochemical literature
-      and with the accepted curated annotations for this gene.
+    reason: The automated call is consistent with the direct biochemical literature and with the
+      accepted curated annotations for this gene.
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:0016773
     label: phosphotransferase activity, alcohol group as acceptor
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: >-
-      This broad phosphotransferase term is less informative than the specific
-      class III phosphatidylinositol 3-kinase activity term that is available
-      for PIK3C3.
+    summary: This broad phosphotransferase term is less informative than the specific class III
+      phosphatidylinositol 3-kinase activity term that is available for PIK3C3.
     action: MODIFY
-    reason: >-
-      Human VPS34 has well-defined lipid-substrate specificity, so the specific
-      GO molecular function should replace this high-level transferase term.
+    reason: Human VPS34 has well-defined lipid-substrate specificity, so the specific GO molecular
+      function should replace this high-level transferase term.
     proposed_replacement_terms:
-      - id: GO:0016303
-        label: 1-phosphatidylinositol-3-kinase activity
+    - id: GO:0016303
+      label: 1-phosphatidylinositol-3-kinase activity
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
 - term:
     id: GO:0030496
     label: midbody
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Midbody localization is a supported non-core cytokinesis context.
+    action: KEEP_AS_NON_CORE
+    reason: Human PIK3C3 has experimental midbody localization and a PI3P-dependent cytokinesis
+      role, but this is not the main conserved function emphasized for this review.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Midbody {ECO:0000269|PubMed:20208530}. Late endosome
+        {ECO:0000269|PubMed:14617358}. Cytoplasmic vesicle, autophagosome
+        {ECO:0000305|PubMed:14617358}.
 - term:
     id: GO:0036092
     label: phosphatidylinositol-3-phosphate biosynthetic process
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: >-
-      Automated duplicate of a reviewed core process. VPS34-driven PI3P
-      generation is the central biochemical output of PIK3C3.
+    summary: Automated duplicate of a reviewed core process. VPS34-driven PI3P generation is the
+      central biochemical output of PIK3C3.
     action: ACCEPT
-    reason: >-
-      This specific process term correctly captures the immediate product of
-      VPS34 catalytic activity and is preferable to broader phosphoinositide
-      biosynthesis labels.
+    reason: This specific process term correctly captures the immediate product of VPS34 catalytic
+      activity and is preferable to broader phosphoinositide biosynthesis labels.
     supported_by:
-      - reference_id: PMID:33637724
-        supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.
+    - reference_id: PMID:33637724
+      supporting_text: This complex catalyzes the production of PI3P and is required for both bulk
+        and selective types of autophagy by controlling both autophagosome formation and maturation
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
 - term:
     id: GO:0046854
     label: phosphatidylinositol phosphate biosynthetic process
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: >-
-      The process is directionally correct but too broad. For PIK3C3 the
-      literature supports the specific PI3P biosynthetic process term.
+    summary: The process is directionally correct but too broad. For PIK3C3 the literature supports
+      the specific PI3P biosynthetic process term.
     action: MODIFY
-    reason: >-
-      Human VPS34 is specifically responsible for generating
-      phosphatidylinositol 3-phosphate rather than phosphatidylinositol
-      phosphates in general.
+    reason: Human VPS34 is specifically responsible for generating phosphatidylinositol 3-phosphate
+      rather than phosphatidylinositol phosphates in general.
     proposed_replacement_terms:
-      - id: GO:0036092
-        label: phosphatidylinositol-3-phosphate biosynthetic process
+    - id: GO:0036092
+      label: phosphatidylinositol-3-phosphate biosynthetic process
     supported_by:
-      - reference_id: PMID:33637724
-        supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.
+    - reference_id: PMID:33637724
+      supporting_text: This complex catalyzes the production of PI3P and is required for both bulk
+        and selective types of autophagy by controlling both autophagosome formation and maturation
 - term:
     id: GO:0006622
     label: protein targeting to lysosome
   evidence_type: NAS
   original_reference_id: PMID:16467569
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Protein targeting to lysosome is a contextual trafficking assignment.
+    action: MODIFY
+    reason: The accessible review evidence supports class III PI3K roles in endocytic membrane
+      traffic, phagosome maturation, and autophagy; a more informative term is endosome organization
+      or early-to-late endosome transport.
+    proposed_replacement_terms:
+    - id: GO:0007032
+      label: endosome organization
+    - id: GO:0045022
+      label: early endosome to late endosome transport
+    supported_by:
+    - reference_id: PMID:16467569
+      supporting_text: By contrast, class III PI 3-kinases mainly mediate receptor-independent
+        trafficking events, which mostly are related to endocytic membrane traffic, phagosome
+        maturation and autophagy.
 - term:
     id: GO:0010506
     label: regulation of autophagy
   evidence_type: IDA
   original_reference_id: PMID:16799551
   review:
-    summary: >-
-      This study supports PIK3C3 participation in macroautophagy, but
-      classifying VPS34 itself as a regulator is too indirect. The gene product
-      is part of the executing PI3KC3 complex.
+    summary: This study supports PIK3C3 participation in macroautophagy, but classifying VPS34
+      itself as a regulator is too indirect. The gene product is part of the executing PI3KC3
+      complex.
     action: MODIFY
-    reason: >-
-      PIK3C3 is not merely upstream of autophagy in this context; it is a core
-      catalytic component of the autophagy machinery. The process annotation
-      should therefore be macroautophagy rather than regulation of autophagy.
+    reason: PIK3C3 is not merely upstream of autophagy in this context; it is a core catalytic
+      component of the autophagy machinery. The process annotation should therefore be
+      macroautophagy rather than regulation of autophagy.
     proposed_replacement_terms:
-      - id: GO:0016236
-        label: macroautophagy
+    - id: GO:0016236
+      label: macroautophagy
     supported_by:
-      - reference_id: PMID:10625637
-        supporting_text: Transfection of a specific class III PI3K antisense oligonucleotide greatly inhibited the rate of macroautophagy.
+    - reference_id: PMID:10625637
+      supporting_text: Transfection of a specific class III PI3K antisense oligonucleotide greatly
+        inhibited the rate of macroautophagy.
 - term:
     id: GO:0016236
     label: macroautophagy
   evidence_type: NAS
   original_reference_id: PMID:40442316
   review:
-    summary: >-
-      Core PN process assignment. Human structural and mechanistic work places
-      PIK3C3 in the autophagy-initiating PI3KC3-C1 complex required for
-      macroautophagy.
+    summary: Core PN process assignment. Human structural and mechanistic work places PIK3C3 in the
+      autophagy-initiating PI3KC3-C1 complex required for macroautophagy.
     action: ACCEPT
-    reason: >-
-      The human literature now directly frames PI3KC3-C1 as an autophagy core
-      complex, which supports macroautophagy as a central process annotation for
-      PIK3C3.
+    reason: The human literature now directly frames PI3KC3-C1 as an autophagy core complex, which
+      supports macroautophagy as a central process annotation for PIK3C3.
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: All forms of canonical autophagy, bulk and selective, are initiated upon the recruitment and activation of the FIP200 protein4 and the class III phosphatidylinositol 3-OH kinase complex I (PI3KC3-C1)5–7.
+    - reference_id: PMID:40442316
+      supporting_text: All forms of canonical autophagy, bulk and selective, are initiated upon the
+        recruitment and activation of the FIP200 protein4 and the class III phosphatidylinositol
+        3-OH kinase complex I (PI3KC3-C1)5–7.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0016241
     label: regulation of macroautophagy
   evidence_type: IDA
   original_reference_id: PMID:10625637
   review:
-    summary: >-
-      The underlying result supports macroautophagy itself rather than a purely
-      regulatory role. PIK3C3 is required for the process.
+    summary: The underlying result supports macroautophagy itself rather than a purely regulatory
+      role. PIK3C3 is required for the process.
     action: MODIFY
-    reason: >-
-      In this experiment class III PI3K activity is necessary for
-      macroautophagy, so the process term is more appropriate than a regulation
-      term for PIK3C3.
+    reason: In this experiment class III PI3K activity is necessary for macroautophagy, so the
+      process term is more appropriate than a regulation term for PIK3C3.
     proposed_replacement_terms:
-      - id: GO:0016236
-        label: macroautophagy
+    - id: GO:0016236
+      label: macroautophagy
     supported_by:
-      - reference_id: PMID:10625637
-        supporting_text: Transfection of a specific class III PI3K antisense oligonucleotide greatly inhibited the rate of macroautophagy.
+    - reference_id: PMID:10625637
+      supporting_text: Transfection of a specific class III PI3K antisense oligonucleotide greatly
+        inhibited the rate of macroautophagy.
 - term:
     id: GO:0036092
     label: phosphatidylinositol-3-phosphate biosynthetic process
   evidence_type: IDA
   original_reference_id: PMID:8999962
   review:
-    summary: >-
-      Reviewed core process assignment. Human VPS34/p150 complex activity is
-      part of the specific PI3P-producing pathway.
+    summary: Reviewed core process assignment. Human VPS34/p150 complex activity is part of the
+      specific PI3P-producing pathway.
     action: ACCEPT
-    reason: >-
-      Across the human literature, VPS34 activity is consistently tied to PI3P
-      generation rather than a generic phosphoinositide biosynthetic role.
+    reason: Across the human literature, VPS34 activity is consistently tied to PI3P generation
+      rather than a generic phosphoinositide biosynthetic role.
     supported_by:
-      - reference_id: PMID:10625637
-        supporting_text: an increase in the class III PI3K product (phosphatidylinositol 3-phosphate), either by feeding cells with a synthetic lipid or by overexpressing the p150 adaptor, stimulates macroautophagy.
+    - reference_id: PMID:10625637
+      supporting_text: an increase in the class III PI3K product (phosphatidylinositol 3-phosphate),
+        either by feeding cells with a synthetic lipid or by overexpressing the p150 adaptor,
+        stimulates macroautophagy.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
 - term:
     id: GO:0045022
     label: early endosome to late endosome transport
   evidence_type: IDA
   original_reference_id: PMID:14617358
   review:
-    summary: >-
-      Human VPS34/p150 participates in Rab7-linked endosomal trafficking. This
-      is supported but is contextual relative to the core PN autophagy role.
+    summary: Human VPS34/p150 participates in Rab7-linked endosomal trafficking. This is supported
+      but is contextual relative to the core PN autophagy role.
     action: KEEP_AS_NON_CORE
-    reason: >-
-      The late-endosomal transport function is directly supported in human
-      cells, but it should be kept distinct from the autophagy-initiation
-      complex that defines the core PN case for PIK3C3.
+    reason: The late-endosomal transport function is directly supported in human cells, but it
+      should be kept distinct from the autophagy-initiation complex that defines the core PN case
+      for PIK3C3.
     supported_by:
-      - reference_id: PMID:14617358
-        supporting_text: The hVPS34/p150 complex colocalized with rab7 on late endosomes and hVPS34 activity was dependent on nucleotide cycling of rab7.
+    - reference_id: PMID:14617358
+      supporting_text: The hVPS34/p150 complex colocalized with rab7 on late endosomes and hVPS34
+        activity was dependent on nucleotide cycling of rab7.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0097352
     label: autophagosome maturation
   evidence_type: IDA
   original_reference_id: PMID:10625637
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Autophagosome maturation is supported as part of the core autophagy role.
+    action: ACCEPT
+    reason: Older macroautophagy evidence and newer VPS34 complex evidence support PIK3C3-dependent
+      PI3P production in autophagosome formation and maturation.
+    supported_by:
+    - reference_id: PMID:10625637
+      supporting_text: Transfection of a specific class III PI3K antisense oligonucleotide greatly
+        inhibited the rate of macroautophagy.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0016236
     label: macroautophagy
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-1632852
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Macroautophagy is a core PIK3C3 process.
+    action: ACCEPT
+    reason: Reactome and literature synthesis support PIK3C3/VPS34 as the catalytic component of the
+      class III PI3K complex needed for early autophagy.
+    supported_by:
+    - reference_id: file:reactome/R-HSA-5672012.md
+      supporting_text: PIK3C3 (VPS34), the catalytic component of this complex, is a class III
+        phosphatidylinositol 3-kinase that phosphorylates phosphatidylinositol (PI) producing
+        phosphatidylinositol 3-phosphate (PI3P).
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0016303
     label: 1-phosphatidylinositol-3-kinase activity
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5672012
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: The Reactome TAS row correctly captures the core VPS34 lipid kinase activity.
+    action: ACCEPT
+    reason: PIK3C3/VPS34 is the catalytic class III PI3K that phosphorylates phosphatidylinositol to
+      produce PI3P.
+    supported_by:
+    - reference_id: file:reactome/R-HSA-5672012.md
+      supporting_text: PIK3C3 (VPS34), the catalytic component of this complex, is a class III
+        phosphatidylinositol 3-kinase that phosphorylates phosphatidylinositol (PI) producing
+        phosphatidylinositol 3-phosphate (PI3P).
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:0016303
     label: 1-phosphatidylinositol-3-kinase activity
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6798174
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: The Reactome TAS row correctly captures the core VPS34 lipid kinase activity.
+    action: ACCEPT
+    reason: PIK3C3/VPS34 is the catalytic class III PI3K that phosphorylates phosphatidylinositol to
+      produce PI3P.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: IDA
   original_reference_id: PMID:17307798
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Plasma membrane localization could not be reviewed from accessible evidence.
+    action: UNDECIDED
+    reason: The cited PMID is not present in the local publication cache, and the Falcon/UniProt
+      evidence reviewed here supports endosomal/autophagic and midbody contexts rather than a clear
+      plasma-membrane localization.
 - term:
     id: GO:0045954
     label: positive regulation of natural killer cell mediated cytotoxicity
   evidence_type: IMP
   original_reference_id: PMID:17307798
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Natural killer cell-mediated cytotoxicity could not be reviewed from accessible
+      evidence.
+    action: UNDECIDED
+    reason: The cited PMID is not present in the local publication cache, and the Falcon report does
+      not cover this immune-cell phenotype sufficiently to decide whether the process annotation
+      should be retained.
 - term:
     id: GO:0052742
     label: phosphatidylinositol kinase activity
   evidence_type: IDA
   original_reference_id: PMID:7628435
   review:
-    summary: >-
-      The activity is valid but too general. Human VPS34 should be annotated to
-      the specific 1-phosphatidylinositol-3-kinase activity term.
+    summary: The activity is valid but too general. Human VPS34 should be annotated to the specific
+      1-phosphatidylinositol-3-kinase activity term.
     action: MODIFY
-    reason: >-
-      The original biochemical characterization resolved the substrate and the
-      3-position specificity, so the narrower MF term is warranted.
+    reason: The original biochemical characterization resolved the substrate and the 3-position
+      specificity, so the narrower MF term is warranted.
     proposed_replacement_terms:
-      - id: GO:0016303
-        label: 1-phosphatidylinositol-3-kinase activity
+    - id: GO:0016303
+      label: 1-phosphatidylinositol-3-kinase activity
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
 - term:
     id: GO:0016303
     label: 1-phosphatidylinositol-3-kinase activity
   evidence_type: IDA
   original_reference_id: PMID:25327288
   review:
-    summary: >-
-      Reviewed core molecular function. Later chemical-genetic work is fully
-      consistent with VPS34 as the relevant class III PI3 kinase.
+    summary: Reviewed core molecular function. Later chemical-genetic work is fully consistent with
+      VPS34 as the relevant class III PI3 kinase.
     action: ACCEPT
-    reason: >-
-      This term matches the established biochemical function of PIK3C3 and is
-      consistent with selective VPS34 inhibition experiments in human systems.
+    reason: This term matches the established biochemical function of PIK3C3 and is consistent with
+      selective VPS34 inhibition experiments in human systems.
     supported_by:
-      - reference_id: PMID:25327288
-        supporting_text: PIK-III is a selective inhibitor of VPS34 that binds a unique hydrophobic pocket not present in related kinases such as PI(3)Kα.
+    - reference_id: PMID:25327288
+      supporting_text: PIK-III is a selective inhibitor of VPS34 that binds a unique hydrophobic
+        pocket not present in related kinases such as PI(3)Kα.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:1903061
     label: positive regulation of protein lipidation
   evidence_type: IMP
   original_reference_id: PMID:25327288
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Positive regulation of protein lipidation is supported as a non-core autophagy pathway
+      effect.
+    action: KEEP_AS_NON_CORE
+    reason: Selective VPS34 inhibition blocks de novo LC3 lipidation, supporting an upstream
+      positive role in LC3 lipidation during autophagy, but the direct core function remains PI3P
+      synthesis.
+    supported_by:
+    - reference_id: PMID:25327288
+      supporting_text: PIK-III acutely inhibits autophagy and de novo lipidation of LC3, and leads
+        to the stabilization of autophagy substrates.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:30767700
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0044829
     label: host-mediated activation of viral genome replication
   evidence_type: IDA
   original_reference_id: PMID:34320401
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Viral genome replication activation could not be confidently reviewed from accessible
+      evidence.
+    action: UNDECIDED
+    reason: The cited PMID is not present in the local publication cache. Falcon evidence supports a
+      PIK3C3 role in Ebola virus entry via endocytic trafficking, but that is not the same as
+      host-mediated activation of viral genome replication.
 - term:
     id: GO:0000045
     label: autophagosome assembly
   evidence_type: IDA
   original_reference_id: PMID:33637724
   review:
-    summary: >-
-      Direct human evidence for a core PN process. VPS34 abundance and
-      regulation affect autophagosome formation.
+    summary: Direct human evidence for a core PN process. VPS34 abundance and regulation affect
+      autophagosome formation.
     action: ACCEPT
-    reason: >-
-      This study explicitly ties VPS34-controlled PI3P production to
-      autophagosome formation and maturation, which is central to the reviewed
-      biology of PIK3C3.
+    reason: This study explicitly ties VPS34-controlled PI3P production to autophagosome formation
+      and maturation, which is central to the reviewed biology of PIK3C3.
     supported_by:
-      - reference_id: PMID:33637724
-        supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.
+    - reference_id: PMID:33637724
+      supporting_text: This complex catalyzes the production of PI3P and is required for both bulk
+        and selective types of autophagy by controlling both autophagosome formation and maturation
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0046854
     label: phosphatidylinositol phosphate biosynthetic process
   evidence_type: IDA
   original_reference_id: PMID:7628435
   review:
-    summary: >-
-      The biochemical direction is correct but the term is too broad. The human
-      enzyme characterized here specifically supports PI3P biosynthesis.
+    summary: The biochemical direction is correct but the term is too broad. The human enzyme
+      characterized here specifically supports PI3P biosynthesis.
     action: MODIFY
-    reason: >-
-      The original paper established the specific phosphatidylinositol
-      3-kinase activity of human VPS34, which is more precisely captured by the
-      PI3P biosynthetic process term.
+    reason: The original paper established the specific phosphatidylinositol 3-kinase activity of
+      human VPS34, which is more precisely captured by the PI3P biosynthetic process term.
     proposed_replacement_terms:
-      - id: GO:0036092
-        label: phosphatidylinositol-3-phosphate biosynthetic process
+    - id: GO:0036092
+      label: phosphatidylinositol-3-phosphate biosynthetic process
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:33473107
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:28890335
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:31806350
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0032465
     label: regulation of cytokinesis
   evidence_type: IMP
   original_reference_id: PMID:20208530
   review:
-    summary: >-
-      Human PIK3C3 contributes to cytokinesis through a PI3P-dependent midbody
-      pathway. This role is supported but is contextual relative to the core PN
-      autophagy case.
+    summary: Human PIK3C3 contributes to cytokinesis through a PI3P-dependent midbody pathway. This
+      role is supported but is contextual relative to the core PN autophagy case.
     action: KEEP_AS_NON_CORE
-    reason: >-
-      The cytokinesis phenotype is convincing, but it reflects a contextual
-      deployment of VPS34 PI3P biology rather than the primary autophagy-focused
-      role being curated here.
+    reason: The cytokinesis phenotype is convincing, but it reflects a contextual deployment of
+      VPS34 PI3P biology rather than the primary autophagy-focused role being curated here.
     supported_by:
-      - reference_id: PMID:20208530
-        supporting_text: Depletion of the VPS34 or Beclin 1 subunits of PI(3)K-III causes cytokinesis arrest and an increased number of binucleate and multinucleate cells, in a similar manner to the depletion of FYVE-CENT, KIF13A or TTC19.
+    - reference_id: PMID:20208530
+      supporting_text: Depletion of the VPS34 or Beclin 1 subunits of PI(3)K-III causes cytokinesis
+        arrest and an increased number of binucleate and multinucleate cells, in a similar manner to
+        the depletion of FYVE-CENT, KIF13A or TTC19.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:28479384
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:22095288
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0006914
     label: autophagy
   evidence_type: IMP
   original_reference_id: PMID:25327288
   review:
-    summary: >-
-      The biology is correct but the process term is too general. For PIK3C3
-      the literature supports macroautophagy specifically.
+    summary: The biology is correct but the process term is too general. For PIK3C3 the literature
+      supports macroautophagy specifically.
     action: MODIFY
-    reason: >-
-      VPS34 inhibition in this study blocks the canonical autophagy pathway
-      tracked by LC3 lipidation and autophagy-substrate turnover, which is
-      better captured as macroautophagy.
+    reason: VPS34 inhibition in this study blocks the canonical autophagy pathway tracked by LC3
+      lipidation and autophagy-substrate turnover, which is better captured as macroautophagy.
     proposed_replacement_terms:
-      - id: GO:0016236
-        label: macroautophagy
+    - id: GO:0016236
+      label: macroautophagy
     supported_by:
-      - reference_id: PMID:25327288
-        supporting_text: PIK-III acutely inhibits autophagy and de novo lipidation of LC3, and leads to the stabilization of autophagy substrates.
+    - reference_id: PMID:25327288
+      supporting_text: PIK-III acutely inhibits autophagy and de novo lipidation of LC3, and leads
+        to the stabilization of autophagy substrates.
 - term:
     id: GO:0044754
     label: autolysosome
   evidence_type: IDA
   original_reference_id: PMID:25327288
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Autolysosome localization is over-annotated from an inhibitor/substrate study.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The cited inhibitor study supports VPS34-dependent autophagy and NCOA4/ferritin delivery
+      to autolysosomes, but it does not directly place PIK3C3 itself in the autolysosome.
+    proposed_replacement_terms:
+    - id: GO:0005776
+      label: autophagosome
+    - id: GO:0016236
+      label: macroautophagy
+    supported_by:
+    - reference_id: PMID:25327288
+      supporting_text: NCOA4 directly binds ferritin heavy chain-1 (FTH1) to target the iron-binding
+        ferritin complex with a relative molecular mass of 450,000 to autolysosomes following
+        starvation or iron depletion.
 - term:
     id: GO:0030670
     label: phagocytic vesicle membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6798174
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Phagocytic vesicle membrane is a supported but non-core trafficking context.
+    action: KEEP_AS_NON_CORE
+    reason: Class III PI3Ks are linked to phagosome maturation and endocytic membrane traffic; this
+      contextual membrane role should not displace the core autophagy-initiation complex function.
+    supported_by:
+    - reference_id: PMID:16467569
+      supporting_text: By contrast, class III PI 3-kinases mainly mediate receptor-independent
+        trafficking events, which mostly are related to endocytic membrane traffic, phagosome
+        maturation and autophagy.
 - term:
     id: GO:0032465
     label: regulation of cytokinesis
   evidence_type: IMP
   original_reference_id: PMID:20643123
   review:
-    summary: >-
-      Supported contextual role for a UVRAG/BIF-1-containing PI3K-III subcomplex
-      in cytokinesis. This remains outside the core PN autophagy framing.
+    summary: Supported contextual role for a UVRAG/BIF-1-containing PI3K-III subcomplex in
+      cytokinesis. This remains outside the core PN autophagy framing.
     action: KEEP_AS_NON_CORE
-    reason: >-
-      The human data support a real cytokinesis role for a VPS34-containing
-      complex, but the review should keep this separate from the central
-      autophagy-initiation assignment.
+    reason: The human data support a real cytokinesis role for a VPS34-containing complex, but the
+      review should keep this separate from the central autophagy-initiation assignment.
     supported_by:
-      - reference_id: PMID:20643123
-        supporting_text: High-content microscopy-based assays combined with siRNA-mediated depletion of individual subunits indicated that a specific sub-complex containing VPS15, VPS34, Beclin 1, UVRAG and BIF-1 regulates both receptor degradation and cytokinesis, whereas ATG14L, a PI3K-III subunit involved in autophagy, is not required.
+    - reference_id: PMID:20643123
+      supporting_text: High-content microscopy-based assays combined with siRNA-mediated depletion
+        of individual subunits indicated that a specific sub-complex containing VPS15, VPS34, Beclin
+        1, UVRAG and BIF-1 regulates both receptor degradation and cytokinesis, whereas ATG14L, a
+        PI3K-III subunit involved in autophagy, is not required.
 - term:
     id: GO:0016236
     label: macroautophagy
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: >-
-      Conservative orthology-supported duplicate of a core process assignment.
-      Macroautophagy is appropriate for human PIK3C3.
+    summary: Conservative orthology-supported duplicate of a core process assignment. Macroautophagy
+      is appropriate for human PIK3C3.
     action: ACCEPT
-    reason: >-
-      This transfer is consistent with direct human evidence for VPS34 in the
+    reason: This transfer is consistent with direct human evidence for VPS34 in the
       autophagy-initiating PI3KC3-C1 complex.
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: All forms of canonical autophagy, bulk and selective, are initiated upon the recruitment and activation of the FIP200 protein4 and the class III phosphatidylinositol 3-OH kinase complex I (PI3KC3-C1)5–7.
+    - reference_id: PMID:40442316
+      supporting_text: All forms of canonical autophagy, bulk and selective, are initiated upon the
+        recruitment and activation of the FIP200 protein4 and the class III phosphatidylinositol
+        3-OH kinase complex I (PI3KC3-C1)5–7.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0035032
     label: phosphatidylinositol 3-kinase complex, class III
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: >-
-      The generic class III PI3K complex term is true but underspecified for
-      human PIK3C3. The literature supports explicit type I and type II complex
-      membership.
+    summary: The generic class III PI3K complex term is true but underspecified for human PIK3C3.
+      The literature supports explicit type I and type II complex membership.
     action: MODIFY
-    reason: >-
-      For this gene, the main curatorial distinction is between the
-      autophagy-initiating PI3KC3-C1/type I complex and the contextual
-      endosomal PI3KC3-C2/type II complex.
+    reason: For this gene, the main curatorial distinction is between the autophagy-initiating
+      PI3KC3-C1/type I complex and the contextual endosomal PI3KC3-C2/type II complex.
     proposed_replacement_terms:
-      - id: GO:0034271
-        label: phosphatidylinositol 3-kinase complex, class III, type I
-      - id: GO:0034272
-        label: phosphatidylinositol 3-kinase complex, class III, type II
+    - id: GO:0034271
+      label: phosphatidylinositol 3-kinase complex, class III, type I
+    - id: GO:0034272
+      label: phosphatidylinositol 3-kinase complex, class III, type II
     supported_by:
-      - reference_id: PMID:40442316
-        supporting_text: PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase VPS15 and the regulatory subunits BECN1 and ATG14.
-      - reference_id: PMID:40442316
-        supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy initiation.
+    - reference_id: PMID:40442316
+      supporting_text: PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase
+        VPS15 and the regulatory subunits BECN1 and ATG14
+    - reference_id: PMID:40442316
+      supporting_text: The former three subunits are also present in PI3KC3-C2 involved in endosomal
+        sorting and late steps in autophagy, while ATG14 is uniquely involved in autophagy
+        initiation5–7.
 - term:
     id: GO:0042149
     label: cellular response to glucose starvation
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Glucose starvation response is a contextual autophagy input, not the core PIK3C3
+      function.
+    action: KEEP_AS_NON_CORE
+    reason: Starvation-dependent autophagy is a supported context for VPS34 action, but the direct
+      conserved role is PI3P production in autophagy and endosomal pathways.
+    proposed_replacement_terms:
+    - id: GO:0016236
+      label: macroautophagy
+    supported_by:
+    - reference_id: PMID:25327288
+      supporting_text: PIK-III acutely inhibits autophagy and de novo lipidation of LC3, and leads
+        to the stabilization of autophagy substrates.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+        membranes, supporting autophagosome initiation and early biogenesis.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23878393
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0016020
     label: membrane
   evidence_type: HDA
   original_reference_id: PMID:19946888
   review:
-    summary: >-
-      This broad membrane localization call is not reliable enough for manual
-      retention. The source is large-scale membrane proteomics with many
-      transiently associated proteins.
-    action: REMOVE
-    reason: >-
-      The paper does not establish a specific or stable membrane localization
-      for PIK3C3 beyond broad proteomic association, so this annotation is too
-      weak and uninformative to retain.
+    summary: Broad membrane association from large-scale proteomics is weak and uninformative for
+      PIK3C3.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3C3 is a cytosolic/peripheral lipid kinase recruited to autophagy and endosomal
+      membranes, so generic membrane association is not entirely wrong, but this broad HDA row is
+      not specific enough for the reviewed function.
     supported_by:
-      - reference_id: PMID:19946888
-        supporting_text: The remaining species were largely involved in cellular processes and molecular functions that could be predicted to be transiently associated with membranes.
+    - reference_id: PMID:19946888
+      supporting_text: The remaining species were largely involved in cellular processes and
+        molecular functions that could be predicted to be transiently associated with membranes.
 - term:
     id: GO:0005930
     label: axoneme
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Axoneme localization is supported only by similarity and is non-core.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records a ciliary axoneme localization by similarity, but the reviewed human
+      core function is VPS34 lipid kinase activity in autophagy/endosomal complexes.
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-uniprot.txt
+      supporting_text: Also localizes to discrete punctae along the ciliary axoneme and to the base
+        of the ciliary axoneme (By similarity).
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:19270696
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:14617358
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005770
     label: late endosome
   evidence_type: IDA
   original_reference_id: PMID:14617358
   review:
-    summary: >-
-      Supported contextual localization. Human VPS34/p150 colocalizes with Rab7
-      on late endosomes.
+    summary: Supported contextual localization. Human VPS34/p150 colocalizes with Rab7 on late
+      endosomes.
     action: KEEP_AS_NON_CORE
-    reason: >-
-      The localization is directly supported in human cells, but it belongs to
-      the contextual endosomal-trafficking side of PIK3C3 biology rather than
-      the core PN autophagy claim.
+    reason: The localization is directly supported in human cells, but it belongs to the contextual
+      endosomal-trafficking side of PIK3C3 biology rather than the core PN autophagy claim.
     supported_by:
-      - reference_id: PMID:14617358
-        supporting_text: The hVPS34/p150 complex colocalized with rab7 on late endosomes and hVPS34 activity was dependent on nucleotide cycling of rab7.
+    - reference_id: PMID:14617358
+      supporting_text: The hVPS34/p150 complex colocalized with rab7 on late endosomes and hVPS34
+        activity was dependent on nucleotide cycling of rab7.
 - term:
     id: GO:0045022
     label: early endosome to late endosome transport
   evidence_type: IMP
   original_reference_id: PMID:14617358
   review:
-    summary: >-
-      Contextual trafficking role supported by human Rab7/VPS34 data.
-      Appropriate to retain as non-core.
+    summary: Contextual trafficking role supported by human Rab7/VPS34 data. Appropriate to retain
+      as non-core.
     action: KEEP_AS_NON_CORE
-    reason: >-
-      This transport function is part of the broader endosomal deployment of
-      VPS34 PI3P signaling and should remain separate from the core
-      macroautophagy-focused curation.
+    reason: This transport function is part of the broader endosomal deployment of VPS34 PI3P
+      signaling and should remain separate from the core macroautophagy-focused curation.
     supported_by:
-      - reference_id: PMID:14617358
-        supporting_text: The data identify rab7 as an important regulator of late endosomal hVPS34 function and link rab7 to the regulation of phosphatidylinositol 3'-kinase cycling between early and late endosomes.
+    - reference_id: PMID:14617358
+      supporting_text: The data identify rab7 as an important regulator of late endosomal hVPS34
+        function and link rab7 to the regulation of phosphatidylinositol 3'-kinase cycling between
+        early and late endosomes.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 activity is strongly tied to **endosomal PI3P pools** that define
+        **early endosome identity** and sorting, and PI3P serves as a platform for downstream
+        trafficking and maturation processes.
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-109699
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-1632857
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-1675939
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-1675961
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-1676024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-188002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5672012
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5678313
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5678315
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5679205
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5679266
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5682385
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9755359
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9921171
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: Cytosol is a broad Reactome component assignment for PIK3C3 pathway events.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3C3 complexes are cytosolic/peripheral membrane assemblies recruited to autophagy and
+      endosomal membranes; the cytosol rows are retained as non-core pathway context rather than
+      precise localization.
+    proposed_replacement_terms:
+    - id: GO:0000407
+      label: phagophore assembly site
+    - id: GO:0005768
+      label: endosome
+    supported_by:
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome
+        nucleation**.'
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: '**PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+        + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related
+        trafficking.'
 - term:
     id: GO:0016303
     label: 1-phosphatidylinositol-3-kinase activity
   evidence_type: IMP
   original_reference_id: PMID:20208530
   review:
-    summary: >-
-      Contextual cytokinesis paper, but the molecular function assignment itself
-      is core and remains correct for PIK3C3.
+    summary: Contextual cytokinesis paper, but the molecular function assignment itself is core and
+      remains correct for PIK3C3.
     action: ACCEPT
-    reason: >-
-      Even though this paper focuses on cytokinesis, it does so through the
-      catalytic PI3P-generating activity of the class III PI3K complex.
+    reason: Even though this paper focuses on cytokinesis, it does so through the catalytic
+      PI3P-generating activity of the class III PI3K complex.
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 - term:
     id: GO:0030496
     label: midbody
   evidence_type: IDA
   original_reference_id: PMID:20208530
   review:
-    summary: >-
-      Midbody association is part of a supported cytokinesis-specific context
-      for VPS34 biology and should not be treated as core PN localization.
+    summary: Midbody association is part of a supported cytokinesis-specific context for VPS34
+      biology and should not be treated as core PN localization.
     action: KEEP_AS_NON_CORE
-    reason: >-
-      The cytokinesis paper supports a midbody-linked PI3P pathway, but this is
-      a contextual deployment of VPS34 rather than the primary autophagy
-      localization used for core-function synthesis.
+    reason: The cytokinesis paper supports a midbody-linked PI3P pathway, but this is a contextual
+      deployment of VPS34 rather than the primary autophagy localization used for core-function
+      synthesis.
     supported_by:
-      - reference_id: PMID:20208530
-        supporting_text: We show that PtdIns(3)P localizes to the midbody during cytokinesis and recruits a centrosomal protein, FYVE-CENT (ZFYVE26), and its binding partner TTC19, which in turn interacts with CHMP4B, an endosomal sorting complex required for transport (ESCRT)-III subunit implicated in the abscission step of cytokinesis.
+    - reference_id: PMID:20208530
+      supporting_text: We show that PtdIns(3)P localizes to the midbody during cytokinesis and
+        recruits a centrosomal protein, FYVE-CENT (ZFYVE26), and its binding partner TTC19, which in
+        turn interacts with CHMP4B, an endosomal sorting complex required for transport (ESCRT)-III
+        subunit implicated in the abscission step of cytokinesis.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16417406
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:7504174
-  review: *protein_binding_overannotated
+  review:
+    summary: Protein binding is too generic to serve as an informative molecular-function annotation
+      for PIK3C3. Interaction-derived biology is captured elsewhere through specific complex,
+      localization, or process terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Per project convention, `protein binding` should not be retained when it does not convey
+      a specific molecular function. For PIK3C3, these interaction data inform complex membership
+      and contextual pathway roles rather than a standalone MF annotation.
 - term:
     id: GO:0016303
     label: 1-phosphatidylinositol-3-kinase activity
   evidence_type: TAS
   original_reference_id: PMID:7628435
   review:
-    summary: >-
-      Literature-traceable duplicate of the reviewed core molecular function.
-      Human VPS34 is the phosphatidylinositol 3-kinase.
+    summary: Literature-traceable duplicate of the reviewed core molecular function. Human VPS34 is
+      the phosphatidylinositol 3-kinase.
     action: ACCEPT
-    reason: >-
-      This term directly reflects the original biochemical characterization of
-      the human enzyme and should be retained.
+    reason: This term directly reflects the original biochemical characterization of the human
+      enzyme and should be retained.
     supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: PMID:7628435
+      supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but
+        not PtdIns4P or PtdIns(4,5)P2.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+        3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+    - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+      supporting_text: VPS34 is described as **exclusively catalyzing PI3P production from
+        phosphatidylinositol (PI) in vitro and in vivo**
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
 - id: GO_REF:0000024
-  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs by
+    curator judgment of sequence similarity
   findings: []
 - id: GO_REF:0000033
   title: Annotation inferences using phylogenetic trees
@@ -1285,7 +2170,8 @@ references:
   title: 'TODO: Fetch title'
   findings: []
 - id: GO_REF:0000107
-  title: Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara
+  title: Automatic transfer of experimentally verified manual GO annotation data to orthologs using
+    Ensembl Compara
   findings: []
 - id: GO_REF:0000117
   title: Electronic Gene Ontology annotations created by ARBA machine learning models
@@ -1294,7 +2180,8 @@ references:
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:10625637
-  title: Distinct classes of phosphatidylinositol 3'-kinases are involved in signaling pathways that control macroautophagy in HT-29 cells.
+  title: Distinct classes of phosphatidylinositol 3'-kinases are involved in signaling pathways that
+    control macroautophagy in HT-29 cells.
   findings: []
 - id: PMID:14617358
   title: Human VPS34 and p150 are Rab7 interacting partners.
@@ -1324,13 +2211,15 @@ references:
   title: 'TODO: Fetch title'
   findings: []
 - id: PMID:20208530
-  title: PtdIns(3)P controls cytokinesis through KIF13A-mediated recruitment of FYVE-CENT to the midbody.
+  title: PtdIns(3)P controls cytokinesis through KIF13A-mediated recruitment of FYVE-CENT to the
+    midbody.
   findings: []
 - id: PMID:20562859
   title: 'TODO: Fetch title'
   findings: []
 - id: PMID:20643123
-  title: A phosphatidylinositol 3-kinase class III sub-complex containing VPS15, VPS34, Beclin 1, UVRAG and BIF-1 regulates cytokinesis and degradative endocytic traffic.
+  title: A phosphatidylinositol 3-kinase class III sub-complex containing VPS15, VPS34, Beclin 1,
+    UVRAG and BIF-1 regulates cytokinesis and degradative endocytic traffic.
   findings: []
 - id: PMID:21062745
   title: 'TODO: Fetch title'
@@ -1372,7 +2261,8 @@ references:
   title: 'TODO: Fetch title'
   findings: []
 - id: PMID:25327288
-  title: Selective VPS34 inhibitor blocks autophagy and uncovers a role for NCOA4 in ferritin degradation and iron homeostasis in vivo.
+  title: Selective VPS34 inhibitor blocks autophagy and uncovers a role for NCOA4 in ferritin
+    degradation and iron homeostasis in vivo.
   findings: []
 - id: PMID:25490155
   title: 'TODO: Fetch title'
@@ -1408,7 +2298,8 @@ references:
   title: 'TODO: Fetch title'
   findings: []
 - id: PMID:33637724
-  title: VPS34 K29/K48 branched ubiquitination governed by UBE3C and TRABID regulates autophagy, proteostasis and liver metabolism.
+  title: VPS34 K29/K48 branched ubiquitination governed by UBE3C and TRABID regulates autophagy,
+    proteostasis and liver metabolism.
   findings: []
 - id: PMID:33961781
   title: 'TODO: Fetch title'
@@ -1432,10 +2323,13 @@ references:
   title: 'TODO: Fetch title'
   findings: []
 - id: PMID:7628435
-  title: A human phosphatidylinositol 3-kinase complex related to the yeast Vps34p-Vps15p protein sorting system.
+  title: A human phosphatidylinositol 3-kinase complex related to the yeast Vps34p-Vps15p protein
+    sorting system.
   findings: []
 - id: PMID:8999962
-  title: Characterization of p150, an adaptor protein for the human phosphatidylinositol (PtdIns) 3-kinase. Substrate presentation by phosphatidylinositol transfer protein to the p150.Ptdins 3-kinase complex.
+  title: Characterization of p150, an adaptor protein for the human phosphatidylinositol (PtdIns)
+    3-kinase. Substrate presentation by phosphatidylinositol transfer protein to the p150.Ptdins
+    3-kinase complex.
   findings: []
 - id: Reactome:R-HSA-109699
   title: 'TODO: Fetch title'
@@ -1485,32 +2379,55 @@ references:
 - id: Reactome:R-HSA-9921171
   title: 'TODO: Fetch title'
   findings: []
+- id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+  title: Falcon deep research synthesis for PIK3C3
+  findings: []
+- id: file:human/PIK3C3/PIK3C3-uniprot.txt
+  title: UniProt record for human PIK3C3
+  findings: []
+- id: file:reactome/R-HSA-5672012.md
+  title: Reactome autophagy initiation event containing PIK3C3
+  findings: []
 core_functions:
-  - molecular_function:
-      id: GO:0016303
-      label: 1-phosphatidylinositol-3-kinase activity
-    description: >-
-      PIK3C3/VPS34 is the catalytic lipid kinase of the ATG14-containing class
-      III PI3K complex that generates PI3P at early autophagy membranes to
-      drive phagophore formation and autophagosome assembly during
-      macroautophagy.
-    directly_involved_in:
-      - id: GO:0036092
-        label: phosphatidylinositol-3-phosphate biosynthetic process
-      - id: GO:0000045
-        label: autophagosome assembly
-      - id: GO:0016236
-        label: macroautophagy
-    locations:
-      - id: GO:0000407
-        label: phagophore assembly site
-    in_complex:
-      id: GO:0034271
-      label: phosphatidylinositol 3-kinase complex, class III, type I
-    supported_by:
-      - reference_id: PMID:7628435
-        supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not PtdIns4P or PtdIns(4,5)P2.
-      - reference_id: PMID:40442316
-        supporting_text: PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase VPS15 and the regulatory subunits BECN1 and ATG14.
-      - reference_id: PMID:33637724
-        supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and selective types of autophagy by controlling both autophagosome formation and maturation.
+- molecular_function:
+    id: GO:0016303
+    label: 1-phosphatidylinositol-3-kinase activity
+  description: PIK3C3/VPS34 is the catalytic lipid kinase of the ATG14-containing class III PI3K
+    complex that generates PI3P at early autophagy membranes to drive phagophore formation and
+    autophagosome assembly during macroautophagy.
+  directly_involved_in:
+  - id: GO:0036092
+    label: phosphatidylinositol-3-phosphate biosynthetic process
+  - id: GO:0000045
+    label: autophagosome assembly
+  - id: GO:0016236
+    label: macroautophagy
+  - id: GO:0097352
+    label: autophagosome maturation
+  locations:
+  - id: GO:0000407
+    label: phagophore assembly site
+  - id: GO:0005776
+    label: autophagosome
+  in_complex:
+    id: GO:0034271
+    label: phosphatidylinositol 3-kinase complex, class III, type I
+  supported_by:
+  - reference_id: PMID:7628435
+    supporting_text: PtdIns 3-kinase does not associate with p85 and phosphorylates PtdIns, but not
+      PtdIns4P or PtdIns(4,5)P2.
+  - reference_id: PMID:40442316
+    supporting_text: PI3KC3-C1 contains one copy each of the lipid kinase VPS34, the pseudokinase
+      VPS15 and the regulatory subunits BECN1 and ATG14
+  - reference_id: PMID:33637724
+    supporting_text: This complex catalyzes the production of PI3P and is required for both bulk and
+      selective types of autophagy by controlling both autophagosome formation and maturation
+  - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+    supporting_text: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol
+      3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**.
+  - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+    supporting_text: '**PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1**
+      + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**.'
+  - reference_id: file:human/PIK3C3/PIK3C3-deep-research-falcon.md
+    supporting_text: VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore
+      membranes, supporting autophagosome initiation and early biogenesis.

--- a/genes/human/PIK3C3/PIK3C3-deep-research-falcon.md
+++ b/genes/human/PIK3C3/PIK3C3-deep-research-falcon.md
@@ -1,0 +1,185 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-12T07:20:13.222491'
+end_time: '2026-05-12T07:27:33.020845'
+duration_seconds: 439.8
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 28
+---
+
+## Question
+
+Perform concise GO-focused deep research on the human PIK3C3 gene (UniProt Q8NEB9; phosphatidylinositol 3-kinase catalytic subunit type 3/Vps34). Summarize the core molecular function, major biological processes, cellular locations, key experimental evidence, and any GO annotation caveats. Include PMID or DOI citations where available, and keep the report focused for gene annotation review.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+Perform concise GO-focused deep research on the human PIK3C3 gene (UniProt Q8NEB9; phosphatidylinositol 3-kinase catalytic subunit type 3/Vps34). Summarize the core molecular function, major biological processes, cellular locations, key experimental evidence, and any GO annotation caveats. Include PMID or DOI citations where available, and keep the report focused for gene annotation review.
+
+## GO-focused gene annotation research report: human **PIK3C3** (VPS34) (UniProt Q8NEB9)
+
+### 1) Key concepts and definitions (current understanding)
+
+**Gene/protein**: Human **PIK3C3** encodes **VPS34**, the *class III phosphatidylinositol 3-kinase* catalytic subunit that produces **phosphatidylinositol 3-phosphate (PI3P)**. In the most authoritative recent pharmacology-focused synthesis, VPS34 is described as **exclusively catalyzing PI3P production from phosphatidylinositol (PI) in vitro and in vivo**—a key point for GO molecular function specificity (i.e., not generating PIP3 from PI(4,5)P2 as class I PI3Ks do). (burke2023beyondpi3kstargeting pages 22-23)
+
+**GO-relevant biochemical reaction** (MF + BP):
+- Substrate/product specificity for curation: **PI → PI3P** (phosphatidylinositol 3-phosphate biosynthesis) as the defining catalytic activity of VPS34. (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 1-2)
+
+**Complex architecture and nomenclature** (GO CC + context for BP): VPS34 functions as a subunit of two **distinct tetrameric complexes**:
+- **PI3KC3 Complex I (PI3KC3-C1)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **ATG14**. This complex is classically associated with **autophagy initiation/autophagosome nucleation**. (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 1-2, chau2024thecellularadaptor pages 1-2)
+- **PI3KC3 Complex II (PI3KC3-C2)**: VPS34 (**PIK3C3**) + **VPS15 (PIK3R4)** + **BECN1** + **UVRAG**, classically associated with **endocytic sorting/endosome maturation** and related trafficking. (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 1-2)
+
+**Key regulators frequently relevant to annotation context**:
+- **NRBF2**: described as an activator of **Complex I** (and thus relevant when annotating autophagy-initiation-linked PI3P production). (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 12-12)
+- **Rubicon (RUBCN)**: described as a Complex-II-associated regulator that can modulate autophagy stages and endocytic roles in a context-dependent manner; it contributes to why Complex I vs II should be separated in annotation where possible. (lee2024regulatorymechanismsgoverning pages 12-12)
+
+### 2) Core GO Molecular Function (MF): what VPS34 does
+
+**Core MF statement for PIK3C3**: VPS34 is the catalytic subunit of class III PI3K and **produces PI3P from PI**, with major sources emphasizing the **exclusivity** of this reaction for VPS34 in vivo/in vitro among class III PI3Ks. (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 1-2)
+
+**Complex requirement for activity**: VPS34 activity depends on its complex context; notably **VPS15/PIK3R4 is described as required for VPS34 activity**, reinforcing that MF evidence often comes from complex-level biochemistry/structural studies rather than isolated VPS34. (lee2024regulatorymechanismsgoverning pages 1-2)
+
+### 3) Major GO Biological Processes (BP): autophagy and endocytosis-centered roles
+
+#### 3.1 Autophagy initiation / autophagosome nucleation (canonical macroautophagy)
+- Multiple sources converge on the model that **Complex I (ATG14-containing)** is the **autophagy initiation** VPS34 complex, generating PI3P to recruit downstream PI3P-binding effectors (including WIPI proteins) to early autophagic membranes. (lee2024regulatorymechanismsgoverning pages 1-2, lee2024regulatorymechanismsgoverning pages 12-12)
+- In an experimentally grounded signaling study (STING/autophagy), PI3P is described as a key product that **recruits ATG12–ATG5–ATG16L1 via WIPI2 to target LC3 to the phagophore**, consistent with a canonical pathway in which VPS34-derived PI3P supports phagophore maturation steps. (wan2023stingdirectlyrecruits pages 1-2)
+
+#### 3.2 Endocytic trafficking, endosomal identity, and endolysosomal maturation
+- VPS34 activity is strongly tied to **endosomal PI3P pools** that define **early endosome identity** and sorting, and PI3P serves as a platform for downstream trafficking and maturation processes. (thibault2023targetingclassiiiiii pages 8-10, swamynathan2024dietaryprooxidanttherapy pages 8-9)
+- A recent 2024 *Science* study provides direct phenotype-level support consistent with an endosomal identity role: both a selective VPS34 inhibitor (**VPS34-IN1**) and an oxidative intervention (**MSB**) produce endosomal defects alongside a reduction in PI3P-reporter puncta (GFP-2xFYVE), and CRISPR targeting of VPS34 phenocopies these effects. This supports annotating VPS34 to **PI3P-dependent endosomal organization/trafficking** processes. (swamynathan2024dietaryprooxidanttherapy pages 8-9)
+
+### 4) GO Cellular Component (CC): where VPS34 acts
+
+**Complex-level CC annotations (high confidence)**:
+- **PI3KC3-C1 (Complex I)** and **PI3KC3-C2 (Complex II)** as distinct cellular components/complexes are directly supported by recent authoritative reviews describing their tetrameric composition and functional distinctness. (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 1-2)
+
+**Membrane compartments** (context-dependent localization):
+- **ER-linked autophagy initiation sites / phagophore assembly sites**: Evidence that Complex I is functionally tied to ER-associated initiation emerges from work showing that factors can promote **ATG14 targeting to the ER** and enhance PI3KC3-C1 activity, supporting ER/phagophore-associated CC assignments for the autophagy-initiation complex. (chau2024thecellularadaptor pages 1-2)
+- **Early endosomes**: A recent *Science* study reports that VPS34 perturbation reduces PI3P reporter puncta and yields vacuoles retaining early-endosome markers (e.g., Rab5 association) while lacking lysosomal marker LAMP1 in the tested context, consistent with a key VPS34 role at early endosomal membranes. (swamynathan2024dietaryprooxidanttherapy pages 8-9)
+- **Endosomes and endosome–lysosome interface**: Complex composition is described as directing VPS34 to endosome-linked vs phagophore-linked functions, and VPS34-dependent PI3P is connected to later fusion/maturation events involving late endosomes/lysosomes in trafficking-centric models. (wible2024unexpectedinhibitionof pages 1-3, thibault2023targetingclassiiiiii pages 8-10)
+
+### 5) Key experimental evidence (selected, GO-curation-relevant)
+
+#### 5.1 PI3P reporter depletion and endosomal phenotypes (2024)
+- **Swamynathan et al., Science (Oct 2024; DOI: 10.1126/science.adk9167; URL: https://doi.org/10.1126/science.adk9167)**: Demonstrates that an oxidative agent (MSB) functionally antagonizes VPS34 and phenocopies VPS34 inhibition, sharply reducing PI3P reporter puncta (GFP-2xFYVE) and producing endosome identity defects; NAC reverses MSB effects consistent with oxidative inactivation rather than simple competitive inhibition. This is strong support for **PI3P biosynthesis** and **endosomal organization** functions at the cellular level. (swamynathan2024dietaryprooxidanttherapy pages 8-9, swamynathan2024dietaryprooxidanttherapy pages 1-3)
+
+#### 5.2 Genetic + inhibitor evidence tying VPS34 to endosomal trafficking during viral entry (2024; quantitative)
+- **Gong et al., PLoS Pathogens (Aug 2024; DOI: 10.1371/journal.ppat.1012444; URL: https://doi.org/10.1371/journal.ppat.1012444)**: Shows VPS34/PIK3C3 is required for **Ebola virus entry** via endocytic trafficking. Quantitatively, **VPS34-IN-1** inhibits EBOV infection with **IC50 = 371 nM** (EBOVΔVP30-EGFP model) and **IC50 = 405 nM** (authentic EBOV), and a **kinase-dead PIK3C3 D761A** does not complement PIK3C3 KO. These results link **VPS34 kinase activity** to **endosomal maturation/trafficking to NPC1-positive endolysosomal compartments**. (gong2024genomewidecrisprcas9screen pages 7-10)
+
+#### 5.3 Autophagy-independent PI3P-dependent membrane phenotypes (2024)
+- **Wible et al., Cell Death & Disease (Jan 2024; DOI: 10.1038/s41419-024-06423-0; URL: https://doi.org/10.1038/s41419-024-06423-0)**: Reports that a vacuolation phenotype can **rely on the PIK3C3 complex and PI(3)P production but not on autophagy per se**, supporting VPS34 assignment to endolysosomal organization/volume control processes that are distinct from canonical macroautophagy readouts. (wible2024unexpectedinhibitionof pages 1-3)
+
+#### 5.4 Noncanonical autophagy route bypassing PIK3C3 (2023; caveat)
+- **Wan et al., EMBO Journal (Mar 2023; DOI: 10.15252/embj.2022112387; URL: https://doi.org/10.15252/embj.2022112387)**: Shows **STING-induced autophagy requires WIPI2 but not the PIK3C3 complex**, an important warning against blanket annotation of PIK3C3 as required for all forms of autophagosome formation/LC3 lipidation. (wan2023stingdirectlyrecruits pages 1-2)
+
+### 6) GO annotation caveats and curation guidance (for review)
+
+1. **Avoid class I PI3K conflation**: VPS34 produces **PI3P from PI**, not PIP3 from PI(4,5)P2; MF terms should reflect PI3P biosynthesis rather than PI(3,4,5)P3-linked signaling. (burke2023beyondpi3kstargeting pages 22-23)
+
+2. **Complex-specific annotation is preferred**: When evidence indicates autophagy initiation, it is most consistent with **Complex I (ATG14; NRBF2-activated)**; when evidence indicates endocytic sorting/viral entry/early endosome identity, it is most consistent with **Complex II (UVRAG)** and shared core subunits. Consider annotating to both BP terms only when evidence supports both, or qualifying via complex context. (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 1-2, thibault2023targetingclassiiiiii pages 8-10)
+
+3. **Noncanonical autophagy can be VPS34-independent**: STING-induced autophagy provides a clear example that autophagy-related phenotypes can occur without PIK3C3 dependency; phenotype-only studies should not automatically imply direct PIK3C3 participation in all autophagy initiation contexts. (wan2023stingdirectlyrecruits pages 1-2)
+
+4. **Endosomal PI3P roles can masquerade as ‘autophagy’ phenotypes**: PI3P-dependent vacuolation and endolysosomal swelling can depend on PIK3C3 but be **autophagy-independent**, affecting inference of BP terms from morphology alone. (wible2024unexpectedinhibitionof pages 1-3)
+
+5. **Phenotype interpretation (KO vs kinase-dead; compensatory PI3P)**: A synthesis focused on PI3K targeting highlights that VPS34 has roles that can be complicated by scaffolding/complex-level effects, differences between genetic knockout and catalytic inactivation, and potential compensatory PI3P sources in specific contexts; this argues for prioritizing direct biochemical/kinase-activity evidence (IDAs/IMP with catalytic mutants) for MF/BP assertions. (thibault2023targetingclassiiiiii pages 8-10)
+
+### 7) Recent developments and real-world applications (2023–2024)
+
+- **Therapeutic targeting/redox pharmacology**: A high-impact 2024 *Science* paper identifies an oxidative dietary compound (MSB) as functionally antagonizing VPS34 by **oxidation of key cysteines**, tying VPS34 to endosomal identity/sorting and suggesting redox-sensitive control points relevant to drug development and disease models. (Oct 2024; https://doi.org/10.1126/science.adk9167). (swamynathan2024dietaryprooxidanttherapy pages 1-3, swamynathan2024dietaryprooxidanttherapy pages 8-9)
+
+- **Antiviral host-factor targeting**: A 2024 *PLOS Pathogens* study provides quantitative inhibitor potency (sub-micromolar IC50s) and genetic validation of kinase activity requirement for EBOV entry, supporting VPS34 as a potential host-directed antiviral target specifically through endocytic/endolysosomal trafficking mechanisms. (Aug 2024; https://doi.org/10.1371/journal.ppat.1012444). (gong2024genomewidecrisprcas9screen pages 7-10)
+
+- **Expert synthesis of complex biology and druggability**: A widely cited 2023 *Nature Reviews Drug Discovery* review emphasizes VPS34’s catalytic specificity and clear complex partitioning (C1 vs C2), supporting precise GO MF/CC curation and motivating use of complex-aware annotations. (Nov 2023; https://doi.org/10.1038/s41573-022-00582-5). (burke2023beyondpi3kstargeting pages 22-23)
+
+### 8) GO-focused evidence summary table
+
+| GO aspect | Proposed GO concept / term label | Evidence summary | Key complex context | Representative experimental evidence types | Citations |
+|---|---|---|---|---|---|
+| MF | Phosphatidylinositol 3-kinase activity; phosphatidylinositol-3-phosphate biosynthetic process | Human VPS34/PIK3C3 is the class III PI3K catalytic subunit that converts phosphatidylinositol (PI) to PI3P, with recent reviews emphasizing this as its defining enzymatic activity and distinguishing it from class I PI3Ks. | Shared catalytic core in both Complex I and II with VPS15/PIK3R4 and BECN1; VPS15 is required for full VPS34 activity. | Biochemical/structural studies; kinase inhibition; PI3P-effector recruitment analyses. | Burke et al., *Nat Rev Drug Discov* (Nov 2023), DOI: 10.1038/s41573-022-00582-5, https://doi.org/10.1038/s41573-022-00582-5 (burke2023beyondpi3kstargeting pages 22-23, lee2024regulatorymechanismsgoverning pages 1-2) |
+| BP | Macroautophagy initiation / autophagosome nucleation | VPS34-generated PI3P promotes recruitment of WIPI/ATG machinery to phagophore membranes, supporting autophagosome initiation and early biogenesis. | Complex I: PIK3C3-VPS15-BECN1-ATG14; activated by NRBF2 and regulated by ULK1-linked inputs. | Complex reconstitution/structural studies; localization of ATG14 puncta; PI3P-dependent effector recruitment. | Lee et al., *Biomol Ther* (Oct 2024), DOI: 10.4062/biomolther.2024.094, https://doi.org/10.4062/biomolther.2024.094 (lee2024regulatorymechanismsgoverning pages 12-12, lee2024regulatorymechanismsgoverning pages 6-7) |
+| CC | PI3KC3-C1 autophagy initiation complex; ER/phagophore assembly site / omegasome-associated membrane | PI3KC3-C1 is targeted to ER-linked autophagy initiation sites, and ATG14-directed ER localization promotes autophagic vacuole formation. | Complex I with ATG14 as specifying subunit; GULP1 can enhance ATG14 targeting to ER and stimulate PI3KC3-C1 activity. | ER localization microscopy; autophagic vacuole analysis; modulation of ATG14 targeting. | Chau et al., *Cell Mol Life Sci* (Jul 2024), DOI: 10.1007/s00018-024-05351-8, https://doi.org/10.1007/s00018-024-05351-8 (chau2024thecellularadaptor pages 1-2) |
+| BP | Endocytic trafficking / early endosome organization | VPS34 activity is required to maintain PI3P-positive early endosome identity, and oxidative or pharmacologic VPS34 inhibition depletes PI3P and disrupts endosomal sorting. | Most consistent with endosomal VPS34 complexes, especially Complex II-linked endocytic function; shared VPS34-VPS15-BECN1 core. | GFP-2xFYVE PI3P reporter loss; CRISPR targeting; VPS34-IN1; live-cell vacuolization imaging. | Swamynathan et al., *Science* (Oct 2024), DOI: 10.1126/science.adk9167, https://doi.org/10.1126/science.adk9167 (swamynathan2024dietaryprooxidanttherapy pages 8-9, swamynathan2024dietaryprooxidanttherapy pages 1-3) |
+| CC | Early endosome | PI3P reporter depletion, Rab5-associated vacuoles, and loss of normal endosomal identity after VPS34 perturbation support localization/function at early endosomal membranes. | Endosomal VPS34 complexes; Rab5-dependent recruitment of hVPS34/p150 noted in review-level mechanistic summaries. | PI3P reporter imaging; Rab5 colocalization; inhibitor phenocopy; CRISPR knockout. | Swamynathan et al., *Science* (Oct 2024), DOI: 10.1126/science.adk9167, https://doi.org/10.1126/science.adk9167; Lee et al., *Biomol Ther* (Oct 2024), DOI: 10.4062/biomolther.2024.094, https://doi.org/10.4062/biomolther.2024.094 (swamynathan2024dietaryprooxidanttherapy pages 8-9, lee2024regulatorymechanismsgoverning pages 12-12) |
+| BP | Endosome maturation / endolysosomal trafficking | VPS34 kinase activity is necessary for trafficking cargo/virions into NPC1-positive endolysosomal compartments, supporting a role in endosomal maturation and membrane traffic beyond canonical autophagy. | Functional emphasis on endocytic VPS34 activity; Complex II is the main endocytic sorting complex in current models. | KO/rescue with kinase-dead mutant; selective inhibitor; confocal colocalization with NPC1; viral entry assays. | Gong et al., *PLoS Pathog* (Aug 2024), DOI: 10.1371/journal.ppat.1012444, https://doi.org/10.1371/journal.ppat.1012444; VPS34-IN-1 IC50 = 371 nM for EBOVΔVP30-EGFP and 405 nM for authentic EBOV (gong2024genomewidecrisprcas9screen pages 7-10) |
+| BP | Regulation of autophagy-independent endolysosomal membrane organization | Some VPS34-dependent PI3P phenotypes reflect endolysosomal control rather than autophagy itself, since vacuolation can require the PIK3C3 complex and PI3P but occur independently of autophagy per se. | Shared VPS34 complex with context-dependent adaptor usage; not uniquely attributable to Complex I. | Pharmacologic perturbation; PI3P dependence tests; endolysosomal morphology assays. | Wible et al., *Cell Death & Disease* (Jan 2024), DOI: 10.1038/s41419-024-06423-0, https://doi.org/10.1038/s41419-024-06423-0 (wible2024unexpectedinhibitionof pages 1-3) |
+| CC | Endosome/lysosome fusion pathway; autophagosome-endolysosome interface | VPS34 participates in pathways linking PI3P-positive autophagic/endosomal membranes to later Rab7-dependent fusion with late endosomes and lysosomes. | Complex composition helps determine whether VPS34 acts at phagophore-associated or endosomal membranes; UVRAG/Rubicon-linked contexts are especially relevant downstream. | Membrane-trafficking studies; inhibitor phenotypes; pathway reconstruction from imaging and genetics. | Wible et al., *Cell Death & Disease* (Jan 2024), DOI: 10.1038/s41419-024-06423-0, https://doi.org/10.1038/s41419-024-06423-0; Thibault et al., *Cancers* (Jan 2023), DOI: 10.3390/cancers15030784, https://doi.org/10.3390/cancers15030784 (wible2024unexpectedinhibitionof pages 1-3, thibault2023targetingclassiiiiii pages 8-10) |
+| CC/BP caveat | Context-specific: not all LC3 lipidation/autophagosome formation is VPS34-dependent | STING-induced autophagy can require WIPI2 but not the PIK3C3 complex, so annotations for autophagosome formation should avoid overgeneralizing VPS34 dependence to all noncanonical autophagy pathways. | Canonical autophagy uses Complex I; this caveat applies to noncanonical STING-driven LC3 lipidation/autophagosome formation. | Genetic pathway dissection; VPS34 inhibitor insensitivity in STING context; WIPI2 dependency tests. | Wan et al., *EMBO J* (Mar 2023), DOI: 10.15252/embj.2022112387, https://doi.org/10.15252/embj.2022112387 (wan2023stingdirectlyrecruits pages 1-2) |
+
+
+*Table: This table summarizes GO-relevant molecular function, biological process, and cellular component evidence for human PIK3C3/VPS34, with emphasis on complex-specific context and annotation caveats. It also includes the key quantitative antiviral statistic from Gong 2024 for VPS34-IN-1.*
+
+
+References
+
+1. (burke2023beyondpi3kstargeting pages 22-23): John E Burke, Joanna Catherine Caprio Triscott, Brooke M Emerling, and Gerald R V Hammond. Beyond pi3ks: targeting phosphoinositide kinases in disease. Nature Reviews. Drug Discovery, 22:357-386, Nov 2023. URL: https://doi.org/10.1038/s41573-022-00582-5, doi:10.1038/s41573-022-00582-5. This article has 157 citations.
+
+2. (lee2024regulatorymechanismsgoverning pages 1-2): Yongook Lee, Nguyen Minh Tuan, Gi Jeong Lee, Boram Kim, Jung Ho Park, and Chang Hoon Lee. Regulatory mechanisms governing the autophagy-initiating vps34 complex and its inhibitors. Biomolecules & Therapeutics, 32:723-735, Oct 2024. URL: https://doi.org/10.4062/biomolther.2024.094, doi:10.4062/biomolther.2024.094. This article has 16 citations and is from a peer-reviewed journal.
+
+3. (chau2024thecellularadaptor pages 1-2): Dennis Dik-Long Chau, Zhicheng Yu, Wai Wa Ray Chan, Zhai Yuqi, Raymond Chuen Chung Chang, Jacky Chi Ki Ngo, Ho Yin Edwin Chan, and Kwok-Fai Lau. The cellular adaptor gulp1 interacts with atg14 to potentiate autophagy and app processing. Cellular and Molecular Life Sciences: CMLS, Jul 2024. URL: https://doi.org/10.1007/s00018-024-05351-8, doi:10.1007/s00018-024-05351-8. This article has 6 citations.
+
+4. (lee2024regulatorymechanismsgoverning pages 12-12): Yongook Lee, Nguyen Minh Tuan, Gi Jeong Lee, Boram Kim, Jung Ho Park, and Chang Hoon Lee. Regulatory mechanisms governing the autophagy-initiating vps34 complex and its inhibitors. Biomolecules & Therapeutics, 32:723-735, Oct 2024. URL: https://doi.org/10.4062/biomolther.2024.094, doi:10.4062/biomolther.2024.094. This article has 16 citations and is from a peer-reviewed journal.
+
+5. (wan2023stingdirectlyrecruits pages 1-2): Wei Wan, Chuying Qian, Qian Wang, Jin Li, Hongtao Zhang, Lei Wang, Maomao Pu, Yewei Huang, Zhengfu He, Tianhua Zhou, Han‐Ming Shen, and Wei Liu. Sting directly recruits wipi2 for autophagosome formation during sting‐induced autophagy. The EMBO Journal, Mar 2023. URL: https://doi.org/10.15252/embj.2022112387, doi:10.15252/embj.2022112387. This article has 71 citations.
+
+6. (thibault2023targetingclassiiiiii pages 8-10): Benoît Thibault, Fernanda Ramos-Delgado, and Julie Guillermet-Guibert. Targeting class i-ii-iii pi3ks in cancer therapy: recent advances in tumor biology and preclinical research. Cancers, 15:784, Jan 2023. URL: https://doi.org/10.3390/cancers15030784, doi:10.3390/cancers15030784. This article has 36 citations.
+
+7. (swamynathan2024dietaryprooxidanttherapy pages 8-9): Manojit M. Swamynathan, Shan Kuang, Kaitlin E. Watrud, Mary R. Doherty, Charlotte Gineste, Grinu Mathew, Grace Q. Gong, Hilary Cox, Eileen Cheng, David Reiss, Jude Kendall, Diya Ghosh, Colleen R. Reczek, Xiang Zhao, Tali Herzka, Saulė Špokaitė, Antoine N. Dessus, Seung Tea Kim, Olaf Klingbeil, Juan Liu, Dawid G. Nowak, Habeeb Alsudani, Tse-Luen Wee, Youngkyu Park, Francesca Minicozzi, Keith Rivera, Ana S. Almeida, Kenneth Chang, Ram P. Chakrabarty, John E. Wilkinson, Phyllis A. Gimotty, Sarah D. Diermeier, Mikala Egeblad, Christopher R. Vakoc, Jason W. Locasale, Navdeep S. Chandel, Tobias Janowitz, James B. Hicks, Michael Wigler, Darryl J. Pappin, Roger L. Williams, Paolo Cifani, David A. Tuveson, Jocelyn Laporte, and Lloyd C. Trotman. Dietary pro-oxidant therapy by a vitamin k precursor targets pi 3-kinase vps34 function. Science, Oct 2024. URL: https://doi.org/10.1126/science.adk9167, doi:10.1126/science.adk9167. This article has 41 citations and is from a highest quality peer-reviewed journal.
+
+8. (wible2024unexpectedinhibitionof pages 1-3): Daric J. Wible, Zalak Parikh, Eun Jeong Cho, Miao-Der Chen, Collene R. Jeter, Somshuvra Mukhopadhyay, Kevin N. Dalby, Shankar Varadarajan, and Shawn B. Bratton. Unexpected inhibition of the lipid kinase pikfyve reveals an epistatic role for p38 mapks in endolysosomal fission and volume control. Cell Death &amp; Disease, Jan 2024. URL: https://doi.org/10.1038/s41419-024-06423-0, doi:10.1038/s41419-024-06423-0. This article has 19 citations and is from a peer-reviewed journal.
+
+9. (swamynathan2024dietaryprooxidanttherapy pages 1-3): Manojit M. Swamynathan, Shan Kuang, Kaitlin E. Watrud, Mary R. Doherty, Charlotte Gineste, Grinu Mathew, Grace Q. Gong, Hilary Cox, Eileen Cheng, David Reiss, Jude Kendall, Diya Ghosh, Colleen R. Reczek, Xiang Zhao, Tali Herzka, Saulė Špokaitė, Antoine N. Dessus, Seung Tea Kim, Olaf Klingbeil, Juan Liu, Dawid G. Nowak, Habeeb Alsudani, Tse-Luen Wee, Youngkyu Park, Francesca Minicozzi, Keith Rivera, Ana S. Almeida, Kenneth Chang, Ram P. Chakrabarty, John E. Wilkinson, Phyllis A. Gimotty, Sarah D. Diermeier, Mikala Egeblad, Christopher R. Vakoc, Jason W. Locasale, Navdeep S. Chandel, Tobias Janowitz, James B. Hicks, Michael Wigler, Darryl J. Pappin, Roger L. Williams, Paolo Cifani, David A. Tuveson, Jocelyn Laporte, and Lloyd C. Trotman. Dietary pro-oxidant therapy by a vitamin k precursor targets pi 3-kinase vps34 function. Science, Oct 2024. URL: https://doi.org/10.1126/science.adk9167, doi:10.1126/science.adk9167. This article has 41 citations and is from a highest quality peer-reviewed journal.
+
+10. (gong2024genomewidecrisprcas9screen pages 7-10): Mingli Gong, Cheng Peng, Chen Yang, Zhenhua Wang, Hongwu Qian, Xue Hu, Peng Zhou, Chao Shan, and Qiang Ding. Genome-wide crispr/cas9 screen identifies slc39a9 and pik3c3 as crucial entry factors for ebola virus infection. PLOS Pathogens, 20:e1012444, Aug 2024. URL: https://doi.org/10.1371/journal.ppat.1012444, doi:10.1371/journal.ppat.1012444. This article has 12 citations and is from a highest quality peer-reviewed journal.
+
+11. (lee2024regulatorymechanismsgoverning pages 6-7): Yongook Lee, Nguyen Minh Tuan, Gi Jeong Lee, Boram Kim, Jung Ho Park, and Chang Hoon Lee. Regulatory mechanisms governing the autophagy-initiating vps34 complex and its inhibitors. Biomolecules & Therapeutics, 32:723-735, Oct 2024. URL: https://doi.org/10.4062/biomolther.2024.094, doi:10.4062/biomolther.2024.094. This article has 16 citations and is from a peer-reviewed journal.
+
+## Citations
+
+1. lee2024regulatorymechanismsgoverning pages 12-12
+2. lee2024regulatorymechanismsgoverning pages 1-2
+3. wan2023stingdirectlyrecruits pages 1-2
+4. swamynathan2024dietaryprooxidanttherapy pages 8-9
+5. chau2024thecellularadaptor pages 1-2
+6. wible2024unexpectedinhibitionof pages 1-3
+7. thibault2023targetingclassiiiiii pages 8-10
+8. swamynathan2024dietaryprooxidanttherapy pages 1-3
+9. lee2024regulatorymechanismsgoverning pages 6-7
+10. https://doi.org/10.1126/science.adk9167
+11. https://doi.org/10.1371/journal.ppat.1012444
+12. https://doi.org/10.1038/s41419-024-06423-0
+13. https://doi.org/10.15252/embj.2022112387
+14. https://doi.org/10.1038/s41573-022-00582-5
+15. https://doi.org/10.4062/biomolther.2024.094
+16. https://doi.org/10.1007/s00018-024-05351-8
+17. https://doi.org/10.1126/science.adk9167;
+18. https://doi.org/10.1371/journal.ppat.1012444;
+19. https://doi.org/10.1038/s41419-024-06423-0;
+20. https://doi.org/10.3390/cancers15030784
+21. https://doi.org/10.1038/s41573-022-00582-5,
+22. https://doi.org/10.4062/biomolther.2024.094,
+23. https://doi.org/10.1007/s00018-024-05351-8,
+24. https://doi.org/10.15252/embj.2022112387,
+25. https://doi.org/10.3390/cancers15030784,
+26. https://doi.org/10.1126/science.adk9167,
+27. https://doi.org/10.1038/s41419-024-06423-0,
+28. https://doi.org/10.1371/journal.ppat.1012444,


### PR DESCRIPTION
## Summary
- add Falcon deep research report for human PIK3C3/VPS34
- incorporate Falcon evidence into the PIK3C3 GO annotation review
- resolve all remaining PIK3C3 pending annotation rows, with 3 rows left as `UNDECIDED` because the cited PMIDs are not locally available and Falcon did not cover the claim
- re-render the PIK3C3 review HTML

## Validation
- `just validate human PIK3C3`
- `uv run python scripts/validate_deep_research.py genes/human/PIK3C3/PIK3C3-deep-research-falcon.md`
- exact support audit: 152 file/PMID-backed `supporting_text` snippets checked
- `git diff --cached --check`

## Notes
- Standard template Falcon runs timed out for several uncached human candidates. This PR uses a concise Falcon provider query for PIK3C3, which completed successfully and produced valid provider frontmatter.
