### PR TITLE
[codex] Add Falcon deep research for PIK3CD

### DIFF
--- a/genes/human/PIK3CD/PIK3CD-ai-review.html
+++ b/genes/human/PIK3CD/PIK3CD-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>PIK3CD</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/O00329" target="_blank" class="term-link">
                         O00329
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
-                <span class="status-badge status-initialized">
-                    INITIALIZED
+                <span class="status-badge status-complete">
+                    COMPLETE
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="O00329" data-a="DESCRIPTION: TODO: Add description for PIK3CD..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="O00329" data-a="DESCRIPTION: PIK3CD encodes p110delta, the leukocyte-enriched c..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for PIK3CD</p>
+        <p>PIK3CD encodes p110delta, the leukocyte-enriched catalytic subunit of class IA phosphoinositide 3-kinase delta. In p85-family regulatory complexes, p110delta phosphorylates membrane phosphoinositides, especially PI(4,5)P2, to generate PIP3 downstream of immune receptors including BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40, Fc receptors, and cytokine/growth-factor receptors. The core curatable function is PIP3-producing lipid kinase activity in PI3K/AKT immune receptor signaling; broad immune phenotypes, chemotaxis, angiogenesis, and migration annotations are supported contextual outputs rather than the core molecular function.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,6558 +758,9711 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported cytoplasmic or cytosolic localization, but this is the resting/general pool rather than the most informative activated signaling site.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records cytoplasmic localization and the deep research report describes resting p110delta-p85 complexes as cytosolic. The functionally decisive event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be treated as the core location.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016477" target="_blank" class="term-link">
                                     GO:0016477
                                 </a>
                             </span>
                             <span class="term-label">cell migration</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0016477" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0016477" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported cell-migration role in specific leukocyte and glioma contexts, but non-core relative to lipid kinase signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD knockdown decreases glioma-cell migration and PI3Kdelta also affects leukocyte migration; these are downstream context-specific outputs rather than the core function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22079609" target="_blank" class="term-link">
+                                        PMID:22079609
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Interestingly, knockdown of p110δ decreased the cell migration and invasion ability of all GBM cell lines tested.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005942" target="_blank" class="term-link">
                                     GO:0005942
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol 3-kinase complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005942" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005942" data-r="GO_REF:0000033" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The complex assignment is valid but should use the more specific class IA phosphatidylinositol 3-kinase complex term.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD is not just any PI3K-complex component; it is the p110delta catalytic subunit of class IA p85-family regulatory complexes. GO:0005943 captures the correct complex subtype.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005943" target="_blank" class="term-link">
+                                    phosphatidylinositol 3-kinase complex, class IA
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex class IA, p110delta/p85alpha.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9235916" target="_blank" class="term-link">
+                                        PMID:9235916
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Recombinant p110delta phosphorylates phosphatidylinositol and coimmunoprecipitates with p85.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043491" target="_blank" class="term-link">
                                     GO:0043491
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol 3-kinase/protein kinase B signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0043491" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0043491" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported PI3K/AKT signaling annotation downstream of PIK3CD-generated PIP3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIP3 produced by p110delta recruits AKT-linked signaling modules. This pathway term captures the central signaling output of PI3Kdelta even when the initiating receptor or cell type differs.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide 3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes downstream of receptor signaling in immune cells, particularly in lymphocytes.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In immune cells, class IA PI3K (including p110δ) propagates signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related receptor/adaptor systems), framing the major immune-cell BP terms relevant for PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PI3Kδ is a lipid kinase of the PI3K class IA family involved in early signaling events of leukocytes responding to a wide variety of stimuli.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036092" target="_blank" class="term-link">
                                     GO:0036092
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol-3-phosphate biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0036092" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0036092" data-r="GO_REF:0000033" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The PI3P biosynthetic-process term is too specific for a class III/VPS34-like product and is not the best process term for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD/p110delta primarily generates PIP3 from PI(4,5)P2 in class IA receptor signaling. A broader phosphatidylinositol phosphate biosynthetic process term better reflects the current GO vocabulary without implying class III PI3P-centered biology.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046854" target="_blank" class="term-link">
+                                    phosphatidylinositol phosphate biosynthetic process
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-389158
+
+                                </span>
+
+                                <div class="support-text">Upon binding to CD28, the PI3K enzyme catalyzes the phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate phosphatidylinositol 3,4,5-trisphosphate (PIP3).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048015" target="_blank" class="term-link">
                                     GO:0048015
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol-mediated signaling</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0048015" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0048015" data-r="GO_REF:0000033" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The phosphatidylinositol-mediated signaling term is correct but too broad for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD is specifically a class IA PIP3-producing PI3K that feeds PI3K/AKT receptor signaling, so the more specific PI3K/AKT signal-transduction term is preferred.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043491" target="_blank" class="term-link">
+                                    phosphatidylinositol 3-kinase/protein kinase B signal transduction
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide 3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes downstream of receptor signaling in immune cells, particularly in lymphocytes.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In immune cells, class IA PI3K (including p110δ) propagates signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related receptor/adaptor systems), framing the major immune-cell BP terms relevant for PIK3CD.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported core activated-site localization. PI3Kdelta is recruited to plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates reside.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Membrane recruitment is central to class IA PI3Kdelta activity because PIP2 substrate is membrane localized and receptor phosphotyrosine signals recruit the p85-p110delta complex to the plasma membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1676048
+
+                                </span>
+
+                                <div class="support-text">At the plasma membrane, phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunits form complexes with regulatory subunits.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016303" target="_blank" class="term-link">
                                     GO:0016303
                                 </a>
                             </span>
                             <span class="term-label">1-phosphatidylinositol-3-kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0016303" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0016303" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Core molecular function as a phosphatidylinositol 3-kinase catalytic subunit.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> This parent PI3K activity term is valid for p110delta, although GO:0046934 is the most specific MF term for its canonical PIP2-to-PIP3 reaction.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9235916" target="_blank" class="term-link">
+                                        PMID:9235916
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Recombinant p110delta phosphorylates phosphatidylinositol and coimmunoprecipitates with p85.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035005" target="_blank" class="term-link">
                                     GO:0035005
                                 </a>
                             </span>
                             <span class="term-label">1-phosphatidylinositol-4-phosphate 3-kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0035005" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0035005" data-r="GO_REF:0000033" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported phosphoinositide 3-kinase substrate activity, but PI4P phosphorylation is not the primary curatable core activity for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Class I PI3Kdelta can act on phosphorylated phosphoinositides, and Reactome includes PIK3CD complexes in PI4P-to-PI(3,4)P2 reactions. The canonical core activity remains PI(4,5)P2-to-PIP3.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1676109
+
+                                </span>
+
+                                <div class="support-text">These complexes along with phosphatidylinositol-4-phosphate 3-kinase C2 domain-containing subunits alpha (PIK3C2A), beta (PIK3C2B), and gamma (PIK3C2G) phosphorylate phosphatidylinositol 4-phosphate (PI4P) to phosphatidylinositol 3,4-bisphosphate (PI(3,4)P2).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000166" target="_blank" class="term-link">
                                     GO:0000166
                                 </a>
                             </span>
                             <span class="term-label">nucleotide binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0000166" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The nucleotide-binding annotation is too generic for a lipid kinase and should be narrowed to ATP binding.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD catalysis uses ATP; the broad nucleotide-binding term loses the catalytic context and is less informative than GO:0005524 ATP binding or the catalytic PI(4,5)P2 3-kinase MF.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                                    ATP binding
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002250" target="_blank" class="term-link">
                                     GO:0002250
                                 </a>
                             </span>
                             <span class="term-label">adaptive immune response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0002250" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0002250" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported adaptive-immune output, but this is a systems-level consequence of PI3Kdelta immune receptor signaling rather than the core molecular function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Human disease genetics and leukocyte studies support a role in adaptive immunity, but the core function should remain PIP3-producing class IA PI3K signaling.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27616589" target="_blank" class="term-link">
+                                        PMID:27616589
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here, we review the roles of PI3Kδ in adaptive immunity, describe the clinical manifestations and mechanisms of disease in APDS and highlight new insights into PI3Kδ gleaned from these patients, as well as implications of these findings for clinical therapy.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">As a result of the broad effects of PI3Kδ in leukocyte functions, the disruption of PI3Kδ expression or activity leads to decreased inflammatory and immune responses in vivo.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002376" target="_blank" class="term-link">
                                     GO:0002376
                                 </a>
                             </span>
                             <span class="term-label">immune system process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0002376" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0002376" data-r="GO_REF:0000043" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Correct directionally but too broad to be useful for PIK3CD curation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD has immune functions, but GO:0002376 is a very broad parent term. More informative annotations are BCR/TCR signaling, PI3K/AKT signaling, and specific leukocyte activation/migration processes.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In immune cells, class IA PI3K (including p110δ) propagates signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related receptor/adaptor systems), framing the major immune-cell BP terms relevant for PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">As a result of the broad effects of PI3Kδ in leukocyte functions, the disruption of PI3Kδ expression or activity leads to decreased inflammatory and immune responses in vivo.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002443" target="_blank" class="term-link">
                                     GO:0002443
                                 </a>
                             </span>
                             <span class="term-label">leukocyte mediated immunity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0002443" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0002443" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported leukocyte/immune response involvement, but non-core and broad relative to receptor-proximal PI3Kdelta signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD is leukocyte-enriched and affects immune responses, yet this broad immune-process term should not define the core function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PI3Kδ is a lipid kinase of the PI3K class IA family involved in early signaling events of leukocytes responding to a wide variety of stimuli.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27616589" target="_blank" class="term-link">
+                                        PMID:27616589
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Here, we review the roles of PI3Kδ in adaptive immunity, describe the clinical manifestations and mechanisms of disease in APDS and highlight new insights into PI3Kδ gleaned from these patients, as well as implications of these findings for clinical therapy.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005524" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005524" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ATP binding is valid for the catalytic kinase domain, but it is generic relative to the core lipid kinase activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP is required for PI3Kdelta catalysis, yet ATP binding alone is not a specific description of the gene product function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005737" data-r="GO_REF:0000044" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported cytoplasmic or cytosolic localization, but this is the resting/general pool rather than the most informative activated signaling site.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records cytoplasmic localization and the deep research report describes resting p110delta-p85 complexes as cytosolic. The functionally decisive event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be treated as the core location.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported cytoplasmic or cytosolic localization, but this is the resting/general pool rather than the most informative activated signaling site.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records cytoplasmic localization and the deep research report describes resting p110delta-p85 complexes as cytosolic. The functionally decisive event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be treated as the core location.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005943" target="_blank" class="term-link">
                                     GO:0005943
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol 3-kinase complex, class IA</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005943" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005943" data-r="GO_REF:0000117" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Correct class IA PI3K complex annotation for p110delta/p85-family regulatory assemblies.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the most specific existing CC term for PIK3CD complex membership and is supported by ComplexPortal entries and synthesis of the class IA p110delta-p85 regulatory complex.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex class IA, p110delta/p85alpha.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-2316434
+
+                                </span>
+
+                                <div class="support-text">In unstimulated cells, PI3K class IA exists as an inactive heterodimer of a p85 regulatory subunit (encoded by PIK3R1, PIK3R2 or PIK3R3) and a p110 catalytic subunit (encoded by PIK3CA, PIK3CB or PIK3CD).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006629" target="_blank" class="term-link">
                                     GO:0006629
                                 </a>
                             </span>
                             <span class="term-label">lipid metabolic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0006629" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0006629" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The lipid metabolic process term is directionally correct but too broad for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD is specifically a phosphoinositide lipid kinase that produces 3-phosphoinositides/PIP3 in signaling contexts; phosphatidylinositol phosphate biosynthesis and PI(4,5)P2 3-kinase activity are more informative.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046854" target="_blank" class="term-link">
+                                    phosphatidylinositol phosphate biosynthetic process
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046934" target="_blank" class="term-link">
+                                    1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006935" target="_blank" class="term-link">
                                     GO:0006935
                                 </a>
                             </span>
                             <span class="term-label">chemotaxis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0006935" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0006935" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The generic chemotaxis annotation should be narrowed to the specific leukocyte chemotaxis processes supported for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The evidence supports T-cell, B-cell, neutrophil, and mast-cell chemotaxis contexts rather than chemotaxis as a broad parent term.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010818" target="_blank" class="term-link">
+                                    T cell chemotaxis
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035754" target="_blank" class="term-link">
+                                    B cell chemotaxis
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030593" target="_blank" class="term-link">
+                                    neutrophil chemotaxis
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002551" target="_blank" class="term-link">
+                                    mast cell chemotaxis
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006954" target="_blank" class="term-link">
                                     GO:0006954
                                 </a>
                             </span>
                             <span class="term-label">inflammatory response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0006954" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0006954" data-r="GO_REF:0000043" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported inflammatory-response involvement, but it is a downstream physiological output of PI3Kdelta activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI3Kdelta disruption alters inflammatory responses in vivo and PI3K lipid messengers control leukocyte signaling, but inflammation is a non-core phenotype/process relative to lipid kinase signaling.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17290298" target="_blank" class="term-link">
+                                        PMID:17290298
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second messengers that control an array of intracellular signalling pathways that are known to have important roles in leukocytes.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">As a result of the broad effects of PI3Kδ in leukocyte functions, the disruption of PI3Kδ expression or activity leads to decreased inflammatory and immune responses in vivo.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007166" target="_blank" class="term-link">
                                     GO:0007166
                                 </a>
                             </span>
                             <span class="term-label">cell surface receptor signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0007166" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0007166" data-r="GO_REF:0000117" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The broad cell-surface receptor signaling annotation should be narrowed to the immune receptor signaling pathways where PIK3CD has strong support.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD acts downstream of immune receptors such as BCR, TCR, and CD28. Those terms are more informative and better supported than the generic cell-surface receptor signaling parent.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050853" target="_blank" class="term-link">
+                                    B cell receptor signaling pathway
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050852" target="_blank" class="term-link">
+                                    T cell receptor signaling pathway
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031295" target="_blank" class="term-link">
+                                    T cell costimulation
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In immune cells, class IA PI3K (including p110δ) propagates signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related receptor/adaptor systems), framing the major immune-cell BP terms relevant for PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Required for B-cell receptor (BCR) signaling.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Required for T-cell receptor (TCR) signaling.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010595" target="_blank" class="term-link">
                                     GO:0010595
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of endothelial cell migration</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0010595" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0010595" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported endothelial/angiogenesis context, but non-core and tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cultured endothelial-cell work supports VEGF-induced Akt activation, proliferation, migration, tube formation, and retinal angiogenesis. This is a real contextual role, not the primary leukocyte-enriched core function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31915155" target="_blank" class="term-link">
+                                        PMID:31915155
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Using genetic and pharmacological approaches, we show that p110δ activity in cultured ECs controls Akt activation, cell proliferation, migration, and tube formation induced by vascular endothelial growth factor, basic fibroblast growth factor, and epidermal growth factor.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many downstream readouts (e.g., pAKT, pS6) are not isoform-specific, and class I PI3Ks share overlapping functions; p110δ is leukocyte-enriched but not exclusively expressed, so immune-context evidence is strongest for PIK3CD-specific BP claims.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010628" target="_blank" class="term-link">
                                     GO:0010628
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of gene expression</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0010628" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0010628" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Over-annotation to positive regulation of gene expression. The available PIK3CD evidence supports upstream PI3K/AKT signaling more directly than this distal transcriptional-output term.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Gene-expression changes can occur downstream of PI3K/AKT/FOXO signaling, but the cited evidence is more direct for lipid kinase signaling, migration, and protein-level pathway outputs. This broad distal term should not be retained as a core annotation.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many downstream readouts (e.g., pAKT, pS6) are not isoform-specific, and class I PI3Ks share overlapping functions; p110δ is leukocyte-enriched but not exclusively expressed, so immune-context evidence is strongest for PIK3CD-specific BP claims.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22079609" target="_blank" class="term-link">
+                                        PMID:22079609
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Interestingly, knockdown of p110δ decreased the cell migration and invasion ability of all GBM cell lines tested.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016301" target="_blank" class="term-link">
                                     GO:0016301
                                 </a>
                             </span>
                             <span class="term-label">kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0016301" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0016301" data-r="GO_REF:0000120" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The generic enzyme-activity annotation is valid only as a distant parent and should be replaced by the specific lipid kinase activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD is not merely a generic kinase/transferase; the evidence supports phosphoinositide 3-kinase activity, especially PI(4,5)P2 3-kinase activity.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046934" target="_blank" class="term-link">
+                                    1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9235916" target="_blank" class="term-link">
+                                        PMID:9235916
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Recombinant p110delta phosphorylates phosphatidylinositol and coimmunoprecipitates with p85.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016303" target="_blank" class="term-link">
                                     GO:0016303
                                 </a>
                             </span>
                             <span class="term-label">1-phosphatidylinositol-3-kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0016303" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0016303" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Core molecular function as a phosphatidylinositol 3-kinase catalytic subunit.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> This parent PI3K activity term is valid for p110delta, although GO:0046934 is the most specific MF term for its canonical PIP2-to-PIP3 reaction.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9235916" target="_blank" class="term-link">
+                                        PMID:9235916
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Recombinant p110delta phosphorylates phosphatidylinositol and coimmunoprecipitates with p85.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016740" target="_blank" class="term-link">
                                     GO:0016740
                                 </a>
                             </span>
                             <span class="term-label">transferase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0016740" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0016740" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The generic enzyme-activity annotation is valid only as a distant parent and should be replaced by the specific lipid kinase activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD is not merely a generic kinase/transferase; the evidence supports phosphoinositide 3-kinase activity, especially PI(4,5)P2 3-kinase activity.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046934" target="_blank" class="term-link">
+                                    1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9235916" target="_blank" class="term-link">
+                                        PMID:9235916
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Recombinant p110delta phosphorylates phosphatidylinositol and coimmunoprecipitates with p85.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0022603" target="_blank" class="term-link">
                                     GO:0022603
                                 </a>
                             </span>
                             <span class="term-label">regulation of anatomical structure morphogenesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0022603" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0022603" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Over-annotation to broad developmental, morphogenesis, or adhesion regulation terms.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD has specific leukocyte, endothelial, and migration phenotypes, but these broad regulation terms over-generalize downstream effects and obscure the better-supported PI3Kdelta receptor-signaling biology.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many downstream readouts (e.g., pAKT, pS6) are not isoform-specific, and class I PI3Ks share overlapping functions; p110δ is leukocyte-enriched but not exclusively expressed, so immune-context evidence is strongest for PIK3CD-specific BP claims.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">As a result of the broad effects of PI3Kδ in leukocyte functions, the disruption of PI3Kδ expression or activity leads to decreased inflammatory and immune responses in vivo.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030154" target="_blank" class="term-link">
                                     GO:0030154
                                 </a>
                             </span>
                             <span class="term-label">cell differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030154" data-r="GO_REF:0000043" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030154" data-r="GO_REF:0000043" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The generic cell differentiation annotation should be narrowed to the specific leukocyte differentiation processes supported for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The evidence supports B-cell, T-cell, NK-cell, and mast-cell differentiation contexts rather than undifferentiated cell differentiation as a generic parent.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030183" target="_blank" class="term-link">
+                                    B cell differentiation
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030217" target="_blank" class="term-link">
+                                    T cell differentiation
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001779" target="_blank" class="term-link">
+                                    natural killer cell differentiation
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060374" target="_blank" class="term-link">
+                                    mast cell differentiation
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20200404" target="_blank" class="term-link">
+                                        PMID:20200404
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Thus, we provide novel evidence that p110gamma and p110delta have overlapping and cell-extrinsic roles in the development, peripheral maintenance, and function of B cells.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17371229" target="_blank" class="term-link">
+                                        PMID:17371229
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In addition, p110delta regulates the differentiation of peripheral Th (helper T-cells) towards the Th1 and Th2 lineages.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030155" target="_blank" class="term-link">
                                     GO:0030155
                                 </a>
                             </span>
                             <span class="term-label">regulation of cell adhesion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030155" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030155" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Over-annotation to broad developmental, morphogenesis, or adhesion regulation terms.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD has specific leukocyte, endothelial, and migration phenotypes, but these broad regulation terms over-generalize downstream effects and obscure the better-supported PI3Kdelta receptor-signaling biology.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many downstream readouts (e.g., pAKT, pS6) are not isoform-specific, and class I PI3Ks share overlapping functions; p110δ is leukocyte-enriched but not exclusively expressed, so immune-context evidence is strongest for PIK3CD-specific BP claims.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">As a result of the broad effects of PI3Kδ in leukocyte functions, the disruption of PI3Kδ expression or activity leads to decreased inflammatory and immune responses in vivo.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033031" target="_blank" class="term-link">
                                     GO:0033031
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of neutrophil apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0033031" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0033031" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported neutrophil-death/apoptotic-process annotation, but non-core and context-dependent.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> FcαRI-triggered neutrophil death requires class IA PI3K signaling in inflammatory contexts. This supports the annotation as a non-core immune effector process.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25339672" target="_blank" class="term-link">
+                                        PMID:25339672
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">preactivation with cytokines or TLR agonists in vitro enhanced FcαRI-mediated death by additional recruitment of caspase-independent pathways, but this required PI3K class IA and MAPK signaling.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042113" target="_blank" class="term-link">
                                     GO:0042113
                                 </a>
                             </span>
                             <span class="term-label">B cell activation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0042113" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0042113" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported B-cell activation/function annotation, but downstream of the more core BCR signaling role.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD is important for B-cell development and function. B-cell activation is real, but BCR signaling and PI3K/AKT signaling are the more precise core process annotations.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20200404" target="_blank" class="term-link">
+                                        PMID:20200404
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Thus, we provide novel evidence that p110gamma and p110delta have overlapping and cell-extrinsic roles in the development, peripheral maintenance, and function of B cells.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Required for B-cell receptor (BCR) signaling.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043491" target="_blank" class="term-link">
                                     GO:0043491
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol 3-kinase/protein kinase B signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0043491" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0043491" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported PI3K/AKT signaling annotation downstream of PIK3CD-generated PIP3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIP3 produced by p110delta recruits AKT-linked signaling modules. This pathway term captures the central signaling output of PI3Kdelta even when the initiating receptor or cell type differs.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide 3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes downstream of receptor signaling in immune cells, particularly in lymphocytes.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In immune cells, class IA PI3K (including p110δ) propagates signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related receptor/adaptor systems), framing the major immune-cell BP terms relevant for PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PI3Kδ is a lipid kinase of the PI3K class IA family involved in early signaling events of leukocytes responding to a wide variety of stimuli.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045087" target="_blank" class="term-link">
                                     GO:0045087
                                 </a>
                             </span>
                             <span class="term-label">innate immune response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0045087" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0045087" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported innate-immune involvement, but this is a broad non-core immune-system output.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI3Kdelta contributes to myeloid and innate leukocyte activities, but the precise core function is receptor-linked PIP3 production rather than innate immunity as a whole.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17290298" target="_blank" class="term-link">
+                                        PMID:17290298
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second messengers that control an array of intracellular signalling pathways that are known to have important roles in leukocytes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046854" target="_blank" class="term-link">
                                     GO:0046854
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol phosphate biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0046854" data-r="GO_REF:0000002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0046854" data-r="GO_REF:0000002" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported core process output of PI3Kdelta lipid kinase activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD produces 3-phosphoinositides, especially PIP3, as the biochemical product of its class IA lipid kinase activity. This process term is broader than an ideal PIP3-biosynthesis term but is correct.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-389158
+
+                                </span>
+
+                                <div class="support-text">Upon binding to CD28, the PI3K enzyme catalyzes the phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate phosphatidylinositol 3,4,5-trisphosphate (PIP3).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046934" target="_blank" class="term-link">
                                     GO:0046934
                                 </a>
                             </span>
                             <span class="term-label">1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0046934" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0046934" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Core specific molecular function: p110delta phosphorylates PI(4,5)P2 to generate PIP3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI(4,5)P2 3-kinase activity is the specific catalytic activity that drives PI3Kdelta receptor signaling and PIP3-dependent AKT pathway recruitment.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-389158
+
+                                </span>
+
+                                <div class="support-text">Upon binding to CD28, the PI3K enzyme catalyzes the phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate phosphatidylinositol 3,4,5-trisphosphate (PIP3).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051094" target="_blank" class="term-link">
                                     GO:0051094
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of developmental process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0051094" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0051094" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Over-annotation to broad developmental, morphogenesis, or adhesion regulation terms.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD has specific leukocyte, endothelial, and migration phenotypes, but these broad regulation terms over-generalize downstream effects and obscure the better-supported PI3Kdelta receptor-signaling biology.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many downstream readouts (e.g., pAKT, pS6) are not isoform-specific, and class I PI3Ks share overlapping functions; p110δ is leukocyte-enriched but not exclusively expressed, so immune-context evidence is strongest for PIK3CD-specific BP claims.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">As a result of the broad effects of PI3Kδ in leukocyte functions, the disruption of PI3Kδ expression or activity leads to decreased inflammatory and immune responses in vivo.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051240" target="_blank" class="term-link">
                                     GO:0051240
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of multicellular organismal process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0051240" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0051240" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Over-annotation to broad developmental, morphogenesis, or adhesion regulation terms.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD has specific leukocyte, endothelial, and migration phenotypes, but these broad regulation terms over-generalize downstream effects and obscure the better-supported PI3Kdelta receptor-signaling biology.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many downstream readouts (e.g., pAKT, pS6) are not isoform-specific, and class I PI3Ks share overlapping functions; p110δ is leukocyte-enriched but not exclusively expressed, so immune-context evidence is strongest for PIK3CD-specific BP claims.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">As a result of the broad effects of PI3Kδ in leukocyte functions, the disruption of PI3Kδ expression or activity leads to decreased inflammatory and immune responses in vivo.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2000026" target="_blank" class="term-link">
                                     GO:2000026
                                 </a>
                             </span>
                             <span class="term-label">regulation of multicellular organismal development</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:2000026" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:2000026" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Over-annotation to broad developmental, morphogenesis, or adhesion regulation terms.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD has specific leukocyte, endothelial, and migration phenotypes, but these broad regulation terms over-generalize downstream effects and obscure the better-supported PI3Kdelta receptor-signaling biology.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many downstream readouts (e.g., pAKT, pS6) are not isoform-specific, and class I PI3Ks share overlapping functions; p110δ is leukocyte-enriched but not exclusively expressed, so immune-context evidence is strongest for PIK3CD-specific BP claims.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">As a result of the broad effects of PI3Kδ in leukocyte functions, the disruption of PI3Kδ expression or activity leads to decreased inflammatory and immune responses in vivo.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21827948" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21827948
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dynamics of the phosphoinositide 3-kinase p110δ interaction ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:21827948" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:21827948" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is an uninformative over-annotation for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD does interact with p85-family regulatory subunits and other signaling proteins, but GO:0005515 does not capture the meaningful function. The informative annotations are class IA PI3K complex membership and phosphoinositide kinase activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/21827948" target="_blank" class="term-link">
-                                        PMID:21827948
-                                    </a>
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Dynamics of the phosphoinositide 3-kinase p110δ interaction with p85α and membranes reveals aspects of regulation distinct from p110α.</div>
-                                
+
+                                <div class="support-text">p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex class IA, p110delta/p85alpha.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22020336" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22020336
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     p37δ is a new isoform of PI3K p110δ that increases cell prol...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:22020336" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:22020336" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is an uninformative over-annotation for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD does interact with p85-family regulatory subunits and other signaling proteins, but GO:0005515 does not capture the meaningful function. The informative annotations are class IA PI3K complex membership and phosphoinositide kinase activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22020336" target="_blank" class="term-link">
-                                        PMID:22020336
-                                    </a>
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">p37δ is a new isoform of PI3K p110δ that increases cell proliferation and is overexpressed in tumors.</div>
-                                
+
+                                <div class="support-text">p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex class IA, p110delta/p85alpha.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24165795" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24165795
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dominant-activating germline mutations in the gene encoding ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:24165795" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:24165795" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is an uninformative over-annotation for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD does interact with p85-family regulatory subunits and other signaling proteins, but GO:0005515 does not capture the meaningful function. The informative annotations are class IA PI3K complex membership and phosphoinositide kinase activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24165795" target="_blank" class="term-link">
-                                        PMID:24165795
-                                    </a>
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Dominant-activating germline mutations in the gene encoding the PI(3)K catalytic subunit p110δ result in T cell senescence and human immunodeficiency.</div>
-                                
+
+                                <div class="support-text">p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex class IA, p110delta/p85alpha.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:28514442
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Architecture of the human interactome defines protein commun...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:28514442" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:28514442" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is an uninformative over-annotation for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD does interact with p85-family regulatory subunits and other signaling proteins, but GO:0005515 does not capture the meaningful function. The informative annotations are class IA PI3K complex membership and phosphoinositide kinase activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
-                                        PMID:28514442
-                                    </a>
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Architecture of the human interactome defines protein communities and disease networks.</div>
-                                
+
+                                <div class="support-text">p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex class IA, p110delta/p85alpha.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31031754" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31031754
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Case Study: Mechanism for Increased Follicular Helper T Cell...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:31031754" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:31031754" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is an uninformative over-annotation for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD does interact with p85-family regulatory subunits and other signaling proteins, but GO:0005515 does not capture the meaningful function. The informative annotations are class IA PI3K complex membership and phosphoinositide kinase activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31031754" target="_blank" class="term-link">
-                                        PMID:31031754
-                                    </a>
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Case Study: Mechanism for Increased Follicular Helper T Cell Development in Activated PI3K Delta Syndrome.</div>
-                                
+
+                                <div class="support-text">p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex class IA, p110delta/p85alpha.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:32296183" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:32296183" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is an uninformative over-annotation for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD does interact with p85-family regulatory subunits and other signaling proteins, but GO:0005515 does not capture the meaningful function. The informative annotations are class IA PI3K complex membership and phosphoinositide kinase activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
-                                        PMID:32296183
-                                    </a>
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Apr 8. A reference map of the human binary protein interactome.</div>
-                                
+
+                                <div class="support-text">p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex class IA, p110delta/p85alpha.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:33961781" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:33961781" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is an uninformative over-annotation for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD does interact with p85-family regulatory subunits and other signaling proteins, but GO:0005515 does not capture the meaningful function. The informative annotations are class IA PI3K complex membership and phosphoinositide kinase activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
-                                        PMID:33961781
-                                    </a>
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2021 May 6. Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                                
+
+                                <div class="support-text">p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex class IA, p110delta/p85alpha.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35271311
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     OpenCell: Endogenous tagging for the cartography of human ce...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:35271311" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:35271311" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is an uninformative over-annotation for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD does interact with p85-family regulatory subunits and other signaling proteins, but GO:0005515 does not capture the meaningful function. The informative annotations are class IA PI3K complex membership and phosphoinositide kinase activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
-                                        PMID:35271311
-                                    </a>
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2022 Mar 11. OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
-                                
+
+                                <div class="support-text">p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex class IA, p110delta/p85alpha.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:40205054" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:40205054" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is an uninformative over-annotation for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD does interact with p85-family regulatory subunits and other signaling proteins, but GO:0005515 does not capture the meaningful function. The informative annotations are class IA PI3K complex membership and phosphoinositide kinase activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
-                                        PMID:40205054
-                                    </a>
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">Apr 9. Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                                
+
+                                <div class="support-text">p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex class IA, p110delta/p85alpha.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported cytoplasmic or cytosolic localization, but this is the resting/general pool rather than the most informative activated signaling site.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records cytoplasmic localization and the deep research report describes resting p110delta-p85 complexes as cytosolic. The functionally decisive event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be treated as the core location.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32606397" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32606397
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PI3K activation is enhanced by FOXM1D binding to p110 and p8...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:32606397" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005515" data-r="PMID:32606397" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Protein binding is an uninformative over-annotation for PIK3CD.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD does interact with p85-family regulatory subunits and other signaling proteins, but GO:0005515 does not capture the meaningful function. The informative annotations are class IA PI3K complex membership and phosphoinositide kinase activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/32606397" target="_blank" class="term-link">
-                                        PMID:32606397
-                                    </a>
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">PI3K activation is enhanced by FOXM1D binding to p110 and p85 subunits.</div>
-                                
+
+                                <div class="support-text">p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex class IA, p110delta/p85alpha.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031295" target="_blank" class="term-link">
                                     GO:0031295
                                 </a>
                             </span>
                             <span class="term-label">T cell costimulation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-389356
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0031295" data-r="Reactome:R-HSA-389356" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0031295" data-r="Reactome:R-HSA-389356" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported CD28/T-cell costimulation context for PI3Kdelta signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> CD28 is a direct immune receptor context in which PI3K participates in costimulatory signaling and PIP3 generation. This is part of the core immune-receptor signaling frame for PIK3CD.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In immune cells, class IA PI3K (including p110δ) propagates signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related receptor/adaptor systems), framing the major immune-cell BP terms relevant for PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-389356
+
+                                </span>
+
+                                <div class="support-text">The cytoplasmic tail of CD28, upon ligand binding, undergoes phosphorylation by Src family kinases like LCK and FYN, triggering downstream signaling pathways involving PI3K, VAV-1, Tec family kinases, AKT, and other adaptor proteins (Sharpe &amp; Freeman 2002; Chen &amp; Flies 2013).</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-389158
+
+                                </span>
+
+                                <div class="support-text">Upon binding to CD28, the PI3K enzyme catalyzes the phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate phosphatidylinositol 3,4,5-trisphosphate (PIP3).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046934" target="_blank" class="term-link">
                                     GO:0046934
                                 </a>
                             </span>
                             <span class="term-label">1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-389158
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0046934" data-r="Reactome:R-HSA-389158" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0046934" data-r="Reactome:R-HSA-389158" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Core specific molecular function: p110delta phosphorylates PI(4,5)P2 to generate PIP3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI(4,5)P2 3-kinase activity is the specific catalytic activity that drives PI3Kdelta receptor signaling and PIP3-dependent AKT pathway recruitment.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-389158
+
+                                </span>
+
+                                <div class="support-text">Upon binding to CD28, the PI3K enzyme catalyzes the phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate phosphatidylinositol 3,4,5-trisphosphate (PIP3).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006955" target="_blank" class="term-link">
                                     GO:0006955
                                 </a>
                             </span>
                             <span class="term-label">immune response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27616589" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27616589
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PI3Kδ and primary immunodeficiencies.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0006955" data-r="PMID:27616589" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0006955" data-r="PMID:27616589" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported leukocyte/immune response involvement, but non-core and broad relative to receptor-proximal PI3Kdelta signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD is leukocyte-enriched and affects immune responses, yet this broad immune-process term should not define the core function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PI3Kδ is a lipid kinase of the PI3K class IA family involved in early signaling events of leukocytes responding to a wide variety of stimuli.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/27616589" target="_blank" class="term-link">
                                         PMID:27616589
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Sep 12. PI3Kδ and primary immunodeficiencies.</div>
-                                
+
+                                <div class="support-text">Here, we review the roles of PI3Kδ in adaptive immunity, describe the clinical manifestations and mechanisms of disease in APDS and highlight new insights into PI3Kδ gleaned from these patients, as well as implications of these findings for clinical therapy.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030183" target="_blank" class="term-link">
                                     GO:0030183
                                 </a>
                             </span>
                             <span class="term-label">B cell differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20200404" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20200404
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The catalytic PI3K isoforms p110gamma and p110delta contribu...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030183" data-r="PMID:20200404" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030183" data-r="PMID:20200404" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported B-cell differentiation/development role, but non-core relative to PI3Kdelta catalytic signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> B-cell developmental phenotypes are well supported, but they are downstream organism/cell lineage consequences of PIP3-producing PI3Kdelta signaling.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20200404" target="_blank" class="term-link">
                                         PMID:20200404
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">The catalytic PI3K isoforms p110gamma and p110delta contribute to B cell development and maintenance, transformation, and proliferation.</div>
-                                
+
+                                <div class="support-text">Thus, we provide novel evidence that p110gamma and p110delta have overlapping and cell-extrinsic roles in the development, peripheral maintenance, and function of B cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Required for B-cell receptor (BCR) signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030217" target="_blank" class="term-link">
                                     GO:0030217
                                 </a>
                             </span>
                             <span class="term-label">T cell differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17371229" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17371229
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The PI3K p110delta controls T-cell development, differentiat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030217" data-r="PMID:17371229" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030217" data-r="PMID:17371229" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported T-cell differentiation role, but non-core relative to receptor-proximal PI3Kdelta signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> T-cell differentiation is a supported immune-cell outcome of p110delta activity, not the core molecular function itself.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17371229" target="_blank" class="term-link">
                                         PMID:17371229
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">The PI3K p110delta controls T-cell development, differentiation and regulation.</div>
-                                
+
+                                <div class="support-text">In addition, p110delta regulates the differentiation of peripheral Th (helper T-cells) towards the Th1 and Th2 lineages.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038084" target="_blank" class="term-link">
                                     GO:0038084
                                 </a>
                             </span>
                             <span class="term-label">vascular endothelial growth factor signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31915155" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31915155
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PI3Kδ as a Novel Therapeutic Target in Pathological Angiogen...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0038084" data-r="PMID:31915155" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0038084" data-r="PMID:31915155" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported endothelial/angiogenesis context, but non-core and tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cultured endothelial-cell work supports VEGF-induced Akt activation, proliferation, migration, tube formation, and retinal angiogenesis. This is a real contextual role, not the primary leukocyte-enriched core function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/31915155" target="_blank" class="term-link">
                                         PMID:31915155
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">PI3Kδ as a Novel Therapeutic Target in Pathological Angiogenesis.</div>
-                                
+
+                                <div class="support-text">Using genetic and pharmacological approaches, we show that p110δ activity in cultured ECs controls Akt activation, cell proliferation, migration, and tube formation induced by vascular endothelial growth factor, basic fibroblast growth factor, and epidermal growth factor.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many downstream readouts (e.g., pAKT, pS6) are not isoform-specific, and class I PI3Ks share overlapping functions; p110δ is leukocyte-enriched but not exclusively expressed, so immune-context evidence is strongest for PIK3CD-specific BP claims.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010595" target="_blank" class="term-link">
                                     GO:0010595
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of endothelial cell migration</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31915155" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31915155
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PI3Kδ as a Novel Therapeutic Target in Pathological Angiogen...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0010595" data-r="PMID:31915155" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0010595" data-r="PMID:31915155" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported endothelial/angiogenesis context, but non-core and tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cultured endothelial-cell work supports VEGF-induced Akt activation, proliferation, migration, tube formation, and retinal angiogenesis. This is a real contextual role, not the primary leukocyte-enriched core function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/31915155" target="_blank" class="term-link">
                                         PMID:31915155
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">PI3Kδ as a Novel Therapeutic Target in Pathological Angiogenesis.</div>
-                                
+
+                                <div class="support-text">Using genetic and pharmacological approaches, we show that p110δ activity in cultured ECs controls Akt activation, cell proliferation, migration, and tube formation induced by vascular endothelial growth factor, basic fibroblast growth factor, and epidermal growth factor.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many downstream readouts (e.g., pAKT, pS6) are not isoform-specific, and class I PI3Ks share overlapping functions; p110δ is leukocyte-enriched but not exclusively expressed, so immune-context evidence is strongest for PIK3CD-specific BP claims.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001938" target="_blank" class="term-link">
                                     GO:0001938
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of endothelial cell proliferation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31915155" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31915155
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PI3Kδ as a Novel Therapeutic Target in Pathological Angiogen...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0001938" data-r="PMID:31915155" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0001938" data-r="PMID:31915155" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported endothelial/angiogenesis context, but non-core and tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cultured endothelial-cell work supports VEGF-induced Akt activation, proliferation, migration, tube formation, and retinal angiogenesis. This is a real contextual role, not the primary leukocyte-enriched core function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/31915155" target="_blank" class="term-link">
                                         PMID:31915155
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">PI3Kδ as a Novel Therapeutic Target in Pathological Angiogenesis.</div>
-                                
+
+                                <div class="support-text">Using genetic and pharmacological approaches, we show that p110δ activity in cultured ECs controls Akt activation, cell proliferation, migration, and tube formation induced by vascular endothelial growth factor, basic fibroblast growth factor, and epidermal growth factor.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many downstream readouts (e.g., pAKT, pS6) are not isoform-specific, and class I PI3Ks share overlapping functions; p110δ is leukocyte-enriched but not exclusively expressed, so immune-context evidence is strongest for PIK3CD-specific BP claims.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043491" target="_blank" class="term-link">
                                     GO:0043491
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol 3-kinase/protein kinase B signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31915155" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31915155
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PI3Kδ as a Novel Therapeutic Target in Pathological Angiogen...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0043491" data-r="PMID:31915155" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0043491" data-r="PMID:31915155" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported PI3K/AKT signaling annotation downstream of PIK3CD-generated PIP3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIP3 produced by p110delta recruits AKT-linked signaling modules. This pathway term captures the central signaling output of PI3Kdelta even when the initiating receptor or cell type differs.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31915155" target="_blank" class="term-link">
-                                        PMID:31915155
-                                    </a>
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">PI3Kδ as a Novel Therapeutic Target in Pathological Angiogenesis.</div>
-                                
+
+                                <div class="support-text">**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide 3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes downstream of receptor signaling in immune cells, particularly in lymphocytes.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In immune cells, class IA PI3K (including p110δ) propagates signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related receptor/adaptor systems), framing the major immune-cell BP terms relevant for PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PI3Kδ is a lipid kinase of the PI3K class IA family involved in early signaling events of leukocytes responding to a wide variety of stimuli.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045766" target="_blank" class="term-link">
                                     GO:0045766
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of angiogenesis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0045766" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0045766" data-r="GO_REF:0000024" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported endothelial/angiogenesis context, but non-core and tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cultured endothelial-cell work supports VEGF-induced Akt activation, proliferation, migration, tube formation, and retinal angiogenesis. This is a real contextual role, not the primary leukocyte-enriched core function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/31915155" target="_blank" class="term-link">
+                                        PMID:31915155
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Using genetic and pharmacological approaches, we show that p110δ activity in cultured ECs controls Akt activation, cell proliferation, migration, and tube formation induced by vascular endothelial growth factor, basic fibroblast growth factor, and epidermal growth factor.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many downstream readouts (e.g., pAKT, pS6) are not isoform-specific, and class I PI3Ks share overlapping functions; p110δ is leukocyte-enriched but not exclusively expressed, so immune-context evidence is strongest for PIK3CD-specific BP claims.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1905278" target="_blank" class="term-link">
                                     GO:1905278
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of epithelial tube formation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31915155" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31915155
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PI3Kδ as a Novel Therapeutic Target in Pathological Angiogen...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:1905278" data-r="PMID:31915155" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:1905278" data-r="PMID:31915155" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported endothelial/angiogenesis context, but non-core and tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cultured endothelial-cell work supports VEGF-induced Akt activation, proliferation, migration, tube formation, and retinal angiogenesis. This is a real contextual role, not the primary leukocyte-enriched core function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/31915155" target="_blank" class="term-link">
                                         PMID:31915155
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">PI3Kδ as a Novel Therapeutic Target in Pathological Angiogenesis.</div>
-                                
+
+                                <div class="support-text">Using genetic and pharmacological approaches, we show that p110δ activity in cultured ECs controls Akt activation, cell proliferation, migration, and tube formation induced by vascular endothelial growth factor, basic fibroblast growth factor, and epidermal growth factor.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many downstream readouts (e.g., pAKT, pS6) are not isoform-specific, and class I PI3Ks share overlapping functions; p110δ is leukocyte-enriched but not exclusively expressed, so immune-context evidence is strongest for PIK3CD-specific BP claims.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0033031" target="_blank" class="term-link">
                                     GO:0033031
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of neutrophil apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25339672" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25339672
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human IgA Fc receptor FcαRI (CD89) triggers different forms ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0033031" data-r="PMID:25339672" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0033031" data-r="PMID:25339672" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported neutrophil-death/apoptotic-process annotation, but non-core and context-dependent.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> FcαRI-triggered neutrophil death requires class IA PI3K signaling in inflammatory contexts. This supports the annotation as a non-core immune effector process.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/25339672" target="_blank" class="term-link">
                                         PMID:25339672
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2014 Oct 22. Human IgA Fc receptor FcαRI (CD89) triggers different forms of neutrophil death depending on the inflammatory microenvironment.</div>
-                                
+
+                                <div class="support-text">preactivation with cytokines or TLR agonists in vitro enhanced FcαRI-mediated death by additional recruitment of caspase-independent pathways, but this required PI3K class IA and MAPK signaling.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043491" target="_blank" class="term-link">
                                     GO:0043491
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol 3-kinase/protein kinase B signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25339672" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25339672
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human IgA Fc receptor FcαRI (CD89) triggers different forms ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0043491" data-r="PMID:25339672" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0043491" data-r="PMID:25339672" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported PI3K/AKT signaling annotation downstream of PIK3CD-generated PIP3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIP3 produced by p110delta recruits AKT-linked signaling modules. This pathway term captures the central signaling output of PI3Kdelta even when the initiating receptor or cell type differs.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/25339672" target="_blank" class="term-link">
-                                        PMID:25339672
-                                    </a>
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">2014 Oct 22. Human IgA Fc receptor FcαRI (CD89) triggers different forms of neutrophil death depending on the inflammatory microenvironment.</div>
-                                
+
+                                <div class="support-text">**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide 3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes downstream of receptor signaling in immune cells, particularly in lymphocytes.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In immune cells, class IA PI3K (including p110δ) propagates signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related receptor/adaptor systems), framing the major immune-cell BP terms relevant for PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PI3Kδ is a lipid kinase of the PI3K class IA family involved in early signaling events of leukocytes responding to a wide variety of stimuli.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001779" target="_blank" class="term-link">
                                     GO:0001779
                                 </a>
                             </span>
                             <span class="term-label">natural killer cell differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0001779" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0001779" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported NK-cell differentiation role, but non-core relative to PI3Kdelta catalytic signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI3Kdelta participates in NK-cell development and migration, but this is a leukocyte-specific cellular outcome rather than the core lipid kinase function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PI3Kδ is a lipid kinase of the PI3K class IA family involved in early signaling events of leukocytes responding to a wide variety of stimuli.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001819" target="_blank" class="term-link">
                                     GO:0001819
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of cytokine production</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0001819" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0001819" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported cytokine-production role, but non-core and downstream of immune receptor signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytokine-production changes are leukocyte outputs of PI3Kdelta signaling, not the primary biochemical function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">As a result of the broad effects of PI3Kδ in leukocyte functions, the disruption of PI3Kδ expression or activity leads to decreased inflammatory and immune responses in vivo.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Required for T-cell receptor (TCR) signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002250" target="_blank" class="term-link">
                                     GO:0002250
                                 </a>
                             </span>
                             <span class="term-label">adaptive immune response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17290298" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17290298
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PI3K delta and PI3K gamma: partners in crime in inflammation...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0002250" data-r="PMID:17290298" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0002250" data-r="PMID:17290298" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported adaptive-immune output, but this is a systems-level consequence of PI3Kdelta immune receptor signaling rather than the core molecular function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Human disease genetics and leukocyte studies support a role in adaptive immunity, but the core function should remain PIP3-producing class IA PI3K signaling.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17290298" target="_blank" class="term-link">
-                                        PMID:17290298
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/27616589" target="_blank" class="term-link">
+                                        PMID:27616589
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">PI3K delta and PI3K gamma: partners in crime in inflammation in rheumatoid arthritis and beyond? Rommel C(1), Camps M, Ji H.</div>
-                                
+
+                                <div class="support-text">Here, we review the roles of PI3Kδ in adaptive immunity, describe the clinical manifestations and mechanisms of disease in APDS and highlight new insights into PI3Kδ gleaned from these patients, as well as implications of these findings for clinical therapy.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">As a result of the broad effects of PI3Kδ in leukocyte functions, the disruption of PI3Kδ expression or activity leads to decreased inflammatory and immune responses in vivo.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002551" target="_blank" class="term-link">
                                     GO:0002551
                                 </a>
                             </span>
                             <span class="term-label">mast cell chemotaxis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0002551" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0002551" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported leukocyte migration/chemotaxis/extravasation role, but non-core relative to receptor-proximal PI3Kdelta signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI3Kdelta affects migration of multiple leukocyte types, but these are cell-type-specific outputs of the core PIP3-generating immune signaling function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002679" target="_blank" class="term-link">
                                     GO:0002679
                                 </a>
                             </span>
                             <span class="term-label">respiratory burst involved in defense response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0002679" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0002679" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported neutrophil respiratory-burst role, but non-core relative to the catalytic PI3Kdelta signaling function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI3Kdelta contributes to neutrophil respiratory burst as a myeloid effector output, but this is not the core molecular function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006954" target="_blank" class="term-link">
                                     GO:0006954
                                 </a>
                             </span>
                             <span class="term-label">inflammatory response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17290298" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17290298
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PI3K delta and PI3K gamma: partners in crime in inflammation...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0006954" data-r="PMID:17290298" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0006954" data-r="PMID:17290298" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported inflammatory-response involvement, but it is a downstream physiological output of PI3Kdelta activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI3Kdelta disruption alters inflammatory responses in vivo and PI3K lipid messengers control leukocyte signaling, but inflammation is a non-core phenotype/process relative to lipid kinase signaling.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17290298" target="_blank" class="term-link">
                                         PMID:17290298
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">PI3K delta and PI3K gamma: partners in crime in inflammation in rheumatoid arthritis and beyond? Rommel C(1), Camps M, Ji H.</div>
-                                
+
+                                <div class="support-text">Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second messengers that control an array of intracellular signalling pathways that are known to have important roles in leukocytes.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">As a result of the broad effects of PI3Kδ in leukocyte functions, the disruption of PI3Kδ expression or activity leads to decreased inflammatory and immune responses in vivo.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006954" target="_blank" class="term-link">
                                     GO:0006954
                                 </a>
                             </span>
                             <span class="term-label">inflammatory response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0006954" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0006954" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported inflammatory-response involvement, but it is a downstream physiological output of PI3Kdelta activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI3Kdelta disruption alters inflammatory responses in vivo and PI3K lipid messengers control leukocyte signaling, but inflammation is a non-core phenotype/process relative to lipid kinase signaling.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17290298" target="_blank" class="term-link">
+                                        PMID:17290298
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second messengers that control an array of intracellular signalling pathways that are known to have important roles in leukocytes.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">As a result of the broad effects of PI3Kδ in leukocyte functions, the disruption of PI3Kδ expression or activity leads to decreased inflammatory and immune responses in vivo.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010818" target="_blank" class="term-link">
                                     GO:0010818
                                 </a>
                             </span>
                             <span class="term-label">T cell chemotaxis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0010818" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0010818" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported leukocyte migration/chemotaxis/extravasation role, but non-core relative to receptor-proximal PI3Kdelta signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI3Kdelta affects migration of multiple leukocyte types, but these are cell-type-specific outputs of the core PIP3-generating immune signaling function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016303" target="_blank" class="term-link">
                                     GO:0016303
                                 </a>
                             </span>
                             <span class="term-label">1-phosphatidylinositol-3-kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17290298" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17290298
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PI3K delta and PI3K gamma: partners in crime in inflammation...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0016303" data-r="PMID:17290298" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0016303" data-r="PMID:17290298" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Core molecular function as a phosphatidylinositol 3-kinase catalytic subunit.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> This parent PI3K activity term is valid for p110delta, although GO:0046934 is the most specific MF term for its canonical PIP2-to-PIP3 reaction.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17290298" target="_blank" class="term-link">
-                                        PMID:17290298
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9235916" target="_blank" class="term-link">
+                                        PMID:9235916
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">PI3K delta and PI3K gamma: partners in crime in inflammation in rheumatoid arthritis and beyond? Rommel C(1), Camps M, Ji H.</div>
-                                
+
+                                <div class="support-text">Recombinant p110delta phosphorylates phosphatidylinositol and coimmunoprecipitates with p85.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030101" target="_blank" class="term-link">
                                     GO:0030101
                                 </a>
                             </span>
                             <span class="term-label">natural killer cell activation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030101" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030101" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported NK-cell activation context, but non-core relative to receptor-proximal PI3Kdelta signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> NK-cell activation is a supported immune output; the central curatable function remains PI3Kdelta PIP3 production in leukocyte signaling.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PI3Kδ is a lipid kinase of the PI3K class IA family involved in early signaling events of leukocytes responding to a wide variety of stimuli.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030217" target="_blank" class="term-link">
                                     GO:0030217
                                 </a>
                             </span>
                             <span class="term-label">T cell differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030217" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030217" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported T-cell differentiation role, but non-core relative to receptor-proximal PI3Kdelta signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> T-cell differentiation is a supported immune-cell outcome of p110delta activity, not the core molecular function itself.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17371229" target="_blank" class="term-link">
+                                        PMID:17371229
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">In addition, p110delta regulates the differentiation of peripheral Th (helper T-cells) towards the Th1 and Th2 lineages.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030593" target="_blank" class="term-link">
                                     GO:0030593
                                 </a>
                             </span>
                             <span class="term-label">neutrophil chemotaxis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030593" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030593" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported leukocyte migration/chemotaxis/extravasation role, but non-core relative to receptor-proximal PI3Kdelta signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI3Kdelta affects migration of multiple leukocyte types, but these are cell-type-specific outputs of the core PIP3-generating immune signaling function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035747" target="_blank" class="term-link">
                                     GO:0035747
                                 </a>
                             </span>
                             <span class="term-label">natural killer cell chemotaxis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0035747" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0035747" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported leukocyte migration/chemotaxis/extravasation role, but non-core relative to receptor-proximal PI3Kdelta signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI3Kdelta affects migration of multiple leukocyte types, but these are cell-type-specific outputs of the core PIP3-generating immune signaling function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035754" target="_blank" class="term-link">
                                     GO:0035754
                                 </a>
                             </span>
                             <span class="term-label">B cell chemotaxis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0035754" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0035754" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported leukocyte migration/chemotaxis/extravasation role, but non-core relative to receptor-proximal PI3Kdelta signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI3Kdelta affects migration of multiple leukocyte types, but these are cell-type-specific outputs of the core PIP3-generating immune signaling function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042110" target="_blank" class="term-link">
                                     GO:0042110
                                 </a>
                             </span>
                             <span class="term-label">T cell activation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0042110" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0042110" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported T-cell activation/function annotation, but downstream of the more core TCR/CD28 signaling role.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD contributes to T-cell development, activation, and migration. The T-cell activation process is supported but is a cellular outcome of the core TCR/CD28 PI3K signaling function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Required for T-cell receptor (TCR) signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042113" target="_blank" class="term-link">
                                     GO:0042113
                                 </a>
                             </span>
                             <span class="term-label">B cell activation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0042113" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0042113" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported B-cell activation/function annotation, but downstream of the more core BCR signaling role.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD is important for B-cell development and function. B-cell activation is real, but BCR signaling and PI3K/AKT signaling are the more precise core process annotations.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
-                                        PMID:20940048
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20200404" target="_blank" class="term-link">
+                                        PMID:20200404
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">Thus, we provide novel evidence that p110gamma and p110delta have overlapping and cell-extrinsic roles in the development, peripheral maintenance, and function of B cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Required for B-cell receptor (BCR) signaling.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043303" target="_blank" class="term-link">
                                     GO:0043303
                                 </a>
                             </span>
                             <span class="term-label">mast cell degranulation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0043303" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0043303" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported mast-cell degranulation role, but non-core relative to the catalytic PI3Kdelta function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI3Kdelta contributes to mast-cell degranulation, but this is a cell-type-specific effector output rather than the core molecular function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043491" target="_blank" class="term-link">
                                     GO:0043491
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol 3-kinase/protein kinase B signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17290298" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17290298
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PI3K delta and PI3K gamma: partners in crime in inflammation...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0043491" data-r="PMID:17290298" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0043491" data-r="PMID:17290298" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported PI3K/AKT signaling annotation downstream of PIK3CD-generated PIP3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIP3 produced by p110delta recruits AKT-linked signaling modules. This pathway term captures the central signaling output of PI3Kdelta even when the initiating receptor or cell type differs.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17290298" target="_blank" class="term-link">
-                                        PMID:17290298
-                                    </a>
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">PI3K delta and PI3K gamma: partners in crime in inflammation in rheumatoid arthritis and beyond? Rommel C(1), Camps M, Ji H.</div>
-                                
+
+                                <div class="support-text">**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide 3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes downstream of receptor signaling in immune cells, particularly in lymphocytes.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In immune cells, class IA PI3K (including p110δ) propagates signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related receptor/adaptor systems), framing the major immune-cell BP terms relevant for PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PI3Kδ is a lipid kinase of the PI3K class IA family involved in early signaling events of leukocytes responding to a wide variety of stimuli.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045087" target="_blank" class="term-link">
                                     GO:0045087
                                 </a>
                             </span>
                             <span class="term-label">innate immune response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17290298" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17290298
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     PI3K delta and PI3K gamma: partners in crime in inflammation...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0045087" data-r="PMID:17290298" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0045087" data-r="PMID:17290298" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported innate-immune involvement, but this is a broad non-core immune-system output.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI3Kdelta contributes to myeloid and innate leukocyte activities, but the precise core function is receptor-linked PIP3 production rather than innate immunity as a whole.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17290298" target="_blank" class="term-link">
                                         PMID:17290298
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">PI3K delta and PI3K gamma: partners in crime in inflammation in rheumatoid arthritis and beyond? Rommel C(1), Camps M, Ji H.</div>
-                                
+
+                                <div class="support-text">Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second messengers that control an array of intracellular signalling pathways that are known to have important roles in leukocytes.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045087" target="_blank" class="term-link">
                                     GO:0045087
                                 </a>
                             </span>
                             <span class="term-label">innate immune response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0045087" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0045087" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported innate-immune involvement, but this is a broad non-core immune-system output.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI3Kdelta contributes to myeloid and innate leukocyte activities, but the precise core function is receptor-linked PIP3 production rather than innate immunity as a whole.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17290298" target="_blank" class="term-link">
+                                        PMID:17290298
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second messengers that control an array of intracellular signalling pathways that are known to have important roles in leukocytes.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050852" target="_blank" class="term-link">
                                     GO:0050852
                                 </a>
                             </span>
                             <span class="term-label">T cell receptor signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0050852" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0050852" data-r="PMID:20940048" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported TCR signaling role for PI3Kdelta.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt and the literature synthesis identify p110delta as required for TCR signaling, making this one of the core immune receptor signaling processes for PIK3CD.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">Required for T-cell receptor (TCR) signaling.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In immune cells, class IA PI3K (including p110δ) propagates signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related receptor/adaptor systems), framing the major immune-cell BP terms relevant for PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050853" target="_blank" class="term-link">
                                     GO:0050853
                                 </a>
                             </span>
                             <span class="term-label">B cell receptor signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0050853" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0050853" data-r="PMID:20940048" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported BCR signaling role for PI3Kdelta.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> p110delta is required for BCR signaling and B-cell functional outputs; this is one of the strongest process annotations for PIK3CD.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
-                                        PMID:20940048
-                                    </a>
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">Required for B-cell receptor (BCR) signaling.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In immune cells, class IA PI3K (including p110δ) propagates signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related receptor/adaptor systems), framing the major immune-cell BP terms relevant for PIK3CD.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20200404" target="_blank" class="term-link">
+                                        PMID:20200404
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Thus, we provide novel evidence that p110gamma and p110delta have overlapping and cell-extrinsic roles in the development, peripheral maintenance, and function of B cells.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060374" target="_blank" class="term-link">
                                     GO:0060374
                                 </a>
                             </span>
                             <span class="term-label">mast cell differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0060374" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0060374" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported mast-cell differentiation role, but non-core relative to the catalytic PI3Kdelta function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Mast-cell maturation/differentiation is a supported leukocyte-cell output of PI3Kdelta signaling, not the core molecular activity.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072672" target="_blank" class="term-link">
                                     GO:0072672
                                 </a>
                             </span>
                             <span class="term-label">neutrophil extravasation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20940048
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signali...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0072672" data-r="PMID:20940048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0072672" data-r="PMID:20940048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported leukocyte migration/chemotaxis/extravasation role, but non-core relative to receptor-proximal PI3Kdelta signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PI3Kdelta affects migration of multiple leukocyte types, but these are cell-type-specific outputs of the core PIP3-generating immune signaling function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                                         PMID:20940048
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                                
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010628" target="_blank" class="term-link">
                                     GO:0010628
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of gene expression</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22079609" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22079609
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The catalytic phosphoinositol 3-kinase isoform p110δ is requ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0010628" data-r="PMID:22079609" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0010628" data-r="PMID:22079609" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Over-annotation to positive regulation of gene expression. The available PIK3CD evidence supports upstream PI3K/AKT signaling more directly than this distal transcriptional-output term.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Gene-expression changes can occur downstream of PI3K/AKT/FOXO signaling, but the cited evidence is more direct for lipid kinase signaling, migration, and protein-level pathway outputs. This broad distal term should not be retained as a core annotation.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many downstream readouts (e.g., pAKT, pS6) are not isoform-specific, and class I PI3Ks share overlapping functions; p110δ is leukocyte-enriched but not exclusively expressed, so immune-context evidence is strongest for PIK3CD-specific BP claims.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22079609" target="_blank" class="term-link">
                                         PMID:22079609
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2011 Nov 11. The catalytic phosphoinositol 3-kinase isoform p110δ is required for glioma cell migration and invasion.</div>
-                                
+
+                                <div class="support-text">Interestingly, knockdown of p110δ decreased the cell migration and invasion ability of all GBM cell lines tested.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0030335" target="_blank" class="term-link">
                                     GO:0030335
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of cell migration</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22079609" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22079609
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The catalytic phosphoinositol 3-kinase isoform p110δ is requ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030335" data-r="PMID:22079609" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0030335" data-r="PMID:22079609" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported cell-migration role in specific leukocyte and glioma contexts, but non-core relative to lipid kinase signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD knockdown decreases glioma-cell migration and PI3Kdelta also affects leukocyte migration; these are downstream context-specific outputs rather than the core function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22079609" target="_blank" class="term-link">
                                         PMID:22079609
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2011 Nov 11. The catalytic phosphoinositol 3-kinase isoform p110δ is required for glioma cell migration and invasion.</div>
-                                
+
+                                <div class="support-text">Interestingly, knockdown of p110δ decreased the cell migration and invasion ability of all GBM cell lines tested.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
+                                        PMID:20940048
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">PI3Kδ participates in the development, activation and migration of T cells and NK cells.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1676048
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="Reactome:R-HSA-1676048" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="Reactome:R-HSA-1676048" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported cytoplasmic or cytosolic localization, but this is the resting/general pool rather than the most informative activated signaling site.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records cytoplasmic localization and the deep research report describes resting p110delta-p85 complexes as cytosolic. The functionally decisive event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be treated as the core location.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1676109
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="Reactome:R-HSA-1676109" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="Reactome:R-HSA-1676109" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported cytoplasmic or cytosolic localization, but this is the resting/general pool rather than the most informative activated signaling site.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records cytoplasmic localization and the deep research report describes resting p110delta-p85 complexes as cytosolic. The functionally decisive event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be treated as the core location.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9012657
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="Reactome:R-HSA-9012657" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="Reactome:R-HSA-9012657" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported cytoplasmic or cytosolic localization, but this is the resting/general pool rather than the most informative activated signaling site.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records cytoplasmic localization and the deep research report describes resting p110delta-p85 complexes as cytosolic. The functionally decisive event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be treated as the core location.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9021627
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="Reactome:R-HSA-9021627" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="Reactome:R-HSA-9021627" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported cytoplasmic or cytosolic localization, but this is the resting/general pool rather than the most informative activated signaling site.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records cytoplasmic localization and the deep research report describes resting p110delta-p85 complexes as cytosolic. The functionally decisive event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be treated as the core location.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9027275
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="Reactome:R-HSA-9027275" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="Reactome:R-HSA-9027275" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported cytoplasmic or cytosolic localization, but this is the resting/general pool rather than the most informative activated signaling site.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records cytoplasmic localization and the deep research report describes resting p110delta-p85 complexes as cytosolic. The functionally decisive event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be treated as the core location.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9606887
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="Reactome:R-HSA-9606887" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005829" data-r="Reactome:R-HSA-9606887" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported cytoplasmic or cytosolic localization, but this is the resting/general pool rather than the most informative activated signaling site.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> UniProt records cytoplasmic localization and the deep research report describes resting p110delta-p85 complexes as cytosolic. The functionally decisive event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be treated as the core location.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-2045911
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-2045911" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-2045911" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported core activated-site localization. PI3Kdelta is recruited to plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates reside.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Membrane recruitment is central to class IA PI3Kdelta activity because PIP2 substrate is membrane localized and receptor phosphotyrosine signals recruit the p85-p110delta complex to the plasma membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1676048
+
+                                </span>
+
+                                <div class="support-text">At the plasma membrane, phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunits form complexes with regulatory subunits.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-2076220
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-2076220" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-2076220" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported core activated-site localization. PI3Kdelta is recruited to plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates reside.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Membrane recruitment is central to class IA PI3Kdelta activity because PIP2 substrate is membrane localized and receptor phosphotyrosine signals recruit the p85-p110delta complex to the plasma membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1676048
+
+                                </span>
+
+                                <div class="support-text">At the plasma membrane, phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunits form complexes with regulatory subunits.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-2316434
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-2316434" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-2316434" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported core activated-site localization. PI3Kdelta is recruited to plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates reside.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Membrane recruitment is central to class IA PI3Kdelta activity because PIP2 substrate is membrane localized and receptor phosphotyrosine signals recruit the p85-p110delta complex to the plasma membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1676048
+
+                                </span>
+
+                                <div class="support-text">At the plasma membrane, phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunits form complexes with regulatory subunits.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-2400009
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-2400009" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-2400009" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported core activated-site localization. PI3Kdelta is recruited to plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates reside.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Membrane recruitment is central to class IA PI3Kdelta activity because PIP2 substrate is membrane localized and receptor phosphotyrosine signals recruit the p85-p110delta complex to the plasma membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1676048
+
+                                </span>
+
+                                <div class="support-text">At the plasma membrane, phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunits form complexes with regulatory subunits.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-388830
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-388830" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-388830" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported core activated-site localization. PI3Kdelta is recruited to plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates reside.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Membrane recruitment is central to class IA PI3Kdelta activity because PIP2 substrate is membrane localized and receptor phosphotyrosine signals recruit the p85-p110delta complex to the plasma membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1676048
+
+                                </span>
+
+                                <div class="support-text">At the plasma membrane, phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunits form complexes with regulatory subunits.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-388832
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-388832" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-388832" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported core activated-site localization. PI3Kdelta is recruited to plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates reside.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Membrane recruitment is central to class IA PI3Kdelta activity because PIP2 substrate is membrane localized and receptor phosphotyrosine signals recruit the p85-p110delta complex to the plasma membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1676048
+
+                                </span>
+
+                                <div class="support-text">At the plasma membrane, phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunits form complexes with regulatory subunits.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-389158
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-389158" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-389158" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported core activated-site localization. PI3Kdelta is recruited to plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates reside.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Membrane recruitment is central to class IA PI3Kdelta activity because PIP2 substrate is membrane localized and receptor phosphotyrosine signals recruit the p85-p110delta complex to the plasma membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1676048
+
+                                </span>
+
+                                <div class="support-text">At the plasma membrane, phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunits form complexes with regulatory subunits.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-508247
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-508247" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-508247" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported core activated-site localization. PI3Kdelta is recruited to plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates reside.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Membrane recruitment is central to class IA PI3Kdelta activity because PIP2 substrate is membrane localized and receptor phosphotyrosine signals recruit the p85-p110delta complex to the plasma membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1676048
+
+                                </span>
+
+                                <div class="support-text">At the plasma membrane, phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunits form complexes with regulatory subunits.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-879917
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-879917" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-879917" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported core activated-site localization. PI3Kdelta is recruited to plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates reside.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Membrane recruitment is central to class IA PI3Kdelta activity because PIP2 substrate is membrane localized and receptor phosphotyrosine signals recruit the p85-p110delta complex to the plasma membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1676048
+
+                                </span>
+
+                                <div class="support-text">At the plasma membrane, phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunits form complexes with regulatory subunits.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8854905
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-8854905" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-8854905" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported core activated-site localization. PI3Kdelta is recruited to plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates reside.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Membrane recruitment is central to class IA PI3Kdelta activity because PIP2 substrate is membrane localized and receptor phosphotyrosine signals recruit the p85-p110delta complex to the plasma membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1676048
+
+                                </span>
+
+                                <div class="support-text">At the plasma membrane, phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunits form complexes with regulatory subunits.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-912627
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-912627" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-912627" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported core activated-site localization. PI3Kdelta is recruited to plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates reside.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Membrane recruitment is central to class IA PI3Kdelta activity because PIP2 substrate is membrane localized and receptor phosphotyrosine signals recruit the p85-p110delta complex to the plasma membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1676048
+
+                                </span>
+
+                                <div class="support-text">At the plasma membrane, phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunits form complexes with regulatory subunits.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-914182
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-914182" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-914182" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported core activated-site localization. PI3Kdelta is recruited to plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates reside.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Membrane recruitment is central to class IA PI3Kdelta activity because PIP2 substrate is membrane localized and receptor phosphotyrosine signals recruit the p85-p110delta complex to the plasma membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1676048
+
+                                </span>
+
+                                <div class="support-text">At the plasma membrane, phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunits form complexes with regulatory subunits.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9606887
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-9606887" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005886" data-r="Reactome:R-HSA-9606887" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Supported core activated-site localization. PI3Kdelta is recruited to plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates reside.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Membrane recruitment is central to class IA PI3Kdelta activity because PIP2 substrate is membrane localized and receptor phosphotyrosine signals recruit the p85-p110delta complex to the plasma membrane.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    Reactome:R-HSA-1676048
+
+                                </span>
+
+                                <div class="support-text">At the plasma membrane, phosphatidylinositol-4,5-bisphosphate 3-kinase catalytic subunits form complexes with regulatory subunits.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005942" target="_blank" class="term-link">
                                     GO:0005942
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol 3-kinase complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9113989
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     P110delta, a novel phosphoinositide 3-kinase in leukocytes.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005942" data-r="PMID:9113989" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005942" data-r="PMID:9113989" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The complex assignment is valid but should use the more specific class IA phosphatidylinositol 3-kinase complex term.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD is not just any PI3K-complex component; it is the p110delta catalytic subunit of class IA p85-family regulatory complexes. GO:0005943 captures the correct complex subtype.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005943" target="_blank" class="term-link">
+                                    phosphatidylinositol 3-kinase complex, class IA
+                                </a>
+                            </span>
+
+                        </div>
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
-                                        PMID:9113989
-                                    </a>
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
                                 </span>
-                                
-                                <div class="support-text">P110delta, a novel phosphoinositide 3-kinase in leukocytes.</div>
-                                
+
+                                <div class="support-text">p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex class IA, p110delta/p85alpha.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9235916" target="_blank" class="term-link">
+                                        PMID:9235916
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Recombinant p110delta phosphorylates phosphatidylinositol and coimmunoprecipitates with p85.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005942" target="_blank" class="term-link">
                                     GO:0005942
                                 </a>
                             </span>
                             <span class="term-label">phosphatidylinositol 3-kinase complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9235916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9235916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     p110delta, a novel phosphatidylinositol 3-kinase catalytic s...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005942" data-r="PMID:9235916" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0005942" data-r="PMID:9235916" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The complex assignment is valid but should use the more specific class IA phosphatidylinositol 3-kinase complex term.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD is not just any PI3K-complex component; it is the p110delta catalytic subunit of class IA p85-family regulatory complexes. GO:0005943 captures the correct complex subtype.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005943" target="_blank" class="term-link">
+                                    phosphatidylinositol 3-kinase complex, class IA
+                                </a>
+                            </span>
+
+                        </div>
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                                </span>
+
+                                <div class="support-text">ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex class IA, p110delta/p85alpha.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9235916" target="_blank" class="term-link">
                                         PMID:9235916
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">p110delta, a novel phosphatidylinositol 3-kinase catalytic subunit that associates with p85 and is expressed predominantly in leukocytes.</div>
-                                
+
+                                <div class="support-text">Recombinant p110delta phosphorylates phosphatidylinositol and coimmunoprecipitates with p85.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006468" target="_blank" class="term-link">
                                     GO:0006468
                                 </a>
                             </span>
                             <span class="term-label">protein phosphorylation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9113989
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     P110delta, a novel phosphoinositide 3-kinase in leukocytes.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -7321,940 +10474,1706 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> OVER-ANNOTATION: PIK3CD (p110delta) is primarily a LIPID kinase, not a protein kinase. PMID:9113989 explicitly states PIK3CD &#34;displays a broad phosphoinositide lipid substrate specificity&#34; and notably &#34;does not phosphorylate p85&#34; (unlike p110alpha). The paper mentions only &#34;intrinsic autophosphorylation capacity&#34;, which is distinct from general protein phosphorylation. PIK3CD has EC 2.7.1.137 (phosphatidylinositol-4,5-bisphosphate 3-kinase) for lipid phosphorylation. The annotation should be to lipid phosphorylation (GO:0046834) or the specific PI3K process, not protein phosphorylation.
+                            <strong>Summary:</strong> Over-annotation to protein phosphorylation. PIK3CD is primarily a phosphoinositide lipid kinase, not a protein kinase.
                         </div>
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PMID:9113989 reports lipid substrate specificity and explicitly distinguishes p110delta from p110alpha by noting that it does not phosphorylate p85, despite intrinsic autophosphorylation. The annotation should point to lipid phosphorylation or PI(4,5)P2 3-kinase activity rather than general protein phosphorylation.
+                        </div>
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046834" target="_blank" class="term-link">
                                     lipid phosphorylation
                                 </a>
                             </span>
-                            
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046934" target="_blank" class="term-link">
+                                    1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+                                </a>
+                            </span>
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
                                         PMID:9113989
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">P110delta, a novel phosphoinositide 3-kinase in leukocytes.</div>
-                                
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Unlike p110alpha, p110delta does not phosphorylate p85 but instead harbors an intrinsic autophosphorylation capacity.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007165" target="_blank" class="term-link">
                                     GO:0007165
                                 </a>
                             </span>
                             <span class="term-label">signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9113989
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     P110delta, a novel phosphoinositide 3-kinase in leukocytes.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0007165" data-r="PMID:9113989" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0007165" data-r="PMID:9113989" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The generic signal-transduction annotation should be narrowed to PI3K/AKT and immune receptor signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> PIK3CD participates in signaling by generating PIP3 downstream of receptor activation. The generic signal transduction parent obscures the specific PI3K/AKT, BCR, and TCR pathways supported by the evidence.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043491" target="_blank" class="term-link">
+                                    phosphatidylinositol 3-kinase/protein kinase B signal transduction
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050853" target="_blank" class="term-link">
+                                    B cell receptor signaling pathway
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050852" target="_blank" class="term-link">
+                                    T cell receptor signaling pathway
+                                </a>
+                            </span>
+
+                        </div>
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
                                         PMID:9113989
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">P110delta, a novel phosphoinositide 3-kinase in leukocytes.</div>
-                                
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">In immune cells, class IA PI3K (including p110δ) propagates signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related receptor/adaptor systems), framing the major immune-cell BP terms relevant for PIK3CD.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016303" target="_blank" class="term-link">
                                     GO:0016303
                                 </a>
                             </span>
                             <span class="term-label">1-phosphatidylinositol-3-kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9235916" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9235916
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     p110delta, a novel phosphatidylinositol 3-kinase catalytic s...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="O00329" data-a="GO:0016303" data-r="PMID:9235916" data-act="PENDING">
+                        <span class="vote-buttons" data-g="O00329" data-a="GO:0016303" data-r="PMID:9235916" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Core molecular function as a phosphatidylinositol 3-kinase catalytic subunit.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> This parent PI3K activity term is valid for p110delta, although GO:0046934 is the most specific MF term for its canonical PIP2-to-PIP3 reaction.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9235916" target="_blank" class="term-link">
                                         PMID:9235916
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">p110delta, a novel phosphatidylinositol 3-kinase catalytic subunit that associates with p85 and is expressed predominantly in leukocytes.</div>
-                                
+
+                                <div class="support-text">Recombinant p110delta phosphorylates phosphatidylinositol and coimmunoprecipitates with p85.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
+                                        PMID:9113989
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">p110delta displays a broad phosphoinositide lipid substrate specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins and with GTP-bound Ras.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>PIK3CD/p110delta is the leukocyte-enriched class IA PI3K catalytic subunit that forms p85-family regulatory complexes and generates PIP3 from PI(4,5)P2 at receptor-activated membranes.</h3>
+                <span class="vote-buttons" data-g="O00329" data-a="FUNCTION: PIK3CD/p110delta is the leukocyte-enriched class I..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046934" target="_blank" class="term-link">
+                            1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043491" target="_blank" class="term-link">
+                                phosphatidylinositol 3-kinase/protein kinase B signal transduction
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050853" target="_blank" class="term-link">
+                                B cell receptor signaling pathway
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050852" target="_blank" class="term-link">
+                                T cell receptor signaling pathway
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031295" target="_blank" class="term-link">
+                                T cell costimulation
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
+                                plasma membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005943" target="_blank" class="term-link">
+                            phosphatidylinositol 3-kinase complex, class IA
+                        </a>
+                    </span>
+                </div>
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide 3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes downstream of receptor signaling in immune cells, particularly in lymphocytes.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">In immune cells, class IA PI3K (including p110δ) propagates signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related receptor/adaptor systems), framing the major immune-cell BP terms relevant for PIK3CD.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            Reactome:R-HSA-389158
+
+                        </span>
+
+                        <div class="finding-text">Upon binding to CD28, the PI3K enzyme catalyzes the phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate phosphatidylinositol 3,4,5-trisphosphate (PIP3).</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                        </span>
+
+                        <div class="finding-text">ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex class IA, p110delta/p85alpha.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
                             GO_REF:0000024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by ARBA machine learning models</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17290298" target="_blank" class="term-link">
                             PMID:17290298
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PI3K delta and PI3K gamma: partners in crime in inflammation in rheumatoid arthritis and beyond?</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17371229" target="_blank" class="term-link">
                             PMID:17371229
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The PI3K p110delta controls T-cell development, differentiation and regulation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20200404" target="_blank" class="term-link">
                             PMID:20200404
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The catalytic PI3K isoforms p110gamma and p110delta contribute to B cell development and maintenance, transformation, and proliferation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" target="_blank" class="term-link">
                             PMID:20940048
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21827948" target="_blank" class="term-link">
                             PMID:21827948
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dynamics of the phosphoinositide 3-kinase p110δ interaction with p85α and membranes reveals aspects of regulation distinct from p110α.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22020336" target="_blank" class="term-link">
                             PMID:22020336
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">p37δ is a new isoform of PI3K p110δ that increases cell proliferation and is overexpressed in tumors.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22079609" target="_blank" class="term-link">
                             PMID:22079609
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The catalytic phosphoinositol 3-kinase isoform p110δ is required for glioma cell migration and invasion.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24165795" target="_blank" class="term-link">
                             PMID:24165795
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dominant-activating germline mutations in the gene encoding the PI(3)K catalytic subunit p110δ result in T cell senescence and human immunodeficiency.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25339672" target="_blank" class="term-link">
                             PMID:25339672
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human IgA Fc receptor FcαRI (CD89) triggers different forms of neutrophil death depending on the inflammatory microenvironment.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27616589" target="_blank" class="term-link">
                             PMID:27616589
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PI3Kδ and primary immunodeficiencies.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/28514442" target="_blank" class="term-link">
                             PMID:28514442
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Architecture of the human interactome defines protein communities and disease networks.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31031754" target="_blank" class="term-link">
                             PMID:31031754
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Case Study: Mechanism for Increased Follicular Helper T Cell Development in Activated PI3K Delta Syndrome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31915155" target="_blank" class="term-link">
                             PMID:31915155
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PI3Kδ as a Novel Therapeutic Target in Pathological Angiogenesis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32606397" target="_blank" class="term-link">
                             PMID:32606397
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PI3K activation is enhanced by FOXM1D binding to p110 and p85 subunits.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
                             PMID:35271311
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9113989" target="_blank" class="term-link">
                             PMID:9113989
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">P110delta, a novel phosphoinositide 3-kinase in leukocytes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9235916" target="_blank" class="term-link">
                             PMID:9235916
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">p110delta, a novel phosphatidylinositol 3-kinase catalytic subunit that associates with p85 and is expressed predominantly in leukocytes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1676048
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PI(4,5)P2 is phosphorylated to PI(3,4,5)P3 by PIK3C[1] at the plasma membrane</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1676109
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PI4P is phosphorylated to PI(3,4)P2 by PI3K3C[2] at the plasma membrane</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-2045911
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">BCAP Signalosome phosphorylates PI(4,5)P2 forming PI(3,4,5)P3</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-2076220
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CD19 Signalosome phosphorylates PI(4,5)P2 forming PI(3,4,5)P3</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-2316434
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PI3K phosphorylates PIP2 to PIP3</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-2400009
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PI3K inhibitors block PI3K catalytic activity</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-388830
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PI3K binds ICOS</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-388832
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">PI3K binds CD28</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-389158
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CD28 bound PI3K phosphorylates PIP2 to PIP3</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-389356
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Co-stimulation by CD28</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-508247
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gab2 binds the p85 subunit of Class 1A PI3 kinases</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-879917
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CBL, GRB2, FYN and PI3K p85 subunit are constitutively associated</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8854905
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">p-5Y-GAB in the RET-GRB2-GAB complexes binds p85-PI3K</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9012657
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">EPO:phospho-EPOR:phospho-JAK2:LYN:phospho-IRS2 binds PI3K</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9021627
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">EPOR-associated PI3K phosphorylates PIP2 to PIP3</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9027275
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">EPO:phospho-EPOR:phospho-JAK2:LYN:IRS2:phospho-GAB1 binds PI3K</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-912627
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CBL ubiquitinates PI3K</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-914182
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">14-3-3 zeta binding allows recruitment of PI3K</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9606887
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">p-CD19:VAV binds PI3K and GRB2</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report on PIK3CD</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/PIK3CD/PIK3CD-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProtKB record for PIK3CD</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which PIK3CD-dependent leukocyte migration, neutrophil death, and endothelial angiogenesis annotations remain physiologically relevant in human primary cells after controlling for class I PI3K isoform redundancy and inhibitor selectivity?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O00329" data-a="Q: Which PIK3CD-dependent leukocyte migration, neutro..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should GO include a more specific biological-process term for class I PI3K-mediated PI(3,4,5)P3 biosynthesis to avoid using PI3P-centered or overly broad phosphatidylinositol phosphate biosynthetic process terms for PIK3CD?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O00329" data-a="Q: Should GO include a more specific biological-proce..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use isoform-selective genetic rescue in human primary B and T cells to separate PIK3CD-specific BCR, TCR, and CD28 signaling outputs from overlapping PIK3CA/PIK3CB/PIK3CG class I PI3K activity.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: primary-cell genetic rescue and phosphoprotein/PIP3 readout</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O00329" data-a="EXPERIMENT: Use isoform-selective genetic rescue in human prim..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Measure PI(4,5)P2-to-PIP3 and PI4P-to-PI(3,4)P2 product formation for p110delta-p85 complexes under matched in vitro and membrane-recruitment conditions to clarify whether PI4P kinase annotations should remain non-core.</p>
+
+
+
+                    <p style="margin-top: 0.5rem;">Type: lipid kinase substrate-specificity assay</p>
+
+                </div>
+                <span class="vote-buttons" data-g="O00329" data-a="EXPERIMENT: Measure PI(4,5)P2-to-PIP3 and PI4P-to-PI(3,4)P2 pr..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIK3CD-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O00329" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-12T09:51:43.581323'<br />
+end_time: '2026-05-12T10:05:46.915578'<br />
+duration_seconds: 843.33<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 26</p>
+<hr />
+<h2 id="question">Question</h2>
+<p>Perform concise GO-focused deep research on the human PIK3CD gene (UniProt O00329; phosphatidylinositol 4,5-bisphosphate 3-kinase catalytic subunit delta isoform / PI3K p110-delta). Summarize the core molecular function, major biological processes, cellular locations, key experimental evidence, immune-cell signaling context, disease context only where relevant to function, and GO annotation caveats. Include PMID or DOI citations where available, and keep the report focused for gene annotation review.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<p>Perform concise GO-focused deep research on the human PIK3CD gene (UniProt O00329; phosphatidylinositol 4,5-bisphosphate 3-kinase catalytic subunit delta isoform / PI3K p110-delta). Summarize the core molecular function, major biological processes, cellular locations, key experimental evidence, immune-cell signaling context, disease context only where relevant to function, and GO annotation caveats. Include PMID or DOI citations where available, and keep the report focused for gene annotation review.</p>
+<h1 id="go-focused-deep-research-report-human-pik3cd-uniprot-o00329-pi3k-p110">GO-focused deep research report: human <strong>PIK3CD</strong> (UniProt O00329; PI3K p110δ)</h1>
+<h2 id="0-geneproduct-synopsis-annotation-scope">0) Gene/product synopsis (annotation scope)</h2>
+<p><strong>PIK3CD</strong> encodes the catalytic subunit <strong>p110δ</strong> of <strong>class IA phosphoinositide 3-kinase (PI3Kδ)</strong>, a lipid kinase that produces <strong>PI(3,4,5)P3 (PIP3)</strong> at membranes downstream of receptor signaling in immune cells, particularly in lymphocytes. p110δ acts as a heterodimer with <strong>p85-family regulatory subunits</strong>, and receptor-triggered recruitment/relief of p85 inhibition is central to its regulated activity. (ijspeert2024hyperactivationofthe pages 2-4, ijspeert2024hyperactivationofthe pages 1-2)</p>
+<p><strong>Canonical record for protein identity</strong>: UniProt O00329 (https://www.uniprot.org/uniprotkb/O00329/). (No UniProt text was retrieved via tools; URL provided for curator convenience.)</p>
+<h2 id="1-key-go-concepts-and-definitions-current-understanding">1) Key GO concepts and definitions (current understanding)</h2>
+<h3 id="11-molecular-function-mf-what-p110-does-biochemically">1.1 Molecular function (MF): what p110δ <em>does biochemically</em></h3>
+<p><strong>Core enzymatic activity (lipid phosphorylation at D3 position):</strong> Class I PI3Ks phosphorylate membrane inositol phospholipids at the <strong>3′ position</strong>; class IA enzymes (including p110δ) act on PI(4,5)P2 to generate <strong>PIP3</strong>, which serves as a membrane docking lipid for downstream signaling proteins. (ijspeert2024hyperactivationofthe pages 1-2, stokoe2005thephosphoinositide3kinase pages 1-3)</p>
+<p><strong>ATP dependence / catalytic-site context:</strong> PI3Kδ catalysis requires ATP; this is strongly supported indirectly by inhibitor mechanism studies contrasting <strong>ATP-competitive</strong> inhibitors (idelalisib) with <strong>non–ATP-competitive</strong> allosteric PI3Kδ inhibition (IOA-244), which alters enzyme kinetics consistent with catalytic-site ATP usage in the reaction. (johnson2023ioa244isa pages 6-7)</p>
+<h3 id="12-cellular-component-cc-where-p110-is-and-what-complex-it-is-part-of">1.2 Cellular component (CC): where p110δ is and what complex it is part of</h3>
+<p><strong>Class IA PI3K complex membership:</strong> Class IA PI3Ks function as <strong>heterodimers of p110 catalytic subunits and p85-family regulatory subunits</strong>; p85 stabilizes and inhibits p110 in resting state. (ijspeert2024hyperactivationofthe pages 2-4, stokoe2005thephosphoinositide3kinase pages 1-3)</p>
+<p><strong>Membrane recruitment as a key localization event:</strong> Upon receptor activation, p85 SH2 domains bind <strong>phosphotyrosine motifs</strong> (e.g., YxxM-containing motifs) on receptors/adaptors, recruiting the p85–p110δ complex to the <strong>plasma membrane</strong>, where phosphoinositide substrates reside and catalytic activity increases. (ijspeert2024hyperactivationofthe pages 2-4, stokoe2005thephosphoinositide3kinase pages 1-3)</p>
+<h3 id="13-biological-process-bp-what-p110-does-in-cellstissues">1.3 Biological process (BP): what p110δ <em>does in cells/tissues</em></h3>
+<p><strong>PI3K→AKT→mTOR/FOXO axis:</strong> PIP3 recruits <strong>AKT</strong> to the plasma membrane for phosphorylation (PDK1/mTORC2 context) and downstream regulation of <strong>mTORC1/S6</strong> and <strong>FOXO</strong> transcription factor localization/function. (ijspeert2024hyperactivationofthe pages 2-4, ijspeert2024hyperactivationofthe pages 1-2)</p>
+<p><strong>Immune receptor signaling context:</strong> In immune cells, class IA PI3K (including p110δ) propagates signaling downstream of <strong>BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40</strong> (and related receptor/adaptor systems), framing the major immune-cell BP terms relevant for PIK3CD. (ijspeert2024hyperactivationofthe pages 2-4)</p>
+<h2 id="2-major-immune-cell-signaling-roles-with-key-experimental-evidence-curation-relevant">2) Major immune-cell signaling roles with key experimental evidence (curation-relevant)</h2>
+<h3 id="21-b-cell-receptor-bcr-signaling-and-ca2-mobilization-high-confidence-genetic-evidence">2.1 B cell receptor (BCR) signaling and Ca2+ mobilization (high-confidence genetic evidence)</h3>
+<p>A foundational genetic study using <strong>p110δ-deficient mice</strong> demonstrates that p110δ is <strong>essential and nonredundant</strong> for effective BCR signaling.</p>
+<p><em>Key experimental findings (Mol Cell Biol, 2002-12; DOI:10.1128/MCB.22.24.8580-8591.2002; URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002)</em>:<br />
+- <strong>Anti-IgM–induced intracellular Ca2+ mobilization</strong> in p110δ−/− B cells was reduced to <strong>~25% of wild type</strong>, while ionomycin response was preserved, indicating a BCR-proximal signaling defect requiring p110δ. (jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole media 9f8002cf)<br />
+- Proximal BCR signaling events (e.g., Btk and PLCγ2 tyrosine phosphorylation) occurred comparably, consistent with p110δ acting in the pathway needed for full Ca2+ signaling output. (jou2002essentialnonredundantrole pages 4-8)</p>
+<p><strong>GO interpretation:</strong> supports BP annotations for <strong>B cell receptor signaling pathway</strong> and <strong>intracellular calcium ion mobilization</strong> in B cells, with p110δ as a positive regulator/essential component in this context. (jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole media 9f8002cf)</p>
+<h3 id="22-b-cell-development-activation-proliferation-germinal-centers-humoral-immunity">2.2 B cell development, activation, proliferation; germinal centers; humoral immunity</h3>
+<p>In the same p110δ knockout model:<br />
+- B cell developmental and compartment defects include reduced mature peripheral B cells and loss of B1 cells. (jou2002essentialnonredundantrole pages 1-2, jou2002essentialnonredundantrole pages 2-4)<br />
+- <strong>In vitro proliferation</strong>: p110δ−/− B cells showed decreased proliferation to <strong>anti-CD40</strong> and <strong>LPS</strong>, and impaired responses to BCR crosslinking; bypass stimulation (PMA+ionomycin) was relatively preserved. (jou2002essentialnonredundantrole pages 4-8)<br />
+- <strong>Humoral immunity in vivo</strong>: reduced baseline serum immunoglobulins and impaired antigen-specific antibody responses—T-independent responses reduced and <strong>T-dependent antibody responses absent</strong>; <strong>germinal center formation impaired/absent</strong> by splenic staining after immunization. (jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole media 9f8002cf)</p>
+<p><strong>Visual evidence from the primary paper</strong> (used here as supporting data displays): ELISA immunoglobulin panels, antigen-response panels, absent germinal center staining, and Ca2+ flux traces in wild-type vs p110δ−/− are captured in the retrieved figure crops. (jou2002essentialnonredundantrole media 9f8002cf, jou2002essentialnonredundantrole media 37876baa, jou2002essentialnonredundantrole media 7d2b61ed, jou2002essentialnonredundantrole media 3b78ec57)</p>
+<p><strong>GO interpretation:</strong> supports BP annotations such as <strong>B cell development</strong>, <strong>B cell activation</strong>, <strong>B cell proliferation</strong>, <strong>germinal center formation</strong>, and <strong>T-dependent humoral immune response</strong>. (jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole pages 1-2, jou2002essentialnonredundantrole media 9f8002cf)</p>
+<h3 id="23-regulatory-t-cell-treg-homeostasis-and-immune-tolerance-2024-mechanisticphenotypic-update">2.3 Regulatory T cell (Treg) homeostasis and immune tolerance (2024 mechanistic/phenotypic update)</h3>
+<p>A 2024 conditional mouse model interrogated <strong>activated PI3Kδ signaling specifically within Foxp3+ Tregs</strong>, clarifying how PI3Kδ activity thresholds control tolerance.</p>
+<p><em>Key recent study (J Immunol, 2024-06; DOI:10.4049/jimmunol.2400032; URL: https://doi.org/10.4049/jimmunol.2400032)</em>:<br />
+- Treg-restricted activated PI3Kδ (<strong>aPIK3CD</strong>) <strong>increased thymic Treg precursors and peripheral Treg numbers</strong>, yet Tregs displayed altered phenotype (e.g., increased PD-1) and reduced competitive fitness. (singh2024activatedpi3kδspecifically pages 1-3)<br />
+- Despite increased Treg counts, mice developed <strong>chronic inflammation</strong>, increased memory/effector CD4+/CD8+ T cells and enhanced <strong>IFN-γ secretion</strong>, plus <strong>spontaneous germinal center responses</strong> and <strong>broad autoantibody production</strong>. (singh2024activatedpi3kδspecifically pages 3-4, singh2024activatedpi3kδspecifically pages 1-3)<br />
+- Mechanistic linkage is consistent with PI3K→AKT→FOXO regulation (AKT phosphorylation, FOXO1 nuclear exclusion) affecting Treg stability/function. (singh2024activatedpi3kδspecifically pages 11-13)</p>
+<p><strong>GO interpretation:</strong> supports BP terms around <strong>regulatory T cell homeostasis</strong>, <strong>immune tolerance/negative regulation of immune response</strong>, and <strong>regulation of germinal center response/humoral immunity</strong>, with an explicit caveat that both <strong>loss</strong> and <strong>gain</strong> of PI3Kδ signaling can disrupt tolerance (directionality depends on activity threshold/context). (singh2024activatedpi3kδspecifically pages 1-3, singh2024activatedpi3kδspecifically pages 10-11)</p>
+<h2 id="3-recent-developments-prioritize-20232024">3) Recent developments (prioritize 2023–2024)</h2>
+<h3 id="31-refined-pathway-framing-for-go-receptor-repertoire-and-downstream-readouts">3.1 Refined pathway framing for GO: receptor repertoire and downstream readouts</h3>
+<p>A 2024 review synthesizes receptor contexts and regulatory mechanisms relevant to GO process selection:<br />
+- Class IA PI3K (p85–p110δ) is recruited downstream of immune receptors including <strong>BCR/TCR/CD28/ICOS/CD19/BAFF-R/CD40</strong>, producing PIP3 that drives AKT/mTOR/FOXO-linked programs. (ijspeert2024hyperactivationofthe pages 2-4, ijspeert2024hyperactivationofthe pages 1-2)<br />
+- It highlights pathway antagonism by PTEN/SHIP and connects FOXO-regulated transcription (e.g., immune differentiation programs) to PI3K signaling outputs (useful for downstream BP annotations, but requires careful evidence attribution if annotating those distal effects). (ijspeert2024hyperactivationofthe pages 2-4)</p>
+<p><em>Source (Immunotherapy Advances, 2024-11; DOI:10.1093/immadv/ltae009; URL: https://doi.org/10.1093/immadv/ltae009)</em> (ijspeert2024hyperactivationofthe pages 2-4, ijspeert2024hyperactivationofthe pages 1-2)</p>
+<h3 id="32-quantitative-inhibitorprobe-landscape-mechanism-selectivity-and-caveats">3.2 Quantitative inhibitor/probe landscape (mechanism, selectivity, and caveats)</h3>
+<p>Because PI3Kδ is frequently perturbed pharmacologically (both experimentally and clinically), inhibitor properties are directly relevant to interpreting evidence used for GO assertions.</p>
+<p><strong>Allosteric vs ATP-competitive PI3Kδ inhibition (2023):</strong><br />
+- <strong>IOA-244 (roginolisib)</strong> behaves as a <strong>non–ATP-competitive</strong> PI3Kδ inhibitor; kinetic data show minimal ATP Km shift but a strong Vmax reduction in a PIP3 production assay; biochemical IC50 ~<strong>19 nM</strong> and whole blood IC50 <strong>0.28 μM</strong> were reported (plus extensive selectivity profiling). (johnson2023ioa244isa pages 6-7, johnson2023ioa244isa pages 13-14)<br />
+- <strong>Idelalisib</strong> shows <strong>ATP-competitive</strong> behavior (Km shift) and strong PI3Kδ potency (KiNativ PI3Kδ IC50 <strong>1.3 nM</strong>), but with additional off-target activity and an active metabolite (GS-563117) with its own target spectrum, supporting strong GO curation caveats for pharmacology-derived functional claims. (johnson2023ioa244isa pages 6-7, johnson2023ioa244isa pages 13-14)</p>
+<p><em>Source (Cancer Research Communications, 2023-04; DOI:10.1158/2767-9764.CRC-22-0477; URL: https://doi.org/10.1158/2767-9764.crc-22-0477)</em> (johnson2023ioa244isa pages 6-7, johnson2023ioa244isa pages 13-14)</p>
+<p><strong>Leniolisib potency and isoform selectivity (2024):</strong><br />
+- Leniolisib is reported as PI3Kδ-selective with <strong>IC50 11 nM</strong> (PI3Kδ) vs <strong>244 nM (α)</strong>, <strong>424 nM (β)</strong>, <strong>2230 nM (γ)</strong>. (de2024leniolisibanovel pages 1-2, cant2024pi3kδpathwaydysregulation pages 19-20)</p>
+<p><em>Sources:</em> Frontiers in Pharmacology (2024-02; DOI:10.3389/fphar.2024.1337436; URL: https://doi.org/10.3389/fphar.2024.1337436) (de2024leniolisibanovel pages 1-2) and JACI-In Practice (2024-01; DOI:10.1016/j.jaip.2023.09.016; URL: https://doi.org/10.1016/j.jaip.2023.09.016) (cant2024pi3kδpathwaydysregulation pages 19-20)</p>
+<p><strong>GO curation implication:</strong> inhibitor-based inference is useful for pathway placement (PI3Kδ dependence), but should be down-weighted unless selectivity, concentrations, and metabolites are controlled and accompanied by genetic corroboration. (johnson2023ioa244isa pages 6-7, cant2024pi3kδpathwaydysregulation pages 13-14)</p>
+<h2 id="4-cellular-locations-and-trafficking-go-cc-focused-synthesis">4) Cellular locations and trafficking (GO CC-focused synthesis)</h2>
+<ul>
+<li><strong>Resting state:</strong> cytosolic complex of p110δ with p85-family regulatory subunits, with p85 inhibiting catalytic activity until activation signals occur. (ijspeert2024hyperactivationofthe pages 2-4)</li>
+<li><strong>Activated state:</strong> recruitment/translocation of the p85–p110δ complex to <strong>plasma membrane</strong> via SH2 binding to receptor/adaptor phosphotyrosines, enabling access to PI(4,5)P2 substrate and local PIP3 generation. (ijspeert2024hyperactivationofthe pages 2-4, stokoe2005thephosphoinositide3kinase pages 1-3)</li>
+</ul>
+<p><strong>Caveat for CC annotation:</strong> Much localization evidence in the retrieved sources is mechanistic/consensus (review synthesis). For strict experimental CC evidence codes, curators may prefer direct imaging/biochemical fractionation papers (not retrieved here in full). (ijspeert2024hyperactivationofthe pages 2-4, stokoe2005thephosphoinositide3kinase pages 1-3)</p>
+<h2 id="5-disease-context-only-where-functionally-informative">5) Disease context (only where functionally informative)</h2>
+<p>Disease genetics mainly reinforce <strong>dosage/threshold sensitivity</strong> of PI3Kδ signaling in immune function. For example, the Treg-conditional activation study demonstrates that hyperactive PI3Kδ signaling can paradoxically increase Treg numbers while impairing tolerance, emphasizing that GO BP annotations should avoid implying monotonic positive regulation for all downstream immune outcomes. (singh2024activatedpi3kδspecifically pages 1-3)</p>
+<p>APDS-focused reviews (2024) frame PI3Kδ hyperactivation as driving excessive AKT/mTOR pathway activity in immune cells and motivating use of selective inhibitors; this is functionally relevant as it highlights pathway readouts (pAKT/pS6) used experimentally. (cant2024pi3kδpathwaydysregulation pages 1-3)</p>
+<h2 id="6-go-annotation-caveats-and-curator-notes">6) GO annotation caveats and curator notes</h2>
+<ol>
+<li><strong>Isoform redundancy / shared PI3K outputs:</strong> Many downstream readouts (e.g., pAKT, pS6) are not isoform-specific, and class I PI3Ks share overlapping functions; p110δ is leukocyte-enriched but not exclusively expressed, so immune-context evidence is strongest for PIK3CD-specific BP claims. (ijspeert2024hyperactivationofthe pages 1-2, cant2024pi3kδpathwaydysregulation pages 1-3)</li>
+<li><strong>Pharmacology confounding:</strong> PI3Kδ inhibitors differ in mechanism (ATP-competitive vs allosteric), cellular potency vs biochemical potency, off-target profiles, and metabolites; GO assertions based solely on inhibitor phenotypes can be misleading without genetic confirmation. (johnson2023ioa244isa pages 6-7, johnson2023ioa244isa pages 13-14, cant2024pi3kδpathwaydysregulation pages 13-14)</li>
+<li><strong>Pathological hyperactivation ≠ physiological role directionality:</strong> Hyperactive PI3Kδ in Tregs produces immune dysregulation and autoantibodies despite increased Treg numbers, so annotations should favor neutral process placement (e.g., “involved in”) or carefully qualified regulation terms when direction is context-dependent. (singh2024activatedpi3kδspecifically pages 1-3, singh2024activatedpi3kδspecifically pages 11-13)</li>
+<li><strong>Species-to-human transfer:</strong> Foundational functional genetics are largely from mouse models (e.g., p110δ knockout). These are highly informative for GO, but annotation should note organism context and confirmability in human systems when possible. (jou2002essentialnonredundantrole pages 4-8)</li>
+</ol>
+<h2 id="7-curator-facing-go-mapping-table-artifact">7) Curator-facing GO mapping table (artifact)</h2>
+<p>The following table compiles recommended MF/BP/CC terms with evidence summaries and traceable citations.</p>
+<table>
+<thead>
+<tr>
+<th>GO aspect</th>
+<th>Recommended GO term name</th>
+<th>Evidence summary (1 line)</th>
+<th>Key experimental system</th>
+<th>Best supporting citation IDs</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>MF</td>
+<td>phosphatidylinositol-4,5-bisphosphate 3-kinase activity</td>
+<td>Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.</td>
+<td>Cell-free / review synthesis</td>
+<td>(ijspeert2024hyperactivationofthe pages 1-2, stokoe2005thephosphoinositide3kinase pages 1-3)</td>
+</tr>
+<tr>
+<td>MF</td>
+<td>ATP binding</td>
+<td>PI3Kδ catalytic activity is ATP-dependent; inhibitor kinetic studies distinguish ATP-competitive idelalisib from non-ATP-competitive IOA-244, reinforcing ATP use at the catalytic site.</td>
+<td>Cell-free biochemical assays</td>
+<td>(johnson2023ioa244isa pages 6-7, cant2024pi3kδpathwaydysregulation pages 19-20)</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>class IA phosphatidylinositol 3-kinase complex</td>
+<td>p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells.</td>
+<td>Human / review synthesis</td>
+<td>(ijspeert2024hyperactivationofthe pages 2-4, stokoe2005thephosphoinositide3kinase pages 1-3, berglund2024modulatingthepi3k pages 8-8)</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>plasma membrane recruitment</td>
+<td>Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside.</td>
+<td>Human / review synthesis</td>
+<td>(ijspeert2024hyperactivationofthe pages 2-4, ijspeert2024hyperactivationofthe pages 1-2, stokoe2005thephosphoinositide3kinase pages 1-3)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>phosphatidylinositol 3-kinase signaling</td>
+<td>PI3Kδ-generated PIP3 recruits and activates AKT-linked signaling modules controlling downstream immune-cell responses.</td>
+<td>Human / mouse / review synthesis</td>
+<td>(ijspeert2024hyperactivationofthe pages 2-4, ijspeert2024hyperactivationofthe pages 1-2)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>B cell receptor signaling pathway</td>
+<td>Genetic loss of p110δ causes a specific BCR signaling defect, indicating a nonredundant positive role downstream of the BCR/CD19 axis.</td>
+<td>Mouse knockout</td>
+<td>(jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole pages 8-10, jou2002essentialnonredundantrole pages 1-2)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>intracellular calcium ion mobilization</td>
+<td>Anti-IgM-induced Ca2+ mobilization in p110δ-deficient B cells is reduced to about 25% of wild type, supporting a role in BCR-triggered Ca2+ signaling.</td>
+<td>Mouse knockout</td>
+<td>(jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole media 9f8002cf)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>B cell development</td>
+<td>p110δ deficiency reduces mature peripheral B cells, causes a developmental block and loss of B1 cells, supporting annotation to B-cell developmental processes.</td>
+<td>Mouse knockout</td>
+<td>(jou2002essentialnonredundantrole pages 1-2, jou2002essentialnonredundantrole pages 2-4)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>B cell activation</td>
+<td>p110δ-deficient B cells show impaired responses to BCR ligation and reduced activation-associated functional outputs.</td>
+<td>Mouse knockout</td>
+<td>(jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole pages 2-4)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>B cell proliferation</td>
+<td>Splenic p110δ-deficient B cells proliferate poorly in response to anti-IgM, anti-CD40 and LPS, while bypass stimulation is relatively preserved.</td>
+<td>Mouse knockout</td>
+<td>(jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole pages 2-4)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>germinal center formation</td>
+<td>Immunized p110δ-deficient mice fail to form splenic germinal centers, demonstrating a requirement for PI3Kδ in this humoral immune process.</td>
+<td>Mouse knockout</td>
+<td>(jou2002essentialnonredundantrole pages 1-2, jou2002essentialnonredundantrole media 9f8002cf)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>T-dependent humoral immune response</td>
+<td>T-dependent antibody responses are absent in p110δ-deficient mice, with severe defects also seen for TI responses, supporting a role in antibody production pathways.</td>
+<td>Mouse knockout</td>
+<td>(jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole media 9f8002cf)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>AKT signaling / positive regulation of TOR signaling</td>
+<td>Recent reviews and APDS-related studies place PI3Kδ upstream of AKT, mTORC1/S6 and FOXO regulation; pS6 elevation is used as a downstream readout of pathway activation.</td>
+<td>Human patients / mouse models</td>
+<td>(ijspeert2024hyperactivationofthe pages 2-4, nguyen2023humanpik3r1mutations pages 24-25, singh2024activatedpi3kδspecifically pages 11-13)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>regulatory T cell homeostasis</td>
+<td>Balanced PI3Kδ activity is required in Tregs: hyperactive PI3Kδ increases Treg numbers but reduces fitness and functional stability, whereas insufficient signaling also impairs tolerance.</td>
+<td>Mouse conditional GOF / review synthesis</td>
+<td>(singh2024activatedpi3kδspecifically pages 3-4, singh2024activatedpi3kδspecifically pages 11-13, singh2024activatedpi3kδspecifically pages 1-3)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>immune tolerance / negative regulation of immune response</td>
+<td>Treg-restricted activated PI3Kδ drives chronic inflammation, elevated IFN-γ, increased Tfh/GC responses and broad autoantibody production, indicating loss of tolerance when PI3Kδ is dysregulated.</td>
+<td>Mouse conditional GOF</td>
+<td>(singh2024activatedpi3kδspecifically pages 3-4, singh2024activatedpi3kδspecifically pages 10-11, singh2024activatedpi3kδspecifically pages 1-3)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>caveat: isoform redundancy and context dependence</td>
+<td>Some PI3K outputs can be shared with other class I isoforms; p110δ is leukocyte-enriched but not absolutely exclusive, so annotations should favor immune-context evidence over broad generic signaling claims.</td>
+<td>Curation note</td>
+<td>(ijspeert2024hyperactivationofthe pages 1-2, wright2024theimportanceof pages 4-6, cant2024pi3kδpathwaydysregulation pages 1-3)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>caveat: inhibitor-based evidence can be confounded</td>
+<td>PI3Kδ inhibitors differ in selectivity, mechanism and metabolites (e.g., ATP-competitive vs noncompetitive; off-target active metabolites), so pharmacology alone should not be over-weighted for direct GO assignment.</td>
+<td>Curation note / cell-free and cellular pharmacology</td>
+<td>(johnson2023ioa244isa pages 6-7, de2024leniolisibanovel pages 2-4, cant2024pi3kδpathwaydysregulation pages 13-14, johnson2023ioa244isa pages 15-16)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes high-confidence, curator-facing GO annotation suggestions for human PIK3CD/p110δ, mapped to the strongest experimental evidence retrieved in this session. It highlights core molecular function, complex/localization, immune signaling processes, and key curation caveats.</em></p>
+<h2 id="8-key-references-with-publication-dates-and-urls-subset">8) Key references with publication dates and URLs (subset)</h2>
+<ul>
+<li>Jou ST et al. <em>Molecular and Cellular Biology</em> (2002-12). “Essential, Nonredundant Role for the Phosphoinositide 3-Kinase p110δ in Signaling by the B-Cell Receptor Complex.” DOI:10.1128/MCB.22.24.8580-8591.2002. https://doi.org/10.1128/mcb.22.24.8580-8591.2002 (jou2002essentialnonredundantrole pages 4-8)</li>
+<li>IJspeert H et al. <em>Immunotherapy Advances</em> (2024-11). DOI:10.1093/immadv/ltae009. https://doi.org/10.1093/immadv/ltae009 (ijspeert2024hyperactivationofthe pages 2-4)</li>
+<li>Singh AK et al. <em>Journal of Immunology</em> (2024-06). DOI:10.4049/jimmunol.2400032. https://doi.org/10.4049/jimmunol.2400032 (singh2024activatedpi3kδspecifically pages 1-3)</li>
+<li>Cant AJ et al. <em>J Allergy Clin Immunol: In Practice</em> (2024-01). DOI:10.1016/j.jaip.2023.09.016. https://doi.org/10.1016/j.jaip.2023.09.016 (cant2024pi3kδpathwaydysregulation pages 19-20)</li>
+<li>Johnson Z et al. <em>Cancer Research Communications</em> (2023-04). DOI:10.1158/2767-9764.CRC-22-0477. https://doi.org/10.1158/2767-9764.crc-22-0477 (johnson2023ioa244isa pages 6-7)</li>
+<li>De SK. <em>Frontiers in Pharmacology</em> (2024-02). DOI:10.3389/fphar.2024.1337436. https://doi.org/10.3389/fphar.2024.1337436 (de2024leniolisibanovel pages 1-2)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(ijspeert2024hyperactivationofthe pages 2-4): Hanna IJspeert, Virgil A S H Dalm, Menno C van Zelm, and Emily S J Edwards. Hyperactivation of the pi3k pathway in inborn errors of immunity: current understanding and therapeutic perspectives. Immunotherapy Advances, Nov 2024. URL: https://doi.org/10.1093/immadv/ltae009, doi:10.1093/immadv/ltae009. This article has 11 citations.</p>
+</li>
+<li>
+<p>(ijspeert2024hyperactivationofthe pages 1-2): Hanna IJspeert, Virgil A S H Dalm, Menno C van Zelm, and Emily S J Edwards. Hyperactivation of the pi3k pathway in inborn errors of immunity: current understanding and therapeutic perspectives. Immunotherapy Advances, Nov 2024. URL: https://doi.org/10.1093/immadv/ltae009, doi:10.1093/immadv/ltae009. This article has 11 citations.</p>
+</li>
+<li>
+<p>(stokoe2005thephosphoinositide3kinase pages 1-3): David Stokoe. The phosphoinositide 3-kinase pathway and cancer. Expert Reviews in Molecular Medicine, 7:1-22, Jun 2005. URL: https://doi.org/10.1017/s1462399405009361, doi:10.1017/s1462399405009361. This article has 73 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(johnson2023ioa244isa pages 6-7): Zoë Johnson, Chiara Tarantelli, Elisa Civanelli, Luciano Cascione, Filippo Spriano, Amy Fraser, Pritom Shah, Tyzoon Nomanbhoy, Sara Napoli, Andrea Rinaldi, Karolina Niewola-Staszkowska, Michael Lahn, Dominique Perrin, Mathias Wenes, Denis Migliorini, Francesco Bertoni, Lars van der Veen, and Giusy Di Conza. Ioa-244 is a non–atp-competitive, highly selective, tolerable pi3k delta inhibitor that targets solid tumors and breaks immune tolerance. Cancer Research Communications, 3:576-591, Apr 2023. URL: https://doi.org/10.1158/2767-9764.crc-22-0477, doi:10.1158/2767-9764.crc-22-0477. This article has 33 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jou2002essentialnonredundantrole pages 4-8): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jou2002essentialnonredundantrole media 9f8002cf): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jou2002essentialnonredundantrole pages 1-2): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jou2002essentialnonredundantrole pages 2-4): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jou2002essentialnonredundantrole media 37876baa): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jou2002essentialnonredundantrole media 7d2b61ed): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jou2002essentialnonredundantrole media 3b78ec57): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singh2024activatedpi3kδspecifically pages 1-3): Akhilesh K. Singh, Fahd Al Qureshah, Travis Drow, Baidong Hou, and David J. Rawlings. Activated pi3kδ specifically perturbs mouse regulatory t cell homeostasis and function leading to immune dysregulation. Journal of immunology, 213:135-147, Jun 2024. URL: https://doi.org/10.4049/jimmunol.2400032, doi:10.4049/jimmunol.2400032. This article has 8 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singh2024activatedpi3kδspecifically pages 3-4): Akhilesh K. Singh, Fahd Al Qureshah, Travis Drow, Baidong Hou, and David J. Rawlings. Activated pi3kδ specifically perturbs mouse regulatory t cell homeostasis and function leading to immune dysregulation. Journal of immunology, 213:135-147, Jun 2024. URL: https://doi.org/10.4049/jimmunol.2400032, doi:10.4049/jimmunol.2400032. This article has 8 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singh2024activatedpi3kδspecifically pages 11-13): Akhilesh K. Singh, Fahd Al Qureshah, Travis Drow, Baidong Hou, and David J. Rawlings. Activated pi3kδ specifically perturbs mouse regulatory t cell homeostasis and function leading to immune dysregulation. Journal of immunology, 213:135-147, Jun 2024. URL: https://doi.org/10.4049/jimmunol.2400032, doi:10.4049/jimmunol.2400032. This article has 8 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(singh2024activatedpi3kδspecifically pages 10-11): Akhilesh K. Singh, Fahd Al Qureshah, Travis Drow, Baidong Hou, and David J. Rawlings. Activated pi3kδ specifically perturbs mouse regulatory t cell homeostasis and function leading to immune dysregulation. Journal of immunology, 213:135-147, Jun 2024. URL: https://doi.org/10.4049/jimmunol.2400032, doi:10.4049/jimmunol.2400032. This article has 8 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(johnson2023ioa244isa pages 13-14): Zoë Johnson, Chiara Tarantelli, Elisa Civanelli, Luciano Cascione, Filippo Spriano, Amy Fraser, Pritom Shah, Tyzoon Nomanbhoy, Sara Napoli, Andrea Rinaldi, Karolina Niewola-Staszkowska, Michael Lahn, Dominique Perrin, Mathias Wenes, Denis Migliorini, Francesco Bertoni, Lars van der Veen, and Giusy Di Conza. Ioa-244 is a non–atp-competitive, highly selective, tolerable pi3k delta inhibitor that targets solid tumors and breaks immune tolerance. Cancer Research Communications, 3:576-591, Apr 2023. URL: https://doi.org/10.1158/2767-9764.crc-22-0477, doi:10.1158/2767-9764.crc-22-0477. This article has 33 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(de2024leniolisibanovel pages 1-2): Surya K. De. Leniolisib: a novel treatment for activated phosphoinositide-3 kinase delta syndrome. Frontiers in Pharmacology, Feb 2024. URL: https://doi.org/10.3389/fphar.2024.1337436, doi:10.3389/fphar.2024.1337436. This article has 12 citations.</p>
+</li>
+<li>
+<p>(cant2024pi3kδpathwaydysregulation pages 19-20): Andrew J. Cant, Anita Chandra, Ewen Munro, V. Koneti Rao, and Carrie L. Lucas. Pi3kδ pathway dysregulation and unique features of its inhibition by leniolisib in activated pi3kδ syndrome and beyond. The Journal of Allergy and Clinical Immunology: In Practice, 12:69-78, Jan 2024. URL: https://doi.org/10.1016/j.jaip.2023.09.016, doi:10.1016/j.jaip.2023.09.016. This article has 34 citations.</p>
+</li>
+<li>
+<p>(cant2024pi3kδpathwaydysregulation pages 13-14): Andrew J. Cant, Anita Chandra, Ewen Munro, V. Koneti Rao, and Carrie L. Lucas. Pi3kδ pathway dysregulation and unique features of its inhibition by leniolisib in activated pi3kδ syndrome and beyond. The Journal of Allergy and Clinical Immunology: In Practice, 12:69-78, Jan 2024. URL: https://doi.org/10.1016/j.jaip.2023.09.016, doi:10.1016/j.jaip.2023.09.016. This article has 34 citations.</p>
+</li>
+<li>
+<p>(cant2024pi3kδpathwaydysregulation pages 1-3): Andrew J. Cant, Anita Chandra, Ewen Munro, V. Koneti Rao, and Carrie L. Lucas. Pi3kδ pathway dysregulation and unique features of its inhibition by leniolisib in activated pi3kδ syndrome and beyond. The Journal of Allergy and Clinical Immunology: In Practice, 12:69-78, Jan 2024. URL: https://doi.org/10.1016/j.jaip.2023.09.016, doi:10.1016/j.jaip.2023.09.016. This article has 34 citations.</p>
+</li>
+<li>
+<p>(berglund2024modulatingthepi3k pages 8-8): Lucinda J. Berglund. Modulating the pi3k signalling pathway in activated pi3k delta syndrome: a clinical perspective. Journal of Clinical Immunology, Dec 2024. URL: https://doi.org/10.1007/s10875-023-01626-0, doi:10.1007/s10875-023-01626-0. This article has 20 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jou2002essentialnonredundantrole pages 8-10): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(nguyen2023humanpik3r1mutations pages 24-25): Tina Nguyen, Anthony Lau, Julia Bier, Kristen C. Cooke, Helen Lenthall, Stephanie Ruiz-Diaz, Danielle T. Avery, Henry Brigden, David Zahra, William A Sewell, Luke Droney, Satoshi Okada, Takaki Asano, Hassan Abolhassani, Zahra Chavoshzadeh, Roshini S. Abraham, Nipunie Rajapakse, Eric W. Klee, Joseph A. Church, Andrew Williams, Melanie Wong, Christoph Burkhart, Gulbu Uzel, David R. Croucher, David E. James, Cindy S. Ma, Robert Brink, Stuart G. Tangye, and Elissa K. Deenick. Human pik3r1 mutations disrupt lymphocyte differentiation to cause activated pi3kδ syndrome 2. The Journal of Experimental Medicine, Mar 2023. URL: https://doi.org/10.1084/jem.20221020, doi:10.1084/jem.20221020. This article has 32 citations.</p>
+</li>
+<li>
+<p>(wright2024theimportanceof pages 4-6): Brock Wright, Samuel King, and Cenk Suphioglu. The importance of phosphoinositide 3-kinase in neuroinflammation. International Journal of Molecular Sciences, 25:11638, Oct 2024. URL: https://doi.org/10.3390/ijms252111638, doi:10.3390/ijms252111638. This article has 43 citations.</p>
+</li>
+<li>
+<p>(de2024leniolisibanovel pages 2-4): Surya K. De. Leniolisib: a novel treatment for activated phosphoinositide-3 kinase delta syndrome. Frontiers in Pharmacology, Feb 2024. URL: https://doi.org/10.3389/fphar.2024.1337436, doi:10.3389/fphar.2024.1337436. This article has 12 citations.</p>
+</li>
+<li>
+<p>(johnson2023ioa244isa pages 15-16): Zoë Johnson, Chiara Tarantelli, Elisa Civanelli, Luciano Cascione, Filippo Spriano, Amy Fraser, Pritom Shah, Tyzoon Nomanbhoy, Sara Napoli, Andrea Rinaldi, Karolina Niewola-Staszkowska, Michael Lahn, Dominique Perrin, Mathias Wenes, Denis Migliorini, Francesco Bertoni, Lars van der Veen, and Giusy Di Conza. Ioa-244 is a non–atp-competitive, highly selective, tolerable pi3k delta inhibitor that targets solid tumors and breaks immune tolerance. Cancer Research Communications, 3:576-591, Apr 2023. URL: https://doi.org/10.1158/2767-9764.crc-22-0477, doi:10.1158/2767-9764.crc-22-0477. This article has 33 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>ijspeert2024hyperactivationofthe pages 2-4</li>
+<li>jou2002essentialnonredundantrole pages 4-8</li>
+<li>de2024leniolisibanovel pages 1-2</li>
+<li>ijspeert2024hyperactivationofthe pages 1-2</li>
+<li>jou2002essentialnonredundantrole pages 1-2</li>
+<li>jou2002essentialnonredundantrole pages 2-4</li>
+<li>jou2002essentialnonredundantrole pages 8-10</li>
+<li>wright2024theimportanceof pages 4-6</li>
+<li>de2024leniolisibanovel pages 2-4</li>
+<li>https://www.uniprot.org/uniprotkb/O00329/</li>
+<li>https://doi.org/10.1128/mcb.22.24.8580-8591.2002</li>
+<li>https://doi.org/10.4049/jimmunol.2400032</li>
+<li>https://doi.org/10.1093/immadv/ltae009</li>
+<li>https://doi.org/10.1158/2767-9764.crc-22-0477</li>
+<li>https://doi.org/10.3389/fphar.2024.1337436</li>
+<li>https://doi.org/10.1016/j.jaip.2023.09.016</li>
+<li>https://doi.org/10.1093/immadv/ltae009,</li>
+<li>https://doi.org/10.1017/s1462399405009361,</li>
+<li>https://doi.org/10.1158/2767-9764.crc-22-0477,</li>
+<li>https://doi.org/10.1128/mcb.22.24.8580-8591.2002,</li>
+<li>https://doi.org/10.4049/jimmunol.2400032,</li>
+<li>https://doi.org/10.3389/fphar.2024.1337436,</li>
+<li>https://doi.org/10.1016/j.jaip.2023.09.016,</li>
+<li>https://doi.org/10.1007/s10875-023-01626-0,</li>
+<li>https://doi.org/10.1084/jem.20221020,</li>
+<li>https://doi.org/10.3390/ijms252111638,</li>
+</ol>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(PIK3CD-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="O00329" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="pik3cd-curation-notes">PIK3CD curation notes</h1>
+<h2 id="2026-05-12-falcon-integration">2026-05-12 Falcon integration</h2>
+<p>Generated Falcon deep research at <code>PIK3CD-deep-research-falcon.md</code> and used it with<br />
+UniProt plus cached publications to complete the initialized GO review.</p>
+<p>Core synthesis: PIK3CD encodes p110delta, a leukocyte-enriched class IA PI3K<br />
+catalytic subunit. The central molecular function is PI(4,5)P2 3-kinase<br />
+activity producing PIP3 in p85-family regulatory complexes at receptor-activated<br />
+membranes. Falcon summarizes this as: [file:human/PIK3CD/PIK3CD-deep-research-falcon.md<br />
+"<strong>PIK3CD</strong> encodes the catalytic subunit <strong>p110δ</strong> of <strong>class IA phosphoinositide<br />
+3-kinase (PI3Kδ)</strong>, a lipid kinase that produces <strong>PI(3,4,5)P3 (PIP3)</strong> at<br />
+membranes downstream of receptor signaling in immune cells, particularly in<br />
+lymphocytes."] Direct biochemical work also reports that recombinant p110delta<br />
+phosphorylates phosphatidylinositol and associates with p85 <a href="https://pubmed.ncbi.nlm.nih.gov/9235916" title="Recombinant p110delta phosphorylates phosphatidylinositol and coimmunoprecipitates with p85.">PMID:9235916</a>.</p>
+<p>The most informative process terms are PI3K/AKT signaling plus immune receptor<br />
+contexts, especially BCR, TCR, and CD28. Falcon frames the receptor context as<br />
+[file:human/PIK3CD/PIK3CD-deep-research-falcon.md "In immune cells, class IA PI3K<br />
+(including p110δ) propagates signaling downstream of <strong>BCR, TCR, CD28, ICOS,<br />
+CD19, BAFF-R, CD40</strong>"] and UniProt separately records BCR and TCR requirements<br />
+[file:human/PIK3CD/PIK3CD-uniprot.txt "Required for B-cell receptor (BCR) signaling."]<br />
+[file:human/PIK3CD/PIK3CD-uniprot.txt "Required for T-cell receptor (TCR) signaling."].</p>
+<p>Broad immune, chemotaxis, endothelial migration, angiogenesis, mast-cell,<br />
+neutrophil, NK-cell, and cytokine-production annotations were retained as<br />
+non-core where supported. The main evidence is that PI3Kdelta participates in<br />
+multiple leukocyte outputs <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" title="PI3Kδ participates in the development, activation and migration of T cells and NK cells.">PMID:20940048</a> and myeloid<br />
+activities <a href="https://pubmed.ncbi.nlm.nih.gov/20940048" title="The role of PI3Kδ in myeloid cell activities, such as inflammation driven cell infiltration, neutrophil oxidative burst, immune complex mediated macrophage activation, as well as mast cell maturation and degranulation, has been well illustrated in various studies.">PMID:20940048</a>.</p>
+<p>Several terms were deliberately modified or marked over-annotated:</p>
+<ul>
+<li>Generic PI3K complex was modified to class IA PI3K complex.</li>
+<li>Generic kinase/transferase/nucleotide-binding terms were narrowed toward ATP<br />
+  binding or PI(4,5)P2 3-kinase activity.</li>
+<li>PI3P biosynthetic process was modified because that term implies class<br />
+  III/VPS34-like biology; PIK3CD is primarily a PIP3-producing class IA kinase.</li>
+<li>Protein binding was marked over-annotated because complex membership and lipid<br />
+  kinase activity are the informative annotations.</li>
+<li>Protein phosphorylation was modified because PMID:9113989 supports lipid<br />
+  substrate specificity and says p110delta does not phosphorylate p85<br />
+<a href="https://pubmed.ncbi.nlm.nih.gov/9113989" title="Unlike p110alpha, p110delta does not phosphorylate p85 but   instead harbors an intrinsic autophosphorylation capacity.">PMID:9113989</a>.</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -8266,1308 +12185,2691 @@
                 <pre><code>id: O00329
 gene_symbol: PIK3CD
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: &#39;TODO: Add description for PIK3CD&#39;
+description: &#39;PIK3CD encodes p110delta, the leukocyte-enriched catalytic subunit of class
+  IA phosphoinositide 3-kinase delta. In p85-family regulatory complexes, p110delta phosphorylates
+  membrane phosphoinositides, especially PI(4,5)P2, to generate PIP3 downstream of immune
+  receptors including BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40, Fc receptors, and cytokine/growth-factor
+  receptors. The core curatable function is PIP3-producing lipid kinase activity in PI3K/AKT
+  immune receptor signaling; broad immune phenotypes, chemotaxis, angiogenesis, and migration
+  annotations are supported contextual outputs rather than the core molecular function.&#39;
 alternative_products:
-  - name: 1 (p110-delta)
-    id: O00329-1
-  - name: 2 (p37-delta)
-    id: O00329-2
-    sequence_note: VSP_044409, VSP_044410
+- name: 1 (p110-delta)
+  id: O00329-1
+- name: 2 (p37-delta)
+  id: O00329-2
+  sequence_note: VSP_044409, VSP_044410
 existing_annotations:
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0016477
-      label: cell migration
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005942
-      label: phosphatidylinositol 3-kinase complex
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0043491
-      label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0036092
-      label: phosphatidylinositol-3-phosphate biosynthetic process
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0048015
-      label: phosphatidylinositol-mediated signaling
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0016303
-      label: 1-phosphatidylinositol-3-kinase activity
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0035005
-      label: 1-phosphatidylinositol-4-phosphate 3-kinase activity
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0000166
-      label: nucleotide binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0002250
-      label: adaptive immune response
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0002376
-      label: immune system process
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0002443
-      label: leukocyte mediated immunity
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005524
-      label: ATP binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000044
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005943
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0016477
+    label: cell migration
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Supported cell-migration role in specific leukocyte and glioma contexts,
+      but non-core relative to lipid kinase signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3CD knockdown decreases glioma-cell migration and PI3Kdelta also affects
+      leukocyte migration; these are downstream context-specific outputs rather than the
+      core function.
+    supported_by:
+    - reference_id: PMID:22079609
+      supporting_text: Interestingly, knockdown of p110δ decreased the cell migration
+        and invasion ability of all GBM cell lines tested.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+- term:
+    id: GO:0005942
+    label: phosphatidylinositol 3-kinase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: The complex assignment is valid but should use the more specific class IA
+      phosphatidylinositol 3-kinase complex term.
+    action: MODIFY
+    reason: PIK3CD is not just any PI3K-complex component; it is the p110delta catalytic
+      subunit of class IA p85-family regulatory complexes. GO:0005943 captures the
+      correct complex subtype.
+    proposed_replacement_terms:
+    - id: GO:0005943
       label: phosphatidylinositol 3-kinase complex, class IA
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0006629
-      label: lipid metabolic process
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0006935
-      label: chemotaxis
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0006954
-      label: inflammatory response
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0007166
-      label: cell surface receptor signaling pathway
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0010595
-      label: positive regulation of endothelial cell migration
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0010628
-      label: positive regulation of gene expression
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0016301
-      label: kinase activity
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0016303
-      label: 1-phosphatidylinositol-3-kinase activity
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0016740
-      label: transferase activity
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0022603
-      label: regulation of anatomical structure morphogenesis
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0030154
-      label: cell differentiation
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0030155
-      label: regulation of cell adhesion
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0033031
-      label: positive regulation of neutrophil apoptotic process
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0042113
-      label: B cell activation
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0043491
-      label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0045087
-      label: innate immune response
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0046854
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+- term:
+    id: GO:0043491
+    label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Supported PI3K/AKT signaling annotation downstream of PIK3CD-generated
+      PIP3.
+    action: ACCEPT
+    reason: PIP3 produced by p110delta recruits AKT-linked signaling modules. This
+      pathway term captures the central signaling output of PI3Kdelta even when the
+      initiating receptor or cell type differs.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: &#39;**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide
+        3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes
+        downstream of receptor signaling in immune cells, particularly in lymphocytes.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+- term:
+    id: GO:0036092
+    label: phosphatidylinositol-3-phosphate biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: The PI3P biosynthetic-process term is too specific for a class
+      III/VPS34-like product and is not the best process term for PIK3CD.
+    action: MODIFY
+    reason: PIK3CD/p110delta primarily generates PIP3 from PI(4,5)P2 in class IA
+      receptor signaling. A broader phosphatidylinositol phosphate biosynthetic process
+      term better reflects the current GO vocabulary without implying class III
+      PI3P-centered biology.
+    proposed_replacement_terms:
+    - id: GO:0046854
       label: phosphatidylinositol phosphate biosynthetic process
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0046934
-      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0051094
-      label: positive regulation of developmental process
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0051240
-      label: positive regulation of multicellular organismal process
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:2000026
-      label: regulation of multicellular organismal development
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:21827948
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:21827948
-          supporting_text: Dynamics of the phosphoinositide 3-kinase p110δ 
-            interaction with p85α and membranes reveals aspects of regulation 
-            distinct from p110α.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:22020336
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:22020336
-          supporting_text: p37δ is a new isoform of PI3K p110δ that increases 
-            cell proliferation and is overexpressed in tumors.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:24165795
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:24165795
-          supporting_text: Dominant-activating germline mutations in the gene 
-            encoding the PI(3)K catalytic subunit p110δ result in T cell 
-            senescence and human immunodeficiency.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:28514442
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:28514442
-          supporting_text: Architecture of the human interactome defines protein
-            communities and disease networks.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:31031754
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31031754
-          supporting_text: &#39;Case Study: Mechanism for Increased Follicular Helper
-            T Cell Development in Activated PI3K Delta Syndrome.&#39;
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:32296183
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32296183
-          supporting_text: Apr 8. A reference map of the human binary protein 
-            interactome.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:33961781
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:33961781
-          supporting_text: 2021 May 6. Dual proteome-scale networks reveal 
-            cell-specific remodeling of the human interactome.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:35271311
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:35271311
-          supporting_text: &#39;2022 Mar 11. OpenCell: Endogenous tagging for the cartography
-            of human cellular organization.&#39;
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:40205054
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:40205054
-          supporting_text: Apr 9. Multimodal cell maps as a foundation for 
-            structural and functional genomics.
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: IDA
-    original_reference_id: GO_REF:0000052
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:32606397
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32606397
-          supporting_text: PI3K activation is enhanced by FOXM1D binding to p110
-            and p85 subunits.
-  - term:
-      id: GO:0031295
-      label: T cell costimulation
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-389356
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0046934
-      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-389158
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0006955
-      label: immune response
-    evidence_type: NAS
-    original_reference_id: PMID:27616589
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:27616589
-          supporting_text: Sep 12. PI3Kδ and primary immunodeficiencies.
-  - term:
-      id: GO:0030183
-      label: B cell differentiation
-    evidence_type: NAS
-    original_reference_id: PMID:20200404
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20200404
-          supporting_text: The catalytic PI3K isoforms p110gamma and p110delta 
-            contribute to B cell development and maintenance, transformation, 
-            and proliferation.
-  - term:
-      id: GO:0030217
-      label: T cell differentiation
-    evidence_type: NAS
-    original_reference_id: PMID:17371229
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17371229
-          supporting_text: The PI3K p110delta controls T-cell development, 
-            differentiation and regulation.
-  - term:
-      id: GO:0038084
-      label: vascular endothelial growth factor signaling pathway
-    evidence_type: IGI
-    original_reference_id: PMID:31915155
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31915155
-          supporting_text: PI3Kδ as a Novel Therapeutic Target in Pathological 
-            Angiogenesis.
-  - term:
-      id: GO:0010595
-      label: positive regulation of endothelial cell migration
-    evidence_type: IGI
-    original_reference_id: PMID:31915155
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31915155
-          supporting_text: PI3Kδ as a Novel Therapeutic Target in Pathological 
-            Angiogenesis.
-  - term:
-      id: GO:0001938
-      label: positive regulation of endothelial cell proliferation
-    evidence_type: IGI
-    original_reference_id: PMID:31915155
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31915155
-          supporting_text: PI3Kδ as a Novel Therapeutic Target in Pathological 
-            Angiogenesis.
-  - term:
-      id: GO:0043491
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+    - reference_id: Reactome:R-HSA-389158
+      supporting_text: Upon binding to CD28, the PI3K enzyme catalyzes the
+        phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate
+        phosphatidylinositol 3,4,5-trisphosphate (PIP3).
+- term:
+    id: GO:0048015
+    label: phosphatidylinositol-mediated signaling
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: The phosphatidylinositol-mediated signaling term is correct but too broad
+      for PIK3CD.
+    action: MODIFY
+    reason: PIK3CD is specifically a class IA PIP3-producing PI3K that feeds PI3K/AKT
+      receptor signaling, so the more specific PI3K/AKT signal-transduction term is
+      preferred.
+    proposed_replacement_terms:
+    - id: GO:0043491
       label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
-    evidence_type: IGI
-    original_reference_id: PMID:31915155
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31915155
-          supporting_text: PI3Kδ as a Novel Therapeutic Target in Pathological 
-            Angiogenesis.
-  - term:
-      id: GO:0045766
-      label: positive regulation of angiogenesis
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:1905278
-      label: positive regulation of epithelial tube formation
-    evidence_type: IGI
-    original_reference_id: PMID:31915155
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31915155
-          supporting_text: PI3Kδ as a Novel Therapeutic Target in Pathological 
-            Angiogenesis.
-  - term:
-      id: GO:0033031
-      label: positive regulation of neutrophil apoptotic process
-    evidence_type: IMP
-    original_reference_id: PMID:25339672
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:25339672
-          supporting_text: 2014 Oct 22. Human IgA Fc receptor FcαRI (CD89) 
-            triggers different forms of neutrophil death depending on the 
-            inflammatory microenvironment.
-  - term:
-      id: GO:0043491
-      label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
-    evidence_type: IMP
-    original_reference_id: PMID:25339672
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:25339672
-          supporting_text: 2014 Oct 22. Human IgA Fc receptor FcαRI (CD89) 
-            triggers different forms of neutrophil death depending on the 
-            inflammatory microenvironment.
-  - term:
-      id: GO:0001779
-      label: natural killer cell differentiation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0001819
-      label: positive regulation of cytokine production
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0002250
-      label: adaptive immune response
-    evidence_type: TAS
-    original_reference_id: PMID:17290298
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17290298
-          supporting_text: &#39;PI3K delta and PI3K gamma: partners in crime in inflammation
-            in rheumatoid arthritis and beyond? Rommel C(1), Camps M, Ji H.&#39;
-  - term:
-      id: GO:0002551
-      label: mast cell chemotaxis
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0002679
-      label: respiratory burst involved in defense response
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0006954
-      label: inflammatory response
-    evidence_type: TAS
-    original_reference_id: PMID:17290298
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17290298
-          supporting_text: &#39;PI3K delta and PI3K gamma: partners in crime in inflammation
-            in rheumatoid arthritis and beyond? Rommel C(1), Camps M, Ji H.&#39;
-  - term:
-      id: GO:0006954
-      label: inflammatory response
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0010818
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: &#39;**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide
+        3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes
+        downstream of receptor signaling in immune cells, particularly in lymphocytes.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0016303
+    label: 1-phosphatidylinositol-3-kinase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Core molecular function as a phosphatidylinositol 3-kinase catalytic
+      subunit.
+    action: ACCEPT
+    reason: This parent PI3K activity term is valid for p110delta, although GO:0046934
+      is the most specific MF term for its canonical PIP2-to-PIP3 reaction.
+    supported_by:
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+- term:
+    id: GO:0035005
+    label: 1-phosphatidylinositol-4-phosphate 3-kinase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Supported phosphoinositide 3-kinase substrate activity, but PI4P
+      phosphorylation is not the primary curatable core activity for PIK3CD.
+    action: KEEP_AS_NON_CORE
+    reason: Class I PI3Kdelta can act on phosphorylated phosphoinositides, and Reactome
+      includes PIK3CD complexes in PI4P-to-PI(3,4)P2 reactions. The canonical core
+      activity remains PI(4,5)P2-to-PIP3.
+    supported_by:
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+    - reference_id: Reactome:R-HSA-1676109
+      supporting_text: These complexes along with phosphatidylinositol-4-phosphate
+        3-kinase C2 domain-containing subunits alpha (PIK3C2A), beta (PIK3C2B), and
+        gamma (PIK3C2G) phosphorylate phosphatidylinositol 4-phosphate (PI4P) to
+        phosphatidylinositol 3,4-bisphosphate (PI(3,4)P2).
+- term:
+    id: GO:0000166
+    label: nucleotide binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: The nucleotide-binding annotation is too generic for a lipid kinase and
+      should be narrowed to ATP binding.
+    action: MODIFY
+    reason: PIK3CD catalysis uses ATP; the broad nucleotide-binding term loses the
+      catalytic context and is less informative than GO:0005524 ATP binding or the
+      catalytic PI(4,5)P2 3-kinase MF.
+    proposed_replacement_terms:
+    - id: GO:0005524
+      label: ATP binding
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+- term:
+    id: GO:0002250
+    label: adaptive immune response
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: Supported adaptive-immune output, but this is a systems-level consequence
+      of PI3Kdelta immune receptor signaling rather than the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: Human disease genetics and leukocyte studies support a role in adaptive
+      immunity, but the core function should remain PIP3-producing class IA PI3K
+      signaling.
+    supported_by:
+    - reference_id: PMID:27616589
+      supporting_text: Here, we review the roles of PI3Kδ in adaptive immunity, describe
+        the clinical manifestations and mechanisms of disease in APDS and highlight new
+        insights into PI3Kδ gleaned from these patients, as well as implications of
+        these findings for clinical therapy.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0002376
+    label: immune system process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: Correct directionally but too broad to be useful for PIK3CD curation.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD has immune functions, but GO:0002376 is a very broad parent term.
+      More informative annotations are BCR/TCR signaling, PI3K/AKT signaling, and
+      specific leukocyte activation/migration processes.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0002443
+    label: leukocyte mediated immunity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Supported leukocyte/immune response involvement, but non-core and broad
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3CD is leukocyte-enriched and affects immune responses, yet this broad
+      immune-process term should not define the core function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+    - reference_id: PMID:27616589
+      supporting_text: Here, we review the roles of PI3Kδ in adaptive immunity, describe
+        the clinical manifestations and mechanisms of disease in APDS and highlight new
+        insights into PI3Kδ gleaned from these patients, as well as implications of
+        these findings for clinical therapy.
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: ATP binding is valid for the catalytic kinase domain, but it is generic
+      relative to the core lipid kinase activity.
+    action: KEEP_AS_NON_CORE
+    reason: ATP is required for PI3Kdelta catalysis, yet ATP binding alone is not a
+      specific description of the gene product function.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005943
+    label: phosphatidylinositol 3-kinase complex, class IA
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Correct class IA PI3K complex annotation for p110delta/p85-family
+      regulatory assemblies.
+    action: ACCEPT
+    reason: This is the most specific existing CC term for PIK3CD complex membership and
+      is supported by ComplexPortal entries and synthesis of the class IA p110delta-p85
+      regulatory complex.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: Reactome:R-HSA-2316434
+      supporting_text: In unstimulated cells, PI3K class IA exists as an inactive
+        heterodimer of a p85 regulatory subunit (encoded by PIK3R1, PIK3R2 or PIK3R3)
+        and a p110 catalytic subunit (encoded by PIK3CA, PIK3CB or PIK3CD).
+- term:
+    id: GO:0006629
+    label: lipid metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: The lipid metabolic process term is directionally correct but too broad for
+      PIK3CD.
+    action: MODIFY
+    reason: PIK3CD is specifically a phosphoinositide lipid kinase that produces
+      3-phosphoinositides/PIP3 in signaling contexts; phosphatidylinositol phosphate
+      biosynthesis and PI(4,5)P2 3-kinase activity are more informative.
+    proposed_replacement_terms:
+    - id: GO:0046854
+      label: phosphatidylinositol phosphate biosynthetic process
+    - id: GO:0046934
+      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0006935
+    label: chemotaxis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: The generic chemotaxis annotation should be narrowed to the specific
+      leukocyte chemotaxis processes supported for PIK3CD.
+    action: MODIFY
+    reason: The evidence supports T-cell, B-cell, neutrophil, and mast-cell chemotaxis
+      contexts rather than chemotaxis as a broad parent term.
+    proposed_replacement_terms:
+    - id: GO:0010818
       label: T cell chemotaxis
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0016303
-      label: 1-phosphatidylinositol-3-kinase activity
-    evidence_type: TAS
-    original_reference_id: PMID:17290298
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17290298
-          supporting_text: &#39;PI3K delta and PI3K gamma: partners in crime in inflammation
-            in rheumatoid arthritis and beyond? Rommel C(1), Camps M, Ji H.&#39;
-  - term:
-      id: GO:0030101
-      label: natural killer cell activation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0030217
-      label: T cell differentiation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0030593
-      label: neutrophil chemotaxis
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0035747
-      label: natural killer cell chemotaxis
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0035754
+    - id: GO:0035754
       label: B cell chemotaxis
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0042110
-      label: T cell activation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0042113
-      label: B cell activation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0043303
-      label: mast cell degranulation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0043491
-      label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
-    evidence_type: TAS
-    original_reference_id: PMID:17290298
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17290298
-          supporting_text: &#39;PI3K delta and PI3K gamma: partners in crime in inflammation
-            in rheumatoid arthritis and beyond? Rommel C(1), Camps M, Ji H.&#39;
-  - term:
-      id: GO:0045087
-      label: innate immune response
-    evidence_type: TAS
-    original_reference_id: PMID:17290298
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17290298
-          supporting_text: &#39;PI3K delta and PI3K gamma: partners in crime in inflammation
-            in rheumatoid arthritis and beyond? Rommel C(1), Camps M, Ji H.&#39;
-  - term:
-      id: GO:0045087
-      label: innate immune response
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0050852
-      label: T cell receptor signaling pathway
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0050853
+    - id: GO:0030593
+      label: neutrophil chemotaxis
+    - id: GO:0002551
+      label: mast cell chemotaxis
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0006954
+    label: inflammatory response
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: Supported inflammatory-response involvement, but it is a downstream
+      physiological output of PI3Kdelta activity.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta disruption alters inflammatory responses in vivo and PI3K lipid
+      messengers control leukocyte signaling, but inflammation is a non-core
+      phenotype/process relative to lipid kinase signaling.
+    supported_by:
+    - reference_id: PMID:17290298
+      supporting_text: Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second
+        messengers that control an array of intracellular signalling pathways that are
+        known to have important roles in leukocytes.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0007166
+    label: cell surface receptor signaling pathway
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: The broad cell-surface receptor signaling annotation should be narrowed to
+      the immune receptor signaling pathways where PIK3CD has strong support.
+    action: MODIFY
+    reason: PIK3CD acts downstream of immune receptors such as BCR, TCR, and CD28. Those
+      terms are more informative and better supported than the generic cell-surface
+      receptor signaling parent.
+    proposed_replacement_terms:
+    - id: GO:0050853
       label: B cell receptor signaling pathway
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0060374
+    - id: GO:0050852
+      label: T cell receptor signaling pathway
+    - id: GO:0031295
+      label: T cell costimulation
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for B-cell receptor (BCR) signaling.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for T-cell receptor (TCR) signaling.
+- term:
+    id: GO:0010595
+    label: positive regulation of endothelial cell migration
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Supported endothelial/angiogenesis context, but non-core and
+      tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
+    action: KEEP_AS_NON_CORE
+    reason: Cultured endothelial-cell work supports VEGF-induced Akt activation,
+      proliferation, migration, tube formation, and retinal angiogenesis. This is a real
+      contextual role, not the primary leukocyte-enriched core function.
+    supported_by:
+    - reference_id: PMID:31915155
+      supporting_text: Using genetic and pharmacological approaches, we show that p110δ
+        activity in cultured ECs controls Akt activation, cell proliferation, migration,
+        and tube formation induced by vascular endothelial growth factor, basic
+        fibroblast growth factor, and epidermal growth factor.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+- term:
+    id: GO:0010628
+    label: positive regulation of gene expression
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Over-annotation to positive regulation of gene expression. The available
+      PIK3CD evidence supports upstream PI3K/AKT signaling more directly than this
+      distal transcriptional-output term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Gene-expression changes can occur downstream of PI3K/AKT/FOXO signaling, but
+      the cited evidence is more direct for lipid kinase signaling, migration, and
+      protein-level pathway outputs. This broad distal term should not be retained as a
+      core annotation.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+    - reference_id: PMID:22079609
+      supporting_text: Interestingly, knockdown of p110δ decreased the cell migration
+        and invasion ability of all GBM cell lines tested.
+- term:
+    id: GO:0016301
+    label: kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: The generic enzyme-activity annotation is valid only as a distant parent
+      and should be replaced by the specific lipid kinase activity.
+    action: MODIFY
+    reason: PIK3CD is not merely a generic kinase/transferase; the evidence supports
+      phosphoinositide 3-kinase activity, especially PI(4,5)P2 3-kinase activity.
+    proposed_replacement_terms:
+    - id: GO:0046934
+      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+- term:
+    id: GO:0016303
+    label: 1-phosphatidylinositol-3-kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Core molecular function as a phosphatidylinositol 3-kinase catalytic
+      subunit.
+    action: ACCEPT
+    reason: This parent PI3K activity term is valid for p110delta, although GO:0046934
+      is the most specific MF term for its canonical PIP2-to-PIP3 reaction.
+    supported_by:
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+- term:
+    id: GO:0016740
+    label: transferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: The generic enzyme-activity annotation is valid only as a distant parent
+      and should be replaced by the specific lipid kinase activity.
+    action: MODIFY
+    reason: PIK3CD is not merely a generic kinase/transferase; the evidence supports
+      phosphoinositide 3-kinase activity, especially PI(4,5)P2 3-kinase activity.
+    proposed_replacement_terms:
+    - id: GO:0046934
+      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+- term:
+    id: GO:0022603
+    label: regulation of anatomical structure morphogenesis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Over-annotation to broad developmental, morphogenesis, or adhesion
+      regulation terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD has specific leukocyte, endothelial, and migration phenotypes, but
+      these broad regulation terms over-generalize downstream effects and obscure the
+      better-supported PI3Kdelta receptor-signaling biology.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0030154
+    label: cell differentiation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: The generic cell differentiation annotation should be narrowed to the
+      specific leukocyte differentiation processes supported for PIK3CD.
+    action: MODIFY
+    reason: The evidence supports B-cell, T-cell, NK-cell, and mast-cell differentiation
+      contexts rather than undifferentiated cell differentiation as a generic parent.
+    proposed_replacement_terms:
+    - id: GO:0030183
+      label: B cell differentiation
+    - id: GO:0030217
+      label: T cell differentiation
+    - id: GO:0001779
+      label: natural killer cell differentiation
+    - id: GO:0060374
       label: mast cell differentiation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0072672
-      label: neutrophil extravasation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0010628
-      label: positive regulation of gene expression
-    evidence_type: IMP
-    original_reference_id: PMID:22079609
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:22079609
-          supporting_text: 2011 Nov 11. The catalytic phosphoinositol 3-kinase 
-            isoform p110δ is required for glioma cell migration and invasion.
-  - term:
-      id: GO:0030335
-      label: positive regulation of cell migration
-    evidence_type: IMP
-    original_reference_id: PMID:22079609
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:22079609
-          supporting_text: 2011 Nov 11. The catalytic phosphoinositol 3-kinase 
-            isoform p110δ is required for glioma cell migration and invasion.
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-1676048
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-1676109
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9012657
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9021627
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9027275
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9606887
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-2045911
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-2076220
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-2316434
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-2400009
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-388830
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-388832
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-389158
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-508247
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-879917
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8854905
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-912627
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-914182
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9606887
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-  - term:
-      id: GO:0005942
-      label: phosphatidylinositol 3-kinase complex
-    evidence_type: NAS
-    original_reference_id: PMID:9113989
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9113989
-          supporting_text: P110delta, a novel phosphoinositide 3-kinase in 
-            leukocytes.
-  - term:
-      id: GO:0005942
-      label: phosphatidylinositol 3-kinase complex
-    evidence_type: NAS
-    original_reference_id: PMID:9235916
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9235916
-          supporting_text: p110delta, a novel phosphatidylinositol 3-kinase 
-            catalytic subunit that associates with p85 and is expressed 
-            predominantly in leukocytes.
-  - term:
-      id: GO:0006468
-      label: protein phosphorylation
-    evidence_type: NAS
-    original_reference_id: PMID:9113989
-    review:
-      summary: &gt;-
-        OVER-ANNOTATION: PIK3CD (p110delta) is primarily a LIPID kinase, not a protein
-        kinase. PMID:9113989 explicitly states PIK3CD &#34;displays a broad phosphoinositide
-        lipid substrate specificity&#34; and notably &#34;does not phosphorylate p85&#34; (unlike
-        p110alpha). The paper mentions only &#34;intrinsic autophosphorylation capacity&#34;,
-        which is distinct from general protein phosphorylation. PIK3CD has EC 2.7.1.137
-        (phosphatidylinositol-4,5-bisphosphate 3-kinase) for lipid phosphorylation.
-        The annotation should be to lipid phosphorylation (GO:0046834) or the specific
-        PI3K process, not protein phosphorylation.
-      action: MODIFY
-      proposed_replacement_terms:
-        - id: GO:0046834
-          label: lipid phosphorylation
-      supported_by:
-        - reference_id: PMID:9113989
-          supporting_text: P110delta, a novel phosphoinositide 3-kinase in 
-            leukocytes.
-  - term:
-      id: GO:0007165
-      label: signal transduction
-    evidence_type: NAS
-    original_reference_id: PMID:9113989
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9113989
-          supporting_text: P110delta, a novel phosphoinositide 3-kinase in 
-            leukocytes.
-  - term:
-      id: GO:0016303
-      label: 1-phosphatidylinositol-3-kinase activity
-    evidence_type: NAS
-    original_reference_id: PMID:9235916
-    review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9235916
-          supporting_text: p110delta, a novel phosphatidylinositol 3-kinase 
-            catalytic subunit that associates with p85 and is expressed 
-            predominantly in leukocytes.
+    supported_by:
+    - reference_id: PMID:20200404
+      supporting_text: Thus, we provide novel evidence that p110gamma and p110delta have
+        overlapping and cell-extrinsic roles in the development, peripheral maintenance,
+        and function of B cells.
+    - reference_id: PMID:17371229
+      supporting_text: In addition, p110delta regulates the differentiation of
+        peripheral Th (helper T-cells) towards the Th1 and Th2 lineages.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+- term:
+    id: GO:0030155
+    label: regulation of cell adhesion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Over-annotation to broad developmental, morphogenesis, or adhesion
+      regulation terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD has specific leukocyte, endothelial, and migration phenotypes, but
+      these broad regulation terms over-generalize downstream effects and obscure the
+      better-supported PI3Kdelta receptor-signaling biology.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0033031
+    label: positive regulation of neutrophil apoptotic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Supported neutrophil-death/apoptotic-process annotation, but non-core and
+      context-dependent.
+    action: KEEP_AS_NON_CORE
+    reason: FcαRI-triggered neutrophil death requires class IA PI3K signaling in
+      inflammatory contexts. This supports the annotation as a non-core immune effector
+      process.
+    supported_by:
+    - reference_id: PMID:25339672
+      supporting_text: preactivation with cytokines or TLR agonists in vitro enhanced
+        FcαRI-mediated death by additional recruitment of caspase-independent pathways,
+        but this required PI3K class IA and MAPK signaling.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0042113
+    label: B cell activation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Supported B-cell activation/function annotation, but downstream of the more
+      core BCR signaling role.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3CD is important for B-cell development and function. B-cell activation
+      is real, but BCR signaling and PI3K/AKT signaling are the more precise core
+      process annotations.
+    supported_by:
+    - reference_id: PMID:20200404
+      supporting_text: Thus, we provide novel evidence that p110gamma and p110delta have
+        overlapping and cell-extrinsic roles in the development, peripheral maintenance,
+        and function of B cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for B-cell receptor (BCR) signaling.
+- term:
+    id: GO:0043491
+    label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Supported PI3K/AKT signaling annotation downstream of PIK3CD-generated
+      PIP3.
+    action: ACCEPT
+    reason: PIP3 produced by p110delta recruits AKT-linked signaling modules. This
+      pathway term captures the central signaling output of PI3Kdelta even when the
+      initiating receptor or cell type differs.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: &#39;**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide
+        3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes
+        downstream of receptor signaling in immune cells, particularly in lymphocytes.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+- term:
+    id: GO:0045087
+    label: innate immune response
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Supported innate-immune involvement, but this is a broad non-core
+      immune-system output.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta contributes to myeloid and innate leukocyte activities, but the
+      precise core function is receptor-linked PIP3 production rather than innate
+      immunity as a whole.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+    - reference_id: PMID:17290298
+      supporting_text: Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second
+        messengers that control an array of intracellular signalling pathways that are
+        known to have important roles in leukocytes.
+- term:
+    id: GO:0046854
+    label: phosphatidylinositol phosphate biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Supported core process output of PI3Kdelta lipid kinase activity.
+    action: ACCEPT
+    reason: PIK3CD produces 3-phosphoinositides, especially PIP3, as the biochemical
+      product of its class IA lipid kinase activity. This process term is broader than
+      an ideal PIP3-biosynthesis term but is correct.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+    - reference_id: Reactome:R-HSA-389158
+      supporting_text: Upon binding to CD28, the PI3K enzyme catalyzes the
+        phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate
+        phosphatidylinositol 3,4,5-trisphosphate (PIP3).
+- term:
+    id: GO:0046934
+    label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: &#39;Core specific molecular function: p110delta phosphorylates PI(4,5)P2 to generate
+      PIP3.&#39;
+    action: ACCEPT
+    reason: PI(4,5)P2 3-kinase activity is the specific catalytic activity that drives
+      PI3Kdelta receptor signaling and PIP3-dependent AKT pathway recruitment.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+    - reference_id: Reactome:R-HSA-389158
+      supporting_text: Upon binding to CD28, the PI3K enzyme catalyzes the
+        phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate
+        phosphatidylinositol 3,4,5-trisphosphate (PIP3).
+- term:
+    id: GO:0051094
+    label: positive regulation of developmental process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Over-annotation to broad developmental, morphogenesis, or adhesion
+      regulation terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD has specific leukocyte, endothelial, and migration phenotypes, but
+      these broad regulation terms over-generalize downstream effects and obscure the
+      better-supported PI3Kdelta receptor-signaling biology.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0051240
+    label: positive regulation of multicellular organismal process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Over-annotation to broad developmental, morphogenesis, or adhesion
+      regulation terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD has specific leukocyte, endothelial, and migration phenotypes, but
+      these broad regulation terms over-generalize downstream effects and obscure the
+      better-supported PI3Kdelta receptor-signaling biology.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:2000026
+    label: regulation of multicellular organismal development
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Over-annotation to broad developmental, morphogenesis, or adhesion
+      regulation terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD has specific leukocyte, endothelial, and migration phenotypes, but
+      these broad regulation terms over-generalize downstream effects and obscure the
+      better-supported PI3Kdelta receptor-signaling biology.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21827948
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:22020336
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:24165795
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31031754
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35271311
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32606397
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0031295
+    label: T cell costimulation
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-389356
+  review:
+    summary: Supported CD28/T-cell costimulation context for PI3Kdelta signaling.
+    action: ACCEPT
+    reason: CD28 is a direct immune receptor context in which PI3K participates in
+      costimulatory signaling and PIP3 generation. This is part of the core
+      immune-receptor signaling frame for PIK3CD.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: Reactome:R-HSA-389356
+      supporting_text: The cytoplasmic tail of CD28, upon ligand binding, undergoes
+        phosphorylation by Src family kinases like LCK and FYN, triggering downstream
+        signaling pathways involving PI3K, VAV-1, Tec family kinases, AKT, and other
+        adaptor proteins (Sharpe &amp; Freeman 2002; Chen &amp; Flies 2013).
+    - reference_id: Reactome:R-HSA-389158
+      supporting_text: Upon binding to CD28, the PI3K enzyme catalyzes the
+        phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate
+        phosphatidylinositol 3,4,5-trisphosphate (PIP3).
+- term:
+    id: GO:0046934
+    label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-389158
+  review:
+    summary: &#39;Core specific molecular function: p110delta phosphorylates PI(4,5)P2 to generate
+      PIP3.&#39;
+    action: ACCEPT
+    reason: PI(4,5)P2 3-kinase activity is the specific catalytic activity that drives
+      PI3Kdelta receptor signaling and PIP3-dependent AKT pathway recruitment.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+    - reference_id: Reactome:R-HSA-389158
+      supporting_text: Upon binding to CD28, the PI3K enzyme catalyzes the
+        phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate
+        phosphatidylinositol 3,4,5-trisphosphate (PIP3).
+- term:
+    id: GO:0006955
+    label: immune response
+  evidence_type: NAS
+  original_reference_id: PMID:27616589
+  review:
+    summary: Supported leukocyte/immune response involvement, but non-core and broad
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3CD is leukocyte-enriched and affects immune responses, yet this broad
+      immune-process term should not define the core function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+    - reference_id: PMID:27616589
+      supporting_text: Here, we review the roles of PI3Kδ in adaptive immunity, describe
+        the clinical manifestations and mechanisms of disease in APDS and highlight new
+        insights into PI3Kδ gleaned from these patients, as well as implications of
+        these findings for clinical therapy.
+- term:
+    id: GO:0030183
+    label: B cell differentiation
+  evidence_type: NAS
+  original_reference_id: PMID:20200404
+  review:
+    summary: Supported B-cell differentiation/development role, but non-core relative to
+      PI3Kdelta catalytic signaling.
+    action: KEEP_AS_NON_CORE
+    reason: B-cell developmental phenotypes are well supported, but they are downstream
+      organism/cell lineage consequences of PIP3-producing PI3Kdelta signaling.
+    supported_by:
+    - reference_id: PMID:20200404
+      supporting_text: Thus, we provide novel evidence that p110gamma and p110delta have
+        overlapping and cell-extrinsic roles in the development, peripheral maintenance,
+        and function of B cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for B-cell receptor (BCR) signaling.
+- term:
+    id: GO:0030217
+    label: T cell differentiation
+  evidence_type: NAS
+  original_reference_id: PMID:17371229
+  review:
+    summary: Supported T-cell differentiation role, but non-core relative to
+      receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: T-cell differentiation is a supported immune-cell outcome of p110delta
+      activity, not the core molecular function itself.
+    supported_by:
+    - reference_id: PMID:17371229
+      supporting_text: In addition, p110delta regulates the differentiation of
+        peripheral Th (helper T-cells) towards the Th1 and Th2 lineages.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+- term:
+    id: GO:0038084
+    label: vascular endothelial growth factor signaling pathway
+  evidence_type: IGI
+  original_reference_id: PMID:31915155
+  review:
+    summary: Supported endothelial/angiogenesis context, but non-core and
+      tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
+    action: KEEP_AS_NON_CORE
+    reason: Cultured endothelial-cell work supports VEGF-induced Akt activation,
+      proliferation, migration, tube formation, and retinal angiogenesis. This is a real
+      contextual role, not the primary leukocyte-enriched core function.
+    supported_by:
+    - reference_id: PMID:31915155
+      supporting_text: Using genetic and pharmacological approaches, we show that p110δ
+        activity in cultured ECs controls Akt activation, cell proliferation, migration,
+        and tube formation induced by vascular endothelial growth factor, basic
+        fibroblast growth factor, and epidermal growth factor.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+- term:
+    id: GO:0010595
+    label: positive regulation of endothelial cell migration
+  evidence_type: IGI
+  original_reference_id: PMID:31915155
+  review:
+    summary: Supported endothelial/angiogenesis context, but non-core and
+      tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
+    action: KEEP_AS_NON_CORE
+    reason: Cultured endothelial-cell work supports VEGF-induced Akt activation,
+      proliferation, migration, tube formation, and retinal angiogenesis. This is a real
+      contextual role, not the primary leukocyte-enriched core function.
+    supported_by:
+    - reference_id: PMID:31915155
+      supporting_text: Using genetic and pharmacological approaches, we show that p110δ
+        activity in cultured ECs controls Akt activation, cell proliferation, migration,
+        and tube formation induced by vascular endothelial growth factor, basic
+        fibroblast growth factor, and epidermal growth factor.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+- term:
+    id: GO:0001938
+    label: positive regulation of endothelial cell proliferation
+  evidence_type: IGI
+  original_reference_id: PMID:31915155
+  review:
+    summary: Supported endothelial/angiogenesis context, but non-core and
+      tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
+    action: KEEP_AS_NON_CORE
+    reason: Cultured endothelial-cell work supports VEGF-induced Akt activation,
+      proliferation, migration, tube formation, and retinal angiogenesis. This is a real
+      contextual role, not the primary leukocyte-enriched core function.
+    supported_by:
+    - reference_id: PMID:31915155
+      supporting_text: Using genetic and pharmacological approaches, we show that p110δ
+        activity in cultured ECs controls Akt activation, cell proliferation, migration,
+        and tube formation induced by vascular endothelial growth factor, basic
+        fibroblast growth factor, and epidermal growth factor.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+- term:
+    id: GO:0043491
+    label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
+  evidence_type: IGI
+  original_reference_id: PMID:31915155
+  review:
+    summary: Supported PI3K/AKT signaling annotation downstream of PIK3CD-generated
+      PIP3.
+    action: ACCEPT
+    reason: PIP3 produced by p110delta recruits AKT-linked signaling modules. This
+      pathway term captures the central signaling output of PI3Kdelta even when the
+      initiating receptor or cell type differs.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: &#39;**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide
+        3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes
+        downstream of receptor signaling in immune cells, particularly in lymphocytes.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+- term:
+    id: GO:0045766
+    label: positive regulation of angiogenesis
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: Supported endothelial/angiogenesis context, but non-core and
+      tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
+    action: KEEP_AS_NON_CORE
+    reason: Cultured endothelial-cell work supports VEGF-induced Akt activation,
+      proliferation, migration, tube formation, and retinal angiogenesis. This is a real
+      contextual role, not the primary leukocyte-enriched core function.
+    supported_by:
+    - reference_id: PMID:31915155
+      supporting_text: Using genetic and pharmacological approaches, we show that p110δ
+        activity in cultured ECs controls Akt activation, cell proliferation, migration,
+        and tube formation induced by vascular endothelial growth factor, basic
+        fibroblast growth factor, and epidermal growth factor.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+- term:
+    id: GO:1905278
+    label: positive regulation of epithelial tube formation
+  evidence_type: IGI
+  original_reference_id: PMID:31915155
+  review:
+    summary: Supported endothelial/angiogenesis context, but non-core and
+      tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
+    action: KEEP_AS_NON_CORE
+    reason: Cultured endothelial-cell work supports VEGF-induced Akt activation,
+      proliferation, migration, tube formation, and retinal angiogenesis. This is a real
+      contextual role, not the primary leukocyte-enriched core function.
+    supported_by:
+    - reference_id: PMID:31915155
+      supporting_text: Using genetic and pharmacological approaches, we show that p110δ
+        activity in cultured ECs controls Akt activation, cell proliferation, migration,
+        and tube formation induced by vascular endothelial growth factor, basic
+        fibroblast growth factor, and epidermal growth factor.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+- term:
+    id: GO:0033031
+    label: positive regulation of neutrophil apoptotic process
+  evidence_type: IMP
+  original_reference_id: PMID:25339672
+  review:
+    summary: Supported neutrophil-death/apoptotic-process annotation, but non-core and
+      context-dependent.
+    action: KEEP_AS_NON_CORE
+    reason: FcαRI-triggered neutrophil death requires class IA PI3K signaling in
+      inflammatory contexts. This supports the annotation as a non-core immune effector
+      process.
+    supported_by:
+    - reference_id: PMID:25339672
+      supporting_text: preactivation with cytokines or TLR agonists in vitro enhanced
+        FcαRI-mediated death by additional recruitment of caspase-independent pathways,
+        but this required PI3K class IA and MAPK signaling.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0043491
+    label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
+  evidence_type: IMP
+  original_reference_id: PMID:25339672
+  review:
+    summary: Supported PI3K/AKT signaling annotation downstream of PIK3CD-generated
+      PIP3.
+    action: ACCEPT
+    reason: PIP3 produced by p110delta recruits AKT-linked signaling modules. This
+      pathway term captures the central signaling output of PI3Kdelta even when the
+      initiating receptor or cell type differs.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: &#39;**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide
+        3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes
+        downstream of receptor signaling in immune cells, particularly in lymphocytes.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+- term:
+    id: GO:0001779
+    label: natural killer cell differentiation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported NK-cell differentiation role, but non-core relative to PI3Kdelta
+      catalytic signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta participates in NK-cell development and migration, but this is a
+      leukocyte-specific cellular outcome rather than the core lipid kinase function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+- term:
+    id: GO:0001819
+    label: positive regulation of cytokine production
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported cytokine-production role, but non-core and downstream of immune
+      receptor signaling.
+    action: KEEP_AS_NON_CORE
+    reason: Cytokine-production changes are leukocyte outputs of PI3Kdelta signaling,
+      not the primary biochemical function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for T-cell receptor (TCR) signaling.
+- term:
+    id: GO:0002250
+    label: adaptive immune response
+  evidence_type: TAS
+  original_reference_id: PMID:17290298
+  review:
+    summary: Supported adaptive-immune output, but this is a systems-level consequence
+      of PI3Kdelta immune receptor signaling rather than the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: Human disease genetics and leukocyte studies support a role in adaptive
+      immunity, but the core function should remain PIP3-producing class IA PI3K
+      signaling.
+    supported_by:
+    - reference_id: PMID:27616589
+      supporting_text: Here, we review the roles of PI3Kδ in adaptive immunity, describe
+        the clinical manifestations and mechanisms of disease in APDS and highlight new
+        insights into PI3Kδ gleaned from these patients, as well as implications of
+        these findings for clinical therapy.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0002551
+    label: mast cell chemotaxis
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported leukocyte migration/chemotaxis/extravasation role, but non-core
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta affects migration of multiple leukocyte types, but these are
+      cell-type-specific outputs of the core PIP3-generating immune signaling function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0002679
+    label: respiratory burst involved in defense response
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported neutrophil respiratory-burst role, but non-core relative to the
+      catalytic PI3Kdelta signaling function.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta contributes to neutrophil respiratory burst as a myeloid effector
+      output, but this is not the core molecular function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0006954
+    label: inflammatory response
+  evidence_type: TAS
+  original_reference_id: PMID:17290298
+  review:
+    summary: Supported inflammatory-response involvement, but it is a downstream
+      physiological output of PI3Kdelta activity.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta disruption alters inflammatory responses in vivo and PI3K lipid
+      messengers control leukocyte signaling, but inflammation is a non-core
+      phenotype/process relative to lipid kinase signaling.
+    supported_by:
+    - reference_id: PMID:17290298
+      supporting_text: Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second
+        messengers that control an array of intracellular signalling pathways that are
+        known to have important roles in leukocytes.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0006954
+    label: inflammatory response
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported inflammatory-response involvement, but it is a downstream
+      physiological output of PI3Kdelta activity.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta disruption alters inflammatory responses in vivo and PI3K lipid
+      messengers control leukocyte signaling, but inflammation is a non-core
+      phenotype/process relative to lipid kinase signaling.
+    supported_by:
+    - reference_id: PMID:17290298
+      supporting_text: Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second
+        messengers that control an array of intracellular signalling pathways that are
+        known to have important roles in leukocytes.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0010818
+    label: T cell chemotaxis
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported leukocyte migration/chemotaxis/extravasation role, but non-core
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta affects migration of multiple leukocyte types, but these are
+      cell-type-specific outputs of the core PIP3-generating immune signaling function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0016303
+    label: 1-phosphatidylinositol-3-kinase activity
+  evidence_type: TAS
+  original_reference_id: PMID:17290298
+  review:
+    summary: Core molecular function as a phosphatidylinositol 3-kinase catalytic
+      subunit.
+    action: ACCEPT
+    reason: This parent PI3K activity term is valid for p110delta, although GO:0046934
+      is the most specific MF term for its canonical PIP2-to-PIP3 reaction.
+    supported_by:
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+- term:
+    id: GO:0030101
+    label: natural killer cell activation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported NK-cell activation context, but non-core relative to
+      receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: NK-cell activation is a supported immune output; the central curatable
+      function remains PI3Kdelta PIP3 production in leukocyte signaling.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+- term:
+    id: GO:0030217
+    label: T cell differentiation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported T-cell differentiation role, but non-core relative to
+      receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: T-cell differentiation is a supported immune-cell outcome of p110delta
+      activity, not the core molecular function itself.
+    supported_by:
+    - reference_id: PMID:17371229
+      supporting_text: In addition, p110delta regulates the differentiation of
+        peripheral Th (helper T-cells) towards the Th1 and Th2 lineages.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+- term:
+    id: GO:0030593
+    label: neutrophil chemotaxis
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported leukocyte migration/chemotaxis/extravasation role, but non-core
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta affects migration of multiple leukocyte types, but these are
+      cell-type-specific outputs of the core PIP3-generating immune signaling function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0035747
+    label: natural killer cell chemotaxis
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported leukocyte migration/chemotaxis/extravasation role, but non-core
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta affects migration of multiple leukocyte types, but these are
+      cell-type-specific outputs of the core PIP3-generating immune signaling function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0035754
+    label: B cell chemotaxis
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported leukocyte migration/chemotaxis/extravasation role, but non-core
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta affects migration of multiple leukocyte types, but these are
+      cell-type-specific outputs of the core PIP3-generating immune signaling function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0042110
+    label: T cell activation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported T-cell activation/function annotation, but downstream of the more
+      core TCR/CD28 signaling role.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3CD contributes to T-cell development, activation, and migration. The
+      T-cell activation process is supported but is a cellular outcome of the core
+      TCR/CD28 PI3K signaling function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for T-cell receptor (TCR) signaling.
+- term:
+    id: GO:0042113
+    label: B cell activation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported B-cell activation/function annotation, but downstream of the more
+      core BCR signaling role.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3CD is important for B-cell development and function. B-cell activation
+      is real, but BCR signaling and PI3K/AKT signaling are the more precise core
+      process annotations.
+    supported_by:
+    - reference_id: PMID:20200404
+      supporting_text: Thus, we provide novel evidence that p110gamma and p110delta have
+        overlapping and cell-extrinsic roles in the development, peripheral maintenance,
+        and function of B cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for B-cell receptor (BCR) signaling.
+- term:
+    id: GO:0043303
+    label: mast cell degranulation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported mast-cell degranulation role, but non-core relative to the
+      catalytic PI3Kdelta function.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta contributes to mast-cell degranulation, but this is a
+      cell-type-specific effector output rather than the core molecular function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0043491
+    label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
+  evidence_type: TAS
+  original_reference_id: PMID:17290298
+  review:
+    summary: Supported PI3K/AKT signaling annotation downstream of PIK3CD-generated
+      PIP3.
+    action: ACCEPT
+    reason: PIP3 produced by p110delta recruits AKT-linked signaling modules. This
+      pathway term captures the central signaling output of PI3Kdelta even when the
+      initiating receptor or cell type differs.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: &#39;**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide
+        3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes
+        downstream of receptor signaling in immune cells, particularly in lymphocytes.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+- term:
+    id: GO:0045087
+    label: innate immune response
+  evidence_type: TAS
+  original_reference_id: PMID:17290298
+  review:
+    summary: Supported innate-immune involvement, but this is a broad non-core
+      immune-system output.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta contributes to myeloid and innate leukocyte activities, but the
+      precise core function is receptor-linked PIP3 production rather than innate
+      immunity as a whole.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+    - reference_id: PMID:17290298
+      supporting_text: Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second
+        messengers that control an array of intracellular signalling pathways that are
+        known to have important roles in leukocytes.
+- term:
+    id: GO:0045087
+    label: innate immune response
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported innate-immune involvement, but this is a broad non-core
+      immune-system output.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta contributes to myeloid and innate leukocyte activities, but the
+      precise core function is receptor-linked PIP3 production rather than innate
+      immunity as a whole.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+    - reference_id: PMID:17290298
+      supporting_text: Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second
+        messengers that control an array of intracellular signalling pathways that are
+        known to have important roles in leukocytes.
+- term:
+    id: GO:0050852
+    label: T cell receptor signaling pathway
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported TCR signaling role for PI3Kdelta.
+    action: ACCEPT
+    reason: UniProt and the literature synthesis identify p110delta as required for TCR
+      signaling, making this one of the core immune receptor signaling processes for
+      PIK3CD.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for T-cell receptor (TCR) signaling.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+- term:
+    id: GO:0050853
+    label: B cell receptor signaling pathway
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported BCR signaling role for PI3Kdelta.
+    action: ACCEPT
+    reason: p110delta is required for BCR signaling and B-cell functional outputs; this
+      is one of the strongest process annotations for PIK3CD.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for B-cell receptor (BCR) signaling.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20200404
+      supporting_text: Thus, we provide novel evidence that p110gamma and p110delta have
+        overlapping and cell-extrinsic roles in the development, peripheral maintenance,
+        and function of B cells.
+- term:
+    id: GO:0060374
+    label: mast cell differentiation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported mast-cell differentiation role, but non-core relative to the
+      catalytic PI3Kdelta function.
+    action: KEEP_AS_NON_CORE
+    reason: Mast-cell maturation/differentiation is a supported leukocyte-cell output of
+      PI3Kdelta signaling, not the core molecular activity.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0072672
+    label: neutrophil extravasation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported leukocyte migration/chemotaxis/extravasation role, but non-core
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta affects migration of multiple leukocyte types, but these are
+      cell-type-specific outputs of the core PIP3-generating immune signaling function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0010628
+    label: positive regulation of gene expression
+  evidence_type: IMP
+  original_reference_id: PMID:22079609
+  review:
+    summary: Over-annotation to positive regulation of gene expression. The available
+      PIK3CD evidence supports upstream PI3K/AKT signaling more directly than this
+      distal transcriptional-output term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Gene-expression changes can occur downstream of PI3K/AKT/FOXO signaling, but
+      the cited evidence is more direct for lipid kinase signaling, migration, and
+      protein-level pathway outputs. This broad distal term should not be retained as a
+      core annotation.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+    - reference_id: PMID:22079609
+      supporting_text: Interestingly, knockdown of p110δ decreased the cell migration
+        and invasion ability of all GBM cell lines tested.
+- term:
+    id: GO:0030335
+    label: positive regulation of cell migration
+  evidence_type: IMP
+  original_reference_id: PMID:22079609
+  review:
+    summary: Supported cell-migration role in specific leukocyte and glioma contexts,
+      but non-core relative to lipid kinase signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3CD knockdown decreases glioma-cell migration and PI3Kdelta also affects
+      leukocyte migration; these are downstream context-specific outputs rather than the
+      core function.
+    supported_by:
+    - reference_id: PMID:22079609
+      supporting_text: Interestingly, knockdown of p110δ decreased the cell migration
+        and invasion ability of all GBM cell lines tested.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-1676048
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-1676109
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9012657
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9021627
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9027275
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9606887
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: &#39;SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.&#39;
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-2045911
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-2076220
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-2316434
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-2400009
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-388830
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-388832
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-389158
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-508247
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-879917
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8854905
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-912627
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-914182
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9606887
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005942
+    label: phosphatidylinositol 3-kinase complex
+  evidence_type: NAS
+  original_reference_id: PMID:9113989
+  review:
+    summary: The complex assignment is valid but should use the more specific class IA
+      phosphatidylinositol 3-kinase complex term.
+    action: MODIFY
+    reason: PIK3CD is not just any PI3K-complex component; it is the p110delta catalytic
+      subunit of class IA p85-family regulatory complexes. GO:0005943 captures the
+      correct complex subtype.
+    proposed_replacement_terms:
+    - id: GO:0005943
+      label: phosphatidylinositol 3-kinase complex, class IA
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+- term:
+    id: GO:0005942
+    label: phosphatidylinositol 3-kinase complex
+  evidence_type: NAS
+  original_reference_id: PMID:9235916
+  review:
+    summary: The complex assignment is valid but should use the more specific class IA
+      phosphatidylinositol 3-kinase complex term.
+    action: MODIFY
+    reason: PIK3CD is not just any PI3K-complex component; it is the p110delta catalytic
+      subunit of class IA p85-family regulatory complexes. GO:0005943 captures the
+      correct complex subtype.
+    proposed_replacement_terms:
+    - id: GO:0005943
+      label: phosphatidylinositol 3-kinase complex, class IA
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+- term:
+    id: GO:0006468
+    label: protein phosphorylation
+  evidence_type: NAS
+  original_reference_id: PMID:9113989
+  review:
+    summary: Over-annotation to protein phosphorylation. PIK3CD is primarily a
+      phosphoinositide lipid kinase, not a protein kinase.
+    action: MODIFY
+    reason: PMID:9113989 reports lipid substrate specificity and explicitly
+      distinguishes p110delta from p110alpha by noting that it does not phosphorylate
+      p85, despite intrinsic autophosphorylation. The annotation should point to lipid
+      phosphorylation or PI(4,5)P2 3-kinase activity rather than general protein
+      phosphorylation.
+    proposed_replacement_terms:
+    - id: GO:0046834
+      label: lipid phosphorylation
+    - id: GO:0046934
+      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+    supported_by:
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+    - reference_id: PMID:9113989
+      supporting_text: Unlike p110alpha, p110delta does not phosphorylate p85 but
+        instead harbors an intrinsic autophosphorylation capacity.
+- term:
+    id: GO:0007165
+    label: signal transduction
+  evidence_type: NAS
+  original_reference_id: PMID:9113989
+  review:
+    summary: The generic signal-transduction annotation should be narrowed to PI3K/AKT
+      and immune receptor signaling.
+    action: MODIFY
+    reason: PIK3CD participates in signaling by generating PIP3 downstream of receptor
+      activation. The generic signal transduction parent obscures the specific PI3K/AKT,
+      BCR, and TCR pathways supported by the evidence.
+    proposed_replacement_terms:
+    - id: GO:0043491
+      label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
+    - id: GO:0050853
+      label: B cell receptor signaling pathway
+    - id: GO:0050852
+      label: T cell receptor signaling pathway
+    supported_by:
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+- term:
+    id: GO:0016303
+    label: 1-phosphatidylinositol-3-kinase activity
+  evidence_type: NAS
+  original_reference_id: PMID:9235916
+  review:
+    summary: Core molecular function as a phosphatidylinositol 3-kinase catalytic
+      subunit.
+    action: ACCEPT
+    reason: This parent PI3K activity term is valid for p110delta, although GO:0046934
+      is the most specific MF term for its canonical PIP2-to-PIP3 reaction.
+    supported_by:
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
 references:
-  - id: GO_REF:0000002
-    title: Gene Ontology annotation through association of InterPro records with
-      GO terms
-    findings: []
-  - id: GO_REF:0000024
-    title: Manual transfer of experimentally-verified manual GO annotation data 
-      to orthologs by curator judgment of sequence similarity
-    findings: []
-  - id: GO_REF:0000033
-    title: Annotation inferences using phylogenetic trees
-    findings: []
-  - id: GO_REF:0000043
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword 
-      mapping
-    findings: []
-  - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt
-    findings: []
-  - id: GO_REF:0000052
-    title: Gene Ontology annotation based on curation of immunofluorescence data
-    findings: []
-  - id: GO_REF:0000117
-    title: Electronic Gene Ontology annotations created by ARBA machine learning
-      models
-    findings: []
-  - id: GO_REF:0000120
-    title: Combined Automated Annotation using Multiple IEA Methods
-    findings: []
-  - id: PMID:17290298
-    title: &#39;PI3K delta and PI3K gamma: partners in crime in inflammation in rheumatoid
-      arthritis and beyond?&#39;
-    findings: []
-  - id: PMID:17371229
-    title: The PI3K p110delta controls T-cell development, differentiation and 
-      regulation.
-    findings: []
-  - id: PMID:20200404
-    title: The catalytic PI3K isoforms p110gamma and p110delta contribute to B 
-      cell development and maintenance, transformation, and proliferation.
-    findings: []
-  - id: PMID:20940048
-    title: Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and 
-      function.
-    findings: []
-  - id: PMID:21827948
-    title: Dynamics of the phosphoinositide 3-kinase p110δ interaction with p85α
-      and membranes reveals aspects of regulation distinct from p110α.
-    findings: []
-  - id: PMID:22020336
-    title: p37δ is a new isoform of PI3K p110δ that increases cell proliferation
-      and is overexpressed in tumors.
-    findings: []
-  - id: PMID:22079609
-    title: The catalytic phosphoinositol 3-kinase isoform p110δ is required for 
-      glioma cell migration and invasion.
-    findings: []
-  - id: PMID:24165795
-    title: Dominant-activating germline mutations in the gene encoding the 
-      PI(3)K catalytic subunit p110δ result in T cell senescence and human 
-      immunodeficiency.
-    findings: []
-  - id: PMID:25339672
-    title: Human IgA Fc receptor FcαRI (CD89) triggers different forms of 
-      neutrophil death depending on the inflammatory microenvironment.
-    findings: []
-  - id: PMID:27616589
-    title: PI3Kδ and primary immunodeficiencies.
-    findings: []
-  - id: PMID:28514442
-    title: Architecture of the human interactome defines protein communities and
-      disease networks.
-    findings: []
-  - id: PMID:31031754
-    title: &#39;Case Study: Mechanism for Increased Follicular Helper T Cell Development
-      in Activated PI3K Delta Syndrome.&#39;
-    findings: []
-  - id: PMID:31915155
-    title: PI3Kδ as a Novel Therapeutic Target in Pathological Angiogenesis.
-    findings: []
-  - id: PMID:32296183
-    title: A reference map of the human binary protein interactome.
-    findings: []
-  - id: PMID:32606397
-    title: PI3K activation is enhanced by FOXM1D binding to p110 and p85 
-      subunits.
-    findings: []
-  - id: PMID:33961781
-    title: Dual proteome-scale networks reveal cell-specific remodeling of the 
-      human interactome.
-    findings: []
-  - id: PMID:35271311
-    title: &#39;OpenCell: Endogenous tagging for the cartography of human cellular organization.&#39;
-    findings: []
-  - id: PMID:40205054
-    title: Multimodal cell maps as a foundation for structural and functional 
-      genomics.
-    findings: []
-  - id: PMID:9113989
-    title: P110delta, a novel phosphoinositide 3-kinase in leukocytes.
-    findings: []
-  - id: PMID:9235916
-    title: p110delta, a novel phosphatidylinositol 3-kinase catalytic subunit 
-      that associates with p85 and is expressed predominantly in leukocytes.
-    findings: []
-  - id: Reactome:R-HSA-1676048
-    title: PI(4,5)P2 is phosphorylated to PI(3,4,5)P3 by PIK3C[1] at the plasma 
-      membrane
-    findings: []
-  - id: Reactome:R-HSA-1676109
-    title: PI4P is phosphorylated to PI(3,4)P2 by PI3K3C[2] at the plasma 
-      membrane
-    findings: []
-  - id: Reactome:R-HSA-2045911
-    title: BCAP Signalosome phosphorylates PI(4,5)P2 forming PI(3,4,5)P3
-    findings: []
-  - id: Reactome:R-HSA-2076220
-    title: CD19 Signalosome phosphorylates PI(4,5)P2 forming PI(3,4,5)P3
-    findings: []
-  - id: Reactome:R-HSA-2316434
-    title: PI3K phosphorylates PIP2 to PIP3
-    findings: []
-  - id: Reactome:R-HSA-2400009
-    title: PI3K inhibitors block PI3K catalytic activity
-    findings: []
-  - id: Reactome:R-HSA-388830
-    title: PI3K binds ICOS
-    findings: []
-  - id: Reactome:R-HSA-388832
-    title: PI3K binds CD28
-    findings: []
-  - id: Reactome:R-HSA-389158
-    title: CD28 bound PI3K phosphorylates PIP2 to PIP3
-    findings: []
-  - id: Reactome:R-HSA-389356
-    title: Co-stimulation by CD28
-    findings: []
-  - id: Reactome:R-HSA-508247
-    title: Gab2 binds the p85 subunit of Class 1A PI3 kinases
-    findings: []
-  - id: Reactome:R-HSA-879917
-    title: CBL, GRB2, FYN and PI3K p85 subunit are constitutively associated
-    findings: []
-  - id: Reactome:R-HSA-8854905
-    title: p-5Y-GAB in the RET-GRB2-GAB complexes binds p85-PI3K
-    findings: []
-  - id: Reactome:R-HSA-9012657
-    title: EPO:phospho-EPOR:phospho-JAK2:LYN:phospho-IRS2 binds PI3K
-    findings: []
-  - id: Reactome:R-HSA-9021627
-    title: EPOR-associated PI3K phosphorylates PIP2 to PIP3
-    findings: []
-  - id: Reactome:R-HSA-9027275
-    title: EPO:phospho-EPOR:phospho-JAK2:LYN:IRS2:phospho-GAB1 binds PI3K
-    findings: []
-  - id: Reactome:R-HSA-912627
-    title: CBL ubiquitinates PI3K
-    findings: []
-  - id: Reactome:R-HSA-914182
-    title: 14-3-3 zeta binding allows recruitment of PI3K
-    findings: []
-  - id: Reactome:R-HSA-9606887
-    title: p-CD19:VAV binds PI3K and GRB2
-    findings: []
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to
+    orthologs by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000043
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:17290298
+  title: &#39;PI3K delta and PI3K gamma: partners in crime in inflammation in rheumatoid arthritis
+    and beyond?&#39;
+  findings: []
+- id: PMID:17371229
+  title: The PI3K p110delta controls T-cell development, differentiation and regulation.
+  findings: []
+- id: PMID:20200404
+  title: The catalytic PI3K isoforms p110gamma and p110delta contribute to B cell
+    development and maintenance, transformation, and proliferation.
+  findings: []
+- id: PMID:20940048
+  title: Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.
+  findings: []
+- id: PMID:21827948
+  title: Dynamics of the phosphoinositide 3-kinase p110δ interaction with p85α and
+    membranes reveals aspects of regulation distinct from p110α.
+  findings: []
+- id: PMID:22020336
+  title: p37δ is a new isoform of PI3K p110δ that increases cell proliferation and is
+    overexpressed in tumors.
+  findings: []
+- id: PMID:22079609
+  title: The catalytic phosphoinositol 3-kinase isoform p110δ is required for glioma
+    cell migration and invasion.
+  findings: []
+- id: PMID:24165795
+  title: Dominant-activating germline mutations in the gene encoding the PI(3)K
+    catalytic subunit p110δ result in T cell senescence and human immunodeficiency.
+  findings: []
+- id: PMID:25339672
+  title: Human IgA Fc receptor FcαRI (CD89) triggers different forms of neutrophil death
+    depending on the inflammatory microenvironment.
+  findings: []
+- id: PMID:27616589
+  title: PI3Kδ and primary immunodeficiencies.
+  findings: []
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings: []
+- id: PMID:31031754
+  title: &#39;Case Study: Mechanism for Increased Follicular Helper T Cell Development in Activated
+    PI3K Delta Syndrome.&#39;
+  findings: []
+- id: PMID:31915155
+  title: PI3Kδ as a Novel Therapeutic Target in Pathological Angiogenesis.
+  findings: []
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+- id: PMID:32606397
+  title: PI3K activation is enhanced by FOXM1D binding to p110 and p85 subunits.
+  findings: []
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+- id: PMID:35271311
+  title: &#39;OpenCell: Endogenous tagging for the cartography of human cellular organization.&#39;
+  findings: []
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+- id: PMID:9113989
+  title: P110delta, a novel phosphoinositide 3-kinase in leukocytes.
+  findings: []
+- id: PMID:9235916
+  title: p110delta, a novel phosphatidylinositol 3-kinase catalytic subunit that
+    associates with p85 and is expressed predominantly in leukocytes.
+  findings: []
+- id: Reactome:R-HSA-1676048
+  title: PI(4,5)P2 is phosphorylated to PI(3,4,5)P3 by PIK3C[1] at the plasma membrane
+  findings: []
+- id: Reactome:R-HSA-1676109
+  title: PI4P is phosphorylated to PI(3,4)P2 by PI3K3C[2] at the plasma membrane
+  findings: []
+- id: Reactome:R-HSA-2045911
+  title: BCAP Signalosome phosphorylates PI(4,5)P2 forming PI(3,4,5)P3
+  findings: []
+- id: Reactome:R-HSA-2076220
+  title: CD19 Signalosome phosphorylates PI(4,5)P2 forming PI(3,4,5)P3
+  findings: []
+- id: Reactome:R-HSA-2316434
+  title: PI3K phosphorylates PIP2 to PIP3
+  findings: []
+- id: Reactome:R-HSA-2400009
+  title: PI3K inhibitors block PI3K catalytic activity
+  findings: []
+- id: Reactome:R-HSA-388830
+  title: PI3K binds ICOS
+  findings: []
+- id: Reactome:R-HSA-388832
+  title: PI3K binds CD28
+  findings: []
+- id: Reactome:R-HSA-389158
+  title: CD28 bound PI3K phosphorylates PIP2 to PIP3
+  findings: []
+- id: Reactome:R-HSA-389356
+  title: Co-stimulation by CD28
+  findings: []
+- id: Reactome:R-HSA-508247
+  title: Gab2 binds the p85 subunit of Class 1A PI3 kinases
+  findings: []
+- id: Reactome:R-HSA-879917
+  title: CBL, GRB2, FYN and PI3K p85 subunit are constitutively associated
+  findings: []
+- id: Reactome:R-HSA-8854905
+  title: p-5Y-GAB in the RET-GRB2-GAB complexes binds p85-PI3K
+  findings: []
+- id: Reactome:R-HSA-9012657
+  title: EPO:phospho-EPOR:phospho-JAK2:LYN:phospho-IRS2 binds PI3K
+  findings: []
+- id: Reactome:R-HSA-9021627
+  title: EPOR-associated PI3K phosphorylates PIP2 to PIP3
+  findings: []
+- id: Reactome:R-HSA-9027275
+  title: EPO:phospho-EPOR:phospho-JAK2:LYN:IRS2:phospho-GAB1 binds PI3K
+  findings: []
+- id: Reactome:R-HSA-912627
+  title: CBL ubiquitinates PI3K
+  findings: []
+- id: Reactome:R-HSA-914182
+  title: 14-3-3 zeta binding allows recruitment of PI3K
+  findings: []
+- id: Reactome:R-HSA-9606887
+  title: p-CD19:VAV binds PI3K and GRB2
+  findings: []
+- id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+  title: Falcon deep research report on PIK3CD
+  findings: []
+- id: file:human/PIK3CD/PIK3CD-uniprot.txt
+  title: UniProtKB record for PIK3CD
+  findings: []
+core_functions:
+- molecular_function:
+    id: GO:0046934
+    label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+  description: PIK3CD/p110delta is the leukocyte-enriched class IA PI3K catalytic
+    subunit that forms p85-family regulatory complexes and generates PIP3 from PI(4,5)P2
+    at receptor-activated membranes.
+  directly_involved_in:
+  - id: GO:0043491
+    label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
+  - id: GO:0050853
+    label: B cell receptor signaling pathway
+  - id: GO:0050852
+    label: T cell receptor signaling pathway
+  - id: GO:0031295
+    label: T cell costimulation
+  locations:
+  - id: GO:0005886
+    label: plasma membrane
+  in_complex:
+    id: GO:0005943
+    label: phosphatidylinositol 3-kinase complex, class IA
+  supported_by:
+  - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+    supporting_text: &#39;**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide
+      3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes
+      downstream of receptor signaling in immune cells, particularly in lymphocytes.&#39;
+  - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+    supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+      PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+  - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+    supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+      signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related
+      receptor/adaptor systems), framing the major immune-cell BP terms relevant for
+      PIK3CD.
+  - reference_id: Reactome:R-HSA-389158
+    supporting_text: Upon binding to CD28, the PI3K enzyme catalyzes the phosphorylation
+      of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate phosphatidylinositol
+      3,4,5-trisphosphate (PIP3).
+  - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+    supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+      class IA, p110delta/p85alpha.
+proposed_new_terms: []
+suggested_questions:
+- question: Which PIK3CD-dependent leukocyte migration, neutrophil death, and
+    endothelial angiogenesis annotations remain physiologically relevant in human
+    primary cells after controlling for class I PI3K isoform redundancy and inhibitor
+    selectivity?
+- question: Should GO include a more specific biological-process term for class I
+    PI3K-mediated PI(3,4,5)P3 biosynthesis to avoid using PI3P-centered or overly broad
+    phosphatidylinositol phosphate biosynthetic process terms for PIK3CD?
+suggested_experiments:
+- description: Use isoform-selective genetic rescue in human primary B and T cells to
+    separate PIK3CD-specific BCR, TCR, and CD28 signaling outputs from overlapping
+    PIK3CA/PIK3CB/PIK3CG class I PI3K activity.
+  experiment_type: primary-cell genetic rescue and phosphoprotein/PIP3 readout
+- description: Measure PI(4,5)P2-to-PIP3 and PI4P-to-PI(3,4)P2 product formation for
+    p110delta-p85 complexes under matched in vitro and membrane-recruitment conditions
+    to clarify whether PI4P kinase annotations should remain non-core.
+  experiment_type: lipid kinase substrate-specificity assay
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/PIK3CD/PIK3CD-ai-review.html
+++ b/genes/human/PIK3CD/PIK3CD-ai-review.html
@@ -2218,7 +2218,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> PIK3CD is specifically a phosphoinositide lipid kinase that produces 3-phosphoinositides/PIP3 in signaling contexts; phosphatidylinositol phosphate biosynthesis and PI(4,5)P2 3-kinase activity are more informative.
+                            <strong>Reason:</strong> PIK3CD is specifically a phosphoinositide lipid kinase that produces 3-phosphoinositides/PIP3 in signaling contexts; phosphatidylinositol phosphate biosynthesis is the more informative same-aspect process replacement, while the specific PI(4,5)P2 3-kinase molecular function is handled separately.
                         </div>
 
 
@@ -2228,12 +2228,6 @@
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046854" target="_blank" class="term-link">
                                     phosphatidylinositol phosphate biosynthetic process
-                                </a>
-                            </span>
-
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046934" target="_blank" class="term-link">
-                                    1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
                                 </a>
                             </span>
 
@@ -2700,7 +2694,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Gene-expression changes can occur downstream of PI3K/AKT/FOXO signaling, but the cited evidence is more direct for lipid kinase signaling, migration, and protein-level pathway outputs. This broad distal term should not be retained as a core annotation.
+                            <strong>Reason:</strong> Gene-expression changes can occur downstream of PI3K/AKT/FOXO signaling, but the evidence supports this as a distal pathway output requiring careful attribution rather than a direct core PIK3CD function. This broad distal term should not be retained as a core annotation.
                         </div>
 
 
@@ -2722,13 +2716,11 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22079609" target="_blank" class="term-link">
-                                        PMID:22079609
-                                    </a>
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
 
                                 </span>
 
-                                <div class="support-text">Interestingly, knockdown of p110δ decreased the cell migration and invasion ability of all GBM cell lines tested.</div>
+                                <div class="support-text">It highlights pathway antagonism by PTEN/SHIP and connects FOXO-regulated transcription (e.g., immune differentiation programs) to PI3K signaling outputs (useful for downstream BP annotations, but requires careful evidence attribution if annotating those distal effects).</div>
 
                             </div>
 
@@ -8589,7 +8581,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> Gene-expression changes can occur downstream of PI3K/AKT/FOXO signaling, but the cited evidence is more direct for lipid kinase signaling, migration, and protein-level pathway outputs. This broad distal term should not be retained as a core annotation.
+                            <strong>Reason:</strong> Gene-expression changes can occur downstream of PI3K/AKT/FOXO signaling, but the evidence supports this as a distal pathway output requiring careful attribution rather than a direct core PIK3CD function. This broad distal term should not be retained as a core annotation.
                         </div>
 
 
@@ -8611,13 +8603,11 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/22079609" target="_blank" class="term-link">
-                                        PMID:22079609
-                                    </a>
+                                    file:human/PIK3CD/PIK3CD-deep-research-falcon.md
 
                                 </span>
 
-                                <div class="support-text">Interestingly, knockdown of p110δ decreased the cell migration and invasion ability of all GBM cell lines tested.</div>
+                                <div class="support-text">It highlights pathway antagonism by PTEN/SHIP and connects FOXO-regulated transcription (e.g., immune differentiation programs) to PI3K signaling outputs (useful for downstream BP annotations, but requires careful evidence attribution if annotating those distal effects).</div>
 
                             </div>
 
@@ -10481,7 +10471,7 @@
 
 
                         <div>
-                            <strong>Reason:</strong> PMID:9113989 reports lipid substrate specificity and explicitly distinguishes p110delta from p110alpha by noting that it does not phosphorylate p85, despite intrinsic autophosphorylation. The annotation should point to lipid phosphorylation or PI(4,5)P2 3-kinase activity rather than general protein phosphorylation.
+                            <strong>Reason:</strong> PMID:9113989 reports lipid substrate specificity and explicitly distinguishes p110delta from p110alpha by noting that it does not phosphorylate p85, despite intrinsic autophosphorylation. The same-aspect replacement should be lipid phosphorylation rather than general protein phosphorylation; the specific PI(4,5)P2 3-kinase molecular function is handled separately.
                         </div>
 
 
@@ -10491,12 +10481,6 @@
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046834" target="_blank" class="term-link">
                                     lipid phosphorylation
-                                </a>
-                            </span>
-
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046934" target="_blank" class="term-link">
-                                    1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
                                 </a>
                             </span>
 
@@ -12579,12 +12563,11 @@ existing_annotations:
     action: MODIFY
     reason: PIK3CD is specifically a phosphoinositide lipid kinase that produces
       3-phosphoinositides/PIP3 in signaling contexts; phosphatidylinositol phosphate
-      biosynthesis and PI(4,5)P2 3-kinase activity are more informative.
+      biosynthesis is the more informative same-aspect process replacement, while the
+      specific PI(4,5)P2 3-kinase molecular function is handled separately.
     proposed_replacement_terms:
     - id: GO:0046854
       label: phosphatidylinositol phosphate biosynthetic process
-    - id: GO:0046934
-      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
     supported_by:
     - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
       supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
@@ -12706,18 +12689,20 @@ existing_annotations:
       distal transcriptional-output term.
     action: MARK_AS_OVER_ANNOTATED
     reason: Gene-expression changes can occur downstream of PI3K/AKT/FOXO signaling, but
-      the cited evidence is more direct for lipid kinase signaling, migration, and
-      protein-level pathway outputs. This broad distal term should not be retained as a
-      core annotation.
+      the evidence supports this as a distal pathway output requiring careful
+      attribution rather than a direct core PIK3CD function. This broad distal term
+      should not be retained as a core annotation.
     supported_by:
     - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
       supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
         isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
         leukocyte-enriched but not exclusively expressed, so immune-context evidence is
         strongest for PIK3CD-specific BP claims.
-    - reference_id: PMID:22079609
-      supporting_text: Interestingly, knockdown of p110δ decreased the cell migration
-        and invasion ability of all GBM cell lines tested.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: It highlights pathway antagonism by PTEN/SHIP and connects
+        FOXO-regulated transcription (e.g., immune differentiation programs) to PI3K
+        signaling outputs (useful for downstream BP annotations, but requires careful
+        evidence attribution if annotating those distal effects).
 - term:
     id: GO:0016301
     label: kinase activity
@@ -14087,18 +14072,20 @@ existing_annotations:
       distal transcriptional-output term.
     action: MARK_AS_OVER_ANNOTATED
     reason: Gene-expression changes can occur downstream of PI3K/AKT/FOXO signaling, but
-      the cited evidence is more direct for lipid kinase signaling, migration, and
-      protein-level pathway outputs. This broad distal term should not be retained as a
-      core annotation.
+      the evidence supports this as a distal pathway output requiring careful
+      attribution rather than a direct core PIK3CD function. This broad distal term
+      should not be retained as a core annotation.
     supported_by:
     - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
       supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
         isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
         leukocyte-enriched but not exclusively expressed, so immune-context evidence is
         strongest for PIK3CD-specific BP claims.
-    - reference_id: PMID:22079609
-      supporting_text: Interestingly, knockdown of p110δ decreased the cell migration
-        and invasion ability of all GBM cell lines tested.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: It highlights pathway antagonism by PTEN/SHIP and connects
+        FOXO-regulated transcription (e.g., immune differentiation programs) to PI3K
+        signaling outputs (useful for downstream BP annotations, but requires careful
+        evidence attribution if annotating those distal effects).
 - term:
     id: GO:0030335
     label: positive regulation of cell migration
@@ -14574,14 +14561,12 @@ existing_annotations:
     action: MODIFY
     reason: PMID:9113989 reports lipid substrate specificity and explicitly
       distinguishes p110delta from p110alpha by noting that it does not phosphorylate
-      p85, despite intrinsic autophosphorylation. The annotation should point to lipid
-      phosphorylation or PI(4,5)P2 3-kinase activity rather than general protein
-      phosphorylation.
+      p85, despite intrinsic autophosphorylation. The same-aspect replacement should be
+      lipid phosphorylation rather than general protein phosphorylation; the specific
+      PI(4,5)P2 3-kinase molecular function is handled separately.
     proposed_replacement_terms:
     - id: GO:0046834
       label: lipid phosphorylation
-    - id: GO:0046934
-      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
     supported_by:
     - reference_id: PMID:9113989
       supporting_text: p110delta displays a broad phosphoinositide lipid substrate

--- a/genes/human/PIK3CD/PIK3CD-ai-review.yaml
+++ b/genes/human/PIK3CD/PIK3CD-ai-review.yaml
@@ -395,12 +395,11 @@ existing_annotations:
     action: MODIFY
     reason: PIK3CD is specifically a phosphoinositide lipid kinase that produces
       3-phosphoinositides/PIP3 in signaling contexts; phosphatidylinositol phosphate
-      biosynthesis and PI(4,5)P2 3-kinase activity are more informative.
+      biosynthesis is the more informative same-aspect process replacement, while the
+      specific PI(4,5)P2 3-kinase molecular function is handled separately.
     proposed_replacement_terms:
     - id: GO:0046854
       label: phosphatidylinositol phosphate biosynthetic process
-    - id: GO:0046934
-      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
     supported_by:
     - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
       supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
@@ -522,18 +521,20 @@ existing_annotations:
       distal transcriptional-output term.
     action: MARK_AS_OVER_ANNOTATED
     reason: Gene-expression changes can occur downstream of PI3K/AKT/FOXO signaling, but
-      the cited evidence is more direct for lipid kinase signaling, migration, and
-      protein-level pathway outputs. This broad distal term should not be retained as a
-      core annotation.
+      the evidence supports this as a distal pathway output requiring careful
+      attribution rather than a direct core PIK3CD function. This broad distal term
+      should not be retained as a core annotation.
     supported_by:
     - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
       supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
         isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
         leukocyte-enriched but not exclusively expressed, so immune-context evidence is
         strongest for PIK3CD-specific BP claims.
-    - reference_id: PMID:22079609
-      supporting_text: Interestingly, knockdown of p110δ decreased the cell migration
-        and invasion ability of all GBM cell lines tested.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: It highlights pathway antagonism by PTEN/SHIP and connects
+        FOXO-regulated transcription (e.g., immune differentiation programs) to PI3K
+        signaling outputs (useful for downstream BP annotations, but requires careful
+        evidence attribution if annotating those distal effects).
 - term:
     id: GO:0016301
     label: kinase activity
@@ -1903,18 +1904,20 @@ existing_annotations:
       distal transcriptional-output term.
     action: MARK_AS_OVER_ANNOTATED
     reason: Gene-expression changes can occur downstream of PI3K/AKT/FOXO signaling, but
-      the cited evidence is more direct for lipid kinase signaling, migration, and
-      protein-level pathway outputs. This broad distal term should not be retained as a
-      core annotation.
+      the evidence supports this as a distal pathway output requiring careful
+      attribution rather than a direct core PIK3CD function. This broad distal term
+      should not be retained as a core annotation.
     supported_by:
     - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
       supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
         isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
         leukocyte-enriched but not exclusively expressed, so immune-context evidence is
         strongest for PIK3CD-specific BP claims.
-    - reference_id: PMID:22079609
-      supporting_text: Interestingly, knockdown of p110δ decreased the cell migration
-        and invasion ability of all GBM cell lines tested.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: It highlights pathway antagonism by PTEN/SHIP and connects
+        FOXO-regulated transcription (e.g., immune differentiation programs) to PI3K
+        signaling outputs (useful for downstream BP annotations, but requires careful
+        evidence attribution if annotating those distal effects).
 - term:
     id: GO:0030335
     label: positive regulation of cell migration
@@ -2390,14 +2393,12 @@ existing_annotations:
     action: MODIFY
     reason: PMID:9113989 reports lipid substrate specificity and explicitly
       distinguishes p110delta from p110alpha by noting that it does not phosphorylate
-      p85, despite intrinsic autophosphorylation. The annotation should point to lipid
-      phosphorylation or PI(4,5)P2 3-kinase activity rather than general protein
-      phosphorylation.
+      p85, despite intrinsic autophosphorylation. The same-aspect replacement should be
+      lipid phosphorylation rather than general protein phosphorylation; the specific
+      PI(4,5)P2 3-kinase molecular function is handled separately.
     proposed_replacement_terms:
     - id: GO:0046834
       label: lipid phosphorylation
-    - id: GO:0046934
-      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
     supported_by:
     - reference_id: PMID:9113989
       supporting_text: p110delta displays a broad phosphoinositide lipid substrate

--- a/genes/human/PIK3CD/PIK3CD-ai-review.yaml
+++ b/genes/human/PIK3CD/PIK3CD-ai-review.yaml
@@ -1,1298 +1,2681 @@
 id: O00329
 gene_symbol: PIK3CD
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for PIK3CD'
+description: 'PIK3CD encodes p110delta, the leukocyte-enriched catalytic subunit of class
+  IA phosphoinositide 3-kinase delta. In p85-family regulatory complexes, p110delta phosphorylates
+  membrane phosphoinositides, especially PI(4,5)P2, to generate PIP3 downstream of immune
+  receptors including BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40, Fc receptors, and cytokine/growth-factor
+  receptors. The core curatable function is PIP3-producing lipid kinase activity in PI3K/AKT
+  immune receptor signaling; broad immune phenotypes, chemotaxis, angiogenesis, and migration
+  annotations are supported contextual outputs rather than the core molecular function.'
 alternative_products:
-  - name: 1 (p110-delta)
-    id: O00329-1
-  - name: 2 (p37-delta)
-    id: O00329-2
-    sequence_note: VSP_044409, VSP_044410
+- name: 1 (p110-delta)
+  id: O00329-1
+- name: 2 (p37-delta)
+  id: O00329-2
+  sequence_note: VSP_044409, VSP_044410
 existing_annotations:
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0016477
-      label: cell migration
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005942
-      label: phosphatidylinositol 3-kinase complex
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0043491
-      label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0036092
-      label: phosphatidylinositol-3-phosphate biosynthetic process
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0048015
-      label: phosphatidylinositol-mediated signaling
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0016303
-      label: 1-phosphatidylinositol-3-kinase activity
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0035005
-      label: 1-phosphatidylinositol-4-phosphate 3-kinase activity
-    evidence_type: IBA
-    original_reference_id: GO_REF:0000033
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0000166
-      label: nucleotide binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0002250
-      label: adaptive immune response
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0002376
-      label: immune system process
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0002443
-      label: leukocyte mediated immunity
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005524
-      label: ATP binding
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005737
-      label: cytoplasm
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000044
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005943
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0016477
+    label: cell migration
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Supported cell-migration role in specific leukocyte and glioma contexts,
+      but non-core relative to lipid kinase signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3CD knockdown decreases glioma-cell migration and PI3Kdelta also affects
+      leukocyte migration; these are downstream context-specific outputs rather than the
+      core function.
+    supported_by:
+    - reference_id: PMID:22079609
+      supporting_text: Interestingly, knockdown of p110δ decreased the cell migration
+        and invasion ability of all GBM cell lines tested.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+- term:
+    id: GO:0005942
+    label: phosphatidylinositol 3-kinase complex
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: The complex assignment is valid but should use the more specific class IA
+      phosphatidylinositol 3-kinase complex term.
+    action: MODIFY
+    reason: PIK3CD is not just any PI3K-complex component; it is the p110delta catalytic
+      subunit of class IA p85-family regulatory complexes. GO:0005943 captures the
+      correct complex subtype.
+    proposed_replacement_terms:
+    - id: GO:0005943
       label: phosphatidylinositol 3-kinase complex, class IA
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0006629
-      label: lipid metabolic process
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0006935
-      label: chemotaxis
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0006954
-      label: inflammatory response
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0007166
-      label: cell surface receptor signaling pathway
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0010595
-      label: positive regulation of endothelial cell migration
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0010628
-      label: positive regulation of gene expression
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0016301
-      label: kinase activity
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0016303
-      label: 1-phosphatidylinositol-3-kinase activity
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0016740
-      label: transferase activity
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0022603
-      label: regulation of anatomical structure morphogenesis
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0030154
-      label: cell differentiation
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000043
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0030155
-      label: regulation of cell adhesion
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0033031
-      label: positive regulation of neutrophil apoptotic process
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0042113
-      label: B cell activation
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0043491
-      label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0045087
-      label: innate immune response
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0046854
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+- term:
+    id: GO:0043491
+    label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Supported PI3K/AKT signaling annotation downstream of PIK3CD-generated
+      PIP3.
+    action: ACCEPT
+    reason: PIP3 produced by p110delta recruits AKT-linked signaling modules. This
+      pathway term captures the central signaling output of PI3Kdelta even when the
+      initiating receptor or cell type differs.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: '**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide
+        3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes
+        downstream of receptor signaling in immune cells, particularly in lymphocytes.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+- term:
+    id: GO:0036092
+    label: phosphatidylinositol-3-phosphate biosynthetic process
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: The PI3P biosynthetic-process term is too specific for a class
+      III/VPS34-like product and is not the best process term for PIK3CD.
+    action: MODIFY
+    reason: PIK3CD/p110delta primarily generates PIP3 from PI(4,5)P2 in class IA
+      receptor signaling. A broader phosphatidylinositol phosphate biosynthetic process
+      term better reflects the current GO vocabulary without implying class III
+      PI3P-centered biology.
+    proposed_replacement_terms:
+    - id: GO:0046854
       label: phosphatidylinositol phosphate biosynthetic process
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000002
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0046934
-      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000120
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0051094
-      label: positive regulation of developmental process
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0051240
-      label: positive regulation of multicellular organismal process
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:2000026
-      label: regulation of multicellular organismal development
-    evidence_type: IEA
-    original_reference_id: GO_REF:0000117
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:21827948
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:21827948
-          supporting_text: Dynamics of the phosphoinositide 3-kinase p110δ 
-            interaction with p85α and membranes reveals aspects of regulation 
-            distinct from p110α.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:22020336
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:22020336
-          supporting_text: p37δ is a new isoform of PI3K p110δ that increases 
-            cell proliferation and is overexpressed in tumors.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:24165795
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:24165795
-          supporting_text: Dominant-activating germline mutations in the gene 
-            encoding the PI(3)K catalytic subunit p110δ result in T cell 
-            senescence and human immunodeficiency.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:28514442
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:28514442
-          supporting_text: Architecture of the human interactome defines protein
-            communities and disease networks.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:31031754
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31031754
-          supporting_text: 'Case Study: Mechanism for Increased Follicular Helper
-            T Cell Development in Activated PI3K Delta Syndrome.'
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:32296183
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32296183
-          supporting_text: Apr 8. A reference map of the human binary protein 
-            interactome.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:33961781
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:33961781
-          supporting_text: 2021 May 6. Dual proteome-scale networks reveal 
-            cell-specific remodeling of the human interactome.
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:35271311
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:35271311
-          supporting_text: '2022 Mar 11. OpenCell: Endogenous tagging for the cartography
-            of human cellular organization.'
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:40205054
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:40205054
-          supporting_text: Apr 9. Multimodal cell maps as a foundation for 
-            structural and functional genomics.
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: IDA
-    original_reference_id: GO_REF:0000052
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005515
-      label: protein binding
-    evidence_type: IPI
-    original_reference_id: PMID:32606397
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:32606397
-          supporting_text: PI3K activation is enhanced by FOXM1D binding to p110
-            and p85 subunits.
-  - term:
-      id: GO:0031295
-      label: T cell costimulation
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-389356
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0046934
-      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-389158
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0006955
-      label: immune response
-    evidence_type: NAS
-    original_reference_id: PMID:27616589
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:27616589
-          supporting_text: Sep 12. PI3Kδ and primary immunodeficiencies.
-  - term:
-      id: GO:0030183
-      label: B cell differentiation
-    evidence_type: NAS
-    original_reference_id: PMID:20200404
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20200404
-          supporting_text: The catalytic PI3K isoforms p110gamma and p110delta 
-            contribute to B cell development and maintenance, transformation, 
-            and proliferation.
-  - term:
-      id: GO:0030217
-      label: T cell differentiation
-    evidence_type: NAS
-    original_reference_id: PMID:17371229
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17371229
-          supporting_text: The PI3K p110delta controls T-cell development, 
-            differentiation and regulation.
-  - term:
-      id: GO:0038084
-      label: vascular endothelial growth factor signaling pathway
-    evidence_type: IGI
-    original_reference_id: PMID:31915155
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31915155
-          supporting_text: PI3Kδ as a Novel Therapeutic Target in Pathological 
-            Angiogenesis.
-  - term:
-      id: GO:0010595
-      label: positive regulation of endothelial cell migration
-    evidence_type: IGI
-    original_reference_id: PMID:31915155
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31915155
-          supporting_text: PI3Kδ as a Novel Therapeutic Target in Pathological 
-            Angiogenesis.
-  - term:
-      id: GO:0001938
-      label: positive regulation of endothelial cell proliferation
-    evidence_type: IGI
-    original_reference_id: PMID:31915155
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31915155
-          supporting_text: PI3Kδ as a Novel Therapeutic Target in Pathological 
-            Angiogenesis.
-  - term:
-      id: GO:0043491
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+    - reference_id: Reactome:R-HSA-389158
+      supporting_text: Upon binding to CD28, the PI3K enzyme catalyzes the
+        phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate
+        phosphatidylinositol 3,4,5-trisphosphate (PIP3).
+- term:
+    id: GO:0048015
+    label: phosphatidylinositol-mediated signaling
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: The phosphatidylinositol-mediated signaling term is correct but too broad
+      for PIK3CD.
+    action: MODIFY
+    reason: PIK3CD is specifically a class IA PIP3-producing PI3K that feeds PI3K/AKT
+      receptor signaling, so the more specific PI3K/AKT signal-transduction term is
+      preferred.
+    proposed_replacement_terms:
+    - id: GO:0043491
       label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
-    evidence_type: IGI
-    original_reference_id: PMID:31915155
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31915155
-          supporting_text: PI3Kδ as a Novel Therapeutic Target in Pathological 
-            Angiogenesis.
-  - term:
-      id: GO:0045766
-      label: positive regulation of angiogenesis
-    evidence_type: ISS
-    original_reference_id: GO_REF:0000024
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:1905278
-      label: positive regulation of epithelial tube formation
-    evidence_type: IGI
-    original_reference_id: PMID:31915155
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:31915155
-          supporting_text: PI3Kδ as a Novel Therapeutic Target in Pathological 
-            Angiogenesis.
-  - term:
-      id: GO:0033031
-      label: positive regulation of neutrophil apoptotic process
-    evidence_type: IMP
-    original_reference_id: PMID:25339672
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:25339672
-          supporting_text: 2014 Oct 22. Human IgA Fc receptor FcαRI (CD89) 
-            triggers different forms of neutrophil death depending on the 
-            inflammatory microenvironment.
-  - term:
-      id: GO:0043491
-      label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
-    evidence_type: IMP
-    original_reference_id: PMID:25339672
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:25339672
-          supporting_text: 2014 Oct 22. Human IgA Fc receptor FcαRI (CD89) 
-            triggers different forms of neutrophil death depending on the 
-            inflammatory microenvironment.
-  - term:
-      id: GO:0001779
-      label: natural killer cell differentiation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0001819
-      label: positive regulation of cytokine production
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0002250
-      label: adaptive immune response
-    evidence_type: TAS
-    original_reference_id: PMID:17290298
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17290298
-          supporting_text: 'PI3K delta and PI3K gamma: partners in crime in inflammation
-            in rheumatoid arthritis and beyond? Rommel C(1), Camps M, Ji H.'
-  - term:
-      id: GO:0002551
-      label: mast cell chemotaxis
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0002679
-      label: respiratory burst involved in defense response
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0006954
-      label: inflammatory response
-    evidence_type: TAS
-    original_reference_id: PMID:17290298
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17290298
-          supporting_text: 'PI3K delta and PI3K gamma: partners in crime in inflammation
-            in rheumatoid arthritis and beyond? Rommel C(1), Camps M, Ji H.'
-  - term:
-      id: GO:0006954
-      label: inflammatory response
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0010818
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: '**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide
+        3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes
+        downstream of receptor signaling in immune cells, particularly in lymphocytes.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0016303
+    label: 1-phosphatidylinositol-3-kinase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Core molecular function as a phosphatidylinositol 3-kinase catalytic
+      subunit.
+    action: ACCEPT
+    reason: This parent PI3K activity term is valid for p110delta, although GO:0046934
+      is the most specific MF term for its canonical PIP2-to-PIP3 reaction.
+    supported_by:
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+- term:
+    id: GO:0035005
+    label: 1-phosphatidylinositol-4-phosphate 3-kinase activity
+  evidence_type: IBA
+  original_reference_id: GO_REF:0000033
+  review:
+    summary: Supported phosphoinositide 3-kinase substrate activity, but PI4P
+      phosphorylation is not the primary curatable core activity for PIK3CD.
+    action: KEEP_AS_NON_CORE
+    reason: Class I PI3Kdelta can act on phosphorylated phosphoinositides, and Reactome
+      includes PIK3CD complexes in PI4P-to-PI(3,4)P2 reactions. The canonical core
+      activity remains PI(4,5)P2-to-PIP3.
+    supported_by:
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+    - reference_id: Reactome:R-HSA-1676109
+      supporting_text: These complexes along with phosphatidylinositol-4-phosphate
+        3-kinase C2 domain-containing subunits alpha (PIK3C2A), beta (PIK3C2B), and
+        gamma (PIK3C2G) phosphorylate phosphatidylinositol 4-phosphate (PI4P) to
+        phosphatidylinositol 3,4-bisphosphate (PI(3,4)P2).
+- term:
+    id: GO:0000166
+    label: nucleotide binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: The nucleotide-binding annotation is too generic for a lipid kinase and
+      should be narrowed to ATP binding.
+    action: MODIFY
+    reason: PIK3CD catalysis uses ATP; the broad nucleotide-binding term loses the
+      catalytic context and is less informative than GO:0005524 ATP binding or the
+      catalytic PI(4,5)P2 3-kinase MF.
+    proposed_replacement_terms:
+    - id: GO:0005524
+      label: ATP binding
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+- term:
+    id: GO:0002250
+    label: adaptive immune response
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: Supported adaptive-immune output, but this is a systems-level consequence
+      of PI3Kdelta immune receptor signaling rather than the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: Human disease genetics and leukocyte studies support a role in adaptive
+      immunity, but the core function should remain PIP3-producing class IA PI3K
+      signaling.
+    supported_by:
+    - reference_id: PMID:27616589
+      supporting_text: Here, we review the roles of PI3Kδ in adaptive immunity, describe
+        the clinical manifestations and mechanisms of disease in APDS and highlight new
+        insights into PI3Kδ gleaned from these patients, as well as implications of
+        these findings for clinical therapy.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0002376
+    label: immune system process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: Correct directionally but too broad to be useful for PIK3CD curation.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD has immune functions, but GO:0002376 is a very broad parent term.
+      More informative annotations are BCR/TCR signaling, PI3K/AKT signaling, and
+      specific leukocyte activation/migration processes.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0002443
+    label: leukocyte mediated immunity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Supported leukocyte/immune response involvement, but non-core and broad
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3CD is leukocyte-enriched and affects immune responses, yet this broad
+      immune-process term should not define the core function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+    - reference_id: PMID:27616589
+      supporting_text: Here, we review the roles of PI3Kδ in adaptive immunity, describe
+        the clinical manifestations and mechanisms of disease in APDS and highlight new
+        insights into PI3Kδ gleaned from these patients, as well as implications of
+        these findings for clinical therapy.
+- term:
+    id: GO:0005524
+    label: ATP binding
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: ATP binding is valid for the catalytic kinase domain, but it is generic
+      relative to the core lipid kinase activity.
+    action: KEEP_AS_NON_CORE
+    reason: ATP is required for PI3Kdelta catalysis, yet ATP binding alone is not a
+      specific description of the gene product function.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+- term:
+    id: GO:0005737
+    label: cytoplasm
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005943
+    label: phosphatidylinositol 3-kinase complex, class IA
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Correct class IA PI3K complex annotation for p110delta/p85-family
+      regulatory assemblies.
+    action: ACCEPT
+    reason: This is the most specific existing CC term for PIK3CD complex membership and
+      is supported by ComplexPortal entries and synthesis of the class IA p110delta-p85
+      regulatory complex.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: Reactome:R-HSA-2316434
+      supporting_text: In unstimulated cells, PI3K class IA exists as an inactive
+        heterodimer of a p85 regulatory subunit (encoded by PIK3R1, PIK3R2 or PIK3R3)
+        and a p110 catalytic subunit (encoded by PIK3CA, PIK3CB or PIK3CD).
+- term:
+    id: GO:0006629
+    label: lipid metabolic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: The lipid metabolic process term is directionally correct but too broad for
+      PIK3CD.
+    action: MODIFY
+    reason: PIK3CD is specifically a phosphoinositide lipid kinase that produces
+      3-phosphoinositides/PIP3 in signaling contexts; phosphatidylinositol phosphate
+      biosynthesis and PI(4,5)P2 3-kinase activity are more informative.
+    proposed_replacement_terms:
+    - id: GO:0046854
+      label: phosphatidylinositol phosphate biosynthetic process
+    - id: GO:0046934
+      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0006935
+    label: chemotaxis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: The generic chemotaxis annotation should be narrowed to the specific
+      leukocyte chemotaxis processes supported for PIK3CD.
+    action: MODIFY
+    reason: The evidence supports T-cell, B-cell, neutrophil, and mast-cell chemotaxis
+      contexts rather than chemotaxis as a broad parent term.
+    proposed_replacement_terms:
+    - id: GO:0010818
       label: T cell chemotaxis
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0016303
-      label: 1-phosphatidylinositol-3-kinase activity
-    evidence_type: TAS
-    original_reference_id: PMID:17290298
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17290298
-          supporting_text: 'PI3K delta and PI3K gamma: partners in crime in inflammation
-            in rheumatoid arthritis and beyond? Rommel C(1), Camps M, Ji H.'
-  - term:
-      id: GO:0030101
-      label: natural killer cell activation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0030217
-      label: T cell differentiation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0030593
-      label: neutrophil chemotaxis
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0035747
-      label: natural killer cell chemotaxis
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0035754
+    - id: GO:0035754
       label: B cell chemotaxis
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0042110
-      label: T cell activation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0042113
-      label: B cell activation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0043303
-      label: mast cell degranulation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0043491
-      label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
-    evidence_type: TAS
-    original_reference_id: PMID:17290298
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17290298
-          supporting_text: 'PI3K delta and PI3K gamma: partners in crime in inflammation
-            in rheumatoid arthritis and beyond? Rommel C(1), Camps M, Ji H.'
-  - term:
-      id: GO:0045087
-      label: innate immune response
-    evidence_type: TAS
-    original_reference_id: PMID:17290298
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:17290298
-          supporting_text: 'PI3K delta and PI3K gamma: partners in crime in inflammation
-            in rheumatoid arthritis and beyond? Rommel C(1), Camps M, Ji H.'
-  - term:
-      id: GO:0045087
-      label: innate immune response
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0050852
-      label: T cell receptor signaling pathway
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0050853
+    - id: GO:0030593
+      label: neutrophil chemotaxis
+    - id: GO:0002551
+      label: mast cell chemotaxis
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0006954
+    label: inflammatory response
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: Supported inflammatory-response involvement, but it is a downstream
+      physiological output of PI3Kdelta activity.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta disruption alters inflammatory responses in vivo and PI3K lipid
+      messengers control leukocyte signaling, but inflammation is a non-core
+      phenotype/process relative to lipid kinase signaling.
+    supported_by:
+    - reference_id: PMID:17290298
+      supporting_text: Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second
+        messengers that control an array of intracellular signalling pathways that are
+        known to have important roles in leukocytes.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0007166
+    label: cell surface receptor signaling pathway
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: The broad cell-surface receptor signaling annotation should be narrowed to
+      the immune receptor signaling pathways where PIK3CD has strong support.
+    action: MODIFY
+    reason: PIK3CD acts downstream of immune receptors such as BCR, TCR, and CD28. Those
+      terms are more informative and better supported than the generic cell-surface
+      receptor signaling parent.
+    proposed_replacement_terms:
+    - id: GO:0050853
       label: B cell receptor signaling pathway
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0060374
+    - id: GO:0050852
+      label: T cell receptor signaling pathway
+    - id: GO:0031295
+      label: T cell costimulation
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for B-cell receptor (BCR) signaling.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for T-cell receptor (TCR) signaling.
+- term:
+    id: GO:0010595
+    label: positive regulation of endothelial cell migration
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Supported endothelial/angiogenesis context, but non-core and
+      tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
+    action: KEEP_AS_NON_CORE
+    reason: Cultured endothelial-cell work supports VEGF-induced Akt activation,
+      proliferation, migration, tube formation, and retinal angiogenesis. This is a real
+      contextual role, not the primary leukocyte-enriched core function.
+    supported_by:
+    - reference_id: PMID:31915155
+      supporting_text: Using genetic and pharmacological approaches, we show that p110δ
+        activity in cultured ECs controls Akt activation, cell proliferation, migration,
+        and tube formation induced by vascular endothelial growth factor, basic
+        fibroblast growth factor, and epidermal growth factor.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+- term:
+    id: GO:0010628
+    label: positive regulation of gene expression
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Over-annotation to positive regulation of gene expression. The available
+      PIK3CD evidence supports upstream PI3K/AKT signaling more directly than this
+      distal transcriptional-output term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Gene-expression changes can occur downstream of PI3K/AKT/FOXO signaling, but
+      the cited evidence is more direct for lipid kinase signaling, migration, and
+      protein-level pathway outputs. This broad distal term should not be retained as a
+      core annotation.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+    - reference_id: PMID:22079609
+      supporting_text: Interestingly, knockdown of p110δ decreased the cell migration
+        and invasion ability of all GBM cell lines tested.
+- term:
+    id: GO:0016301
+    label: kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: The generic enzyme-activity annotation is valid only as a distant parent
+      and should be replaced by the specific lipid kinase activity.
+    action: MODIFY
+    reason: PIK3CD is not merely a generic kinase/transferase; the evidence supports
+      phosphoinositide 3-kinase activity, especially PI(4,5)P2 3-kinase activity.
+    proposed_replacement_terms:
+    - id: GO:0046934
+      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+- term:
+    id: GO:0016303
+    label: 1-phosphatidylinositol-3-kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Core molecular function as a phosphatidylinositol 3-kinase catalytic
+      subunit.
+    action: ACCEPT
+    reason: This parent PI3K activity term is valid for p110delta, although GO:0046934
+      is the most specific MF term for its canonical PIP2-to-PIP3 reaction.
+    supported_by:
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+- term:
+    id: GO:0016740
+    label: transferase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: The generic enzyme-activity annotation is valid only as a distant parent
+      and should be replaced by the specific lipid kinase activity.
+    action: MODIFY
+    reason: PIK3CD is not merely a generic kinase/transferase; the evidence supports
+      phosphoinositide 3-kinase activity, especially PI(4,5)P2 3-kinase activity.
+    proposed_replacement_terms:
+    - id: GO:0046934
+      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+- term:
+    id: GO:0022603
+    label: regulation of anatomical structure morphogenesis
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Over-annotation to broad developmental, morphogenesis, or adhesion
+      regulation terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD has specific leukocyte, endothelial, and migration phenotypes, but
+      these broad regulation terms over-generalize downstream effects and obscure the
+      better-supported PI3Kdelta receptor-signaling biology.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0030154
+    label: cell differentiation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000043
+  review:
+    summary: The generic cell differentiation annotation should be narrowed to the
+      specific leukocyte differentiation processes supported for PIK3CD.
+    action: MODIFY
+    reason: The evidence supports B-cell, T-cell, NK-cell, and mast-cell differentiation
+      contexts rather than undifferentiated cell differentiation as a generic parent.
+    proposed_replacement_terms:
+    - id: GO:0030183
+      label: B cell differentiation
+    - id: GO:0030217
+      label: T cell differentiation
+    - id: GO:0001779
+      label: natural killer cell differentiation
+    - id: GO:0060374
       label: mast cell differentiation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0072672
-      label: neutrophil extravasation
-    evidence_type: TAS
-    original_reference_id: PMID:20940048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:20940048
-          supporting_text: 2010 Oct 16. Phosphoinositide 3-kinase delta (PI3Kδ) 
-            in leukocyte signaling and function.
-  - term:
-      id: GO:0010628
-      label: positive regulation of gene expression
-    evidence_type: IMP
-    original_reference_id: PMID:22079609
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:22079609
-          supporting_text: 2011 Nov 11. The catalytic phosphoinositol 3-kinase 
-            isoform p110δ is required for glioma cell migration and invasion.
-  - term:
-      id: GO:0030335
-      label: positive regulation of cell migration
-    evidence_type: IMP
-    original_reference_id: PMID:22079609
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:22079609
-          supporting_text: 2011 Nov 11. The catalytic phosphoinositol 3-kinase 
-            isoform p110δ is required for glioma cell migration and invasion.
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-1676048
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-1676109
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9012657
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9021627
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9027275
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005829
-      label: cytosol
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9606887
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-2045911
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-2076220
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-2316434
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-2400009
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-388830
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-388832
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-389158
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-508247
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-879917
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-8854905
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-912627
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-914182
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005886
-      label: plasma membrane
-    evidence_type: TAS
-    original_reference_id: Reactome:R-HSA-9606887
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-  - term:
-      id: GO:0005942
-      label: phosphatidylinositol 3-kinase complex
-    evidence_type: NAS
-    original_reference_id: PMID:9113989
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9113989
-          supporting_text: P110delta, a novel phosphoinositide 3-kinase in 
-            leukocytes.
-  - term:
-      id: GO:0005942
-      label: phosphatidylinositol 3-kinase complex
-    evidence_type: NAS
-    original_reference_id: PMID:9235916
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9235916
-          supporting_text: p110delta, a novel phosphatidylinositol 3-kinase 
-            catalytic subunit that associates with p85 and is expressed 
-            predominantly in leukocytes.
-  - term:
-      id: GO:0006468
-      label: protein phosphorylation
-    evidence_type: NAS
-    original_reference_id: PMID:9113989
-    review:
-      summary: >-
-        OVER-ANNOTATION: PIK3CD (p110delta) is primarily a LIPID kinase, not a protein
-        kinase. PMID:9113989 explicitly states PIK3CD "displays a broad phosphoinositide
-        lipid substrate specificity" and notably "does not phosphorylate p85" (unlike
-        p110alpha). The paper mentions only "intrinsic autophosphorylation capacity",
-        which is distinct from general protein phosphorylation. PIK3CD has EC 2.7.1.137
-        (phosphatidylinositol-4,5-bisphosphate 3-kinase) for lipid phosphorylation.
-        The annotation should be to lipid phosphorylation (GO:0046834) or the specific
-        PI3K process, not protein phosphorylation.
-      action: MODIFY
-      proposed_replacement_terms:
-        - id: GO:0046834
-          label: lipid phosphorylation
-      supported_by:
-        - reference_id: PMID:9113989
-          supporting_text: P110delta, a novel phosphoinositide 3-kinase in 
-            leukocytes.
-  - term:
-      id: GO:0007165
-      label: signal transduction
-    evidence_type: NAS
-    original_reference_id: PMID:9113989
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9113989
-          supporting_text: P110delta, a novel phosphoinositide 3-kinase in 
-            leukocytes.
-  - term:
-      id: GO:0016303
-      label: 1-phosphatidylinositol-3-kinase activity
-    evidence_type: NAS
-    original_reference_id: PMID:9235916
-    review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
-      supported_by:
-        - reference_id: PMID:9235916
-          supporting_text: p110delta, a novel phosphatidylinositol 3-kinase 
-            catalytic subunit that associates with p85 and is expressed 
-            predominantly in leukocytes.
+    supported_by:
+    - reference_id: PMID:20200404
+      supporting_text: Thus, we provide novel evidence that p110gamma and p110delta have
+        overlapping and cell-extrinsic roles in the development, peripheral maintenance,
+        and function of B cells.
+    - reference_id: PMID:17371229
+      supporting_text: In addition, p110delta regulates the differentiation of
+        peripheral Th (helper T-cells) towards the Th1 and Th2 lineages.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+- term:
+    id: GO:0030155
+    label: regulation of cell adhesion
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Over-annotation to broad developmental, morphogenesis, or adhesion
+      regulation terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD has specific leukocyte, endothelial, and migration phenotypes, but
+      these broad regulation terms over-generalize downstream effects and obscure the
+      better-supported PI3Kdelta receptor-signaling biology.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0033031
+    label: positive regulation of neutrophil apoptotic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Supported neutrophil-death/apoptotic-process annotation, but non-core and
+      context-dependent.
+    action: KEEP_AS_NON_CORE
+    reason: FcαRI-triggered neutrophil death requires class IA PI3K signaling in
+      inflammatory contexts. This supports the annotation as a non-core immune effector
+      process.
+    supported_by:
+    - reference_id: PMID:25339672
+      supporting_text: preactivation with cytokines or TLR agonists in vitro enhanced
+        FcαRI-mediated death by additional recruitment of caspase-independent pathways,
+        but this required PI3K class IA and MAPK signaling.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0042113
+    label: B cell activation
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Supported B-cell activation/function annotation, but downstream of the more
+      core BCR signaling role.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3CD is important for B-cell development and function. B-cell activation
+      is real, but BCR signaling and PI3K/AKT signaling are the more precise core
+      process annotations.
+    supported_by:
+    - reference_id: PMID:20200404
+      supporting_text: Thus, we provide novel evidence that p110gamma and p110delta have
+        overlapping and cell-extrinsic roles in the development, peripheral maintenance,
+        and function of B cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for B-cell receptor (BCR) signaling.
+- term:
+    id: GO:0043491
+    label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Supported PI3K/AKT signaling annotation downstream of PIK3CD-generated
+      PIP3.
+    action: ACCEPT
+    reason: PIP3 produced by p110delta recruits AKT-linked signaling modules. This
+      pathway term captures the central signaling output of PI3Kdelta even when the
+      initiating receptor or cell type differs.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: '**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide
+        3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes
+        downstream of receptor signaling in immune cells, particularly in lymphocytes.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+- term:
+    id: GO:0045087
+    label: innate immune response
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: Supported innate-immune involvement, but this is a broad non-core
+      immune-system output.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta contributes to myeloid and innate leukocyte activities, but the
+      precise core function is receptor-linked PIP3 production rather than innate
+      immunity as a whole.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+    - reference_id: PMID:17290298
+      supporting_text: Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second
+        messengers that control an array of intracellular signalling pathways that are
+        known to have important roles in leukocytes.
+- term:
+    id: GO:0046854
+    label: phosphatidylinositol phosphate biosynthetic process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000002
+  review:
+    summary: Supported core process output of PI3Kdelta lipid kinase activity.
+    action: ACCEPT
+    reason: PIK3CD produces 3-phosphoinositides, especially PIP3, as the biochemical
+      product of its class IA lipid kinase activity. This process term is broader than
+      an ideal PIP3-biosynthesis term but is correct.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+    - reference_id: Reactome:R-HSA-389158
+      supporting_text: Upon binding to CD28, the PI3K enzyme catalyzes the
+        phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate
+        phosphatidylinositol 3,4,5-trisphosphate (PIP3).
+- term:
+    id: GO:0046934
+    label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000120
+  review:
+    summary: 'Core specific molecular function: p110delta phosphorylates PI(4,5)P2 to generate
+      PIP3.'
+    action: ACCEPT
+    reason: PI(4,5)P2 3-kinase activity is the specific catalytic activity that drives
+      PI3Kdelta receptor signaling and PIP3-dependent AKT pathway recruitment.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+    - reference_id: Reactome:R-HSA-389158
+      supporting_text: Upon binding to CD28, the PI3K enzyme catalyzes the
+        phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate
+        phosphatidylinositol 3,4,5-trisphosphate (PIP3).
+- term:
+    id: GO:0051094
+    label: positive regulation of developmental process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Over-annotation to broad developmental, morphogenesis, or adhesion
+      regulation terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD has specific leukocyte, endothelial, and migration phenotypes, but
+      these broad regulation terms over-generalize downstream effects and obscure the
+      better-supported PI3Kdelta receptor-signaling biology.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0051240
+    label: positive regulation of multicellular organismal process
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Over-annotation to broad developmental, morphogenesis, or adhesion
+      regulation terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD has specific leukocyte, endothelial, and migration phenotypes, but
+      these broad regulation terms over-generalize downstream effects and obscure the
+      better-supported PI3Kdelta receptor-signaling biology.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:2000026
+    label: regulation of multicellular organismal development
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000117
+  review:
+    summary: Over-annotation to broad developmental, morphogenesis, or adhesion
+      regulation terms.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD has specific leukocyte, endothelial, and migration phenotypes, but
+      these broad regulation terms over-generalize downstream effects and obscure the
+      better-supported PI3Kdelta receptor-signaling biology.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:21827948
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:22020336
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:24165795
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:28514442
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:31031754
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32296183
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:33961781
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:35271311
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:40205054
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: IDA
+  original_reference_id: GO_REF:0000052
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:32606397
+  review:
+    summary: Protein binding is an uninformative over-annotation for PIK3CD.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: PIK3CD does interact with p85-family regulatory subunits and other signaling
+      proteins, but GO:0005515 does not capture the meaningful function. The informative
+      annotations are class IA PI3K complex membership and phosphoinositide kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+- term:
+    id: GO:0031295
+    label: T cell costimulation
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-389356
+  review:
+    summary: Supported CD28/T-cell costimulation context for PI3Kdelta signaling.
+    action: ACCEPT
+    reason: CD28 is a direct immune receptor context in which PI3K participates in
+      costimulatory signaling and PIP3 generation. This is part of the core
+      immune-receptor signaling frame for PIK3CD.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: Reactome:R-HSA-389356
+      supporting_text: The cytoplasmic tail of CD28, upon ligand binding, undergoes
+        phosphorylation by Src family kinases like LCK and FYN, triggering downstream
+        signaling pathways involving PI3K, VAV-1, Tec family kinases, AKT, and other
+        adaptor proteins (Sharpe & Freeman 2002; Chen & Flies 2013).
+    - reference_id: Reactome:R-HSA-389158
+      supporting_text: Upon binding to CD28, the PI3K enzyme catalyzes the
+        phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate
+        phosphatidylinositol 3,4,5-trisphosphate (PIP3).
+- term:
+    id: GO:0046934
+    label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-389158
+  review:
+    summary: 'Core specific molecular function: p110delta phosphorylates PI(4,5)P2 to generate
+      PIP3.'
+    action: ACCEPT
+    reason: PI(4,5)P2 3-kinase activity is the specific catalytic activity that drives
+      PI3Kdelta receptor signaling and PIP3-dependent AKT pathway recruitment.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+    - reference_id: Reactome:R-HSA-389158
+      supporting_text: Upon binding to CD28, the PI3K enzyme catalyzes the
+        phosphorylation of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate
+        phosphatidylinositol 3,4,5-trisphosphate (PIP3).
+- term:
+    id: GO:0006955
+    label: immune response
+  evidence_type: NAS
+  original_reference_id: PMID:27616589
+  review:
+    summary: Supported leukocyte/immune response involvement, but non-core and broad
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3CD is leukocyte-enriched and affects immune responses, yet this broad
+      immune-process term should not define the core function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+    - reference_id: PMID:27616589
+      supporting_text: Here, we review the roles of PI3Kδ in adaptive immunity, describe
+        the clinical manifestations and mechanisms of disease in APDS and highlight new
+        insights into PI3Kδ gleaned from these patients, as well as implications of
+        these findings for clinical therapy.
+- term:
+    id: GO:0030183
+    label: B cell differentiation
+  evidence_type: NAS
+  original_reference_id: PMID:20200404
+  review:
+    summary: Supported B-cell differentiation/development role, but non-core relative to
+      PI3Kdelta catalytic signaling.
+    action: KEEP_AS_NON_CORE
+    reason: B-cell developmental phenotypes are well supported, but they are downstream
+      organism/cell lineage consequences of PIP3-producing PI3Kdelta signaling.
+    supported_by:
+    - reference_id: PMID:20200404
+      supporting_text: Thus, we provide novel evidence that p110gamma and p110delta have
+        overlapping and cell-extrinsic roles in the development, peripheral maintenance,
+        and function of B cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for B-cell receptor (BCR) signaling.
+- term:
+    id: GO:0030217
+    label: T cell differentiation
+  evidence_type: NAS
+  original_reference_id: PMID:17371229
+  review:
+    summary: Supported T-cell differentiation role, but non-core relative to
+      receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: T-cell differentiation is a supported immune-cell outcome of p110delta
+      activity, not the core molecular function itself.
+    supported_by:
+    - reference_id: PMID:17371229
+      supporting_text: In addition, p110delta regulates the differentiation of
+        peripheral Th (helper T-cells) towards the Th1 and Th2 lineages.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+- term:
+    id: GO:0038084
+    label: vascular endothelial growth factor signaling pathway
+  evidence_type: IGI
+  original_reference_id: PMID:31915155
+  review:
+    summary: Supported endothelial/angiogenesis context, but non-core and
+      tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
+    action: KEEP_AS_NON_CORE
+    reason: Cultured endothelial-cell work supports VEGF-induced Akt activation,
+      proliferation, migration, tube formation, and retinal angiogenesis. This is a real
+      contextual role, not the primary leukocyte-enriched core function.
+    supported_by:
+    - reference_id: PMID:31915155
+      supporting_text: Using genetic and pharmacological approaches, we show that p110δ
+        activity in cultured ECs controls Akt activation, cell proliferation, migration,
+        and tube formation induced by vascular endothelial growth factor, basic
+        fibroblast growth factor, and epidermal growth factor.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+- term:
+    id: GO:0010595
+    label: positive regulation of endothelial cell migration
+  evidence_type: IGI
+  original_reference_id: PMID:31915155
+  review:
+    summary: Supported endothelial/angiogenesis context, but non-core and
+      tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
+    action: KEEP_AS_NON_CORE
+    reason: Cultured endothelial-cell work supports VEGF-induced Akt activation,
+      proliferation, migration, tube formation, and retinal angiogenesis. This is a real
+      contextual role, not the primary leukocyte-enriched core function.
+    supported_by:
+    - reference_id: PMID:31915155
+      supporting_text: Using genetic and pharmacological approaches, we show that p110δ
+        activity in cultured ECs controls Akt activation, cell proliferation, migration,
+        and tube formation induced by vascular endothelial growth factor, basic
+        fibroblast growth factor, and epidermal growth factor.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+- term:
+    id: GO:0001938
+    label: positive regulation of endothelial cell proliferation
+  evidence_type: IGI
+  original_reference_id: PMID:31915155
+  review:
+    summary: Supported endothelial/angiogenesis context, but non-core and
+      tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
+    action: KEEP_AS_NON_CORE
+    reason: Cultured endothelial-cell work supports VEGF-induced Akt activation,
+      proliferation, migration, tube formation, and retinal angiogenesis. This is a real
+      contextual role, not the primary leukocyte-enriched core function.
+    supported_by:
+    - reference_id: PMID:31915155
+      supporting_text: Using genetic and pharmacological approaches, we show that p110δ
+        activity in cultured ECs controls Akt activation, cell proliferation, migration,
+        and tube formation induced by vascular endothelial growth factor, basic
+        fibroblast growth factor, and epidermal growth factor.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+- term:
+    id: GO:0043491
+    label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
+  evidence_type: IGI
+  original_reference_id: PMID:31915155
+  review:
+    summary: Supported PI3K/AKT signaling annotation downstream of PIK3CD-generated
+      PIP3.
+    action: ACCEPT
+    reason: PIP3 produced by p110delta recruits AKT-linked signaling modules. This
+      pathway term captures the central signaling output of PI3Kdelta even when the
+      initiating receptor or cell type differs.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: '**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide
+        3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes
+        downstream of receptor signaling in immune cells, particularly in lymphocytes.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+- term:
+    id: GO:0045766
+    label: positive regulation of angiogenesis
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: Supported endothelial/angiogenesis context, but non-core and
+      tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
+    action: KEEP_AS_NON_CORE
+    reason: Cultured endothelial-cell work supports VEGF-induced Akt activation,
+      proliferation, migration, tube formation, and retinal angiogenesis. This is a real
+      contextual role, not the primary leukocyte-enriched core function.
+    supported_by:
+    - reference_id: PMID:31915155
+      supporting_text: Using genetic and pharmacological approaches, we show that p110δ
+        activity in cultured ECs controls Akt activation, cell proliferation, migration,
+        and tube formation induced by vascular endothelial growth factor, basic
+        fibroblast growth factor, and epidermal growth factor.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+- term:
+    id: GO:1905278
+    label: positive regulation of epithelial tube formation
+  evidence_type: IGI
+  original_reference_id: PMID:31915155
+  review:
+    summary: Supported endothelial/angiogenesis context, but non-core and
+      tissue/pathology-specific relative to PI3Kdelta immune receptor signaling.
+    action: KEEP_AS_NON_CORE
+    reason: Cultured endothelial-cell work supports VEGF-induced Akt activation,
+      proliferation, migration, tube formation, and retinal angiogenesis. This is a real
+      contextual role, not the primary leukocyte-enriched core function.
+    supported_by:
+    - reference_id: PMID:31915155
+      supporting_text: Using genetic and pharmacological approaches, we show that p110δ
+        activity in cultured ECs controls Akt activation, cell proliferation, migration,
+        and tube formation induced by vascular endothelial growth factor, basic
+        fibroblast growth factor, and epidermal growth factor.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+- term:
+    id: GO:0033031
+    label: positive regulation of neutrophil apoptotic process
+  evidence_type: IMP
+  original_reference_id: PMID:25339672
+  review:
+    summary: Supported neutrophil-death/apoptotic-process annotation, but non-core and
+      context-dependent.
+    action: KEEP_AS_NON_CORE
+    reason: FcαRI-triggered neutrophil death requires class IA PI3K signaling in
+      inflammatory contexts. This supports the annotation as a non-core immune effector
+      process.
+    supported_by:
+    - reference_id: PMID:25339672
+      supporting_text: preactivation with cytokines or TLR agonists in vitro enhanced
+        FcαRI-mediated death by additional recruitment of caspase-independent pathways,
+        but this required PI3K class IA and MAPK signaling.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0043491
+    label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
+  evidence_type: IMP
+  original_reference_id: PMID:25339672
+  review:
+    summary: Supported PI3K/AKT signaling annotation downstream of PIK3CD-generated
+      PIP3.
+    action: ACCEPT
+    reason: PIP3 produced by p110delta recruits AKT-linked signaling modules. This
+      pathway term captures the central signaling output of PI3Kdelta even when the
+      initiating receptor or cell type differs.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: '**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide
+        3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes
+        downstream of receptor signaling in immune cells, particularly in lymphocytes.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+- term:
+    id: GO:0001779
+    label: natural killer cell differentiation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported NK-cell differentiation role, but non-core relative to PI3Kdelta
+      catalytic signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta participates in NK-cell development and migration, but this is a
+      leukocyte-specific cellular outcome rather than the core lipid kinase function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+- term:
+    id: GO:0001819
+    label: positive regulation of cytokine production
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported cytokine-production role, but non-core and downstream of immune
+      receptor signaling.
+    action: KEEP_AS_NON_CORE
+    reason: Cytokine-production changes are leukocyte outputs of PI3Kdelta signaling,
+      not the primary biochemical function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for T-cell receptor (TCR) signaling.
+- term:
+    id: GO:0002250
+    label: adaptive immune response
+  evidence_type: TAS
+  original_reference_id: PMID:17290298
+  review:
+    summary: Supported adaptive-immune output, but this is a systems-level consequence
+      of PI3Kdelta immune receptor signaling rather than the core molecular function.
+    action: KEEP_AS_NON_CORE
+    reason: Human disease genetics and leukocyte studies support a role in adaptive
+      immunity, but the core function should remain PIP3-producing class IA PI3K
+      signaling.
+    supported_by:
+    - reference_id: PMID:27616589
+      supporting_text: Here, we review the roles of PI3Kδ in adaptive immunity, describe
+        the clinical manifestations and mechanisms of disease in APDS and highlight new
+        insights into PI3Kδ gleaned from these patients, as well as implications of
+        these findings for clinical therapy.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0002551
+    label: mast cell chemotaxis
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported leukocyte migration/chemotaxis/extravasation role, but non-core
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta affects migration of multiple leukocyte types, but these are
+      cell-type-specific outputs of the core PIP3-generating immune signaling function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0002679
+    label: respiratory burst involved in defense response
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported neutrophil respiratory-burst role, but non-core relative to the
+      catalytic PI3Kdelta signaling function.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta contributes to neutrophil respiratory burst as a myeloid effector
+      output, but this is not the core molecular function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0006954
+    label: inflammatory response
+  evidence_type: TAS
+  original_reference_id: PMID:17290298
+  review:
+    summary: Supported inflammatory-response involvement, but it is a downstream
+      physiological output of PI3Kdelta activity.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta disruption alters inflammatory responses in vivo and PI3K lipid
+      messengers control leukocyte signaling, but inflammation is a non-core
+      phenotype/process relative to lipid kinase signaling.
+    supported_by:
+    - reference_id: PMID:17290298
+      supporting_text: Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second
+        messengers that control an array of intracellular signalling pathways that are
+        known to have important roles in leukocytes.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0006954
+    label: inflammatory response
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported inflammatory-response involvement, but it is a downstream
+      physiological output of PI3Kdelta activity.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta disruption alters inflammatory responses in vivo and PI3K lipid
+      messengers control leukocyte signaling, but inflammation is a non-core
+      phenotype/process relative to lipid kinase signaling.
+    supported_by:
+    - reference_id: PMID:17290298
+      supporting_text: Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second
+        messengers that control an array of intracellular signalling pathways that are
+        known to have important roles in leukocytes.
+    - reference_id: PMID:20940048
+      supporting_text: As a result of the broad effects of PI3Kδ in leukocyte functions,
+        the disruption of PI3Kδ expression or activity leads to decreased inflammatory
+        and immune responses in vivo.
+- term:
+    id: GO:0010818
+    label: T cell chemotaxis
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported leukocyte migration/chemotaxis/extravasation role, but non-core
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta affects migration of multiple leukocyte types, but these are
+      cell-type-specific outputs of the core PIP3-generating immune signaling function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0016303
+    label: 1-phosphatidylinositol-3-kinase activity
+  evidence_type: TAS
+  original_reference_id: PMID:17290298
+  review:
+    summary: Core molecular function as a phosphatidylinositol 3-kinase catalytic
+      subunit.
+    action: ACCEPT
+    reason: This parent PI3K activity term is valid for p110delta, although GO:0046934
+      is the most specific MF term for its canonical PIP2-to-PIP3 reaction.
+    supported_by:
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+- term:
+    id: GO:0030101
+    label: natural killer cell activation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported NK-cell activation context, but non-core relative to
+      receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: NK-cell activation is a supported immune output; the central curatable
+      function remains PI3Kdelta PIP3 production in leukocyte signaling.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+- term:
+    id: GO:0030217
+    label: T cell differentiation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported T-cell differentiation role, but non-core relative to
+      receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: T-cell differentiation is a supported immune-cell outcome of p110delta
+      activity, not the core molecular function itself.
+    supported_by:
+    - reference_id: PMID:17371229
+      supporting_text: In addition, p110delta regulates the differentiation of
+        peripheral Th (helper T-cells) towards the Th1 and Th2 lineages.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+- term:
+    id: GO:0030593
+    label: neutrophil chemotaxis
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported leukocyte migration/chemotaxis/extravasation role, but non-core
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta affects migration of multiple leukocyte types, but these are
+      cell-type-specific outputs of the core PIP3-generating immune signaling function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0035747
+    label: natural killer cell chemotaxis
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported leukocyte migration/chemotaxis/extravasation role, but non-core
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta affects migration of multiple leukocyte types, but these are
+      cell-type-specific outputs of the core PIP3-generating immune signaling function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0035754
+    label: B cell chemotaxis
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported leukocyte migration/chemotaxis/extravasation role, but non-core
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta affects migration of multiple leukocyte types, but these are
+      cell-type-specific outputs of the core PIP3-generating immune signaling function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0042110
+    label: T cell activation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported T-cell activation/function annotation, but downstream of the more
+      core TCR/CD28 signaling role.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3CD contributes to T-cell development, activation, and migration. The
+      T-cell activation process is supported but is a cellular outcome of the core
+      TCR/CD28 PI3K signaling function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for T-cell receptor (TCR) signaling.
+- term:
+    id: GO:0042113
+    label: B cell activation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported B-cell activation/function annotation, but downstream of the more
+      core BCR signaling role.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3CD is important for B-cell development and function. B-cell activation
+      is real, but BCR signaling and PI3K/AKT signaling are the more precise core
+      process annotations.
+    supported_by:
+    - reference_id: PMID:20200404
+      supporting_text: Thus, we provide novel evidence that p110gamma and p110delta have
+        overlapping and cell-extrinsic roles in the development, peripheral maintenance,
+        and function of B cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for B-cell receptor (BCR) signaling.
+- term:
+    id: GO:0043303
+    label: mast cell degranulation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported mast-cell degranulation role, but non-core relative to the
+      catalytic PI3Kdelta function.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta contributes to mast-cell degranulation, but this is a
+      cell-type-specific effector output rather than the core molecular function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0043491
+    label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
+  evidence_type: TAS
+  original_reference_id: PMID:17290298
+  review:
+    summary: Supported PI3K/AKT signaling annotation downstream of PIK3CD-generated
+      PIP3.
+    action: ACCEPT
+    reason: PIP3 produced by p110delta recruits AKT-linked signaling modules. This
+      pathway term captures the central signaling output of PI3Kdelta even when the
+      initiating receptor or cell type differs.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: '**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide
+        3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes
+        downstream of receptor signaling in immune cells, particularly in lymphocytes.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ is a lipid kinase of the PI3K class IA family involved in
+        early signaling events of leukocytes responding to a wide variety of stimuli.
+- term:
+    id: GO:0045087
+    label: innate immune response
+  evidence_type: TAS
+  original_reference_id: PMID:17290298
+  review:
+    summary: Supported innate-immune involvement, but this is a broad non-core
+      immune-system output.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta contributes to myeloid and innate leukocyte activities, but the
+      precise core function is receptor-linked PIP3 production rather than innate
+      immunity as a whole.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+    - reference_id: PMID:17290298
+      supporting_text: Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second
+        messengers that control an array of intracellular signalling pathways that are
+        known to have important roles in leukocytes.
+- term:
+    id: GO:0045087
+    label: innate immune response
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported innate-immune involvement, but this is a broad non-core
+      immune-system output.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta contributes to myeloid and innate leukocyte activities, but the
+      precise core function is receptor-linked PIP3 production rather than innate
+      immunity as a whole.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+    - reference_id: PMID:17290298
+      supporting_text: Phosphoinositide 3-kinases (PI3Ks) generate lipid-based second
+        messengers that control an array of intracellular signalling pathways that are
+        known to have important roles in leukocytes.
+- term:
+    id: GO:0050852
+    label: T cell receptor signaling pathway
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported TCR signaling role for PI3Kdelta.
+    action: ACCEPT
+    reason: UniProt and the literature synthesis identify p110delta as required for TCR
+      signaling, making this one of the core immune receptor signaling processes for
+      PIK3CD.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for T-cell receptor (TCR) signaling.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+- term:
+    id: GO:0050853
+    label: B cell receptor signaling pathway
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported BCR signaling role for PI3Kdelta.
+    action: ACCEPT
+    reason: p110delta is required for BCR signaling and B-cell functional outputs; this
+      is one of the strongest process annotations for PIK3CD.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: Required for B-cell receptor (BCR) signaling.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+    - reference_id: PMID:20200404
+      supporting_text: Thus, we provide novel evidence that p110gamma and p110delta have
+        overlapping and cell-extrinsic roles in the development, peripheral maintenance,
+        and function of B cells.
+- term:
+    id: GO:0060374
+    label: mast cell differentiation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported mast-cell differentiation role, but non-core relative to the
+      catalytic PI3Kdelta function.
+    action: KEEP_AS_NON_CORE
+    reason: Mast-cell maturation/differentiation is a supported leukocyte-cell output of
+      PI3Kdelta signaling, not the core molecular activity.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0072672
+    label: neutrophil extravasation
+  evidence_type: TAS
+  original_reference_id: PMID:20940048
+  review:
+    summary: Supported leukocyte migration/chemotaxis/extravasation role, but non-core
+      relative to receptor-proximal PI3Kdelta signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PI3Kdelta affects migration of multiple leukocyte types, but these are
+      cell-type-specific outputs of the core PIP3-generating immune signaling function.
+    supported_by:
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+    - reference_id: PMID:20940048
+      supporting_text: The role of PI3Kδ in myeloid cell activities, such as
+        inflammation driven cell infiltration, neutrophil oxidative burst, immune
+        complex mediated macrophage activation, as well as mast cell maturation and
+        degranulation, has been well illustrated in various studies.
+- term:
+    id: GO:0010628
+    label: positive regulation of gene expression
+  evidence_type: IMP
+  original_reference_id: PMID:22079609
+  review:
+    summary: Over-annotation to positive regulation of gene expression. The available
+      PIK3CD evidence supports upstream PI3K/AKT signaling more directly than this
+      distal transcriptional-output term.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Gene-expression changes can occur downstream of PI3K/AKT/FOXO signaling, but
+      the cited evidence is more direct for lipid kinase signaling, migration, and
+      protein-level pathway outputs. This broad distal term should not be retained as a
+      core annotation.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Many downstream readouts (e.g., pAKT, pS6) are not
+        isoform-specific, and class I PI3Ks share overlapping functions; p110δ is
+        leukocyte-enriched but not exclusively expressed, so immune-context evidence is
+        strongest for PIK3CD-specific BP claims.
+    - reference_id: PMID:22079609
+      supporting_text: Interestingly, knockdown of p110δ decreased the cell migration
+        and invasion ability of all GBM cell lines tested.
+- term:
+    id: GO:0030335
+    label: positive regulation of cell migration
+  evidence_type: IMP
+  original_reference_id: PMID:22079609
+  review:
+    summary: Supported cell-migration role in specific leukocyte and glioma contexts,
+      but non-core relative to lipid kinase signaling.
+    action: KEEP_AS_NON_CORE
+    reason: PIK3CD knockdown decreases glioma-cell migration and PI3Kdelta also affects
+      leukocyte migration; these are downstream context-specific outputs rather than the
+      core function.
+    supported_by:
+    - reference_id: PMID:22079609
+      supporting_text: Interestingly, knockdown of p110δ decreased the cell migration
+        and invasion ability of all GBM cell lines tested.
+    - reference_id: PMID:20940048
+      supporting_text: PI3Kδ participates in the development, activation and migration
+        of T cells and NK cells.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-1676048
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-1676109
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9012657
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9021627
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9027275
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005829
+    label: cytosol
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9606887
+  review:
+    summary: Supported cytoplasmic or cytosolic localization, but this is the
+      resting/general pool rather than the most informative activated signaling site.
+    action: KEEP_AS_NON_CORE
+    reason: UniProt records cytoplasmic localization and the deep research report
+      describes resting p110delta-p85 complexes as cytosolic. The functionally decisive
+      event is receptor-driven membrane recruitment, so cytoplasm/cytosol should not be
+      treated as the core location.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: 'SUBCELLULAR LOCATION: Cytoplasm {ECO:0000269|PubMed:22020336}.'
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-2045911
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-2076220
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-2316434
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-2400009
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-388830
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-388832
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-389158
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-508247
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-879917
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-8854905
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-912627
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-914182
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005886
+    label: plasma membrane
+  evidence_type: TAS
+  original_reference_id: Reactome:R-HSA-9606887
+  review:
+    summary: Supported core activated-site localization. PI3Kdelta is recruited to
+      plasma-membrane receptor/adaptor complexes where its phosphoinositide substrates
+      reside.
+    action: ACCEPT
+    reason: Membrane recruitment is central to class IA PI3Kdelta activity because PIP2
+      substrate is membrane localized and receptor phosphotyrosine signals recruit the
+      p85-p110delta complex to the plasma membrane.
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Upon receptor phosphotyrosine signaling, SH2-containing p85
+        recruits the p85-p110δ complex to the plasma membrane where phosphoinositide
+        substrates reside.
+    - reference_id: Reactome:R-HSA-1676048
+      supporting_text: At the plasma membrane, phosphatidylinositol-4,5-bisphosphate
+        3-kinase catalytic subunits form complexes with regulatory subunits.
+- term:
+    id: GO:0005942
+    label: phosphatidylinositol 3-kinase complex
+  evidence_type: NAS
+  original_reference_id: PMID:9113989
+  review:
+    summary: The complex assignment is valid but should use the more specific class IA
+      phosphatidylinositol 3-kinase complex term.
+    action: MODIFY
+    reason: PIK3CD is not just any PI3K-complex component; it is the p110delta catalytic
+      subunit of class IA p85-family regulatory complexes. GO:0005943 captures the
+      correct complex subtype.
+    proposed_replacement_terms:
+    - id: GO:0005943
+      label: phosphatidylinositol 3-kinase complex, class IA
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+- term:
+    id: GO:0005942
+    label: phosphatidylinositol 3-kinase complex
+  evidence_type: NAS
+  original_reference_id: PMID:9235916
+  review:
+    summary: The complex assignment is valid but should use the more specific class IA
+      phosphatidylinositol 3-kinase complex term.
+    action: MODIFY
+    reason: PIK3CD is not just any PI3K-complex component; it is the p110delta catalytic
+      subunit of class IA p85-family regulatory complexes. GO:0005943 captures the
+      correct complex subtype.
+    proposed_replacement_terms:
+    - id: GO:0005943
+      label: phosphatidylinositol 3-kinase complex, class IA
+    supported_by:
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: p110δ forms a class IA heterodimer with p85-family regulatory
+        subunits, with p85 both stabilizing and inhibiting the catalytic subunit in
+        resting cells.
+    - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+      supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+        class IA, p110delta/p85alpha.
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+- term:
+    id: GO:0006468
+    label: protein phosphorylation
+  evidence_type: NAS
+  original_reference_id: PMID:9113989
+  review:
+    summary: Over-annotation to protein phosphorylation. PIK3CD is primarily a
+      phosphoinositide lipid kinase, not a protein kinase.
+    action: MODIFY
+    reason: PMID:9113989 reports lipid substrate specificity and explicitly
+      distinguishes p110delta from p110alpha by noting that it does not phosphorylate
+      p85, despite intrinsic autophosphorylation. The annotation should point to lipid
+      phosphorylation or PI(4,5)P2 3-kinase activity rather than general protein
+      phosphorylation.
+    proposed_replacement_terms:
+    - id: GO:0046834
+      label: lipid phosphorylation
+    - id: GO:0046934
+      label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+    supported_by:
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+    - reference_id: PMID:9113989
+      supporting_text: Unlike p110alpha, p110delta does not phosphorylate p85 but
+        instead harbors an intrinsic autophosphorylation capacity.
+- term:
+    id: GO:0007165
+    label: signal transduction
+  evidence_type: NAS
+  original_reference_id: PMID:9113989
+  review:
+    summary: The generic signal-transduction annotation should be narrowed to PI3K/AKT
+      and immune receptor signaling.
+    action: MODIFY
+    reason: PIK3CD participates in signaling by generating PIP3 downstream of receptor
+      activation. The generic signal transduction parent obscures the specific PI3K/AKT,
+      BCR, and TCR pathways supported by the evidence.
+    proposed_replacement_terms:
+    - id: GO:0043491
+      label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
+    - id: GO:0050853
+      label: B cell receptor signaling pathway
+    - id: GO:0050852
+      label: T cell receptor signaling pathway
+    supported_by:
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+        signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and
+        related receptor/adaptor systems), framing the major immune-cell BP terms
+        relevant for PIK3CD.
+- term:
+    id: GO:0016303
+    label: 1-phosphatidylinositol-3-kinase activity
+  evidence_type: NAS
+  original_reference_id: PMID:9235916
+  review:
+    summary: Core molecular function as a phosphatidylinositol 3-kinase catalytic
+      subunit.
+    action: ACCEPT
+    reason: This parent PI3K activity term is valid for p110delta, although GO:0046934
+      is the most specific MF term for its canonical PIP2-to-PIP3 reaction.
+    supported_by:
+    - reference_id: PMID:9235916
+      supporting_text: Recombinant p110delta phosphorylates phosphatidylinositol and
+        coimmunoprecipitates with p85.
+    - reference_id: PMID:9113989
+      supporting_text: p110delta displays a broad phosphoinositide lipid substrate
+        specificity and interacts with SH2/SH3 domain-containing p85 adaptor proteins
+        and with GTP-bound Ras.
+    - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+      supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+        PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
 references:
-  - id: GO_REF:0000002
-    title: Gene Ontology annotation through association of InterPro records with
-      GO terms
-    findings: []
-  - id: GO_REF:0000024
-    title: Manual transfer of experimentally-verified manual GO annotation data 
-      to orthologs by curator judgment of sequence similarity
-    findings: []
-  - id: GO_REF:0000033
-    title: Annotation inferences using phylogenetic trees
-    findings: []
-  - id: GO_REF:0000043
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword 
-      mapping
-    findings: []
-  - id: GO_REF:0000044
-    title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular 
-      Location vocabulary mapping, accompanied by conservative changes to GO 
-      terms applied by UniProt
-    findings: []
-  - id: GO_REF:0000052
-    title: Gene Ontology annotation based on curation of immunofluorescence data
-    findings: []
-  - id: GO_REF:0000117
-    title: Electronic Gene Ontology annotations created by ARBA machine learning
-      models
-    findings: []
-  - id: GO_REF:0000120
-    title: Combined Automated Annotation using Multiple IEA Methods
-    findings: []
-  - id: PMID:17290298
-    title: 'PI3K delta and PI3K gamma: partners in crime in inflammation in rheumatoid
-      arthritis and beyond?'
-    findings: []
-  - id: PMID:17371229
-    title: The PI3K p110delta controls T-cell development, differentiation and 
-      regulation.
-    findings: []
-  - id: PMID:20200404
-    title: The catalytic PI3K isoforms p110gamma and p110delta contribute to B 
-      cell development and maintenance, transformation, and proliferation.
-    findings: []
-  - id: PMID:20940048
-    title: Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and 
-      function.
-    findings: []
-  - id: PMID:21827948
-    title: Dynamics of the phosphoinositide 3-kinase p110δ interaction with p85α
-      and membranes reveals aspects of regulation distinct from p110α.
-    findings: []
-  - id: PMID:22020336
-    title: p37δ is a new isoform of PI3K p110δ that increases cell proliferation
-      and is overexpressed in tumors.
-    findings: []
-  - id: PMID:22079609
-    title: The catalytic phosphoinositol 3-kinase isoform p110δ is required for 
-      glioma cell migration and invasion.
-    findings: []
-  - id: PMID:24165795
-    title: Dominant-activating germline mutations in the gene encoding the 
-      PI(3)K catalytic subunit p110δ result in T cell senescence and human 
-      immunodeficiency.
-    findings: []
-  - id: PMID:25339672
-    title: Human IgA Fc receptor FcαRI (CD89) triggers different forms of 
-      neutrophil death depending on the inflammatory microenvironment.
-    findings: []
-  - id: PMID:27616589
-    title: PI3Kδ and primary immunodeficiencies.
-    findings: []
-  - id: PMID:28514442
-    title: Architecture of the human interactome defines protein communities and
-      disease networks.
-    findings: []
-  - id: PMID:31031754
-    title: 'Case Study: Mechanism for Increased Follicular Helper T Cell Development
-      in Activated PI3K Delta Syndrome.'
-    findings: []
-  - id: PMID:31915155
-    title: PI3Kδ as a Novel Therapeutic Target in Pathological Angiogenesis.
-    findings: []
-  - id: PMID:32296183
-    title: A reference map of the human binary protein interactome.
-    findings: []
-  - id: PMID:32606397
-    title: PI3K activation is enhanced by FOXM1D binding to p110 and p85 
-      subunits.
-    findings: []
-  - id: PMID:33961781
-    title: Dual proteome-scale networks reveal cell-specific remodeling of the 
-      human interactome.
-    findings: []
-  - id: PMID:35271311
-    title: 'OpenCell: Endogenous tagging for the cartography of human cellular organization.'
-    findings: []
-  - id: PMID:40205054
-    title: Multimodal cell maps as a foundation for structural and functional 
-      genomics.
-    findings: []
-  - id: PMID:9113989
-    title: P110delta, a novel phosphoinositide 3-kinase in leukocytes.
-    findings: []
-  - id: PMID:9235916
-    title: p110delta, a novel phosphatidylinositol 3-kinase catalytic subunit 
-      that associates with p85 and is expressed predominantly in leukocytes.
-    findings: []
-  - id: Reactome:R-HSA-1676048
-    title: PI(4,5)P2 is phosphorylated to PI(3,4,5)P3 by PIK3C[1] at the plasma 
-      membrane
-    findings: []
-  - id: Reactome:R-HSA-1676109
-    title: PI4P is phosphorylated to PI(3,4)P2 by PI3K3C[2] at the plasma 
-      membrane
-    findings: []
-  - id: Reactome:R-HSA-2045911
-    title: BCAP Signalosome phosphorylates PI(4,5)P2 forming PI(3,4,5)P3
-    findings: []
-  - id: Reactome:R-HSA-2076220
-    title: CD19 Signalosome phosphorylates PI(4,5)P2 forming PI(3,4,5)P3
-    findings: []
-  - id: Reactome:R-HSA-2316434
-    title: PI3K phosphorylates PIP2 to PIP3
-    findings: []
-  - id: Reactome:R-HSA-2400009
-    title: PI3K inhibitors block PI3K catalytic activity
-    findings: []
-  - id: Reactome:R-HSA-388830
-    title: PI3K binds ICOS
-    findings: []
-  - id: Reactome:R-HSA-388832
-    title: PI3K binds CD28
-    findings: []
-  - id: Reactome:R-HSA-389158
-    title: CD28 bound PI3K phosphorylates PIP2 to PIP3
-    findings: []
-  - id: Reactome:R-HSA-389356
-    title: Co-stimulation by CD28
-    findings: []
-  - id: Reactome:R-HSA-508247
-    title: Gab2 binds the p85 subunit of Class 1A PI3 kinases
-    findings: []
-  - id: Reactome:R-HSA-879917
-    title: CBL, GRB2, FYN and PI3K p85 subunit are constitutively associated
-    findings: []
-  - id: Reactome:R-HSA-8854905
-    title: p-5Y-GAB in the RET-GRB2-GAB complexes binds p85-PI3K
-    findings: []
-  - id: Reactome:R-HSA-9012657
-    title: EPO:phospho-EPOR:phospho-JAK2:LYN:phospho-IRS2 binds PI3K
-    findings: []
-  - id: Reactome:R-HSA-9021627
-    title: EPOR-associated PI3K phosphorylates PIP2 to PIP3
-    findings: []
-  - id: Reactome:R-HSA-9027275
-    title: EPO:phospho-EPOR:phospho-JAK2:LYN:IRS2:phospho-GAB1 binds PI3K
-    findings: []
-  - id: Reactome:R-HSA-912627
-    title: CBL ubiquitinates PI3K
-    findings: []
-  - id: Reactome:R-HSA-914182
-    title: 14-3-3 zeta binding allows recruitment of PI3K
-    findings: []
-  - id: Reactome:R-HSA-9606887
-    title: p-CD19:VAV binds PI3K and GRB2
-    findings: []
+- id: GO_REF:0000002
+  title: Gene Ontology annotation through association of InterPro records with GO terms
+  findings: []
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to
+    orthologs by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000033
+  title: Annotation inferences using phylogenetic trees
+  findings: []
+- id: GO_REF:0000043
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: GO_REF:0000052
+  title: Gene Ontology annotation based on curation of immunofluorescence data
+  findings: []
+- id: GO_REF:0000117
+  title: Electronic Gene Ontology annotations created by ARBA machine learning models
+  findings: []
+- id: GO_REF:0000120
+  title: Combined Automated Annotation using Multiple IEA Methods
+  findings: []
+- id: PMID:17290298
+  title: 'PI3K delta and PI3K gamma: partners in crime in inflammation in rheumatoid arthritis
+    and beyond?'
+  findings: []
+- id: PMID:17371229
+  title: The PI3K p110delta controls T-cell development, differentiation and regulation.
+  findings: []
+- id: PMID:20200404
+  title: The catalytic PI3K isoforms p110gamma and p110delta contribute to B cell
+    development and maintenance, transformation, and proliferation.
+  findings: []
+- id: PMID:20940048
+  title: Phosphoinositide 3-kinase delta (PI3Kδ) in leukocyte signaling and function.
+  findings: []
+- id: PMID:21827948
+  title: Dynamics of the phosphoinositide 3-kinase p110δ interaction with p85α and
+    membranes reveals aspects of regulation distinct from p110α.
+  findings: []
+- id: PMID:22020336
+  title: p37δ is a new isoform of PI3K p110δ that increases cell proliferation and is
+    overexpressed in tumors.
+  findings: []
+- id: PMID:22079609
+  title: The catalytic phosphoinositol 3-kinase isoform p110δ is required for glioma
+    cell migration and invasion.
+  findings: []
+- id: PMID:24165795
+  title: Dominant-activating germline mutations in the gene encoding the PI(3)K
+    catalytic subunit p110δ result in T cell senescence and human immunodeficiency.
+  findings: []
+- id: PMID:25339672
+  title: Human IgA Fc receptor FcαRI (CD89) triggers different forms of neutrophil death
+    depending on the inflammatory microenvironment.
+  findings: []
+- id: PMID:27616589
+  title: PI3Kδ and primary immunodeficiencies.
+  findings: []
+- id: PMID:28514442
+  title: Architecture of the human interactome defines protein communities and disease
+    networks.
+  findings: []
+- id: PMID:31031754
+  title: 'Case Study: Mechanism for Increased Follicular Helper T Cell Development in Activated
+    PI3K Delta Syndrome.'
+  findings: []
+- id: PMID:31915155
+  title: PI3Kδ as a Novel Therapeutic Target in Pathological Angiogenesis.
+  findings: []
+- id: PMID:32296183
+  title: A reference map of the human binary protein interactome.
+  findings: []
+- id: PMID:32606397
+  title: PI3K activation is enhanced by FOXM1D binding to p110 and p85 subunits.
+  findings: []
+- id: PMID:33961781
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
+    interactome.
+  findings: []
+- id: PMID:35271311
+  title: 'OpenCell: Endogenous tagging for the cartography of human cellular organization.'
+  findings: []
+- id: PMID:40205054
+  title: Multimodal cell maps as a foundation for structural and functional genomics.
+  findings: []
+- id: PMID:9113989
+  title: P110delta, a novel phosphoinositide 3-kinase in leukocytes.
+  findings: []
+- id: PMID:9235916
+  title: p110delta, a novel phosphatidylinositol 3-kinase catalytic subunit that
+    associates with p85 and is expressed predominantly in leukocytes.
+  findings: []
+- id: Reactome:R-HSA-1676048
+  title: PI(4,5)P2 is phosphorylated to PI(3,4,5)P3 by PIK3C[1] at the plasma membrane
+  findings: []
+- id: Reactome:R-HSA-1676109
+  title: PI4P is phosphorylated to PI(3,4)P2 by PI3K3C[2] at the plasma membrane
+  findings: []
+- id: Reactome:R-HSA-2045911
+  title: BCAP Signalosome phosphorylates PI(4,5)P2 forming PI(3,4,5)P3
+  findings: []
+- id: Reactome:R-HSA-2076220
+  title: CD19 Signalosome phosphorylates PI(4,5)P2 forming PI(3,4,5)P3
+  findings: []
+- id: Reactome:R-HSA-2316434
+  title: PI3K phosphorylates PIP2 to PIP3
+  findings: []
+- id: Reactome:R-HSA-2400009
+  title: PI3K inhibitors block PI3K catalytic activity
+  findings: []
+- id: Reactome:R-HSA-388830
+  title: PI3K binds ICOS
+  findings: []
+- id: Reactome:R-HSA-388832
+  title: PI3K binds CD28
+  findings: []
+- id: Reactome:R-HSA-389158
+  title: CD28 bound PI3K phosphorylates PIP2 to PIP3
+  findings: []
+- id: Reactome:R-HSA-389356
+  title: Co-stimulation by CD28
+  findings: []
+- id: Reactome:R-HSA-508247
+  title: Gab2 binds the p85 subunit of Class 1A PI3 kinases
+  findings: []
+- id: Reactome:R-HSA-879917
+  title: CBL, GRB2, FYN and PI3K p85 subunit are constitutively associated
+  findings: []
+- id: Reactome:R-HSA-8854905
+  title: p-5Y-GAB in the RET-GRB2-GAB complexes binds p85-PI3K
+  findings: []
+- id: Reactome:R-HSA-9012657
+  title: EPO:phospho-EPOR:phospho-JAK2:LYN:phospho-IRS2 binds PI3K
+  findings: []
+- id: Reactome:R-HSA-9021627
+  title: EPOR-associated PI3K phosphorylates PIP2 to PIP3
+  findings: []
+- id: Reactome:R-HSA-9027275
+  title: EPO:phospho-EPOR:phospho-JAK2:LYN:IRS2:phospho-GAB1 binds PI3K
+  findings: []
+- id: Reactome:R-HSA-912627
+  title: CBL ubiquitinates PI3K
+  findings: []
+- id: Reactome:R-HSA-914182
+  title: 14-3-3 zeta binding allows recruitment of PI3K
+  findings: []
+- id: Reactome:R-HSA-9606887
+  title: p-CD19:VAV binds PI3K and GRB2
+  findings: []
+- id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+  title: Falcon deep research report on PIK3CD
+  findings: []
+- id: file:human/PIK3CD/PIK3CD-uniprot.txt
+  title: UniProtKB record for PIK3CD
+  findings: []
+core_functions:
+- molecular_function:
+    id: GO:0046934
+    label: 1-phosphatidylinositol-4,5-bisphosphate 3-kinase activity
+  description: PIK3CD/p110delta is the leukocyte-enriched class IA PI3K catalytic
+    subunit that forms p85-family regulatory complexes and generates PIP3 from PI(4,5)P2
+    at receptor-activated membranes.
+  directly_involved_in:
+  - id: GO:0043491
+    label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
+  - id: GO:0050853
+    label: B cell receptor signaling pathway
+  - id: GO:0050852
+    label: T cell receptor signaling pathway
+  - id: GO:0031295
+    label: T cell costimulation
+  locations:
+  - id: GO:0005886
+    label: plasma membrane
+  in_complex:
+    id: GO:0005943
+    label: phosphatidylinositol 3-kinase complex, class IA
+  supported_by:
+  - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+    supporting_text: '**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide
+      3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes
+      downstream of receptor signaling in immune cells, particularly in lymphocytes.'
+  - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+    supporting_text: Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to
+      PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD.
+  - reference_id: file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+    supporting_text: In immune cells, class IA PI3K (including p110δ) propagates
+      signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related
+      receptor/adaptor systems), framing the major immune-cell BP terms relevant for
+      PIK3CD.
+  - reference_id: Reactome:R-HSA-389158
+    supporting_text: Upon binding to CD28, the PI3K enzyme catalyzes the phosphorylation
+      of phosphatidylinositol 4,5-bisphosphate (PIP2) to generate phosphatidylinositol
+      3,4,5-trisphosphate (PIP3).
+  - reference_id: file:human/PIK3CD/PIK3CD-uniprot.txt
+    supporting_text: ComplexPortal; CPX-5983; Phosphatidylinositol 3-kinase complex
+      class IA, p110delta/p85alpha.
+proposed_new_terms: []
+suggested_questions:
+- question: Which PIK3CD-dependent leukocyte migration, neutrophil death, and
+    endothelial angiogenesis annotations remain physiologically relevant in human
+    primary cells after controlling for class I PI3K isoform redundancy and inhibitor
+    selectivity?
+- question: Should GO include a more specific biological-process term for class I
+    PI3K-mediated PI(3,4,5)P3 biosynthesis to avoid using PI3P-centered or overly broad
+    phosphatidylinositol phosphate biosynthetic process terms for PIK3CD?
+suggested_experiments:
+- description: Use isoform-selective genetic rescue in human primary B and T cells to
+    separate PIK3CD-specific BCR, TCR, and CD28 signaling outputs from overlapping
+    PIK3CA/PIK3CB/PIK3CG class I PI3K activity.
+  experiment_type: primary-cell genetic rescue and phosphoprotein/PIP3 readout
+- description: Measure PI(4,5)P2-to-PIP3 and PI4P-to-PI(3,4)P2 product formation for
+    p110delta-p85 complexes under matched in vitro and membrane-recruitment conditions
+    to clarify whether PI4P kinase annotations should remain non-core.
+  experiment_type: lipid kinase substrate-specificity assay

--- a/genes/human/PIK3CD/PIK3CD-deep-research-falcon.md
+++ b/genes/human/PIK3CD/PIK3CD-deep-research-falcon.md
@@ -1,0 +1,248 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-12T09:51:43.581323'
+end_time: '2026-05-12T10:05:46.915578'
+duration_seconds: 843.33
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 26
+---
+
+## Question
+
+Perform concise GO-focused deep research on the human PIK3CD gene (UniProt O00329; phosphatidylinositol 4,5-bisphosphate 3-kinase catalytic subunit delta isoform / PI3K p110-delta). Summarize the core molecular function, major biological processes, cellular locations, key experimental evidence, immune-cell signaling context, disease context only where relevant to function, and GO annotation caveats. Include PMID or DOI citations where available, and keep the report focused for gene annotation review.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+Perform concise GO-focused deep research on the human PIK3CD gene (UniProt O00329; phosphatidylinositol 4,5-bisphosphate 3-kinase catalytic subunit delta isoform / PI3K p110-delta). Summarize the core molecular function, major biological processes, cellular locations, key experimental evidence, immune-cell signaling context, disease context only where relevant to function, and GO annotation caveats. Include PMID or DOI citations where available, and keep the report focused for gene annotation review.
+
+# GO-focused deep research report: human **PIK3CD** (UniProt O00329; PI3K p110δ)
+
+## 0) Gene/product synopsis (annotation scope)
+**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide 3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at membranes downstream of receptor signaling in immune cells, particularly in lymphocytes. p110δ acts as a heterodimer with **p85-family regulatory subunits**, and receptor-triggered recruitment/relief of p85 inhibition is central to its regulated activity. (ijspeert2024hyperactivationofthe pages 2-4, ijspeert2024hyperactivationofthe pages 1-2)
+
+**Canonical record for protein identity**: UniProt O00329 (https://www.uniprot.org/uniprotkb/O00329/). (No UniProt text was retrieved via tools; URL provided for curator convenience.)
+
+## 1) Key GO concepts and definitions (current understanding)
+### 1.1 Molecular function (MF): what p110δ *does biochemically*
+**Core enzymatic activity (lipid phosphorylation at D3 position):** Class I PI3Ks phosphorylate membrane inositol phospholipids at the **3′ position**; class IA enzymes (including p110δ) act on PI(4,5)P2 to generate **PIP3**, which serves as a membrane docking lipid for downstream signaling proteins. (ijspeert2024hyperactivationofthe pages 1-2, stokoe2005thephosphoinositide3kinase pages 1-3)
+
+**ATP dependence / catalytic-site context:** PI3Kδ catalysis requires ATP; this is strongly supported indirectly by inhibitor mechanism studies contrasting **ATP-competitive** inhibitors (idelalisib) with **non–ATP-competitive** allosteric PI3Kδ inhibition (IOA-244), which alters enzyme kinetics consistent with catalytic-site ATP usage in the reaction. (johnson2023ioa244isa pages 6-7)
+
+### 1.2 Cellular component (CC): where p110δ is and what complex it is part of
+**Class IA PI3K complex membership:** Class IA PI3Ks function as **heterodimers of p110 catalytic subunits and p85-family regulatory subunits**; p85 stabilizes and inhibits p110 in resting state. (ijspeert2024hyperactivationofthe pages 2-4, stokoe2005thephosphoinositide3kinase pages 1-3)
+
+**Membrane recruitment as a key localization event:** Upon receptor activation, p85 SH2 domains bind **phosphotyrosine motifs** (e.g., YxxM-containing motifs) on receptors/adaptors, recruiting the p85–p110δ complex to the **plasma membrane**, where phosphoinositide substrates reside and catalytic activity increases. (ijspeert2024hyperactivationofthe pages 2-4, stokoe2005thephosphoinositide3kinase pages 1-3)
+
+### 1.3 Biological process (BP): what p110δ *does in cells/tissues*
+**PI3K→AKT→mTOR/FOXO axis:** PIP3 recruits **AKT** to the plasma membrane for phosphorylation (PDK1/mTORC2 context) and downstream regulation of **mTORC1/S6** and **FOXO** transcription factor localization/function. (ijspeert2024hyperactivationofthe pages 2-4, ijspeert2024hyperactivationofthe pages 1-2)
+
+**Immune receptor signaling context:** In immune cells, class IA PI3K (including p110δ) propagates signaling downstream of **BCR, TCR, CD28, ICOS, CD19, BAFF-R, CD40** (and related receptor/adaptor systems), framing the major immune-cell BP terms relevant for PIK3CD. (ijspeert2024hyperactivationofthe pages 2-4)
+
+## 2) Major immune-cell signaling roles with key experimental evidence (curation-relevant)
+### 2.1 B cell receptor (BCR) signaling and Ca2+ mobilization (high-confidence genetic evidence)
+A foundational genetic study using **p110δ-deficient mice** demonstrates that p110δ is **essential and nonredundant** for effective BCR signaling.
+
+*Key experimental findings (Mol Cell Biol, 2002-12; DOI:10.1128/MCB.22.24.8580-8591.2002; URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002)*:
+- **Anti-IgM–induced intracellular Ca2+ mobilization** in p110δ−/− B cells was reduced to **~25% of wild type**, while ionomycin response was preserved, indicating a BCR-proximal signaling defect requiring p110δ. (jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole media 9f8002cf)
+- Proximal BCR signaling events (e.g., Btk and PLCγ2 tyrosine phosphorylation) occurred comparably, consistent with p110δ acting in the pathway needed for full Ca2+ signaling output. (jou2002essentialnonredundantrole pages 4-8)
+
+**GO interpretation:** supports BP annotations for **B cell receptor signaling pathway** and **intracellular calcium ion mobilization** in B cells, with p110δ as a positive regulator/essential component in this context. (jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole media 9f8002cf)
+
+### 2.2 B cell development, activation, proliferation; germinal centers; humoral immunity
+In the same p110δ knockout model:
+- B cell developmental and compartment defects include reduced mature peripheral B cells and loss of B1 cells. (jou2002essentialnonredundantrole pages 1-2, jou2002essentialnonredundantrole pages 2-4)
+- **In vitro proliferation**: p110δ−/− B cells showed decreased proliferation to **anti-CD40** and **LPS**, and impaired responses to BCR crosslinking; bypass stimulation (PMA+ionomycin) was relatively preserved. (jou2002essentialnonredundantrole pages 4-8)
+- **Humoral immunity in vivo**: reduced baseline serum immunoglobulins and impaired antigen-specific antibody responses—T-independent responses reduced and **T-dependent antibody responses absent**; **germinal center formation impaired/absent** by splenic staining after immunization. (jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole media 9f8002cf)
+
+**Visual evidence from the primary paper** (used here as supporting data displays): ELISA immunoglobulin panels, antigen-response panels, absent germinal center staining, and Ca2+ flux traces in wild-type vs p110δ−/− are captured in the retrieved figure crops. (jou2002essentialnonredundantrole media 9f8002cf, jou2002essentialnonredundantrole media 37876baa, jou2002essentialnonredundantrole media 7d2b61ed, jou2002essentialnonredundantrole media 3b78ec57)
+
+**GO interpretation:** supports BP annotations such as **B cell development**, **B cell activation**, **B cell proliferation**, **germinal center formation**, and **T-dependent humoral immune response**. (jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole pages 1-2, jou2002essentialnonredundantrole media 9f8002cf)
+
+### 2.3 Regulatory T cell (Treg) homeostasis and immune tolerance (2024 mechanistic/phenotypic update)
+A 2024 conditional mouse model interrogated **activated PI3Kδ signaling specifically within Foxp3+ Tregs**, clarifying how PI3Kδ activity thresholds control tolerance.
+
+*Key recent study (J Immunol, 2024-06; DOI:10.4049/jimmunol.2400032; URL: https://doi.org/10.4049/jimmunol.2400032)*:
+- Treg-restricted activated PI3Kδ (**aPIK3CD**) **increased thymic Treg precursors and peripheral Treg numbers**, yet Tregs displayed altered phenotype (e.g., increased PD-1) and reduced competitive fitness. (singh2024activatedpi3kδspecifically pages 1-3)
+- Despite increased Treg counts, mice developed **chronic inflammation**, increased memory/effector CD4+/CD8+ T cells and enhanced **IFN-γ secretion**, plus **spontaneous germinal center responses** and **broad autoantibody production**. (singh2024activatedpi3kδspecifically pages 3-4, singh2024activatedpi3kδspecifically pages 1-3)
+- Mechanistic linkage is consistent with PI3K→AKT→FOXO regulation (AKT phosphorylation, FOXO1 nuclear exclusion) affecting Treg stability/function. (singh2024activatedpi3kδspecifically pages 11-13)
+
+**GO interpretation:** supports BP terms around **regulatory T cell homeostasis**, **immune tolerance/negative regulation of immune response**, and **regulation of germinal center response/humoral immunity**, with an explicit caveat that both **loss** and **gain** of PI3Kδ signaling can disrupt tolerance (directionality depends on activity threshold/context). (singh2024activatedpi3kδspecifically pages 1-3, singh2024activatedpi3kδspecifically pages 10-11)
+
+## 3) Recent developments (prioritize 2023–2024)
+### 3.1 Refined pathway framing for GO: receptor repertoire and downstream readouts
+A 2024 review synthesizes receptor contexts and regulatory mechanisms relevant to GO process selection:
+- Class IA PI3K (p85–p110δ) is recruited downstream of immune receptors including **BCR/TCR/CD28/ICOS/CD19/BAFF-R/CD40**, producing PIP3 that drives AKT/mTOR/FOXO-linked programs. (ijspeert2024hyperactivationofthe pages 2-4, ijspeert2024hyperactivationofthe pages 1-2)
+- It highlights pathway antagonism by PTEN/SHIP and connects FOXO-regulated transcription (e.g., immune differentiation programs) to PI3K signaling outputs (useful for downstream BP annotations, but requires careful evidence attribution if annotating those distal effects). (ijspeert2024hyperactivationofthe pages 2-4)
+
+*Source (Immunotherapy Advances, 2024-11; DOI:10.1093/immadv/ltae009; URL: https://doi.org/10.1093/immadv/ltae009)* (ijspeert2024hyperactivationofthe pages 2-4, ijspeert2024hyperactivationofthe pages 1-2)
+
+### 3.2 Quantitative inhibitor/probe landscape (mechanism, selectivity, and caveats)
+Because PI3Kδ is frequently perturbed pharmacologically (both experimentally and clinically), inhibitor properties are directly relevant to interpreting evidence used for GO assertions.
+
+**Allosteric vs ATP-competitive PI3Kδ inhibition (2023):**
+- **IOA-244 (roginolisib)** behaves as a **non–ATP-competitive** PI3Kδ inhibitor; kinetic data show minimal ATP Km shift but a strong Vmax reduction in a PIP3 production assay; biochemical IC50 ~**19 nM** and whole blood IC50 **0.28 μM** were reported (plus extensive selectivity profiling). (johnson2023ioa244isa pages 6-7, johnson2023ioa244isa pages 13-14)
+- **Idelalisib** shows **ATP-competitive** behavior (Km shift) and strong PI3Kδ potency (KiNativ PI3Kδ IC50 **1.3 nM**), but with additional off-target activity and an active metabolite (GS-563117) with its own target spectrum, supporting strong GO curation caveats for pharmacology-derived functional claims. (johnson2023ioa244isa pages 6-7, johnson2023ioa244isa pages 13-14)
+
+*Source (Cancer Research Communications, 2023-04; DOI:10.1158/2767-9764.CRC-22-0477; URL: https://doi.org/10.1158/2767-9764.crc-22-0477)* (johnson2023ioa244isa pages 6-7, johnson2023ioa244isa pages 13-14)
+
+**Leniolisib potency and isoform selectivity (2024):**
+- Leniolisib is reported as PI3Kδ-selective with **IC50 11 nM** (PI3Kδ) vs **244 nM (α)**, **424 nM (β)**, **2230 nM (γ)**. (de2024leniolisibanovel pages 1-2, cant2024pi3kδpathwaydysregulation pages 19-20)
+
+*Sources:* Frontiers in Pharmacology (2024-02; DOI:10.3389/fphar.2024.1337436; URL: https://doi.org/10.3389/fphar.2024.1337436) (de2024leniolisibanovel pages 1-2) and JACI-In Practice (2024-01; DOI:10.1016/j.jaip.2023.09.016; URL: https://doi.org/10.1016/j.jaip.2023.09.016) (cant2024pi3kδpathwaydysregulation pages 19-20)
+
+**GO curation implication:** inhibitor-based inference is useful for pathway placement (PI3Kδ dependence), but should be down-weighted unless selectivity, concentrations, and metabolites are controlled and accompanied by genetic corroboration. (johnson2023ioa244isa pages 6-7, cant2024pi3kδpathwaydysregulation pages 13-14)
+
+## 4) Cellular locations and trafficking (GO CC-focused synthesis)
+- **Resting state:** cytosolic complex of p110δ with p85-family regulatory subunits, with p85 inhibiting catalytic activity until activation signals occur. (ijspeert2024hyperactivationofthe pages 2-4)
+- **Activated state:** recruitment/translocation of the p85–p110δ complex to **plasma membrane** via SH2 binding to receptor/adaptor phosphotyrosines, enabling access to PI(4,5)P2 substrate and local PIP3 generation. (ijspeert2024hyperactivationofthe pages 2-4, stokoe2005thephosphoinositide3kinase pages 1-3)
+
+**Caveat for CC annotation:** Much localization evidence in the retrieved sources is mechanistic/consensus (review synthesis). For strict experimental CC evidence codes, curators may prefer direct imaging/biochemical fractionation papers (not retrieved here in full). (ijspeert2024hyperactivationofthe pages 2-4, stokoe2005thephosphoinositide3kinase pages 1-3)
+
+## 5) Disease context (only where functionally informative)
+Disease genetics mainly reinforce **dosage/threshold sensitivity** of PI3Kδ signaling in immune function. For example, the Treg-conditional activation study demonstrates that hyperactive PI3Kδ signaling can paradoxically increase Treg numbers while impairing tolerance, emphasizing that GO BP annotations should avoid implying monotonic positive regulation for all downstream immune outcomes. (singh2024activatedpi3kδspecifically pages 1-3)
+
+APDS-focused reviews (2024) frame PI3Kδ hyperactivation as driving excessive AKT/mTOR pathway activity in immune cells and motivating use of selective inhibitors; this is functionally relevant as it highlights pathway readouts (pAKT/pS6) used experimentally. (cant2024pi3kδpathwaydysregulation pages 1-3)
+
+## 6) GO annotation caveats and curator notes
+1. **Isoform redundancy / shared PI3K outputs:** Many downstream readouts (e.g., pAKT, pS6) are not isoform-specific, and class I PI3Ks share overlapping functions; p110δ is leukocyte-enriched but not exclusively expressed, so immune-context evidence is strongest for PIK3CD-specific BP claims. (ijspeert2024hyperactivationofthe pages 1-2, cant2024pi3kδpathwaydysregulation pages 1-3)
+2. **Pharmacology confounding:** PI3Kδ inhibitors differ in mechanism (ATP-competitive vs allosteric), cellular potency vs biochemical potency, off-target profiles, and metabolites; GO assertions based solely on inhibitor phenotypes can be misleading without genetic confirmation. (johnson2023ioa244isa pages 6-7, johnson2023ioa244isa pages 13-14, cant2024pi3kδpathwaydysregulation pages 13-14)
+3. **Pathological hyperactivation ≠ physiological role directionality:** Hyperactive PI3Kδ in Tregs produces immune dysregulation and autoantibodies despite increased Treg numbers, so annotations should favor neutral process placement (e.g., “involved in”) or carefully qualified regulation terms when direction is context-dependent. (singh2024activatedpi3kδspecifically pages 1-3, singh2024activatedpi3kδspecifically pages 11-13)
+4. **Species-to-human transfer:** Foundational functional genetics are largely from mouse models (e.g., p110δ knockout). These are highly informative for GO, but annotation should note organism context and confirmability in human systems when possible. (jou2002essentialnonredundantrole pages 4-8)
+
+## 7) Curator-facing GO mapping table (artifact)
+The following table compiles recommended MF/BP/CC terms with evidence summaries and traceable citations.
+
+| GO aspect | Recommended GO term name | Evidence summary (1 line) | Key experimental system | Best supporting citation IDs |
+|---|---|---|---|---|
+| MF | phosphatidylinositol-4,5-bisphosphate 3-kinase activity | Class I/IA PI3Ks, including p110δ, phosphorylate PI(4,5)P2 to PI(3,4,5)P3; this is the core enzymatic activity of PIK3CD. | Cell-free / review synthesis | (ijspeert2024hyperactivationofthe pages 1-2, stokoe2005thephosphoinositide3kinase pages 1-3) |
+| MF | ATP binding | PI3Kδ catalytic activity is ATP-dependent; inhibitor kinetic studies distinguish ATP-competitive idelalisib from non-ATP-competitive IOA-244, reinforcing ATP use at the catalytic site. | Cell-free biochemical assays | (johnson2023ioa244isa pages 6-7, cant2024pi3kδpathwaydysregulation pages 19-20) |
+| CC | class IA phosphatidylinositol 3-kinase complex | p110δ forms a class IA heterodimer with p85-family regulatory subunits, with p85 both stabilizing and inhibiting the catalytic subunit in resting cells. | Human / review synthesis | (ijspeert2024hyperactivationofthe pages 2-4, stokoe2005thephosphoinositide3kinase pages 1-3, berglund2024modulatingthepi3k pages 8-8) |
+| CC | plasma membrane recruitment | Upon receptor phosphotyrosine signaling, SH2-containing p85 recruits the p85-p110δ complex to the plasma membrane where phosphoinositide substrates reside. | Human / review synthesis | (ijspeert2024hyperactivationofthe pages 2-4, ijspeert2024hyperactivationofthe pages 1-2, stokoe2005thephosphoinositide3kinase pages 1-3) |
+| BP | phosphatidylinositol 3-kinase signaling | PI3Kδ-generated PIP3 recruits and activates AKT-linked signaling modules controlling downstream immune-cell responses. | Human / mouse / review synthesis | (ijspeert2024hyperactivationofthe pages 2-4, ijspeert2024hyperactivationofthe pages 1-2) |
+| BP | B cell receptor signaling pathway | Genetic loss of p110δ causes a specific BCR signaling defect, indicating a nonredundant positive role downstream of the BCR/CD19 axis. | Mouse knockout | (jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole pages 8-10, jou2002essentialnonredundantrole pages 1-2) |
+| BP | intracellular calcium ion mobilization | Anti-IgM-induced Ca2+ mobilization in p110δ-deficient B cells is reduced to about 25% of wild type, supporting a role in BCR-triggered Ca2+ signaling. | Mouse knockout | (jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole media 9f8002cf) |
+| BP | B cell development | p110δ deficiency reduces mature peripheral B cells, causes a developmental block and loss of B1 cells, supporting annotation to B-cell developmental processes. | Mouse knockout | (jou2002essentialnonredundantrole pages 1-2, jou2002essentialnonredundantrole pages 2-4) |
+| BP | B cell activation | p110δ-deficient B cells show impaired responses to BCR ligation and reduced activation-associated functional outputs. | Mouse knockout | (jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole pages 2-4) |
+| BP | B cell proliferation | Splenic p110δ-deficient B cells proliferate poorly in response to anti-IgM, anti-CD40 and LPS, while bypass stimulation is relatively preserved. | Mouse knockout | (jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole pages 2-4) |
+| BP | germinal center formation | Immunized p110δ-deficient mice fail to form splenic germinal centers, demonstrating a requirement for PI3Kδ in this humoral immune process. | Mouse knockout | (jou2002essentialnonredundantrole pages 1-2, jou2002essentialnonredundantrole media 9f8002cf) |
+| BP | T-dependent humoral immune response | T-dependent antibody responses are absent in p110δ-deficient mice, with severe defects also seen for TI responses, supporting a role in antibody production pathways. | Mouse knockout | (jou2002essentialnonredundantrole pages 4-8, jou2002essentialnonredundantrole media 9f8002cf) |
+| BP | AKT signaling / positive regulation of TOR signaling | Recent reviews and APDS-related studies place PI3Kδ upstream of AKT, mTORC1/S6 and FOXO regulation; pS6 elevation is used as a downstream readout of pathway activation. | Human patients / mouse models | (ijspeert2024hyperactivationofthe pages 2-4, nguyen2023humanpik3r1mutations pages 24-25, singh2024activatedpi3kδspecifically pages 11-13) |
+| BP | regulatory T cell homeostasis | Balanced PI3Kδ activity is required in Tregs: hyperactive PI3Kδ increases Treg numbers but reduces fitness and functional stability, whereas insufficient signaling also impairs tolerance. | Mouse conditional GOF / review synthesis | (singh2024activatedpi3kδspecifically pages 3-4, singh2024activatedpi3kδspecifically pages 11-13, singh2024activatedpi3kδspecifically pages 1-3) |
+| BP | immune tolerance / negative regulation of immune response | Treg-restricted activated PI3Kδ drives chronic inflammation, elevated IFN-γ, increased Tfh/GC responses and broad autoantibody production, indicating loss of tolerance when PI3Kδ is dysregulated. | Mouse conditional GOF | (singh2024activatedpi3kδspecifically pages 3-4, singh2024activatedpi3kδspecifically pages 10-11, singh2024activatedpi3kδspecifically pages 1-3) |
+| BP | caveat: isoform redundancy and context dependence | Some PI3K outputs can be shared with other class I isoforms; p110δ is leukocyte-enriched but not absolutely exclusive, so annotations should favor immune-context evidence over broad generic signaling claims. | Curation note | (ijspeert2024hyperactivationofthe pages 1-2, wright2024theimportanceof pages 4-6, cant2024pi3kδpathwaydysregulation pages 1-3) |
+| BP | caveat: inhibitor-based evidence can be confounded | PI3Kδ inhibitors differ in selectivity, mechanism and metabolites (e.g., ATP-competitive vs noncompetitive; off-target active metabolites), so pharmacology alone should not be over-weighted for direct GO assignment. | Curation note / cell-free and cellular pharmacology | (johnson2023ioa244isa pages 6-7, de2024leniolisibanovel pages 2-4, cant2024pi3kδpathwaydysregulation pages 13-14, johnson2023ioa244isa pages 15-16) |
+
+
+*Table: This table summarizes high-confidence, curator-facing GO annotation suggestions for human PIK3CD/p110δ, mapped to the strongest experimental evidence retrieved in this session. It highlights core molecular function, complex/localization, immune signaling processes, and key curation caveats.*
+
+## 8) Key references with publication dates and URLs (subset)
+- Jou ST et al. *Molecular and Cellular Biology* (2002-12). “Essential, Nonredundant Role for the Phosphoinositide 3-Kinase p110δ in Signaling by the B-Cell Receptor Complex.” DOI:10.1128/MCB.22.24.8580-8591.2002. https://doi.org/10.1128/mcb.22.24.8580-8591.2002 (jou2002essentialnonredundantrole pages 4-8)
+- IJspeert H et al. *Immunotherapy Advances* (2024-11). DOI:10.1093/immadv/ltae009. https://doi.org/10.1093/immadv/ltae009 (ijspeert2024hyperactivationofthe pages 2-4)
+- Singh AK et al. *Journal of Immunology* (2024-06). DOI:10.4049/jimmunol.2400032. https://doi.org/10.4049/jimmunol.2400032 (singh2024activatedpi3kδspecifically pages 1-3)
+- Cant AJ et al. *J Allergy Clin Immunol: In Practice* (2024-01). DOI:10.1016/j.jaip.2023.09.016. https://doi.org/10.1016/j.jaip.2023.09.016 (cant2024pi3kδpathwaydysregulation pages 19-20)
+- Johnson Z et al. *Cancer Research Communications* (2023-04). DOI:10.1158/2767-9764.CRC-22-0477. https://doi.org/10.1158/2767-9764.crc-22-0477 (johnson2023ioa244isa pages 6-7)
+- De SK. *Frontiers in Pharmacology* (2024-02). DOI:10.3389/fphar.2024.1337436. https://doi.org/10.3389/fphar.2024.1337436 (de2024leniolisibanovel pages 1-2)
+
+
+
+References
+
+1. (ijspeert2024hyperactivationofthe pages 2-4): Hanna IJspeert, Virgil A S H Dalm, Menno C van Zelm, and Emily S J Edwards. Hyperactivation of the pi3k pathway in inborn errors of immunity: current understanding and therapeutic perspectives. Immunotherapy Advances, Nov 2024. URL: https://doi.org/10.1093/immadv/ltae009, doi:10.1093/immadv/ltae009. This article has 11 citations.
+
+2. (ijspeert2024hyperactivationofthe pages 1-2): Hanna IJspeert, Virgil A S H Dalm, Menno C van Zelm, and Emily S J Edwards. Hyperactivation of the pi3k pathway in inborn errors of immunity: current understanding and therapeutic perspectives. Immunotherapy Advances, Nov 2024. URL: https://doi.org/10.1093/immadv/ltae009, doi:10.1093/immadv/ltae009. This article has 11 citations.
+
+3. (stokoe2005thephosphoinositide3kinase pages 1-3): David Stokoe. The phosphoinositide 3-kinase pathway and cancer. Expert Reviews in Molecular Medicine, 7:1-22, Jun 2005. URL: https://doi.org/10.1017/s1462399405009361, doi:10.1017/s1462399405009361. This article has 73 citations and is from a peer-reviewed journal.
+
+4. (johnson2023ioa244isa pages 6-7): Zoë Johnson, Chiara Tarantelli, Elisa Civanelli, Luciano Cascione, Filippo Spriano, Amy Fraser, Pritom Shah, Tyzoon Nomanbhoy, Sara Napoli, Andrea Rinaldi, Karolina Niewola-Staszkowska, Michael Lahn, Dominique Perrin, Mathias Wenes, Denis Migliorini, Francesco Bertoni, Lars van der Veen, and Giusy Di Conza. Ioa-244 is a non–atp-competitive, highly selective, tolerable pi3k delta inhibitor that targets solid tumors and breaks immune tolerance. Cancer Research Communications, 3:576-591, Apr 2023. URL: https://doi.org/10.1158/2767-9764.crc-22-0477, doi:10.1158/2767-9764.crc-22-0477. This article has 33 citations and is from a peer-reviewed journal.
+
+5. (jou2002essentialnonredundantrole pages 4-8): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.
+
+6. (jou2002essentialnonredundantrole media 9f8002cf): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.
+
+7. (jou2002essentialnonredundantrole pages 1-2): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.
+
+8. (jou2002essentialnonredundantrole pages 2-4): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.
+
+9. (jou2002essentialnonredundantrole media 37876baa): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.
+
+10. (jou2002essentialnonredundantrole media 7d2b61ed): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.
+
+11. (jou2002essentialnonredundantrole media 3b78ec57): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.
+
+12. (singh2024activatedpi3kδspecifically pages 1-3): Akhilesh K. Singh, Fahd Al Qureshah, Travis Drow, Baidong Hou, and David J. Rawlings. Activated pi3kδ specifically perturbs mouse regulatory t cell homeostasis and function leading to immune dysregulation. Journal of immunology, 213:135-147, Jun 2024. URL: https://doi.org/10.4049/jimmunol.2400032, doi:10.4049/jimmunol.2400032. This article has 8 citations and is from a domain leading peer-reviewed journal.
+
+13. (singh2024activatedpi3kδspecifically pages 3-4): Akhilesh K. Singh, Fahd Al Qureshah, Travis Drow, Baidong Hou, and David J. Rawlings. Activated pi3kδ specifically perturbs mouse regulatory t cell homeostasis and function leading to immune dysregulation. Journal of immunology, 213:135-147, Jun 2024. URL: https://doi.org/10.4049/jimmunol.2400032, doi:10.4049/jimmunol.2400032. This article has 8 citations and is from a domain leading peer-reviewed journal.
+
+14. (singh2024activatedpi3kδspecifically pages 11-13): Akhilesh K. Singh, Fahd Al Qureshah, Travis Drow, Baidong Hou, and David J. Rawlings. Activated pi3kδ specifically perturbs mouse regulatory t cell homeostasis and function leading to immune dysregulation. Journal of immunology, 213:135-147, Jun 2024. URL: https://doi.org/10.4049/jimmunol.2400032, doi:10.4049/jimmunol.2400032. This article has 8 citations and is from a domain leading peer-reviewed journal.
+
+15. (singh2024activatedpi3kδspecifically pages 10-11): Akhilesh K. Singh, Fahd Al Qureshah, Travis Drow, Baidong Hou, and David J. Rawlings. Activated pi3kδ specifically perturbs mouse regulatory t cell homeostasis and function leading to immune dysregulation. Journal of immunology, 213:135-147, Jun 2024. URL: https://doi.org/10.4049/jimmunol.2400032, doi:10.4049/jimmunol.2400032. This article has 8 citations and is from a domain leading peer-reviewed journal.
+
+16. (johnson2023ioa244isa pages 13-14): Zoë Johnson, Chiara Tarantelli, Elisa Civanelli, Luciano Cascione, Filippo Spriano, Amy Fraser, Pritom Shah, Tyzoon Nomanbhoy, Sara Napoli, Andrea Rinaldi, Karolina Niewola-Staszkowska, Michael Lahn, Dominique Perrin, Mathias Wenes, Denis Migliorini, Francesco Bertoni, Lars van der Veen, and Giusy Di Conza. Ioa-244 is a non–atp-competitive, highly selective, tolerable pi3k delta inhibitor that targets solid tumors and breaks immune tolerance. Cancer Research Communications, 3:576-591, Apr 2023. URL: https://doi.org/10.1158/2767-9764.crc-22-0477, doi:10.1158/2767-9764.crc-22-0477. This article has 33 citations and is from a peer-reviewed journal.
+
+17. (de2024leniolisibanovel pages 1-2): Surya K. De. Leniolisib: a novel treatment for activated phosphoinositide-3 kinase delta syndrome. Frontiers in Pharmacology, Feb 2024. URL: https://doi.org/10.3389/fphar.2024.1337436, doi:10.3389/fphar.2024.1337436. This article has 12 citations.
+
+18. (cant2024pi3kδpathwaydysregulation pages 19-20): Andrew J. Cant, Anita Chandra, Ewen Munro, V. Koneti Rao, and Carrie L. Lucas. Pi3kδ pathway dysregulation and unique features of its inhibition by leniolisib in activated pi3kδ syndrome and beyond. The Journal of Allergy and Clinical Immunology: In Practice, 12:69-78, Jan 2024. URL: https://doi.org/10.1016/j.jaip.2023.09.016, doi:10.1016/j.jaip.2023.09.016. This article has 34 citations.
+
+19. (cant2024pi3kδpathwaydysregulation pages 13-14): Andrew J. Cant, Anita Chandra, Ewen Munro, V. Koneti Rao, and Carrie L. Lucas. Pi3kδ pathway dysregulation and unique features of its inhibition by leniolisib in activated pi3kδ syndrome and beyond. The Journal of Allergy and Clinical Immunology: In Practice, 12:69-78, Jan 2024. URL: https://doi.org/10.1016/j.jaip.2023.09.016, doi:10.1016/j.jaip.2023.09.016. This article has 34 citations.
+
+20. (cant2024pi3kδpathwaydysregulation pages 1-3): Andrew J. Cant, Anita Chandra, Ewen Munro, V. Koneti Rao, and Carrie L. Lucas. Pi3kδ pathway dysregulation and unique features of its inhibition by leniolisib in activated pi3kδ syndrome and beyond. The Journal of Allergy and Clinical Immunology: In Practice, 12:69-78, Jan 2024. URL: https://doi.org/10.1016/j.jaip.2023.09.016, doi:10.1016/j.jaip.2023.09.016. This article has 34 citations.
+
+21. (berglund2024modulatingthepi3k pages 8-8): Lucinda J. Berglund. Modulating the pi3k signalling pathway in activated pi3k delta syndrome: a clinical perspective. Journal of Clinical Immunology, Dec 2024. URL: https://doi.org/10.1007/s10875-023-01626-0, doi:10.1007/s10875-023-01626-0. This article has 20 citations and is from a domain leading peer-reviewed journal.
+
+22. (jou2002essentialnonredundantrole pages 8-10): Shiann-Tarng Jou, Nick Carpino, Yutaka Takahashi, Roland Piekorz, Jyh-Rong Chao, Neena Carpino, Demin Wang, and James N. Ihle. Essential, nonredundant role for the phosphoinositide 3-kinase p110δ in signaling by the b-cell receptor complex. Molecular and Cellular Biology, 22:8580-8591, Dec 2002. URL: https://doi.org/10.1128/mcb.22.24.8580-8591.2002, doi:10.1128/mcb.22.24.8580-8591.2002. This article has 480 citations and is from a domain leading peer-reviewed journal.
+
+23. (nguyen2023humanpik3r1mutations pages 24-25): Tina Nguyen, Anthony Lau, Julia Bier, Kristen C. Cooke, Helen Lenthall, Stephanie Ruiz-Diaz, Danielle T. Avery, Henry Brigden, David Zahra, William A Sewell, Luke Droney, Satoshi Okada, Takaki Asano, Hassan Abolhassani, Zahra Chavoshzadeh, Roshini S. Abraham, Nipunie Rajapakse, Eric W. Klee, Joseph A. Church, Andrew Williams, Melanie Wong, Christoph Burkhart, Gulbu Uzel, David R. Croucher, David E. James, Cindy S. Ma, Robert Brink, Stuart G. Tangye, and Elissa K. Deenick. Human pik3r1 mutations disrupt lymphocyte differentiation to cause activated pi3kδ syndrome 2. The Journal of Experimental Medicine, Mar 2023. URL: https://doi.org/10.1084/jem.20221020, doi:10.1084/jem.20221020. This article has 32 citations.
+
+24. (wright2024theimportanceof pages 4-6): Brock Wright, Samuel King, and Cenk Suphioglu. The importance of phosphoinositide 3-kinase in neuroinflammation. International Journal of Molecular Sciences, 25:11638, Oct 2024. URL: https://doi.org/10.3390/ijms252111638, doi:10.3390/ijms252111638. This article has 43 citations.
+
+25. (de2024leniolisibanovel pages 2-4): Surya K. De. Leniolisib: a novel treatment for activated phosphoinositide-3 kinase delta syndrome. Frontiers in Pharmacology, Feb 2024. URL: https://doi.org/10.3389/fphar.2024.1337436, doi:10.3389/fphar.2024.1337436. This article has 12 citations.
+
+26. (johnson2023ioa244isa pages 15-16): Zoë Johnson, Chiara Tarantelli, Elisa Civanelli, Luciano Cascione, Filippo Spriano, Amy Fraser, Pritom Shah, Tyzoon Nomanbhoy, Sara Napoli, Andrea Rinaldi, Karolina Niewola-Staszkowska, Michael Lahn, Dominique Perrin, Mathias Wenes, Denis Migliorini, Francesco Bertoni, Lars van der Veen, and Giusy Di Conza. Ioa-244 is a non–atp-competitive, highly selective, tolerable pi3k delta inhibitor that targets solid tumors and breaks immune tolerance. Cancer Research Communications, 3:576-591, Apr 2023. URL: https://doi.org/10.1158/2767-9764.crc-22-0477, doi:10.1158/2767-9764.crc-22-0477. This article has 33 citations and is from a peer-reviewed journal.
+
+## Citations
+
+1. ijspeert2024hyperactivationofthe pages 2-4
+2. jou2002essentialnonredundantrole pages 4-8
+3. de2024leniolisibanovel pages 1-2
+4. ijspeert2024hyperactivationofthe pages 1-2
+5. jou2002essentialnonredundantrole pages 1-2
+6. jou2002essentialnonredundantrole pages 2-4
+7. jou2002essentialnonredundantrole pages 8-10
+8. wright2024theimportanceof pages 4-6
+9. de2024leniolisibanovel pages 2-4
+10. https://www.uniprot.org/uniprotkb/O00329/
+11. https://doi.org/10.1128/mcb.22.24.8580-8591.2002
+12. https://doi.org/10.4049/jimmunol.2400032
+13. https://doi.org/10.1093/immadv/ltae009
+14. https://doi.org/10.1158/2767-9764.crc-22-0477
+15. https://doi.org/10.3389/fphar.2024.1337436
+16. https://doi.org/10.1016/j.jaip.2023.09.016
+17. https://doi.org/10.1093/immadv/ltae009,
+18. https://doi.org/10.1017/s1462399405009361,
+19. https://doi.org/10.1158/2767-9764.crc-22-0477,
+20. https://doi.org/10.1128/mcb.22.24.8580-8591.2002,
+21. https://doi.org/10.4049/jimmunol.2400032,
+22. https://doi.org/10.3389/fphar.2024.1337436,
+23. https://doi.org/10.1016/j.jaip.2023.09.016,
+24. https://doi.org/10.1007/s10875-023-01626-0,
+25. https://doi.org/10.1084/jem.20221020,
+26. https://doi.org/10.3390/ijms252111638,

--- a/genes/human/PIK3CD/PIK3CD-notes.md
+++ b/genes/human/PIK3CD/PIK3CD-notes.md
@@ -1,0 +1,50 @@
+# PIK3CD curation notes
+
+## 2026-05-12 Falcon integration
+
+Generated Falcon deep research at `PIK3CD-deep-research-falcon.md` and used it with
+UniProt plus cached publications to complete the initialized GO review.
+
+Core synthesis: PIK3CD encodes p110delta, a leukocyte-enriched class IA PI3K
+catalytic subunit. The central molecular function is PI(4,5)P2 3-kinase
+activity producing PIP3 in p85-family regulatory complexes at receptor-activated
+membranes. Falcon summarizes this as: [file:human/PIK3CD/PIK3CD-deep-research-falcon.md
+"**PIK3CD** encodes the catalytic subunit **p110δ** of **class IA phosphoinositide
+3-kinase (PI3Kδ)**, a lipid kinase that produces **PI(3,4,5)P3 (PIP3)** at
+membranes downstream of receptor signaling in immune cells, particularly in
+lymphocytes."] Direct biochemical work also reports that recombinant p110delta
+phosphorylates phosphatidylinositol and associates with p85 [PMID:9235916
+"Recombinant p110delta phosphorylates phosphatidylinositol and coimmunoprecipitates
+with p85."].
+
+The most informative process terms are PI3K/AKT signaling plus immune receptor
+contexts, especially BCR, TCR, and CD28. Falcon frames the receptor context as
+[file:human/PIK3CD/PIK3CD-deep-research-falcon.md "In immune cells, class IA PI3K
+(including p110δ) propagates signaling downstream of **BCR, TCR, CD28, ICOS,
+CD19, BAFF-R, CD40**"] and UniProt separately records BCR and TCR requirements
+[file:human/PIK3CD/PIK3CD-uniprot.txt "Required for B-cell receptor (BCR) signaling."]
+[file:human/PIK3CD/PIK3CD-uniprot.txt "Required for T-cell receptor (TCR) signaling."].
+
+Broad immune, chemotaxis, endothelial migration, angiogenesis, mast-cell,
+neutrophil, NK-cell, and cytokine-production annotations were retained as
+non-core where supported. The main evidence is that PI3Kdelta participates in
+multiple leukocyte outputs [PMID:20940048 "PI3Kδ participates in the
+development, activation and migration of T cells and NK cells."] and myeloid
+activities [PMID:20940048 "The role of PI3Kδ in myeloid cell activities, such
+as inflammation driven cell infiltration, neutrophil oxidative burst, immune
+complex mediated macrophage activation, as well as mast cell maturation and
+degranulation, has been well illustrated in various studies."].
+
+Several terms were deliberately modified or marked over-annotated:
+
+- Generic PI3K complex was modified to class IA PI3K complex.
+- Generic kinase/transferase/nucleotide-binding terms were narrowed toward ATP
+  binding or PI(4,5)P2 3-kinase activity.
+- PI3P biosynthetic process was modified because that term implies class
+  III/VPS34-like biology; PIK3CD is primarily a PIP3-producing class IA kinase.
+- Protein binding was marked over-annotated because complex membership and lipid
+  kinase activity are the informative annotations.
+- Protein phosphorylation was modified because PMID:9113989 supports lipid
+  substrate specificity and says p110delta does not phosphorylate p85
+  [PMID:9113989 "Unlike p110alpha, p110delta does not phosphorylate p85 but
+  instead harbors an intrinsic autophosphorylation capacity."].


### PR DESCRIPTION
## Summary

Adds Falcon deep research for human PIK3CD and completes the initialized GO annotation review.

## Changes

- Added `PIK3CD-deep-research-falcon.md` and curation notes.
- Completed all 112 existing annotation reviews.
- Added a core-function synthesis for class IA PI3Kdelta PIP3-producing lipid kinase activity in immune receptor signaling.
- Rendered the updated HTML review page.

## Validation

- `uv run python scripts/validate_deep_research.py genes/human/PIK3CD/PIK3CD-deep-research-falcon.md`
- `just validate human PIK3CD`
- strict local audit: 252 `supported_by` snippets found in source files after whitespace normalization
- `git diff --check`
