### PR TITLE
Add Falcon deep research for MAML1

### DIFF
--- a/genes/human/MAML1/MAML1-ai-review.html
+++ b/genes/human/MAML1/MAML1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>MAML1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q92585" target="_blank" class="term-link">
                         Q92585
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-initialized">
                     INITIALIZED
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="Q92585" data-a="DESCRIPTION: TODO: Add description for MAML1..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="Q92585" data-a="DESCRIPTION: MAML1 is a nuclear transcriptional coactivator in ..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for MAML1</p>
+        <p>MAML1 is a nuclear transcriptional coactivator in the canonical Notch transcription activation complex. It binds Notch intracellular domains with RBPJ/CSL to promote transcription of Notch target genes such as HES1, and can recruit additional coactivator machinery including CREBBP/EP300 and CDK8.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,419 +758,652 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0005654" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0005654" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAML1 is consistently described as a nuclear coactivator that functions in DNA-bound Notch transcription complexes.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Nucleoplasm/nucleus localization is the supported cellular context for the core transcriptional coactivator function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link">
+                                        PMID:11101851
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAML1/MAML1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Nuclear localization is well supported; “nucleoplasm” is reasonable, but exact subnuclear assignment depends on assay context.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003713" target="_blank" class="term-link">
                                     GO:0003713
                                 </a>
                             </span>
                             <span class="term-label">transcription coactivator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0003713" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0003713" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAML1 is a transcriptional coactivator for Notch intracellular domain complexes and also has evidence for p53 coactivator activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The term captures the principal molecular role of MAML1. Direct experiments show MAML1 amplifies Notch-induced HES1 transcription and acts as a coactivator in p53-dependent transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link">
+                                        PMID:11101851
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17317671" target="_blank" class="term-link">
+                                        PMID:17317671
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Overexpression of wild-type MAML1 as well as a mutant, defective in Notch signaling, enhanced the p53-dependent gene induction in mammalian cells, whereas MAML1 knockdown reduced the p53-dependent gene expression.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007221" target="_blank" class="term-link">
                                     GO:0007221
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of transcription of Notch receptor target</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0007221" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0007221" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAML1 positively regulates transcription of Notch receptor target genes through the ICN-RBPJ/CSL-MAML transcriptional activation complex.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Direct reporter and complex-assembly evidence supports MAML1-dependent activation of HES1-class Notch target transcription.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link">
+                                        PMID:11101851
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAML1/MAML1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">The strongest direct evidence for MAML1 typically reads out **transcriptional activation** (HES/HES4/DTX1 reporters; chromatin templates; ChIP-linked acetylation changes), supporting specific transcriptional regulation terms rather than broad pathway-level terms (which can be context- and tissue-dependent).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003713" target="_blank" class="term-link">
                                     GO:0003713
                                 </a>
                             </span>
                             <span class="term-label">transcription coactivator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0003713" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0003713" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAML1&#39;s transcription coactivator activity is supported by direct experimental evidence and is not just an automated inference.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> This is the core molecular function of MAML1 in Notch transcriptional activation.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link">
+                                        PMID:11101851
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007219" target="_blank" class="term-link">
                                     GO:0007219
                                 </a>
                             </span>
                             <span class="term-label">Notch signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0007219" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0007219" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAML1 participates in canonical Notch signaling through the nuclear transcriptional activation step.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The broad pathway term is defensible, but Falcon and the primary literature indicate the more precise curatable process is positive regulation of transcription of Notch target genes.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11390662" target="_blank" class="term-link">
+                                        PMID:11390662
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">hMam-1 stabilizes and participates in the DNA binding complex of the intracellular domain of human Notch1 and a CSL protein.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAML1/MAML1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Prefer “Notch target gene transcription” over broad “Notch signaling pathway”** unless direct pathway-level phenotypes are tied specifically to human MAML1 (not dnMAML pan-inhibition, not paralog redundancy).</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007221" target="_blank" class="term-link">
                                     GO:0007221
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of transcription of Notch receptor target</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0007221" data-r="GO_REF:0000002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0007221" data-r="GO_REF:0000002" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAML1 positively regulates transcription of Notch receptor target genes through the ICN-RBPJ/CSL-MAML transcriptional activation complex.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> This term is more specific than broad Notch signaling pathway and is directly supported by HES1 activation evidence.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link">
+                                        PMID:11101851
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016607" target="_blank" class="term-link">
                                     GO:0016607
                                 </a>
                             </span>
                             <span class="term-label">nuclear speck</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0016607" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0016607" data-r="GO_REF:0000120" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> Nuclear subcompartment localization has been reported, but Falcon cautions that nuclear-body/speck evidence is often overexpression-based.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The broader nuclear/nucleoplasm localization is well supported, whereas nuclear speck is more specific than the strongest direct evidence warrants for a core annotation.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAML1/MAML1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Nuclear bodies/specks:** nuclear-body localization is supported but is **often overexpression-linked**; annotate cautiously at specific subnuclear compartments.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045944" target="_blank" class="term-link">
                                     GO:0045944
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of transcription by RNA polymerase II</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0045944" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0045944" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAML1 positively regulates RNA polymerase II transcription by acting as a coactivator in Notch and p53-responsive transcriptional complexes.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The term is broad, but it is directly supported by MAML1-dependent activation of Notch target transcription and p53-dependent gene induction.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link">
+                                        PMID:11101851
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/17317671" target="_blank" class="term-link">
+                                        PMID:17317671
+                                    </a>
+
+                                </span>
+
+                                <div class="support-text">Overexpression of wild-type MAML1 as well as a mutant, defective in Notch signaling, enhanced the p53-dependent gene induction in mammalian cells, whereas MAML1 knockdown reduced the p53-dependent gene expression.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12370315" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12370315
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of a family of mastermind-like transcriptiona...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1182,71 +1415,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/12370315" target="_blank" class="term-link">
                                         PMID:12370315
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Identification of a family of mastermind-like transcriptional coactivators for mammalian notch receptors.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16530044" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16530044
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structural basis for cooperativity in recruitment of MAML co...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1258,71 +1491,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16530044" target="_blank" class="term-link">
                                         PMID:16530044
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Structural basis for cooperativity in recruitment of MAML coactivators to Notch transcription complexes.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18427106" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18427106
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Notch signaling mediates hypoxia-induced tumor cell migratio...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1334,71 +1567,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/18427106" target="_blank" class="term-link">
                                         PMID:18427106
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Notch signaling mediates hypoxia-induced tumor cell migration and invasion.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19907488" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19907488
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Direct inhibition of the NOTCH transcription factor complex.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1410,71 +1643,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/19907488" target="_blank" class="term-link">
                                         PMID:19907488
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Direct inhibition of the NOTCH transcription factor complex.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20972443" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20972443
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structural and mechanistic insights into cooperative assembl...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1486,71 +1719,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/20972443" target="_blank" class="term-link">
                                         PMID:20972443
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Oct 24. Structural and mechanistic insights into cooperative assembly of dimeric Notch transcription complexes.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22325781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22325781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Conformational locking upon cooperative assembly of notch tr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1562,71 +1795,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/22325781" target="_blank" class="term-link">
                                         PMID:22325781
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Conformational locking upon cooperative assembly of notch transcription complexes.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23022380" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23022380
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     NOTCH1 nuclear interactome reveals key regulators of its tra...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1638,60 +1871,60 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/23022380" target="_blank" class="term-link">
                                         PMID:23022380
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">2012 Sep 27. NOTCH1 nuclear interactome reveals key regulators of its transcriptional activity and oncogenic function.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1703,42 +1936,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010831" target="_blank" class="term-link">
                                     GO:0010831
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of myotube differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1750,42 +1983,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045445" target="_blank" class="term-link">
                                     GO:0045445
                                 </a>
                             </span>
                             <span class="term-label">myoblast differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1797,42 +2030,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051149" target="_blank" class="term-link">
                                     GO:0051149
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of muscle cell differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1844,42 +2077,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060928" target="_blank" class="term-link">
                                     GO:0060928
                                 </a>
                             </span>
                             <span class="term-label">atrioventricular node cell development</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1891,42 +2124,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1938,53 +2171,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32601208" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32601208
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Pharmacological disruption of the Notch transcription factor...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1996,71 +2229,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32601208" target="_blank" class="term-link">
                                         PMID:32601208
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Pharmacological disruption of the Notch transcription factor complex.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007219" target="_blank" class="term-link">
                                     GO:0007219
                                 </a>
                             </span>
                             <span class="term-label">Notch signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32601208" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32601208
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Pharmacological disruption of the Notch transcription factor...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2072,71 +2305,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32601208" target="_blank" class="term-link">
                                         PMID:32601208
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Pharmacological disruption of the Notch transcription factor complex.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045893" target="_blank" class="term-link">
                                     GO:0045893
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of DNA-templated transcription</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32601208" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32601208
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Pharmacological disruption of the Notch transcription factor...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2148,60 +2381,60 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/32601208" target="_blank" class="term-link">
                                         PMID:32601208
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">Pharmacological disruption of the Notch transcription factor complex.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003162" target="_blank" class="term-link">
                                     GO:0003162
                                 </a>
                             </span>
                             <span class="term-label">atrioventricular node development</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2213,42 +2446,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0060928" target="_blank" class="term-link">
                                     GO:0060928
                                 </a>
                             </span>
                             <span class="term-label">atrioventricular node cell development</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2260,42 +2493,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1912394
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2307,42 +2540,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-212356
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2354,42 +2587,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-2197588
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2401,42 +2634,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-2220957
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2448,42 +2681,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-2220964
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2495,42 +2728,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-2220971
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2542,42 +2775,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-2976742
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2589,42 +2822,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-4396371
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2636,42 +2869,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-4396379
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2683,42 +2916,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-4396392
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2730,42 +2963,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-4396393
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2777,42 +3010,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-4396401
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2824,42 +3057,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-4396402
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2871,42 +3104,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8878220
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2918,42 +3151,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-8878237
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2965,42 +3198,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9017835
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3012,42 +3245,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9018542
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3059,42 +3292,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9021406
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3106,42 +3339,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9021451
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3153,42 +3386,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9021480
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3200,42 +3433,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-NUL-2064916
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3247,42 +3480,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-NUL-2065178
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3294,42 +3527,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-NUL-4396363
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3341,42 +3574,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-NUL-9013647
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3388,42 +3621,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-NUL-9013660
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3435,42 +3668,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-NUL-9013699
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3482,42 +3715,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-NUL-9604511
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3529,129 +3762,144 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0002193" target="_blank" class="term-link">
                                     GO:0002193
                                 </a>
                             </span>
                             <span class="term-label">MAML1-RBP-Jkappa- ICN1 complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16510869" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16510869
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Notch coactivator, MAML1, functions as a novel coactivat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0002193" data-r="PMID:16510869" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0002193" data-r="PMID:16510869" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAML1 is a component of the Notch intracellular domain-RBPJ/CSL transcriptional activation complex.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The term is a specific cellular component representation of the canonical Notch transcription activation complex. The original cited PMID is myogenesis-focused, so the support should rely on the direct Notch complex papers.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16510869" target="_blank" class="term-link">
-                                        PMID:16510869
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/11390662" target="_blank" class="term-link">
+                                        PMID:11390662
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">The Notch coactivator, MAML1, functions as a novel coactivator for MEF2C-mediated transcription and is required for normal myogenesis.</div>
-                                
+
+                                <div class="support-text">hMam-1 stabilizes and participates in the DNA binding complex of the intracellular domain of human Notch1 and a CSL protein.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAML1/MAML1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Specific complex membership: NICD–RBPJ–MAML1.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16510869" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16510869
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Notch coactivator, MAML1, functions as a novel coactivat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3663,71 +3911,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16510869" target="_blank" class="term-link">
                                         PMID:16510869
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The Notch coactivator, MAML1, functions as a novel coactivator for MEF2C-mediated transcription and is required for normal myogenesis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16510869" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16510869
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Notch coactivator, MAML1, functions as a novel coactivat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3739,71 +3987,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16510869" target="_blank" class="term-link">
                                         PMID:16510869
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The Notch coactivator, MAML1, functions as a novel coactivator for MEF2C-mediated transcription and is required for normal myogenesis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006468" target="_blank" class="term-link">
                                     GO:0006468
                                 </a>
                             </span>
                             <span class="term-label">protein phosphorylation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16510869" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16510869
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Notch coactivator, MAML1, functions as a novel coactivat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-modify">
@@ -3815,82 +4063,93 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> MISANNOTATION: MAML1 is a transcriptional coactivator, NOT a kinase. The cited paper PMID:16510869 describes MAML1 as a &#34;coactivator for MEF2C-mediated transcription&#34; and &#34;required for normal myogenesis&#34; - no phosphorylation activity is described. PMID:15546612 shows MAML1 &#34;recruits CycC:CDK8 to phosphorylate the Notch ICD&#34; - meaning MAML1 brings the kinase to its substrate, it doesn&#39;t perform phosphorylation itself. UniProt also shows MAML1 is phosphorylated at Ser-314 and Ser-360 (substrate). MAML1&#39;s role in phosphorylation is regulatory (recruiting kinases), not catalytic.
                         </div>
-                        
-                        
-                        
+
+
+
                         <div style="margin-top: 0.5rem;">
                             <strong>Proposed replacements:</strong>
-                            
+
                             <span class="badge">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045859" target="_blank" class="term-link">
                                     regulation of protein kinase activity
                                 </a>
                             </span>
-                            
+
                         </div>
-                        
-                        
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16510869" target="_blank" class="term-link">
-                                        PMID:16510869
+
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15546612" target="_blank" class="term-link">
+                                        PMID:15546612
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">The Notch coactivator, MAML1, functions as a novel coactivator for MEF2C-mediated transcription and is required for normal myogenesis.</div>
-                                
+
+                                <div class="support-text">MAM interacts directly with CDK8 and can cause it to localize to subnuclear foci.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAML1/MAML1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Mediator kinase module recruitment and NICD phosphorylation/turnover.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010831" target="_blank" class="term-link">
                                     GO:0010831
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of myotube differentiation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16510869" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16510869
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Notch coactivator, MAML1, functions as a novel coactivat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3902,71 +4161,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16510869" target="_blank" class="term-link">
                                         PMID:16510869
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The Notch coactivator, MAML1, functions as a novel coactivator for MEF2C-mediated transcription and is required for normal myogenesis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045944" target="_blank" class="term-link">
                                     GO:0045944
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of transcription by RNA polymerase II</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16510869" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16510869
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Notch coactivator, MAML1, functions as a novel coactivat...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3978,71 +4237,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/16510869" target="_blank" class="term-link">
                                         PMID:16510869
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">The Notch coactivator, MAML1, functions as a novel coactivator for MEF2C-mediated transcription and is required for normal myogenesis.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11101851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MAML1, a human homologue of Drosophila mastermind, is a tran...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4054,71 +4313,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link">
                                         PMID:11101851
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">MAML1, a human homologue of Drosophila mastermind, is a transcriptional co-activator for NOTCH receptors.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11390662" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11390662
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A human protein with sequence similarity to Drosophila maste...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4130,71 +4389,71 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11390662" target="_blank" class="term-link">
                                         PMID:11390662
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">A human protein with sequence similarity to Drosophila mastermind coordinates the nuclear form of notch and a CSL protein to build a transcriptional activator complex on target promoters.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9874765" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9874765
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     CIR, a corepressor linking the DNA binding factor CBF1 to th...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4206,1217 +4465,1953 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/9874765" target="_blank" class="term-link">
                                         PMID:9874765
                                     </a>
-                                    
+
                                 </span>
-                                
+
                                 <div class="support-text">CIR, a corepressor linking the DNA binding factor CBF1 to the histone deacetylase complex.</div>
-                                
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019901" target="_blank" class="term-link">
                                     GO:0019901
                                 </a>
                             </span>
                             <span class="term-label">protein kinase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15546612" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15546612
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mastermind recruits CycC:CDK8 to phosphorylate the Notch ICD...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0019901" data-r="PMID:15546612" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0019901" data-r="PMID:15546612" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAML1 binds/recruits CDK8 in the Notch transcription complex to promote Notch intracellular domain phosphorylation and turnover.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> This is a specific and informative interaction term supported by the CDK8 recruitment paper, unlike generic protein binding rows.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/15546612" target="_blank" class="term-link">
                                         PMID:15546612
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">Mastermind recruits CycC:CDK8 to phosphorylate the Notch ICD and coordinate activation with turnover.</div>
-                                
+
+                                <div class="support-text">MAM interacts directly with CDK8 and can cause it to localize to subnuclear foci.</div>
+
                             </div>
-                            
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAML1/MAML1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Mediator kinase module recruitment and NICD phosphorylation/turnover.</div>
+
+                            </div>
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042605" target="_blank" class="term-link">
                                     GO:0042605
                                 </a>
                             </span>
                             <span class="term-label">peptide antigen binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17317671" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17317671
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The notch regulator MAML1 interacts with p53 and functions a...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0042605" data-r="PMID:17317671" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0042605" data-r="PMID:17317671" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> The cited paper shows MAML1 interaction with p53 and transcriptional coactivator activity, not peptide antigen binding.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Peptide antigen binding is unsupported and appears to be an erroneous interpretation of a p53 interaction/coactivator paper.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/17317671" target="_blank" class="term-link">
                                         PMID:17317671
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">2007 Feb 22. The notch regulator MAML1 interacts with p53 and functions as a coactivator.</div>
-                                
+
+                                <div class="support-text">MAML1-p53 interaction involves the N-terminal region of MAML1 and the DNA-binding domain of p53, and we use a chromatin immunoprecipitation assay to show that MAML1 is part of the activator complex that binds to native p53-response elements within the promoter of the p53 target genes.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003713" target="_blank" class="term-link">
                                     GO:0003713
                                 </a>
                             </span>
                             <span class="term-label">transcription coactivator activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11101851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MAML1, a human homologue of Drosophila mastermind, is a tran...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0003713" data-r="PMID:11101851" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0003713" data-r="PMID:11101851" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAML1 is a transcriptional coactivator for Notch receptor intracellular domains and RBPJ/CSL.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> This direct experimental annotation captures the principal molecular function of MAML1.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link">
                                         PMID:11101851
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">MAML1, a human homologue of Drosophila mastermind, is a transcriptional co-activator for NOTCH receptors.</div>
-                                
+
+                                <div class="support-text">MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11101851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MAML1, a human homologue of Drosophila mastermind, is a tran...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0005634" data-r="PMID:11101851" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0005634" data-r="PMID:11101851" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAML1 is a nuclear protein that acts in nuclear Notch transcription complexes.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Nuclear localization is the supported cellular context for the core transcriptional coactivator function.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link">
                                         PMID:11101851
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">MAML1, a human homologue of Drosophila mastermind, is a transcriptional co-activator for NOTCH receptors.</div>
-                                
+
+                                <div class="support-text">MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007219" target="_blank" class="term-link">
                                     GO:0007219
                                 </a>
                             </span>
                             <span class="term-label">Notch signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11101851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MAML1, a human homologue of Drosophila mastermind, is a tran...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0007219" data-r="PMID:11101851" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0007219" data-r="PMID:11101851" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAML1 acts in the nuclear transcriptional arm of the Notch signaling pathway.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The broad pathway term is acceptable as context, but the more specific curated process is activation of Notch target gene transcription.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link">
                                         PMID:11101851
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">MAML1, a human homologue of Drosophila mastermind, is a transcriptional co-activator for NOTCH receptors.</div>
-                                
+
+                                <div class="support-text">MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045944" target="_blank" class="term-link">
                                     GO:0045944
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of transcription by RNA polymerase II</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11101851
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MAML1, a human homologue of Drosophila mastermind, is a tran...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0045944" data-r="PMID:11101851" data-act="PENDING">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0045944" data-r="PMID:11101851" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAML1 positively regulates RNA polymerase II transcription as a Notch transcriptional coactivator.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Reporter and complex-assembly evidence support MAML1-dependent activation of Notch target transcription.
+                        </div>
+
+
+
                         <div class="supported-by">
                             <div class="supported-by-title">Supporting Evidence:</div>
-                            
+
                             <div class="support-item">
                                 <span class="support-ref">
-                                    
+
                                     <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link">
                                         PMID:11101851
                                     </a>
-                                    
+
                                 </span>
-                                
-                                <div class="support-text">MAML1, a human homologue of Drosophila mastermind, is a transcriptional co-activator for NOTCH receptors.</div>
-                                
+
+                                <div class="support-text">MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.</div>
+
                             </div>
-                            
+
                         </div>
-                        
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MAML1 is a nuclear transcriptional coactivator for Notch intracellular domain-RBPJ/CSL complexes. It forms a DNA-bound transcriptional activation complex that promotes HES1-class Notch target gene transcription, and it also has direct evidence for p53 coactivator activity.</h3>
+                <span class="vote-buttons" data-g="Q92585" data-a="FUNCTION: MAML1 is a nuclear transcriptional coactivator for..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0003713" target="_blank" class="term-link">
+                            transcription coactivator activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007221" target="_blank" class="term-link">
+                                positive regulation of transcription of Notch receptor target
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045944" target="_blank" class="term-link">
+                                positive regulation of transcription by RNA polymerase II
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                nucleoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link">
+                                PMID:11101851
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/17317671" target="_blank" class="term-link">
+                                PMID:17317671
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">Overexpression of wild-type MAML1 as well as a mutant, defective in Notch signaling, enhanced the p53-dependent gene induction in mammalian cells, whereas MAML1 knockdown reduced the p53-dependent gene expression.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MAML1/MAML1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">MAML1 is better captured by Notch transcription coactivator/complex-associated terms than by a broad “protein binding” annotation alone.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MAML1 directly binds/recruits CDK8 in the Notch transcription complex, coupling Notch transcriptional activation to Notch intracellular domain phosphorylation and turnover. This is a specific binding function and should not be collapsed into generic protein binding.</h3>
+                <span class="vote-buttons" data-g="Q92585" data-a="FUNCTION: MAML1 directly binds/recruits CDK8 in the Notch tr..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019901" target="_blank" class="term-link">
+                            protein kinase binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045859" target="_blank" class="term-link">
+                                regulation of protein kinase activity
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
+                                nucleoplasm
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/15546612" target="_blank" class="term-link">
+                                PMID:15546612
+                            </a>
+
+                        </span>
+
+                        <div class="finding-text">MAM interacts directly with CDK8 and can cause it to localize to subnuclear foci.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MAML1/MAML1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Mediator kinase module recruitment and NICD phosphorylation/turnover.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
                             GO_REF:0000024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on curation of immunofluorescence data</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" target="_blank" class="term-link">
                             PMID:11101851
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MAML1, a human homologue of Drosophila mastermind, is a transcriptional co-activator for NOTCH receptors.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MAML1 binds Notch intracellular domains, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies Notch-induced HES1 transcription.</div>
+
+                        <div class="finding-text">"MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11390662" target="_blank" class="term-link">
                             PMID:11390662
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A human protein with sequence similarity to Drosophila mastermind coordinates the nuclear form of notch and a CSL protein to build a transcriptional activator complex on target promoters.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Human MAML1 stabilizes and participates in the DNA-binding complex of intracellular Notch1 and CSL.</div>
+
+                        <div class="finding-text">"hMam-1 stabilizes and participates in the DNA binding complex of the intracellular domain of human Notch1 and a CSL protein."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12370315" target="_blank" class="term-link">
                             PMID:12370315
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification of a family of mastermind-like transcriptional coactivators for mammalian notch receptors.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15546612" target="_blank" class="term-link">
                             PMID:15546612
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mastermind recruits CycC:CDK8 to phosphorylate the Notch ICD and coordinate activation with turnover.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Mastermind/MAML binds CDK8 and helps recruit the kinase machinery that phosphorylates Notch intracellular domain.</div>
+
+                        <div class="finding-text">"MAM interacts directly with CDK8 and can cause it to localize to subnuclear foci."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16510869" target="_blank" class="term-link">
                             PMID:16510869
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Notch coactivator, MAML1, functions as a novel coactivator for MEF2C-mediated transcription and is required for normal myogenesis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16530044" target="_blank" class="term-link">
                             PMID:16530044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structural basis for cooperativity in recruitment of MAML coactivators to Notch transcription complexes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17317671" target="_blank" class="term-link">
                             PMID:17317671
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The notch regulator MAML1 interacts with p53 and functions as a coactivator.</div>
-                
-                
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MAML1 interacts with p53 and acts as a transcriptional coactivator on p53 target genes, supporting coactivator activity but not peptide antigen binding.</div>
+
+                        <div class="finding-text">"MAML1-p53 interaction involves the N-terminal region of MAML1 and the DNA-binding domain of p53, and we use a chromatin immunoprecipitation assay to show that MAML1 is part of the activator complex that binds to native p53-response elements within the promoter of the p53 target genes."</div>
+
+                    </li>
+
+                </ul>
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18427106" target="_blank" class="term-link">
                             PMID:18427106
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Notch signaling mediates hypoxia-induced tumor cell migration and invasion.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19907488" target="_blank" class="term-link">
                             PMID:19907488
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Direct inhibition of the NOTCH transcription factor complex.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20972443" target="_blank" class="term-link">
                             PMID:20972443
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structural and mechanistic insights into cooperative assembly of dimeric Notch transcription complexes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22325781" target="_blank" class="term-link">
                             PMID:22325781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Conformational locking upon cooperative assembly of notch transcription complexes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23022380" target="_blank" class="term-link">
                             PMID:23022380
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NOTCH1 nuclear interactome reveals key regulators of its transcriptional activity and oncogenic function.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32601208" target="_blank" class="term-link">
                             PMID:32601208
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Pharmacological disruption of the Notch transcription factor complex.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9874765" target="_blank" class="term-link">
                             PMID:9874765
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CIR, a corepressor linking the DNA binding factor CBF1 to the histone deacetylase complex.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:human/MAML1/MAML1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research on MAML1 GO-relevant functions</div>
+
+
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <div class="finding-statement">MAML1 is best modeled as a Notch transcription coactivator and complex-associated regulator rather than a generic protein-binding protein.</div>
+
+                        <div class="finding-text">"MAML1 is better captured by Notch transcription coactivator/complex-associated terms than by a broad “protein binding” annotation alone."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Notch target-gene transcription terms are more precise than broad Notch pathway terms for MAML1&#39;s direct role.</div>
+
+                        <div class="finding-text">"**Prefer “Notch target gene transcription” over broad “Notch signaling pathway”** unless direct pathway-level phenotypes are tied specifically to human MAML1 (not dnMAML pan-inhibition, not paralog redundancy)."</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <div class="finding-statement">Nuclear speck/nuclear body annotations should be curated cautiously.</div>
+
+                        <div class="finding-text">"**Nuclear bodies/specks:** nuclear-body localization is supported but is **often overexpression-linked**; annotate cautiously at specific subnuclear compartments."</div>
+
+                    </li>
+
+                </ul>
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         Reactome:R-HSA-1912394
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NICD1 in complex with RBPJ (CSL) recruits MAML</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-212356
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Formation of CSL-NICD coactivator complex</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-2197588
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NICD2 binds RBPJ and MAML in the nucleus</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-2220957
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NOTCH1 PEST domain mutants coactivator complex binds CDK8:CCNC</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-2220964
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NICD1 PEST domain mutants in complex with RBPJ (CSL) bind MAML</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-2220971
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CDK8 phosphorylates NICD1 PEST domain mutants</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-2976742
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NOTCH2 coactivator complex binds FCER2 promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-4396371
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NOTCH1 Coactivator Complex binds MYC promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-4396379
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NOTCH1 Coactivator Complex binds HES5 promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-4396392
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NOTCH1 PEST domain mutants bind HES1 promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-4396393
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NOTCH1 PEST domain mutants bind MYC promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-4396401
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NOTCH1 PEST domain mutants bind HES5 promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-4396402
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NOTCH1 PEST domain mutants bind promoters of HEY genes</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8878220
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3 binds the NOTCH1 coactivator complex</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-8878237
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">RUNX3:NOTCH1 coactivator complex binds the HES1 gene promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9017835
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NOTCH1 coactivator complex binds NOTCH3 gene</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9018542
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NOTCH3 coactivator complex binds DLGAP5 gene promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9021406
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NOTCH3 coactivator complex binds PBX1 gene promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9021451
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NOTCH1,NOTCH3 coactivator complex binds PLXND1 gene promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9021480
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NOTCH3 coactivator complex binds WWC1 (Kibra) gene promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-NUL-2064916
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MAML recruits CDK8:CCNC to xNICD1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-NUL-2065178
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">CDK8 phosphorylates xNICD1</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-NUL-4396363
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">mNICD1 Chimeric Enhancer Complex binds Hes1 promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-NUL-9013647
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NICD3 binds RBPJ and MAML in the nucleus</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-NUL-9013660
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Notch3 coactivator complex binds Hes1 gene promoter</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-NUL-9013699
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">NICD4 binds RBPJ and MAML in the nucleus</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-NUL-9604511
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Notch4 binds FLT4 gene promoter</div>
-                
-                
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which MAML1 developmental annotations are directly supported by human MAML1-specific experiments rather than pan-MAML or Notch pathway perturbation?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q92585" data-a="Q: Which MAML1 developmental annotations are directly..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Are endogenous MAML1 nuclear bodies equivalent to nuclear specks in the contexts represented by GOA annotations?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="Q92585" data-a="Q: Are endogenous MAML1 nuclear bodies equivalent to ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Use endogenous-tagged MAML1 with Notch activation time courses to map nuclear subcompartment localization and distinguish nucleoplasm, nuclear body, and nuclear speck assignments.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q92585" data-a="EXPERIMENT: Use endogenous-tagged MAML1 with Notch activation ..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Perform MAML1-specific rescue after knockout at representative Notch, p53, and myogenic target genes to separate direct MAML1 functions from broader Notch pathway or paralog-redundant effects.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="Q92585" data-a="EXPERIMENT: Perform MAML1-specific rescue after knockout at re..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MAML1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q92585" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-12T16:03:15.806817'<br />
+end_time: '2026-05-12T16:34:44.985399'<br />
+duration_seconds: 1889.18<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 38</p>
+<hr />
+<h2 id="question">Question</h2>
+<p>Concise GO annotation research for human MAML1 / UniProt Q92585. Focus only on GO-relevant evidence for MAML1/Mastermind-like protein 1: transcription coactivator activity in the NOTCH intracellular domain-CSL/RBPJ/RBPSUH transcriptional activation complex; positive regulation of transcription of Notch receptor target genes (for example HES1) versus broader Notch signaling pathway terms; nuclear/nucleoplasm/nuclear speck localization and the specific MAML1-RBP-Jkappa-ICN1 complex; interactions with NOTCH1-4, RBPJ/RBPSUH, CREBBP/CBP, CDK8/Cyclin C, TP53 and whether these support specific terms over generic protein binding; roles in phosphorylation/turnover of NOTCH intracellular domain, chromatin/nucleosome acetylation at Notch enhancers, p53 coactivation, myogenic differentiation, heart/atrioventricular node development, and any caveats for over-broad developmental annotations or high-throughput protein binding. Include PMID/DOI citations and keep under 1500 words.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<p>Concise GO annotation research for human MAML1 / UniProt Q92585. Focus only on GO-relevant evidence for MAML1/Mastermind-like protein 1: transcription coactivator activity in the NOTCH intracellular domain-CSL/RBPJ/RBPSUH transcriptional activation complex; positive regulation of transcription of Notch receptor target genes (for example HES1) versus broader Notch signaling pathway terms; nuclear/nucleoplasm/nuclear speck localization and the specific MAML1-RBP-Jkappa-ICN1 complex; interactions with NOTCH1-4, RBPJ/RBPSUH, CREBBP/CBP, CDK8/Cyclin C, TP53 and whether these support specific terms over generic protein binding; roles in phosphorylation/turnover of NOTCH intracellular domain, chromatin/nucleosome acetylation at Notch enhancers, p53 coactivation, myogenic differentiation, heart/atrioventricular node development, and any caveats for over-broad developmental annotations or high-throughput protein binding. Include PMID/DOI citations and keep under 1500 words.</p>
+<h2 id="concise-go-annotation-research-report-human-maml1-mastermind-like-protein-1-uniprot-q92585">Concise GO annotation research report: Human <strong>MAML1</strong> (Mastermind-like protein 1), UniProt <strong>Q92585</strong></h2>
+<h3 id="scope-and-intent">Scope and intent</h3>
+<p>This report summarizes <strong>GO-relevant</strong> evidence for MAML1, emphasizing (i) its <strong>specific transcription coactivator role</strong> in the <strong>nuclear NOTCH intracellular domain (NICD/ICN)–CSL/RBPJ</strong> activation complex, (ii) <strong>positive regulation of transcription of canonical Notch target genes</strong> (e.g., HES family), (iii) <strong>nuclear subcompartment localization</strong> evidence, (iv) recruitment of <strong>EP300/CREBBP (p300/CBP)</strong> and <strong>Mediator kinase module (CDK8–Cyclin C)</strong>, and (v) evidence/caveats for broader developmental or high-throughput “binding” style annotations.</p>
+<h3 id="key-concepts-and-go-relevant-definitions-current-understanding">Key concepts and GO-relevant definitions (current understanding)</h3>
+<p><strong>Canonical Notch transcription activation complex (NTC).</strong> After Notch receptor activation and cleavage, NICD enters the nucleus and forms a <strong>DNA-bound ternary complex</strong> with <strong>RBPJ/CSL</strong> and <strong>Mastermind-like (MAML)</strong> proteins; this complex recruits coactivators and enables transcription of Notch target genes. Primary and review sources emphasize that MAML proteins act as <strong>core coactivators</strong> of NICD–RBPJ complexes rather than generic interactors. (wu2000maml1ahuman pages 2-3, wu2002identificationofa pages 2-3, hall2022thestructurebinding pages 1-2)</p>
+<p><strong>GO emphasis: “positive regulation of transcription of Notch target genes” vs broad “Notch signaling.”</strong> The strongest direct evidence for MAML1 typically reads out <strong>transcriptional activation</strong> (HES/HES4/DTX1 reporters; chromatin templates; ChIP-linked acetylation changes), supporting specific transcriptional regulation terms rather than broad pathway-level terms (which can be context- and tissue-dependent). (wu2000maml1ahuman pages 2-3, rogers2020maml1dependentnotchresponsivegenes pages 1-2)</p>
+<p><strong>Coactivator recruitment at chromatin.</strong> MAML1 is a scaffold-like coactivator that supports Notch-driven transcription by recruiting/activating histone acetyltransferases (<strong>p300/CBP</strong>) and linking to Mediator kinase module components (<strong>CDK8–Cyclin C</strong>), coupling transcriptional activation with <strong>NICD phosphorylation and turnover</strong>. (ribeiro2009transcriptionalmechanismsby pages 3-4, hansson2009thetranscriptionalcoactivator pages 1-1, ribeiro2009gsk3βisa pages 1-2, hall2022thestructurebinding pages 1-2)</p>
+<h3 id="molecular-function-mf-specific-coactivator-activity-in-the-nicdrbpjcsl-complex">Molecular function (MF): specific coactivator activity in the NICD–RBPJ/CSL complex</h3>
+<p><strong>Ternary complex assembly and specificity.</strong> Seminal work demonstrated that MAML1 forms a <strong>DNA-binding complex</strong> with <strong>ICN (NICD)</strong> and <strong>RBP-Jκ (RBPJ/CSL)</strong> and functions as a <strong>transcriptional co-activator</strong> for Notch receptors; it enhances Notch-induced transcription from a HES1 promoter reporter, and dominant-negative MAML1 reduces activation. (Wu et al., 2000, <em>Nat Genet</em>, Dec 2000, DOI: https://doi.org/10.1038/82644) (wu2000maml1ahuman pages 2-3)</p>
+<p><strong>NOTCH1–4 interaction breadth.</strong> Wu et al. reported that MAML1 can bind ICN1 and also interacts with ICN2–4 in vitro, supporting annotations consistent with coactivator activity across mammalian Notch intracellular domains in canonical transcriptional activation contexts (carefully: intracellular domains, not membrane receptors). (wu2000maml1ahuman pages 2-3)</p>
+<p><strong>Prefer complex/coactivator terms over generic “protein binding.”</strong> Because the core evidence is <strong>functional (reporter activation) + mechanistic (ternary complex formation)</strong>, MAML1 is better captured by Notch transcription coactivator/complex-associated terms than by a broad “protein binding” annotation alone. (wu2000maml1ahuman pages 2-3, wu2002identificationofa pages 2-3)</p>
+<h3 id="biological-process-bp-positive-regulation-of-transcription-of-notch-target-genes-eg-hes-family">Biological process (BP): positive regulation of transcription of Notch target genes (e.g., HES family)</h3>
+<p><strong>HES1-class transcriptional outcomes.</strong> In the original characterization, MAML1 amplified NOTCH-induced transcription and specifically enhanced HES1 promoter activation, while dominant-negative MAML1 reduced it—direct functional support for <strong>positive regulation of transcription of Notch target genes</strong>. (wu2000maml1ahuman pages 2-3)</p>
+<p><strong>Genetic requirement for Notch-responsive target gene induction.</strong> In Jurkat T-ALL cells, <strong>MAML1 knockout</strong> eliminated Notch-responsive activation of representative targets (HES4, DTX1) and mapped essential regions for Notch-dependent induction; reduced transcription associated with reduced histone acetylation at targets (see below). (Rogers et al., 2020, <em>Mol Cell Biol</em>, May 2020, DOI: https://doi.org/10.1128/mcb.00014-20) (rogers2020maml1dependentnotchresponsivegenes pages 1-2)</p>
+<p><strong>Caveat: promoter vs enhancer dependencies.</strong> The same study showed promoter-proximal and enhancer-regulated targets can have different cofactor requirements (e.g., p300-HAT fusion rescue at one locus but not another), arguing for careful selection of GO BP terms focused on transcriptional regulation rather than over-generalizing to all Notch pathway outputs. (rogers2020varyingcofactorrequirements pages 1-5, rogers2020maml1dependentnotchresponsivegenes pages 1-2)</p>
+<h3 id="cellular-component-cc-nucleus-nucleoplasm-nuclear-bodiesspeckles-and-complex-localization">Cellular component (CC): nucleus, nucleoplasm, nuclear bodies/speckles, and complex localization</h3>
+<p><strong>Nuclear localization is robust.</strong> MAML proteins are nuclear and contain an NLS; nuclear localization is consistent with their role in DNA-bound NICD–RBPJ transcriptional activation. (ribeiro2009transcriptionalmechanismsby pages 2-3)</p>
+<p><strong>Nuclear bodies / PML-associated structures (with caveats).</strong> MAML1 was observed to localize to nuclear bodies and to relocalize ICN1 (and, in other work, p300 and acetylated histones) to nuclear bodies. However, several observations rely on overexpression and nuclear-body composition can vary (e.g., not always PML-positive), so “nuclear speck/PML body” annotations should be conservative unless supported by endogenous localization. (wu2000maml1ahuman pages 2-3, hansson2009thetranscriptionalcoactivator pages 1-1, wu2002identificationofa pages 2-3)</p>
+<p><strong>Specific complex membership: NICD–RBPJ–MAML1.</strong> Evidence supports MAML1 as a component of the <strong>Notch transcription activation complex</strong> rather than a generic nuclear complex, including biochemical purification/complex assembly logic in foundational work. (wu2002identificationofa pages 2-3, hall2022thestructurebinding pages 1-2)</p>
+<h3 id="chromatin-and-transcriptional-machinery-ep300crebbp-and-mediator-kinase-module-cdk8cyclin-c">Chromatin and transcriptional machinery: EP300/CREBBP and Mediator kinase module (CDK8–Cyclin C)</h3>
+<p><strong>Recruitment/activation of p300/CBP and histone acetylation.</strong> Primary experimental evidence indicates MAML1 recruits p300 to DNA–CSL–NICD complexes, binds p300 (C/H3 domain), and that p300–MAML1 complexes acetylate histone H3/H4 tails on chromatin in vitro; MAML1 also potentiates p300 autoacetylation and HAT activity, with correlated localization of MAML1/p300/acetylated histones to nuclear bodies. (Hansson et al., 2009, <em>Nucleic Acids Res</em>, Mar 2009, DOI: https://doi.org/10.1093/nar/gkp163) (hansson2009thetranscriptionalcoactivator pages 1-1, hansson2009thetranscriptionalcoactivator pages 9-10)</p>
+<p><strong>H3K27 acetylation at Notch-responsive loci.</strong> In Jurkat T-ALL, loss of MAML1 reduced Notch target gene expression together with decreased H3K27 acetylation, consistent with MAML1-dependent acetyltransferase activity at Notch-responsive chromatin. (rogers2020varyingcofactorrequirements pages 1-5, rogers2020maml1dependentnotchresponsivegenes pages 1-2)</p>
+<p><strong>Mediator kinase module recruitment and NICD phosphorylation/turnover.</strong> Multiple sources support that MAML1 interacts with/recruits <strong>CDK8</strong> (often discussed with Cyclin C as the Mediator kinase module), which phosphorylates serines in the NICD PEST domain and promotes proteasomal turnover linked to FBW7-mediated degradation—supporting GO BP terms around regulation of NICD stability/turnover in the transcription complex context. (ribeiro2009transcriptionalmechanismsby pages 3-4, ribeiro2009gsk3βisa pages 1-2, hall2022thestructurebinding pages 1-2)</p>
+<h3 id="notch-independent-but-go-relevant-transcriptional-coactivation-tp53">Notch-independent but GO-relevant transcriptional coactivation: TP53</h3>
+<p><strong>Direct p53 coactivator function.</strong> Zhao et al. showed MAML1 interacts with p53 (N-terminus of MAML1 with p53 DNA-binding domain), occupies native p53 response elements (ChIP), enhances p53-dependent gene induction, and knockdown reduces p53-dependent gene expression; MAML1 also increased p53 half-life and enhanced phosphorylation/acetylation after DNA damage. (Zhao et al., 2007, <em>J Biol Chem</em>, Apr 2007, DOI: https://doi.org/10.1074/jbc.M608974200) (zhao2007thenotchregulator pages 1-2)</p>
+<p><strong>GO implication.</strong> These data support <strong>specific “transcription coactivator activity” in a p53 context</strong>, but curators should not conflate this with Notch complex membership; separate MF/BP annotations are warranted. (zhao2007thenotchregulator pages 1-2)</p>
+<h3 id="recent-developments-20232024-and-real-world-implementation-context">Recent developments (2023–2024) and real-world implementation context</h3>
+<p><strong>Therapeutic targeting of the Notch transcription complex (NTC).</strong> A 2023 T-ALL review lists agents that disrupt the Notch transcription complex via MAML1/NTC interference, including <strong>SAHM1</strong> (stapled peptide interfering with MAML1 binding to the NTC) and <strong>NADI-351</strong> (described as disrupting the NTC). While not providing new mechanistic data itself, it reflects expert synthesis of an application direction: targeting <strong>NICD–RBPJ–MAML1</strong> transcriptional output rather than upstream cleavage. (Toribio &amp; González-García, 2023, <em>Int J Mol Sci</em>, Jan 2023, DOI: https://doi.org/10.3390/ijms24021383) (toribio2023notchpartnersin pages 5-6)</p>
+<p><strong>Pharmacologic modulation of Notch loss-of-function phenotypes (HDAC axis).</strong> In a 2024 in vivo intestinal context, Dai et al. showed that the HDAC inhibitor <strong>valproic acid</strong> could prevent intestinal consequences caused by Notch dimerization deficiency and by gamma-secretase inhibitors, highlighting real-world translational interplay between Notch transcriptional output and chromatin repression machinery. (Dai et al., 2024, <em>PLOS Genet</em>, Dec 2024, DOI: https://doi.org/10.1371/journal.pgen.1011486) (dai2024lossofnotch pages 1-2)</p>
+<p><strong>Quantitative transcription-hub model (2024) with Mediator CDK module recruitment.</strong> Live-imaging work in 2024 (Drosophila Mastermind, the orthologous coactivator class) provides a modern mechanistic model consistent with MAML1’s GO-relevant role: Mastermind-containing complexes promote formation of Notch transcription hubs that concentrate factors including the Mediator CDK module; importantly, only a subset of hubs become transcriptionally productive (reported ~37%), and a second signal can raise activation probability (~70%). This supports the idea that coactivator-driven assemblies regulate the probability of transcriptional initiation, and it offers a conceptual framework for how Mediator kinase module recruitment might shape Notch target transcription dynamics. (DeHaro-Arbona et al., 2024, <em>eLife</em>, May 2024, DOI: https://doi.org/10.7554/eLife.92083.3) (deharoarbona2024dynamicmodesof pages 1-2, deharoarbona2024dynamicmodesof pages 15-17)</p>
+<h3 id="annotation-caveats-avoid-over-broad-terms-avoid-htp-only-binding">Annotation caveats (avoid over-broad terms; avoid HTP-only binding)</h3>
+<ol>
+<li><strong>Prefer “Notch target gene transcription” over broad “Notch signaling pathway”</strong> unless direct pathway-level phenotypes are tied specifically to human MAML1 (not dnMAML pan-inhibition, not paralog redundancy). (rogers2020maml1dependentnotchresponsivegenes pages 1-2)</li>
+<li><strong>Nuclear bodies/specks:</strong> nuclear-body localization is supported but is <strong>often overexpression-linked</strong>; annotate cautiously at specific subnuclear compartments. (wu2002identificationofa pages 2-3, ribeiro2009transcriptionalmechanismsby pages 2-3)</li>
+<li><strong>Complex vs binding:</strong> many interactions (NOTCH1-4 ICD, RBPJ, p300/CBP, CDK8) are best captured as <strong>functional complex membership/coactivator recruitment</strong> rather than generic “protein binding,” because functional readouts (reporters, chromatin transcription, acetylation, KO) exist. (wu2000maml1ahuman pages 2-3, hansson2009thetranscriptionalcoactivator pages 1-1)</li>
+</ol>
+<h3 id="evidence-to-annotation-map-summary">Evidence-to-annotation map (summary)</h3>
+<table>
+<thead>
+<tr>
+<th>GO aspect (MF/BP/CC)</th>
+<th>Suggested GO term label (not GO ID)</th>
+<th>Evidence summary (1 sentence)</th>
+<th>Key experimental system/assay</th>
+<th>Representative paper (authors, year, journal)</th>
+<th>DOI/URL</th>
+<th>Caveats for annotation breadth/HTP</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>MF</td>
+<td>transcription coactivator activity, RNA polymerase II transcription factor binding</td>
+<td>Human MAML1 binds NICD and RBPJ/CSL to form the canonical Notch ternary complex and amplifies HES1-class reporter activation, supporting a specific coactivator role rather than generic protein binding. (wu2000maml1ahuman pages 2-3, wu2002identificationofa pages 2-3)</td>
+<td>GST pulldown, co-IP, EMSA/co-shift, luciferase reporter</td>
+<td>Wu et al., 2000, <em>Nature Genetics</em>; Wu et al., 2002, <em>MCB</em></td>
+<td>https://doi.org/10.1038/82644 ; https://doi.org/10.1128/MCB.22.21.7688-7700.2002</td>
+<td>Prefer specific Notch transcription-complex/coactivator terms over broad “protein binding”; avoid inferring noncanonical coactivator functions from Notch assays alone.</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>positive regulation of transcription of Notch receptor target genes</td>
+<td>MAML1 is required for activation of canonical Notch targets (HES1/HES4/DTX1 contexts), and knockout or dominant-negative constructs block induction. (wu2000maml1ahuman pages 2-3, rogers2020maml1dependentnotchresponsivegenes pages 1-2)</td>
+<td>Jagged/NICD-responsive reporters, Jurkat MAML1 knockout and rescue</td>
+<td>Wu et al., 2000, <em>Nature Genetics</em>; Rogers et al., 2020, <em>MCB</em></td>
+<td>https://doi.org/10.1038/82644 ; https://doi.org/10.1128/MCB.00014-20</td>
+<td>Strongest support is for positive regulation of transcription of Notch target genes, not necessarily for every broader “Notch signaling pathway” child term.</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>nucleus / nucleoplasm</td>
+<td>MAML1 is a nuclear protein with an NLS and functions in nuclear Notch transcription complexes on DNA/chromatin. (ribeiro2009transcriptionalmechanismsby pages 2-3)</td>
+<td>Localization studies, domain analysis, chromatin transcription assays</td>
+<td>Ribeiro &amp; Wallberg, 2009, <em>Current Protein &amp; Peptide Science</em></td>
+<td>https://doi.org/10.2174/138920309789630543</td>
+<td>Nuclear localization is well supported; “nucleoplasm” is reasonable, but exact subnuclear assignment depends on assay context.</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>nuclear body / nuclear speck / PML body-associated localization</td>
+<td>MAML1 localizes to nuclear bodies and can relocalize ICN1, p300, and acetylated histones there, but much of this evidence uses overexpression and not all bodies are PML-positive. (wu2000maml1ahuman pages 2-3, hansson2009thetranscriptionalcoactivator pages 1-1, wu2002identificationofa pages 2-3)</td>
+<td>Fluorescence colocalization, overexpression microscopy</td>
+<td>Wu et al., 2000, <em>Nature Genetics</em>; Hansson et al., 2009, <em>NAR</em></td>
+<td>https://doi.org/10.1038/82644 ; https://doi.org/10.1093/nar/gkp163</td>
+<td>Use caution with “nuclear speck” or “PML body” annotations because nuclear-body formation is partly overexpression-based and may not reflect a constitutive endogenous compartment.</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>Notch transcription activation complex</td>
+<td>Endogenous and reconstituted data support MAML1 as a component of the DNA-bound NICD–RBPJ/CSL activation complex, including ICN1 and also ICN2-4 binding. (wu2000maml1ahuman pages 2-3, wu2002identificationofa pages 2-3)</td>
+<td>Size-exclusion chromatography, co-IP, in vitro complex assembly</td>
+<td>Wu et al., 2002, <em>MCB</em></td>
+<td>https://doi.org/10.1128/MCB.22.21.7688-7700.2002</td>
+<td>This is stronger than generic “protein-containing complex”; annotate the specific Notch activation complex when possible.</td>
+</tr>
+<tr>
+<td>MF/BP</td>
+<td>NOTCH1-4 intracellular domain binding in activation complex context</td>
+<td>MAML1 directly interacts with ICN1 and can bind ICN2-4, supporting receptor-family breadth within canonical Notch transcriptional activation. (wu2000maml1ahuman pages 2-3, wu2002identificationofa pages 2-3)</td>
+<td>GST pulldown, reporter assays across ICN1-4</td>
+<td>Wu et al., 2000, <em>Nature Genetics</em>; Wu et al., 2002, <em>MCB</em></td>
+<td>https://doi.org/10.1038/82644 ; https://doi.org/10.1128/MCB.22.21.7688-7700.2002</td>
+<td>Binding evidence is strongest for intracellular domains in canonical transcription assays; avoid overextending to all receptor contexts or surface-signaling steps.</td>
+</tr>
+<tr>
+<td>MF/BP</td>
+<td>CREBBP/EP300 recruitment and chromatin acetylation at Notch-regulated loci</td>
+<td>MAML1 recruits p300/CBP to DNA-CSL-NICD complexes, stimulates p300 autoacetylation/HAT activity, and supports H3/H4 acetylation and H3K27ac at Notch-responsive promoters/enhancers. (rogers2020varyingcofactorrequirements pages 1-5, ribeiro2009transcriptionalmechanismsby pages 3-4, hansson2009thetranscriptionalcoactivator pages 1-1)</td>
+<td>In vitro chromatin transcription, HAT assays, ChIP/acetylation readouts, KO-rescue</td>
+<td>Hansson et al., 2009, <em>NAR</em>; Rogers et al., 2020, <em>MCB</em></td>
+<td>https://doi.org/10.1093/nar/gkp163 ; https://doi.org/10.1128/MCB.00014-20</td>
+<td>Strong support for coactivator-mediated recruitment/activation of acetyltransferase activity; do not over-annotate MAML1 itself as the acetyltransferase.</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>regulation of Notch intracellular domain phosphorylation / turnover</td>
+<td>MAML1 recruits CDK8/cyclin C-associated machinery that promotes NICD PEST phosphorylation and subsequent FBW7-linked degradation, coupling transcriptional activation to NICD turnover. (ribeiro2009transcriptionalmechanismsby pages 3-4, ribeiro2009gsk3βisa pages 1-2, rogers2020maml1dependentnotchresponsivegenes pages 1-2)</td>
+<td>Biochemical interaction studies, chromatin assays, mechanistic genetics/review synthesis</td>
+<td>Hansson et al., 2009, <em>NAR</em>; Rogers et al., 2020, <em>MCB</em></td>
+<td>https://doi.org/10.1093/nar/gkp163 ; https://doi.org/10.1128/MCB.00014-20</td>
+<td>Best treated as regulation of NICD stability/turnover in the Notch transcription complex; evidence is partly mechanistic synthesis rather than a single direct human loss-of-function experiment.</td>
+</tr>
+<tr>
+<td>MF/BP</td>
+<td>TP53 coactivator activity / positive regulation of p53 target gene transcription</td>
+<td>MAML1 directly interacts with p53, occupies p53-response elements, increases p53 half-life and phosphorylation/acetylation, and enhances p53-dependent transcription independently of Notch. (zhao2007thenotchregulator pages 1-2, ribeiro2009transcriptionalmechanismsby pages 4-5)</td>
+<td>ChIP, p53 reporter assays, knockdown/overexpression, DNA damage assays</td>
+<td>Zhao et al., 2007, <em>JBC</em></td>
+<td>https://doi.org/10.1074/jbc.M608974200</td>
+<td>This supports specific p53 coactivator terms, not generic protein binding; keep separate from canonical Notch annotations.</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>positive regulation of myogenic differentiation</td>
+<td>MAML1 has reported Notch-independent coactivator activity with MEF2C in myogenesis, supporting a possible myogenic BP annotation if direct human evidence is curated. (ribeiro2009transcriptionalmechanismsby pages 3-4, ribeiro2009transcriptionalmechanismsby pages 1-2)</td>
+<td>Biochemical interaction/function studies summarized in review</td>
+<td>Ribeiro &amp; Wallberg, 2009, <em>Current Protein &amp; Peptide Science</em></td>
+<td>https://doi.org/10.2174/138920309789630543</td>
+<td>Evidence here is largely review-level and cross-species/contextual; weaker than canonical Notch evidence and should be curated conservatively.</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>heart / atrioventricular node development</td>
+<td>Cardiac phenotypes from dominant-negative MAML or pathway-level studies implicate MAML-dependent Notch signaling in AV node development, but direct attribution to human MAML1 is indirect. (dai2024lossofnotch pages 1-2, toribio2023notchpartnersin pages 5-6)</td>
+<td>Mouse developmental genetics, pathway perturbation, review synthesis</td>
+<td>MacGrogan et al., 2018, <em>Nat Rev Cardiol</em>; Zhou &amp; Liu, 2013, <em>Braz J Med Biol Res</em></td>
+<td>https://doi.org/10.1038/s41569-018-0100-2 ; https://doi.org/10.1590/1414-431X20133177</td>
+<td>Avoid over-broad human MAML1 developmental annotations unless supported by direct gene-specific experiments; dnMAML affects multiple MAML paralogs/pathway output.</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table maps the strongest GO-relevant candidate annotations for human MAML1 to representative evidence and highlights where annotations should remain specific rather than broad. It is useful for distinguishing well-supported canonical Notch coactivator functions from weaker or context-dependent developmental and localization claims.</em></p>
+<h3 id="representative-publications-with-dates-and-urls">Representative publications (with dates and URLs)</h3>
+<ul>
+<li>Wu et al. “MAML1… transcriptional co-activator for NOTCH receptors.” <em>Nature Genetics</em> (Dec 2000). https://doi.org/10.1038/82644 (wu2000maml1ahuman pages 2-3)</li>
+<li>Wu et al. “Identification of a family of Mastermind-like transcriptional coactivators…” <em>Molecular and Cellular Biology</em> (Nov 2002). https://doi.org/10.1128/MCB.22.21.7688-7700.2002 (wu2002identificationofa pages 2-3)</li>
+<li>Hansson et al. “MAML1 regulates p300 autoacetylation and HAT activity.” <em>Nucleic Acids Research</em> (Mar 2009). https://doi.org/10.1093/nar/gkp163 (hansson2009thetranscriptionalcoactivator pages 1-1)</li>
+<li>Zhao et al. “MAML1 interacts with p53 and functions as a coactivator.” <em>J Biol Chem</em> (Apr 2007). https://doi.org/10.1074/jbc.M608974200 (zhao2007thenotchregulator pages 1-2)</li>
+<li>Rogers et al. “MAML1-dependent Notch-responsive genes…” <em>Molecular and Cellular Biology</em> (May 2020). https://doi.org/10.1128/mcb.00014-20 (rogers2020maml1dependentnotchresponsivegenes pages 1-2)</li>
+<li>Toribio &amp; González-García. “Notch partners in T-ALL pathogenesis.” <em>Int J Mol Sci</em> (Jan 2023). https://doi.org/10.3390/ijms24021383 (toribio2023notchpartnersin pages 5-6)</li>
+<li>DeHaro-Arbona et al. “Dynamic modes of Notch transcription hubs…” <em>eLife</em> (May 2024). https://doi.org/10.7554/eLife.92083.3 (deharoarbona2024dynamicmodesof pages 1-2, deharoarbona2024dynamicmodesof pages 15-17)</li>
+<li>Dai et al. “Loss of Notch dimerization perturbs intestinal homeostasis…” <em>PLOS Genetics</em> (Dec 2024). https://doi.org/10.1371/journal.pgen.1011486 (dai2024lossofnotch pages 1-2)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(wu2000maml1ahuman pages 2-3): Lizi Wu, Jon C. Aster, Stephen C. Blacklow, Robert Lake, Spyros Artavanis-Tsakonas, and James D. Griffin. Maml1, a human homologue of drosophila mastermind, is a transcriptional co-activator for notch receptors. Nature Genetics, 26:484-489, Dec 2000. URL: https://doi.org/10.1038/82644, doi:10.1038/82644. This article has 757 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(wu2002identificationofa pages 2-3): Lizi Wu, Tao Sun, Karla Kobayashi, Ping Gao, and James D. Griffin. Identification of a family of mastermind-like transcriptional coactivators for mammalian notch receptors. Molecular and Cellular Biology, 22:7688-7700, Nov 2002. URL: https://doi.org/10.1128/mcb.22.21.7688-7700.2002, doi:10.1128/mcb.22.21.7688-7700.2002. This article has 365 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hall2022thestructurebinding pages 1-2): Daniel Hall, Benedetto Daniele Giaimo, Sung-Soo Park, Wiebke Hemmer, Tobias Friedrich, Francesca Ferrante, Marek Bartkuhn, Zhenyu Yuan, Franz Oswald, Tilman Borggrefe, Jean-François Rual, and Rhett A. Kovall. The structure, binding and function of a notch transcription complex involving rbpj and the epigenetic reader protein l3mbtl3. Nucleic Acids Research, 50:13083-13099, Feb 2022. URL: https://doi.org/10.1093/nar/gkac1137, doi:10.1093/nar/gkac1137. This article has 10 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rogers2020maml1dependentnotchresponsivegenes pages 1-2): Julia M. Rogers, Bingqian Guo, Emily D. Egan, Jon C. Aster, Karen Adelman, and Stephen C. Blacklow. Maml1-dependent notch-responsive genes exhibit differing cofactor requirements for transcriptional activation. May 2020. URL: https://doi.org/10.1128/mcb.00014-20, doi:10.1128/mcb.00014-20. This article has 12 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ribeiro2009transcriptionalmechanismsby pages 3-4): M. Saint Just Ribeiro and A. Wallberg. Transcriptional mechanisms by the coregulator maml1. Current Protein &amp; Peptide Science, 10:570-576, Dec 2009. URL: https://doi.org/10.2174/138920309789630543, doi:10.2174/138920309789630543. This article has 32 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hansson2009thetranscriptionalcoactivator pages 1-1): Magnus L. Hansson, Anita E. Popko-Ścibor, Mariana Saint Just Ribeiro, Beverley M. Dancy, Mikael J. Lindberg, Philip A. Cole, and Annika E. Wallberg. The transcriptional coactivator maml1 regulates p300 autoacetylation and hat activity. Nucleic Acids Research, 37:2996-3006, Mar 2009. URL: https://doi.org/10.1093/nar/gkp163, doi:10.1093/nar/gkp163. This article has 76 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ribeiro2009gsk3βisa pages 1-2): M. Saint Just Ribeiro, M. L. Hansson, M. J. Lindberg, A. E. Popko-Scibor, and A. E. Wallberg. Gsk3β is a negative regulator of the transcriptional coactivator maml1. Nucleic Acids Research, 37:6691-6700, Sep 2009. URL: https://doi.org/10.1093/nar/gkp724, doi:10.1093/nar/gkp724. This article has 45 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rogers2020varyingcofactorrequirements pages 1-5): Julia M. Rogers, Bingqian Guo, Emily D. Egan, Jon C. Aster, Karen Adelman, and Stephen C. Blacklow. Varying co-factor requirements for maml1-dependent transcription at different notch-responsive target genes. bioRxiv, Jan 2020. URL: https://doi.org/10.1101/2020.01.13.905612, doi:10.1101/2020.01.13.905612. This article has 0 citations.</p>
+</li>
+<li>
+<p>(ribeiro2009transcriptionalmechanismsby pages 2-3): M. Saint Just Ribeiro and A. Wallberg. Transcriptional mechanisms by the coregulator maml1. Current Protein &amp; Peptide Science, 10:570-576, Dec 2009. URL: https://doi.org/10.2174/138920309789630543, doi:10.2174/138920309789630543. This article has 32 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(hansson2009thetranscriptionalcoactivator pages 9-10): Magnus L. Hansson, Anita E. Popko-Ścibor, Mariana Saint Just Ribeiro, Beverley M. Dancy, Mikael J. Lindberg, Philip A. Cole, and Annika E. Wallberg. The transcriptional coactivator maml1 regulates p300 autoacetylation and hat activity. Nucleic Acids Research, 37:2996-3006, Mar 2009. URL: https://doi.org/10.1093/nar/gkp163, doi:10.1093/nar/gkp163. This article has 76 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zhao2007thenotchregulator pages 1-2): Yongtong Zhao, Rebecca B. Katzman, Laurie M. Delmolino, Ishfaq Bhat, Ying Zhang, Channabasavaiah B. Gurumurthy, Aleksandra Germaniuk-Kurowska, Honey V. Reddi, Aharon Solomon, Mu-Sheng Zeng, Aisha Kung, Hui Ma, Qingshen Gao, Goberdhan Dimri, Adina Stanculescu, Lucio Miele, Lizi Wu, James D. Griffin, David E. Wazer, Hamid Band, and Vimla Band. The notch regulator maml1 interacts with p53 and functions as a coactivator*. Journal of Biological Chemistry, 282:11969-11981, Apr 2007. URL: https://doi.org/10.1074/jbc.m608974200, doi:10.1074/jbc.m608974200. This article has 105 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(toribio2023notchpartnersin pages 5-6): María Luisa Toribio and Sara González-García. Notch partners in the long journey of t-all pathogenesis. International Journal of Molecular Sciences, 24:1383, Jan 2023. URL: https://doi.org/10.3390/ijms24021383, doi:10.3390/ijms24021383. This article has 23 citations.</p>
+</li>
+<li>
+<p>(dai2024lossofnotch pages 1-2): Quanhui Dai, Kristina Preusse, Danni Yu, Rhett A. Kovall, Konrad Thorner, Xinhua Lin, and Raphael Kopan. Loss of notch dimerization perturbs intestinal homeostasis by a mechanism involving hdac activity. PLOS Genetics, 20:e1011486, Dec 2024. URL: https://doi.org/10.1371/journal.pgen.1011486, doi:10.1371/journal.pgen.1011486. This article has 2 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(deharoarbona2024dynamicmodesof pages 1-2): F Javier DeHaro-Arbona, Charalambos Roussos, Sarah Baloul, Jonathan Townson, María J Gómez Lamarca, and Sarah Bray. Dynamic modes of notch transcription hubs conferring memory and stochastic activation revealed by live imaging the co-activator mastermind. eLife, May 2024. URL: https://doi.org/10.7554/elife.92083.3, doi:10.7554/elife.92083.3. This article has 22 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(deharoarbona2024dynamicmodesof pages 15-17): F Javier DeHaro-Arbona, Charalambos Roussos, Sarah Baloul, Jonathan Townson, María J Gómez Lamarca, and Sarah Bray. Dynamic modes of notch transcription hubs conferring memory and stochastic activation revealed by live imaging the co-activator mastermind. eLife, May 2024. URL: https://doi.org/10.7554/elife.92083.3, doi:10.7554/elife.92083.3. This article has 22 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ribeiro2009transcriptionalmechanismsby pages 4-5): M. Saint Just Ribeiro and A. Wallberg. Transcriptional mechanisms by the coregulator maml1. Current Protein &amp; Peptide Science, 10:570-576, Dec 2009. URL: https://doi.org/10.2174/138920309789630543, doi:10.2174/138920309789630543. This article has 32 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ribeiro2009transcriptionalmechanismsby pages 1-2): M. Saint Just Ribeiro and A. Wallberg. Transcriptional mechanisms by the coregulator maml1. Current Protein &amp; Peptide Science, 10:570-576, Dec 2009. URL: https://doi.org/10.2174/138920309789630543, doi:10.2174/138920309789630543. This article has 32 citations and is from a peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>ribeiro2009transcriptionalmechanismsby pages 2-3</li>
+<li>zhao2007thenotchregulator pages 1-2</li>
+<li>toribio2023notchpartnersin pages 5-6</li>
+<li>dai2024lossofnotch pages 1-2</li>
+<li>wu2002identificationofa pages 2-3</li>
+<li>hansson2009thetranscriptionalcoactivator pages 1-1</li>
+<li>hall2022thestructurebinding pages 1-2</li>
+<li>ribeiro2009transcriptionalmechanismsby pages 3-4</li>
+<li>rogers2020varyingcofactorrequirements pages 1-5</li>
+<li>hansson2009thetranscriptionalcoactivator pages 9-10</li>
+<li>deharoarbona2024dynamicmodesof pages 1-2</li>
+<li>deharoarbona2024dynamicmodesof pages 15-17</li>
+<li>ribeiro2009transcriptionalmechanismsby pages 4-5</li>
+<li>ribeiro2009transcriptionalmechanismsby pages 1-2</li>
+<li>https://doi.org/10.1038/82644</li>
+<li>https://doi.org/10.1128/mcb.00014-20</li>
+<li>https://doi.org/10.1093/nar/gkp163</li>
+<li>https://doi.org/10.1074/jbc.M608974200</li>
+<li>https://doi.org/10.3390/ijms24021383</li>
+<li>https://doi.org/10.1371/journal.pgen.1011486</li>
+<li>https://doi.org/10.7554/eLife.92083.3</li>
+<li>https://doi.org/10.1128/MCB.22.21.7688-7700.2002</li>
+<li>https://doi.org/10.1128/MCB.00014-20</li>
+<li>https://doi.org/10.2174/138920309789630543</li>
+<li>https://doi.org/10.1038/s41569-018-0100-2</li>
+<li>https://doi.org/10.1590/1414-431X20133177</li>
+<li>https://doi.org/10.1038/82644,</li>
+<li>https://doi.org/10.1128/mcb.22.21.7688-7700.2002,</li>
+<li>https://doi.org/10.1093/nar/gkac1137,</li>
+<li>https://doi.org/10.1128/mcb.00014-20,</li>
+<li>https://doi.org/10.2174/138920309789630543,</li>
+<li>https://doi.org/10.1093/nar/gkp163,</li>
+<li>https://doi.org/10.1093/nar/gkp724,</li>
+<li>https://doi.org/10.1101/2020.01.13.905612,</li>
+<li>https://doi.org/10.1074/jbc.m608974200,</li>
+<li>https://doi.org/10.3390/ijms24021383,</li>
+<li>https://doi.org/10.1371/journal.pgen.1011486,</li>
+<li>https://doi.org/10.7554/elife.92083.3,</li>
+</ol>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MAML1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q92585" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="maml1-notes">MAML1 notes</h1>
+<h2 id="falcon-integration-2026-05-12">Falcon integration, 2026-05-12</h2>
+<ul>
+<li>Falcon supports MAML1 as a nuclear transcriptional coactivator in the Notch intracellular domain-RBPJ/CSL activation complex, with direct HES1 transcriptional activation evidence <a href="https://pubmed.ncbi.nlm.nih.gov/11101851" title="MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.">PMID:11101851</a>.</li>
+<li>The review should prefer Notch target-gene transcription terms over a broad pathway-only framing: [file:human/MAML1/MAML1-deep-research-falcon.md "<strong>Prefer “Notch target gene transcription” over broad “Notch signaling pathway”</strong> unless direct pathway-level phenotypes are tied specifically to human MAML1 (not dnMAML pan-inhibition, not paralog redundancy)."].</li>
+<li>Generic protein binding rows are less informative than the specific coactivator, complex-membership, and CDK8-binding evidence. CDK8 binding is supported directly <a href="https://pubmed.ncbi.nlm.nih.gov/15546612" title="MAM interacts directly with CDK8 and can cause it to localize to subnuclear foci.">PMID:15546612</a>.</li>
+<li>The PMID:17317671 peptide antigen binding annotation appears erroneous: the paper supports p53 coactivator activity, not antigen binding <a href="https://pubmed.ncbi.nlm.nih.gov/17317671" title="MAML1-p53 interaction involves the N-terminal region of MAML1 and the DNA-binding domain of p53, and we use a chromatin immunoprecipitation assay to show that MAML1 is part of the activator complex that binds to native p53-response elements within the promoter of the p53 target genes.">PMID:17317671</a>.</li>
+<li>Nuclear/nucleoplasm localization is solid as context, but nuclear speck or nuclear-body assignments should be conservative because Falcon notes that the evidence is often overexpression-linked [file:human/MAML1/MAML1-deep-research-falcon.md "<strong>Nuclear bodies/specks:</strong> nuclear-body localization is supported but is <strong>often overexpression-linked</strong>; annotate cautiously at specific subnuclear compartments."].</li>
+</ul>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -5432,7 +6427,11 @@ status: INITIALIZED
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: &#39;TODO: Add description for MAML1&#39;
+description: &gt;-
+  MAML1 is a nuclear transcriptional coactivator in the canonical Notch
+  transcription activation complex. It binds Notch intracellular domains with
+  RBPJ/CSL to promote transcription of Notch target genes such as HES1, and can
+  recruit additional coactivator machinery including CREBBP/EP300 and CDK8.
 existing_annotations:
   - term:
       id: GO:0005654
@@ -5440,64 +6439,185 @@ existing_annotations:
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MAML1 is consistently described as a nuclear coactivator that functions
+        in DNA-bound Notch transcription complexes.
+      action: ACCEPT
+      reason: &gt;-
+        Nucleoplasm/nucleus localization is the supported cellular context for
+        the core transcriptional coactivator function.
+      supported_by:
+        - reference_id: PMID:11101851
+          supporting_text: &gt;-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
+        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+          supporting_text: &gt;-
+            Nuclear localization is well supported; “nucleoplasm” is
+            reasonable, but exact subnuclear assignment depends on assay
+            context.
   - term:
       id: GO:0003713
       label: transcription coactivator activity
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MAML1 is a transcriptional coactivator for Notch intracellular domain
+        complexes and also has evidence for p53 coactivator activity.
+      action: ACCEPT
+      reason: &gt;-
+        The term captures the principal molecular role of MAML1. Direct
+        experiments show MAML1 amplifies Notch-induced HES1 transcription and
+        acts as a coactivator in p53-dependent transcription.
+      supported_by:
+        - reference_id: PMID:11101851
+          supporting_text: &gt;-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
+        - reference_id: PMID:17317671
+          supporting_text: &gt;-
+            Overexpression of wild-type MAML1 as well as a mutant, defective in
+            Notch signaling, enhanced the p53-dependent gene induction in
+            mammalian cells, whereas MAML1 knockdown reduced the p53-dependent
+            gene expression.
   - term:
       id: GO:0007221
       label: positive regulation of transcription of Notch receptor target
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MAML1 positively regulates transcription of Notch receptor target genes
+        through the ICN-RBPJ/CSL-MAML transcriptional activation complex.
+      action: ACCEPT
+      reason: &gt;-
+        Direct reporter and complex-assembly evidence supports MAML1-dependent
+        activation of HES1-class Notch target transcription.
+      supported_by:
+        - reference_id: PMID:11101851
+          supporting_text: &gt;-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
+        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+          supporting_text: &gt;-
+            The strongest direct evidence for MAML1 typically reads out
+            **transcriptional activation** (HES/HES4/DTX1 reporters; chromatin
+            templates; ChIP-linked acetylation changes), supporting specific
+            transcriptional regulation terms rather than broad pathway-level
+            terms (which can be context- and tissue-dependent).
   - term:
       id: GO:0003713
       label: transcription coactivator activity
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MAML1&#39;s transcription coactivator activity is supported by direct
+        experimental evidence and is not just an automated inference.
+      action: ACCEPT
+      reason: &gt;-
+        This is the core molecular function of MAML1 in Notch transcriptional
+        activation.
+      supported_by:
+        - reference_id: PMID:11101851
+          supporting_text: &gt;-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
   - term:
       id: GO:0007219
       label: Notch signaling pathway
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MAML1 participates in canonical Notch signaling through the nuclear
+        transcriptional activation step.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        The broad pathway term is defensible, but Falcon and the primary
+        literature indicate the more precise curatable process is positive
+        regulation of transcription of Notch target genes.
+      supported_by:
+        - reference_id: PMID:11390662
+          supporting_text: &gt;-
+            hMam-1 stabilizes and participates in the DNA binding complex of
+            the intracellular domain of human Notch1 and a CSL protein.
+        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+          supporting_text: &gt;-
+            **Prefer “Notch target gene transcription” over broad “Notch
+            signaling pathway”** unless direct pathway-level phenotypes are
+            tied specifically to human MAML1 (not dnMAML pan-inhibition, not
+            paralog redundancy).
   - term:
       id: GO:0007221
       label: positive regulation of transcription of Notch receptor target
     evidence_type: IEA
     original_reference_id: GO_REF:0000002
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MAML1 positively regulates transcription of Notch receptor target genes
+        through the ICN-RBPJ/CSL-MAML transcriptional activation complex.
+      action: ACCEPT
+      reason: &gt;-
+        This term is more specific than broad Notch signaling pathway and is
+        directly supported by HES1 activation evidence.
+      supported_by:
+        - reference_id: PMID:11101851
+          supporting_text: &gt;-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
   - term:
       id: GO:0016607
       label: nuclear speck
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        Nuclear subcompartment localization has been reported, but Falcon
+        cautions that nuclear-body/speck evidence is often overexpression-based.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: &gt;-
+        The broader nuclear/nucleoplasm localization is well supported, whereas
+        nuclear speck is more specific than the strongest direct evidence
+        warrants for a core annotation.
+      supported_by:
+        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+          supporting_text: &gt;-
+            **Nuclear bodies/specks:** nuclear-body localization is supported
+            but is **often overexpression-linked**; annotate cautiously at
+            specific subnuclear compartments.
   - term:
       id: GO:0045944
       label: positive regulation of transcription by RNA polymerase II
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MAML1 positively regulates RNA polymerase II transcription by acting as
+        a coactivator in Notch and p53-responsive transcriptional complexes.
+      action: ACCEPT
+      reason: &gt;-
+        The term is broad, but it is directly supported by MAML1-dependent
+        activation of Notch target transcription and p53-dependent gene
+        induction.
+      supported_by:
+        - reference_id: PMID:11101851
+          supporting_text: &gt;-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
+        - reference_id: PMID:17317671
+          supporting_text: &gt;-
+            Overexpression of wild-type MAML1 as well as a mutant, defective in
+            Notch signaling, enhanced the p53-dependent gene induction in
+            mammalian cells, whereas MAML1 knockdown reduced the p53-dependent
+            gene expression.
   - term:
       id: GO:0005515
       label: protein binding
@@ -5508,7 +6628,7 @@ existing_annotations:
       action: PENDING
       supported_by:
         - reference_id: PMID:12370315
-          supporting_text: Identification of a family of mastermind-like 
+          supporting_text: Identification of a family of mastermind-like
             transcriptional coactivators for mammalian notch receptors.
   - term:
       id: GO:0005515
@@ -5520,7 +6640,7 @@ existing_annotations:
       action: PENDING
       supported_by:
         - reference_id: PMID:16530044
-          supporting_text: Structural basis for cooperativity in recruitment of 
+          supporting_text: Structural basis for cooperativity in recruitment of
             MAML coactivators to Notch transcription complexes.
   - term:
       id: GO:0005515
@@ -5532,7 +6652,7 @@ existing_annotations:
       action: PENDING
       supported_by:
         - reference_id: PMID:18427106
-          supporting_text: Notch signaling mediates hypoxia-induced tumor cell 
+          supporting_text: Notch signaling mediates hypoxia-induced tumor cell
             migration and invasion.
   - term:
       id: GO:0005515
@@ -5544,7 +6664,7 @@ existing_annotations:
       action: PENDING
       supported_by:
         - reference_id: PMID:19907488
-          supporting_text: Direct inhibition of the NOTCH transcription factor 
+          supporting_text: Direct inhibition of the NOTCH transcription factor
             complex.
   - term:
       id: GO:0005515
@@ -5556,7 +6676,7 @@ existing_annotations:
       action: PENDING
       supported_by:
         - reference_id: PMID:20972443
-          supporting_text: Oct 24. Structural and mechanistic insights into 
+          supporting_text: Oct 24. Structural and mechanistic insights into
             cooperative assembly of dimeric Notch transcription complexes.
   - term:
       id: GO:0005515
@@ -5568,7 +6688,7 @@ existing_annotations:
       action: PENDING
       supported_by:
         - reference_id: PMID:22325781
-          supporting_text: Conformational locking upon cooperative assembly of 
+          supporting_text: Conformational locking upon cooperative assembly of
             notch transcription complexes.
   - term:
       id: GO:0005515
@@ -5580,7 +6700,7 @@ existing_annotations:
       action: PENDING
       supported_by:
         - reference_id: PMID:23022380
-          supporting_text: 2012 Sep 27. NOTCH1 nuclear interactome reveals key 
+          supporting_text: 2012 Sep 27. NOTCH1 nuclear interactome reveals key
             regulators of its transcriptional activity and oncogenic function.
   - term:
       id: GO:0005634
@@ -5904,13 +7024,23 @@ existing_annotations:
     evidence_type: IDA
     original_reference_id: PMID:16510869
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MAML1 is a component of the Notch intracellular domain-RBPJ/CSL
+        transcriptional activation complex.
+      action: ACCEPT
+      reason: &gt;-
+        The term is a specific cellular component representation of the
+        canonical Notch transcription activation complex. The original cited
+        PMID is myogenesis-focused, so the support should rely on the direct
+        Notch complex papers.
       supported_by:
-        - reference_id: PMID:16510869
-          supporting_text: The Notch coactivator, MAML1, functions as a novel 
-            coactivator for MEF2C-mediated transcription and is required for 
-            normal myogenesis.
+        - reference_id: PMID:11390662
+          supporting_text: &gt;-
+            hMam-1 stabilizes and participates in the DNA binding complex of
+            the intracellular domain of human Notch1 and a CSL protein.
+        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+          supporting_text: &gt;-
+            Specific complex membership: NICD–RBPJ–MAML1.
   - term:
       id: GO:0005515
       label: protein binding
@@ -5921,8 +7051,8 @@ existing_annotations:
       action: PENDING
       supported_by:
         - reference_id: PMID:16510869
-          supporting_text: The Notch coactivator, MAML1, functions as a novel 
-            coactivator for MEF2C-mediated transcription and is required for 
+          supporting_text: The Notch coactivator, MAML1, functions as a novel
+            coactivator for MEF2C-mediated transcription and is required for
             normal myogenesis.
   - term:
       id: GO:0005634
@@ -5934,8 +7064,8 @@ existing_annotations:
       action: PENDING
       supported_by:
         - reference_id: PMID:16510869
-          supporting_text: The Notch coactivator, MAML1, functions as a novel 
-            coactivator for MEF2C-mediated transcription and is required for 
+          supporting_text: The Notch coactivator, MAML1, functions as a novel
+            coactivator for MEF2C-mediated transcription and is required for
             normal myogenesis.
   - term:
       id: GO:0006468
@@ -5958,10 +7088,13 @@ existing_annotations:
         - id: GO:0045859
           label: regulation of protein kinase activity
       supported_by:
-        - reference_id: PMID:16510869
-          supporting_text: The Notch coactivator, MAML1, functions as a novel 
-            coactivator for MEF2C-mediated transcription and is required for 
-            normal myogenesis.
+        - reference_id: PMID:15546612
+          supporting_text: &gt;-
+            MAM interacts directly with CDK8 and can cause it to localize to
+            subnuclear foci.
+        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+          supporting_text: &gt;-
+            Mediator kinase module recruitment and NICD phosphorylation/turnover.
   - term:
       id: GO:0010831
       label: positive regulation of myotube differentiation
@@ -5972,8 +7105,8 @@ existing_annotations:
       action: PENDING
       supported_by:
         - reference_id: PMID:16510869
-          supporting_text: The Notch coactivator, MAML1, functions as a novel 
-            coactivator for MEF2C-mediated transcription and is required for 
+          supporting_text: The Notch coactivator, MAML1, functions as a novel
+            coactivator for MEF2C-mediated transcription and is required for
             normal myogenesis.
   - term:
       id: GO:0045944
@@ -5985,8 +7118,8 @@ existing_annotations:
       action: PENDING
       supported_by:
         - reference_id: PMID:16510869
-          supporting_text: The Notch coactivator, MAML1, functions as a novel 
-            coactivator for MEF2C-mediated transcription and is required for 
+          supporting_text: The Notch coactivator, MAML1, functions as a novel
+            coactivator for MEF2C-mediated transcription and is required for
             normal myogenesis.
   - term:
       id: GO:0005515
@@ -6010,9 +7143,9 @@ existing_annotations:
       action: PENDING
       supported_by:
         - reference_id: PMID:11390662
-          supporting_text: A human protein with sequence similarity to 
-            Drosophila mastermind coordinates the nuclear form of notch and a 
-            CSL protein to build a transcriptional activator complex on target 
+          supporting_text: A human protein with sequence similarity to
+            Drosophila mastermind coordinates the nuclear form of notch and a
+            CSL protein to build a transcriptional activator complex on target
             promoters.
   - term:
       id: GO:0005634
@@ -6024,7 +7157,7 @@ existing_annotations:
       action: PENDING
       supported_by:
         - reference_id: PMID:9874765
-          supporting_text: CIR, a corepressor linking the DNA binding factor 
+          supporting_text: CIR, a corepressor linking the DNA binding factor
             CBF1 to the histone deacetylase complex.
   - term:
       id: GO:0019901
@@ -6032,79 +7165,125 @@ existing_annotations:
     evidence_type: IPI
     original_reference_id: PMID:15546612
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MAML1 binds/recruits CDK8 in the Notch transcription complex to promote
+        Notch intracellular domain phosphorylation and turnover.
+      action: ACCEPT
+      reason: &gt;-
+        This is a specific and informative interaction term supported by the
+        CDK8 recruitment paper, unlike generic protein binding rows.
       supported_by:
         - reference_id: PMID:15546612
-          supporting_text: Mastermind recruits CycC:CDK8 to phosphorylate the 
-            Notch ICD and coordinate activation with turnover.
+          supporting_text: &gt;-
+            MAM interacts directly with CDK8 and can cause it to localize to
+            subnuclear foci.
+        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+          supporting_text: &gt;-
+            Mediator kinase module recruitment and NICD phosphorylation/turnover.
   - term:
       id: GO:0042605
       label: peptide antigen binding
     evidence_type: IPI
     original_reference_id: PMID:17317671
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        The cited paper shows MAML1 interaction with p53 and transcriptional
+        coactivator activity, not peptide antigen binding.
+      action: REMOVE
+      reason: &gt;-
+        Peptide antigen binding is unsupported and appears to be an erroneous
+        interpretation of a p53 interaction/coactivator paper.
       supported_by:
         - reference_id: PMID:17317671
-          supporting_text: 2007 Feb 22. The notch regulator MAML1 interacts with
-            p53 and functions as a coactivator.
+          supporting_text: &gt;-
+            MAML1-p53 interaction involves the N-terminal region of MAML1 and
+            the DNA-binding domain of p53, and we use a chromatin
+            immunoprecipitation assay to show that MAML1 is part of the
+            activator complex that binds to native p53-response elements within
+            the promoter of the p53 target genes.
   - term:
       id: GO:0003713
       label: transcription coactivator activity
     evidence_type: IDA
     original_reference_id: PMID:11101851
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MAML1 is a transcriptional coactivator for Notch receptor intracellular
+        domains and RBPJ/CSL.
+      action: ACCEPT
+      reason: &gt;-
+        This direct experimental annotation captures the principal molecular
+        function of MAML1.
       supported_by:
         - reference_id: PMID:11101851
-          supporting_text: MAML1, a human homologue of Drosophila mastermind, is
-            a transcriptional co-activator for NOTCH receptors.
+          supporting_text: &gt;-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IDA
     original_reference_id: PMID:11101851
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MAML1 is a nuclear protein that acts in nuclear Notch transcription
+        complexes.
+      action: ACCEPT
+      reason: &gt;-
+        Nuclear localization is the supported cellular context for the core
+        transcriptional coactivator function.
       supported_by:
         - reference_id: PMID:11101851
-          supporting_text: MAML1, a human homologue of Drosophila mastermind, is
-            a transcriptional co-activator for NOTCH receptors.
+          supporting_text: &gt;-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
   - term:
       id: GO:0007219
       label: Notch signaling pathway
     evidence_type: IDA
     original_reference_id: PMID:11101851
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MAML1 acts in the nuclear transcriptional arm of the Notch signaling
+        pathway.
+      action: KEEP_AS_NON_CORE
+      reason: &gt;-
+        The broad pathway term is acceptable as context, but the more specific
+        curated process is activation of Notch target gene transcription.
       supported_by:
         - reference_id: PMID:11101851
-          supporting_text: MAML1, a human homologue of Drosophila mastermind, is
-            a transcriptional co-activator for NOTCH receptors.
+          supporting_text: &gt;-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
   - term:
       id: GO:0045944
       label: positive regulation of transcription by RNA polymerase II
     evidence_type: IDA
     original_reference_id: PMID:11101851
     review:
-      summary: &#39;TODO: Review this GOA annotation&#39;
-      action: PENDING
+      summary: &gt;-
+        MAML1 positively regulates RNA polymerase II transcription as a Notch
+        transcriptional coactivator.
+      action: ACCEPT
+      reason: &gt;-
+        Reporter and complex-assembly evidence support MAML1-dependent
+        activation of Notch target transcription.
       supported_by:
         - reference_id: PMID:11101851
-          supporting_text: MAML1, a human homologue of Drosophila mastermind, is
-            a transcriptional co-activator for NOTCH receptors.
+          supporting_text: &gt;-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
 references:
   - id: GO_REF:0000002
     title: Gene Ontology annotation through association of InterPro records with
       GO terms
     findings: []
   - id: GO_REF:0000024
-    title: Manual transfer of experimentally-verified manual GO annotation data 
+    title: Manual transfer of experimentally-verified manual GO annotation data
       to orthologs by curator judgment of sequence similarity
     findings: []
   - id: GO_REF:0000033
@@ -6114,58 +7293,88 @@ references:
     title: Gene Ontology annotation based on curation of immunofluorescence data
     findings: []
   - id: GO_REF:0000107
-    title: Automatic transfer of experimentally verified manual GO annotation 
+    title: Automatic transfer of experimentally verified manual GO annotation
       data to orthologs using Ensembl Compara
     findings: []
   - id: GO_REF:0000120
     title: Combined Automated Annotation using Multiple IEA Methods
     findings: []
   - id: PMID:11101851
-    title: MAML1, a human homologue of Drosophila mastermind, is a 
+    title: MAML1, a human homologue of Drosophila mastermind, is a
       transcriptional co-activator for NOTCH receptors.
-    findings: []
+    findings:
+      - statement: &gt;-
+          MAML1 binds Notch intracellular domains, forms a DNA-binding complex
+          with ICN and RBP-Jkappa, and amplifies Notch-induced HES1
+          transcription.
+        supporting_text: &gt;-
+          MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH
+          receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and
+          amplifies NOTCH-induced transcription of HES1.
   - id: PMID:11390662
-    title: A human protein with sequence similarity to Drosophila mastermind 
-      coordinates the nuclear form of notch and a CSL protein to build a 
+    title: A human protein with sequence similarity to Drosophila mastermind
+      coordinates the nuclear form of notch and a CSL protein to build a
       transcriptional activator complex on target promoters.
-    findings: []
+    findings:
+      - statement: &gt;-
+          Human MAML1 stabilizes and participates in the DNA-binding complex of
+          intracellular Notch1 and CSL.
+        supporting_text: &gt;-
+          hMam-1 stabilizes and participates in the DNA binding complex of the
+          intracellular domain of human Notch1 and a CSL protein.
   - id: PMID:12370315
-    title: Identification of a family of mastermind-like transcriptional 
+    title: Identification of a family of mastermind-like transcriptional
       coactivators for mammalian notch receptors.
     findings: []
   - id: PMID:15546612
-    title: Mastermind recruits CycC:CDK8 to phosphorylate the Notch ICD and 
+    title: Mastermind recruits CycC:CDK8 to phosphorylate the Notch ICD and
       coordinate activation with turnover.
-    findings: []
+    findings:
+      - statement: &gt;-
+          Mastermind/MAML binds CDK8 and helps recruit the kinase machinery that
+          phosphorylates Notch intracellular domain.
+        supporting_text: &gt;-
+          MAM interacts directly with CDK8 and can cause it to localize to
+          subnuclear foci.
   - id: PMID:16510869
-    title: The Notch coactivator, MAML1, functions as a novel coactivator for 
+    title: The Notch coactivator, MAML1, functions as a novel coactivator for
       MEF2C-mediated transcription and is required for normal myogenesis.
     findings: []
   - id: PMID:16530044
-    title: Structural basis for cooperativity in recruitment of MAML 
+    title: Structural basis for cooperativity in recruitment of MAML
       coactivators to Notch transcription complexes.
     findings: []
   - id: PMID:17317671
-    title: The notch regulator MAML1 interacts with p53 and functions as a 
+    title: The notch regulator MAML1 interacts with p53 and functions as a
       coactivator.
-    findings: []
+    findings:
+      - statement: &gt;-
+          MAML1 interacts with p53 and acts as a transcriptional coactivator on
+          p53 target genes, supporting coactivator activity but not peptide
+          antigen binding.
+        supporting_text: &gt;-
+          MAML1-p53 interaction involves the N-terminal region of MAML1 and the
+          DNA-binding domain of p53, and we use a chromatin immunoprecipitation
+          assay to show that MAML1 is part of the activator complex that binds
+          to native p53-response elements within the promoter of the p53 target
+          genes.
   - id: PMID:18427106
-    title: Notch signaling mediates hypoxia-induced tumor cell migration and 
+    title: Notch signaling mediates hypoxia-induced tumor cell migration and
       invasion.
     findings: []
   - id: PMID:19907488
     title: Direct inhibition of the NOTCH transcription factor complex.
     findings: []
   - id: PMID:20972443
-    title: Structural and mechanistic insights into cooperative assembly of 
+    title: Structural and mechanistic insights into cooperative assembly of
       dimeric Notch transcription complexes.
     findings: []
   - id: PMID:22325781
-    title: Conformational locking upon cooperative assembly of notch 
+    title: Conformational locking upon cooperative assembly of notch
       transcription complexes.
     findings: []
   - id: PMID:23022380
-    title: NOTCH1 nuclear interactome reveals key regulators of its 
+    title: NOTCH1 nuclear interactome reveals key regulators of its
       transcriptional activity and oncogenic function.
     findings: []
   - id: PMID:32601208
@@ -6175,6 +7384,31 @@ references:
     title: CIR, a corepressor linking the DNA binding factor CBF1 to the histone
       deacetylase complex.
     findings: []
+  - id: file:human/MAML1/MAML1-deep-research-falcon.md
+    title: Falcon deep research on MAML1 GO-relevant functions
+    findings:
+      - statement: &gt;-
+          MAML1 is best modeled as a Notch transcription coactivator and
+          complex-associated regulator rather than a generic protein-binding
+          protein.
+        supporting_text: &gt;-
+          MAML1 is better captured by Notch transcription
+          coactivator/complex-associated terms than by a broad “protein
+          binding” annotation alone.
+      - statement: &gt;-
+          Notch target-gene transcription terms are more precise than broad
+          Notch pathway terms for MAML1&#39;s direct role.
+        supporting_text: &gt;-
+          **Prefer “Notch target gene transcription” over broad “Notch
+          signaling pathway”** unless direct pathway-level phenotypes are tied
+          specifically to human MAML1 (not dnMAML pan-inhibition, not paralog
+          redundancy).
+      - statement: &gt;-
+          Nuclear speck/nuclear body annotations should be curated cautiously.
+        supporting_text: &gt;-
+          **Nuclear bodies/specks:** nuclear-body localization is supported but
+          is **often overexpression-linked**; annotate cautiously at specific
+          subnuclear compartments.
   - id: Reactome:R-HSA-1912394
     title: NICD1 in complex with RBPJ (CSL) recruits MAML
     findings: []
@@ -6256,13 +7490,91 @@ references:
   - id: Reactome:R-NUL-9604511
     title: Notch4 binds FLT4 gene promoter
     findings: []
+core_functions:
+  - molecular_function:
+      id: GO:0003713
+      label: transcription coactivator activity
+    description: &gt;-
+      MAML1 is a nuclear transcriptional coactivator for Notch intracellular
+      domain-RBPJ/CSL complexes. It forms a DNA-bound transcriptional activation
+      complex that promotes HES1-class Notch target gene transcription, and it
+      also has direct evidence for p53 coactivator activity.
+    directly_involved_in:
+      - id: GO:0007221
+        label: positive regulation of transcription of Notch receptor target
+      - id: GO:0045944
+        label: positive regulation of transcription by RNA polymerase II
+    locations:
+      - id: GO:0005634
+        label: nucleus
+      - id: GO:0005654
+        label: nucleoplasm
+    supported_by:
+      - reference_id: PMID:11101851
+        supporting_text: &gt;-
+          MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH
+          receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and
+          amplifies NOTCH-induced transcription of HES1.
+      - reference_id: PMID:17317671
+        supporting_text: &gt;-
+          Overexpression of wild-type MAML1 as well as a mutant, defective in
+          Notch signaling, enhanced the p53-dependent gene induction in
+          mammalian cells, whereas MAML1 knockdown reduced the p53-dependent
+          gene expression.
+      - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+        supporting_text: &gt;-
+          MAML1 is better captured by Notch transcription
+          coactivator/complex-associated terms than by a broad “protein
+          binding” annotation alone.
+  - molecular_function:
+      id: GO:0019901
+      label: protein kinase binding
+    description: &gt;-
+      MAML1 directly binds/recruits CDK8 in the Notch transcription complex,
+      coupling Notch transcriptional activation to Notch intracellular domain
+      phosphorylation and turnover. This is a specific binding function and
+      should not be collapsed into generic protein binding.
+    directly_involved_in:
+      - id: GO:0045859
+        label: regulation of protein kinase activity
+    locations:
+      - id: GO:0005634
+        label: nucleus
+      - id: GO:0005654
+        label: nucleoplasm
+    supported_by:
+      - reference_id: PMID:15546612
+        supporting_text: &gt;-
+          MAM interacts directly with CDK8 and can cause it to localize to
+          subnuclear foci.
+      - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+        supporting_text: &gt;-
+          Mediator kinase module recruitment and NICD phosphorylation/turnover.
+proposed_new_terms: []
+suggested_questions:
+  - question: &gt;-
+      Which MAML1 developmental annotations are directly supported by human
+      MAML1-specific experiments rather than pan-MAML or Notch pathway
+      perturbation?
+  - question: &gt;-
+      Are endogenous MAML1 nuclear bodies equivalent to nuclear specks in the
+      contexts represented by GOA annotations?
+suggested_experiments:
+  - description: &gt;-
+      Use endogenous-tagged MAML1 with Notch activation time courses to map
+      nuclear subcompartment localization and distinguish nucleoplasm, nuclear
+      body, and nuclear speck assignments.
+  - description: &gt;-
+      Perform MAML1-specific rescue after knockout at representative Notch,
+      p53, and myogenic target genes to separate direct MAML1 functions from
+      broader Notch pathway or paralog-redundant effects.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/MAML1/MAML1-ai-review.html
+++ b/genes/human/MAML1/MAML1-ai-review.html
@@ -819,7 +819,7 @@
 
                                 </span>
 
-                                <div class="support-text">MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.</div>
+                                <div class="support-text">Here we clone MAML1, a human homologue of the Drosophila gene Mastermind, and show that it encodes a protein of 130 kD localizing to nuclear bodies.</div>
 
                             </div>
 
@@ -4054,10 +4054,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-remove">
+                            REMOVE
                         </span>
-                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0006468" data-r="PMID:16510869" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="Q92585" data-a="GO:0006468" data-r="PMID:16510869" data-act="REMOVE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -4065,21 +4065,14 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> MISANNOTATION: MAML1 is a transcriptional coactivator, NOT a kinase. The cited paper PMID:16510869 describes MAML1 as a &#34;coactivator for MEF2C-mediated transcription&#34; and &#34;required for normal myogenesis&#34; - no phosphorylation activity is described. PMID:15546612 shows MAML1 &#34;recruits CycC:CDK8 to phosphorylate the Notch ICD&#34; - meaning MAML1 brings the kinase to its substrate, it doesn&#39;t perform phosphorylation itself. UniProt also shows MAML1 is phosphorylated at Ser-314 and Ser-360 (substrate). MAML1&#39;s role in phosphorylation is regulatory (recruiting kinases), not catalytic.
+                            <strong>Summary:</strong> MISANNOTATION: MAML1 is a transcriptional coactivator, not a kinase, and the cited PMID:16510869 supports MEF2C coactivation/myogenesis rather than protein phosphorylation.
                         </div>
 
 
-
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045859" target="_blank" class="term-link">
-                                    regulation of protein kinase activity
-                                </a>
-                            </span>
-
+                        <div>
+                            <strong>Reason:</strong> The essence of the annotation is not sound: MAML1 does not catalyze protein phosphorylation in this paper. MAML1&#39;s non-catalytic CDK8 recruitment role is already captured separately by the accepted GO:0019901 protein kinase binding row based on PMID:15546612.
                         </div>
+
 
 
                         <div class="supported-by">
@@ -4088,24 +4081,13 @@
                             <div class="support-item">
                                 <span class="support-ref">
 
-                                    <a href="https://pubmed.ncbi.nlm.nih.gov/15546612" target="_blank" class="term-link">
-                                        PMID:15546612
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16510869" target="_blank" class="term-link">
+                                        PMID:16510869
                                     </a>
 
                                 </span>
 
-                                <div class="support-text">MAM interacts directly with CDK8 and can cause it to localize to subnuclear foci.</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:human/MAML1/MAML1-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">Mediator kinase module recruitment and NICD phosphorylation/turnover.</div>
+                                <div class="support-text">Our study thus reveals novel and nonredundant functions for MAML1: It acts as a coactivator for MEF2C transcription and is essential for proper muscle development.</div>
 
                             </div>
 
@@ -5134,19 +5116,6 @@
                 </div>
 
 
-
-                <div class="function-term-group">
-                    <div class="function-term-label">Directly Involved In:</div>
-                    <div class="function-annotations">
-
-                        <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045859" target="_blank" class="term-link">
-                                regulation of protein kinase activity
-                            </a>
-                        </span>
-
-                    </div>
-                </div>
 
 
 
@@ -6449,9 +6418,9 @@ existing_annotations:
       supported_by:
         - reference_id: PMID:11101851
           supporting_text: &gt;-
-            MAML1 binds to the ankyrin repeat domain of all four mammalian
-            NOTCH receptors, forms a DNA-binding complex with ICN and
-            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
+            Here we clone MAML1, a human homologue of the Drosophila gene
+            Mastermind, and show that it encodes a protein of 130 kD
+            localizing to nuclear bodies.
         - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
           supporting_text: &gt;-
             Nuclear localization is well supported; “nucleoplasm” is
@@ -7074,27 +7043,21 @@ existing_annotations:
     original_reference_id: PMID:16510869
     review:
       summary: &gt;-
-        MISANNOTATION: MAML1 is a transcriptional coactivator, NOT a kinase. The cited
-        paper PMID:16510869 describes MAML1 as a &#34;coactivator for MEF2C-mediated transcription&#34;
-        and &#34;required for normal myogenesis&#34; - no phosphorylation activity is described.
-        PMID:15546612 shows MAML1 &#34;recruits CycC:CDK8 to phosphorylate the Notch ICD&#34;
-        - meaning
-        MAML1 brings the kinase to its substrate, it doesn&#39;t perform phosphorylation
-        itself.
-        UniProt also shows MAML1 is phosphorylated at Ser-314 and Ser-360 (substrate).
-        MAML1&#39;s role in phosphorylation is regulatory (recruiting kinases), not catalytic.
-      action: MODIFY
-      proposed_replacement_terms:
-        - id: GO:0045859
-          label: regulation of protein kinase activity
+        MISANNOTATION: MAML1 is a transcriptional coactivator, not a kinase,
+        and the cited PMID:16510869 supports MEF2C coactivation/myogenesis
+        rather than protein phosphorylation.
+      action: REMOVE
+      reason: &gt;-
+        The essence of the annotation is not sound: MAML1 does not catalyze
+        protein phosphorylation in this paper. MAML1&#39;s non-catalytic CDK8
+        recruitment role is already captured separately by the accepted
+        GO:0019901 protein kinase binding row based on PMID:15546612.
       supported_by:
-        - reference_id: PMID:15546612
+        - reference_id: PMID:16510869
           supporting_text: &gt;-
-            MAM interacts directly with CDK8 and can cause it to localize to
-            subnuclear foci.
-        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
-          supporting_text: &gt;-
-            Mediator kinase module recruitment and NICD phosphorylation/turnover.
+            Our study thus reveals novel and nonredundant functions for MAML1:
+            It acts as a coactivator for MEF2C transcription and is essential
+            for proper muscle development.
   - term:
       id: GO:0010831
       label: positive regulation of myotube differentiation
@@ -7534,9 +7497,6 @@ core_functions:
       coupling Notch transcriptional activation to Notch intracellular domain
       phosphorylation and turnover. This is a specific binding function and
       should not be collapsed into generic protein binding.
-    directly_involved_in:
-      - id: GO:0045859
-        label: regulation of protein kinase activity
     locations:
       - id: GO:0005634
         label: nucleus

--- a/genes/human/MAML1/MAML1-ai-review.yaml
+++ b/genes/human/MAML1/MAML1-ai-review.yaml
@@ -5,7 +5,11 @@ status: INITIALIZED
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for MAML1'
+description: >-
+  MAML1 is a nuclear transcriptional coactivator in the canonical Notch
+  transcription activation complex. It binds Notch intracellular domains with
+  RBPJ/CSL to promote transcription of Notch target genes such as HES1, and can
+  recruit additional coactivator machinery including CREBBP/EP300 and CDK8.
 existing_annotations:
   - term:
       id: GO:0005654
@@ -13,64 +17,185 @@ existing_annotations:
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MAML1 is consistently described as a nuclear coactivator that functions
+        in DNA-bound Notch transcription complexes.
+      action: ACCEPT
+      reason: >-
+        Nucleoplasm/nucleus localization is the supported cellular context for
+        the core transcriptional coactivator function.
+      supported_by:
+        - reference_id: PMID:11101851
+          supporting_text: >-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
+        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+          supporting_text: >-
+            Nuclear localization is well supported; “nucleoplasm” is
+            reasonable, but exact subnuclear assignment depends on assay
+            context.
   - term:
       id: GO:0003713
       label: transcription coactivator activity
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MAML1 is a transcriptional coactivator for Notch intracellular domain
+        complexes and also has evidence for p53 coactivator activity.
+      action: ACCEPT
+      reason: >-
+        The term captures the principal molecular role of MAML1. Direct
+        experiments show MAML1 amplifies Notch-induced HES1 transcription and
+        acts as a coactivator in p53-dependent transcription.
+      supported_by:
+        - reference_id: PMID:11101851
+          supporting_text: >-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
+        - reference_id: PMID:17317671
+          supporting_text: >-
+            Overexpression of wild-type MAML1 as well as a mutant, defective in
+            Notch signaling, enhanced the p53-dependent gene induction in
+            mammalian cells, whereas MAML1 knockdown reduced the p53-dependent
+            gene expression.
   - term:
       id: GO:0007221
       label: positive regulation of transcription of Notch receptor target
     evidence_type: IBA
     original_reference_id: GO_REF:0000033
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MAML1 positively regulates transcription of Notch receptor target genes
+        through the ICN-RBPJ/CSL-MAML transcriptional activation complex.
+      action: ACCEPT
+      reason: >-
+        Direct reporter and complex-assembly evidence supports MAML1-dependent
+        activation of HES1-class Notch target transcription.
+      supported_by:
+        - reference_id: PMID:11101851
+          supporting_text: >-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
+        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+          supporting_text: >-
+            The strongest direct evidence for MAML1 typically reads out
+            **transcriptional activation** (HES/HES4/DTX1 reporters; chromatin
+            templates; ChIP-linked acetylation changes), supporting specific
+            transcriptional regulation terms rather than broad pathway-level
+            terms (which can be context- and tissue-dependent).
   - term:
       id: GO:0003713
       label: transcription coactivator activity
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MAML1's transcription coactivator activity is supported by direct
+        experimental evidence and is not just an automated inference.
+      action: ACCEPT
+      reason: >-
+        This is the core molecular function of MAML1 in Notch transcriptional
+        activation.
+      supported_by:
+        - reference_id: PMID:11101851
+          supporting_text: >-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
   - term:
       id: GO:0007219
       label: Notch signaling pathway
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MAML1 participates in canonical Notch signaling through the nuclear
+        transcriptional activation step.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        The broad pathway term is defensible, but Falcon and the primary
+        literature indicate the more precise curatable process is positive
+        regulation of transcription of Notch target genes.
+      supported_by:
+        - reference_id: PMID:11390662
+          supporting_text: >-
+            hMam-1 stabilizes and participates in the DNA binding complex of
+            the intracellular domain of human Notch1 and a CSL protein.
+        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+          supporting_text: >-
+            **Prefer “Notch target gene transcription” over broad “Notch
+            signaling pathway”** unless direct pathway-level phenotypes are
+            tied specifically to human MAML1 (not dnMAML pan-inhibition, not
+            paralog redundancy).
   - term:
       id: GO:0007221
       label: positive regulation of transcription of Notch receptor target
     evidence_type: IEA
     original_reference_id: GO_REF:0000002
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MAML1 positively regulates transcription of Notch receptor target genes
+        through the ICN-RBPJ/CSL-MAML transcriptional activation complex.
+      action: ACCEPT
+      reason: >-
+        This term is more specific than broad Notch signaling pathway and is
+        directly supported by HES1 activation evidence.
+      supported_by:
+        - reference_id: PMID:11101851
+          supporting_text: >-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
   - term:
       id: GO:0016607
       label: nuclear speck
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        Nuclear subcompartment localization has been reported, but Falcon
+        cautions that nuclear-body/speck evidence is often overexpression-based.
+      action: MARK_AS_OVER_ANNOTATED
+      reason: >-
+        The broader nuclear/nucleoplasm localization is well supported, whereas
+        nuclear speck is more specific than the strongest direct evidence
+        warrants for a core annotation.
+      supported_by:
+        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+          supporting_text: >-
+            **Nuclear bodies/specks:** nuclear-body localization is supported
+            but is **often overexpression-linked**; annotate cautiously at
+            specific subnuclear compartments.
   - term:
       id: GO:0045944
       label: positive regulation of transcription by RNA polymerase II
     evidence_type: IEA
     original_reference_id: GO_REF:0000120
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MAML1 positively regulates RNA polymerase II transcription by acting as
+        a coactivator in Notch and p53-responsive transcriptional complexes.
+      action: ACCEPT
+      reason: >-
+        The term is broad, but it is directly supported by MAML1-dependent
+        activation of Notch target transcription and p53-dependent gene
+        induction.
+      supported_by:
+        - reference_id: PMID:11101851
+          supporting_text: >-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
+        - reference_id: PMID:17317671
+          supporting_text: >-
+            Overexpression of wild-type MAML1 as well as a mutant, defective in
+            Notch signaling, enhanced the p53-dependent gene induction in
+            mammalian cells, whereas MAML1 knockdown reduced the p53-dependent
+            gene expression.
   - term:
       id: GO:0005515
       label: protein binding
@@ -477,13 +602,23 @@ existing_annotations:
     evidence_type: IDA
     original_reference_id: PMID:16510869
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MAML1 is a component of the Notch intracellular domain-RBPJ/CSL
+        transcriptional activation complex.
+      action: ACCEPT
+      reason: >-
+        The term is a specific cellular component representation of the
+        canonical Notch transcription activation complex. The original cited
+        PMID is myogenesis-focused, so the support should rely on the direct
+        Notch complex papers.
       supported_by:
-        - reference_id: PMID:16510869
-          supporting_text: The Notch coactivator, MAML1, functions as a novel 
-            coactivator for MEF2C-mediated transcription and is required for 
-            normal myogenesis.
+        - reference_id: PMID:11390662
+          supporting_text: >-
+            hMam-1 stabilizes and participates in the DNA binding complex of
+            the intracellular domain of human Notch1 and a CSL protein.
+        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+          supporting_text: >-
+            Specific complex membership: NICD–RBPJ–MAML1.
   - term:
       id: GO:0005515
       label: protein binding
@@ -531,10 +666,13 @@ existing_annotations:
         - id: GO:0045859
           label: regulation of protein kinase activity
       supported_by:
-        - reference_id: PMID:16510869
-          supporting_text: The Notch coactivator, MAML1, functions as a novel 
-            coactivator for MEF2C-mediated transcription and is required for 
-            normal myogenesis.
+        - reference_id: PMID:15546612
+          supporting_text: >-
+            MAM interacts directly with CDK8 and can cause it to localize to
+            subnuclear foci.
+        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+          supporting_text: >-
+            Mediator kinase module recruitment and NICD phosphorylation/turnover.
   - term:
       id: GO:0010831
       label: positive regulation of myotube differentiation
@@ -605,72 +743,118 @@ existing_annotations:
     evidence_type: IPI
     original_reference_id: PMID:15546612
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MAML1 binds/recruits CDK8 in the Notch transcription complex to promote
+        Notch intracellular domain phosphorylation and turnover.
+      action: ACCEPT
+      reason: >-
+        This is a specific and informative interaction term supported by the
+        CDK8 recruitment paper, unlike generic protein binding rows.
       supported_by:
         - reference_id: PMID:15546612
-          supporting_text: Mastermind recruits CycC:CDK8 to phosphorylate the 
-            Notch ICD and coordinate activation with turnover.
+          supporting_text: >-
+            MAM interacts directly with CDK8 and can cause it to localize to
+            subnuclear foci.
+        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+          supporting_text: >-
+            Mediator kinase module recruitment and NICD phosphorylation/turnover.
   - term:
       id: GO:0042605
       label: peptide antigen binding
     evidence_type: IPI
     original_reference_id: PMID:17317671
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        The cited paper shows MAML1 interaction with p53 and transcriptional
+        coactivator activity, not peptide antigen binding.
+      action: REMOVE
+      reason: >-
+        Peptide antigen binding is unsupported and appears to be an erroneous
+        interpretation of a p53 interaction/coactivator paper.
       supported_by:
         - reference_id: PMID:17317671
-          supporting_text: 2007 Feb 22. The notch regulator MAML1 interacts with
-            p53 and functions as a coactivator.
+          supporting_text: >-
+            MAML1-p53 interaction involves the N-terminal region of MAML1 and
+            the DNA-binding domain of p53, and we use a chromatin
+            immunoprecipitation assay to show that MAML1 is part of the
+            activator complex that binds to native p53-response elements within
+            the promoter of the p53 target genes.
   - term:
       id: GO:0003713
       label: transcription coactivator activity
     evidence_type: IDA
     original_reference_id: PMID:11101851
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MAML1 is a transcriptional coactivator for Notch receptor intracellular
+        domains and RBPJ/CSL.
+      action: ACCEPT
+      reason: >-
+        This direct experimental annotation captures the principal molecular
+        function of MAML1.
       supported_by:
         - reference_id: PMID:11101851
-          supporting_text: MAML1, a human homologue of Drosophila mastermind, is
-            a transcriptional co-activator for NOTCH receptors.
+          supporting_text: >-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
   - term:
       id: GO:0005634
       label: nucleus
     evidence_type: IDA
     original_reference_id: PMID:11101851
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MAML1 is a nuclear protein that acts in nuclear Notch transcription
+        complexes.
+      action: ACCEPT
+      reason: >-
+        Nuclear localization is the supported cellular context for the core
+        transcriptional coactivator function.
       supported_by:
         - reference_id: PMID:11101851
-          supporting_text: MAML1, a human homologue of Drosophila mastermind, is
-            a transcriptional co-activator for NOTCH receptors.
+          supporting_text: >-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
   - term:
       id: GO:0007219
       label: Notch signaling pathway
     evidence_type: IDA
     original_reference_id: PMID:11101851
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MAML1 acts in the nuclear transcriptional arm of the Notch signaling
+        pathway.
+      action: KEEP_AS_NON_CORE
+      reason: >-
+        The broad pathway term is acceptable as context, but the more specific
+        curated process is activation of Notch target gene transcription.
       supported_by:
         - reference_id: PMID:11101851
-          supporting_text: MAML1, a human homologue of Drosophila mastermind, is
-            a transcriptional co-activator for NOTCH receptors.
+          supporting_text: >-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
   - term:
       id: GO:0045944
       label: positive regulation of transcription by RNA polymerase II
     evidence_type: IDA
     original_reference_id: PMID:11101851
     review:
-      summary: 'TODO: Review this GOA annotation'
-      action: PENDING
+      summary: >-
+        MAML1 positively regulates RNA polymerase II transcription as a Notch
+        transcriptional coactivator.
+      action: ACCEPT
+      reason: >-
+        Reporter and complex-assembly evidence support MAML1-dependent
+        activation of Notch target transcription.
       supported_by:
         - reference_id: PMID:11101851
-          supporting_text: MAML1, a human homologue of Drosophila mastermind, is
-            a transcriptional co-activator for NOTCH receptors.
+          supporting_text: >-
+            MAML1 binds to the ankyrin repeat domain of all four mammalian
+            NOTCH receptors, forms a DNA-binding complex with ICN and
+            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
 references:
   - id: GO_REF:0000002
     title: Gene Ontology annotation through association of InterPro records with
@@ -696,12 +880,26 @@ references:
   - id: PMID:11101851
     title: MAML1, a human homologue of Drosophila mastermind, is a 
       transcriptional co-activator for NOTCH receptors.
-    findings: []
+    findings:
+      - statement: >-
+          MAML1 binds Notch intracellular domains, forms a DNA-binding complex
+          with ICN and RBP-Jkappa, and amplifies Notch-induced HES1
+          transcription.
+        supporting_text: >-
+          MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH
+          receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and
+          amplifies NOTCH-induced transcription of HES1.
   - id: PMID:11390662
     title: A human protein with sequence similarity to Drosophila mastermind 
       coordinates the nuclear form of notch and a CSL protein to build a 
       transcriptional activator complex on target promoters.
-    findings: []
+    findings:
+      - statement: >-
+          Human MAML1 stabilizes and participates in the DNA-binding complex of
+          intracellular Notch1 and CSL.
+        supporting_text: >-
+          hMam-1 stabilizes and participates in the DNA binding complex of the
+          intracellular domain of human Notch1 and a CSL protein.
   - id: PMID:12370315
     title: Identification of a family of mastermind-like transcriptional 
       coactivators for mammalian notch receptors.
@@ -709,7 +907,13 @@ references:
   - id: PMID:15546612
     title: Mastermind recruits CycC:CDK8 to phosphorylate the Notch ICD and 
       coordinate activation with turnover.
-    findings: []
+    findings:
+      - statement: >-
+          Mastermind/MAML binds CDK8 and helps recruit the kinase machinery that
+          phosphorylates Notch intracellular domain.
+        supporting_text: >-
+          MAM interacts directly with CDK8 and can cause it to localize to
+          subnuclear foci.
   - id: PMID:16510869
     title: The Notch coactivator, MAML1, functions as a novel coactivator for 
       MEF2C-mediated transcription and is required for normal myogenesis.
@@ -721,7 +925,17 @@ references:
   - id: PMID:17317671
     title: The notch regulator MAML1 interacts with p53 and functions as a 
       coactivator.
-    findings: []
+    findings:
+      - statement: >-
+          MAML1 interacts with p53 and acts as a transcriptional coactivator on
+          p53 target genes, supporting coactivator activity but not peptide
+          antigen binding.
+        supporting_text: >-
+          MAML1-p53 interaction involves the N-terminal region of MAML1 and the
+          DNA-binding domain of p53, and we use a chromatin immunoprecipitation
+          assay to show that MAML1 is part of the activator complex that binds
+          to native p53-response elements within the promoter of the p53 target
+          genes.
   - id: PMID:18427106
     title: Notch signaling mediates hypoxia-induced tumor cell migration and 
       invasion.
@@ -748,6 +962,31 @@ references:
     title: CIR, a corepressor linking the DNA binding factor CBF1 to the histone
       deacetylase complex.
     findings: []
+  - id: file:human/MAML1/MAML1-deep-research-falcon.md
+    title: Falcon deep research on MAML1 GO-relevant functions
+    findings:
+      - statement: >-
+          MAML1 is best modeled as a Notch transcription coactivator and
+          complex-associated regulator rather than a generic protein-binding
+          protein.
+        supporting_text: >-
+          MAML1 is better captured by Notch transcription
+          coactivator/complex-associated terms than by a broad “protein
+          binding” annotation alone.
+      - statement: >-
+          Notch target-gene transcription terms are more precise than broad
+          Notch pathway terms for MAML1's direct role.
+        supporting_text: >-
+          **Prefer “Notch target gene transcription” over broad “Notch
+          signaling pathway”** unless direct pathway-level phenotypes are tied
+          specifically to human MAML1 (not dnMAML pan-inhibition, not paralog
+          redundancy).
+      - statement: >-
+          Nuclear speck/nuclear body annotations should be curated cautiously.
+        supporting_text: >-
+          **Nuclear bodies/specks:** nuclear-body localization is supported but
+          is **often overexpression-linked**; annotate cautiously at specific
+          subnuclear compartments.
   - id: Reactome:R-HSA-1912394
     title: NICD1 in complex with RBPJ (CSL) recruits MAML
     findings: []
@@ -829,3 +1068,81 @@ references:
   - id: Reactome:R-NUL-9604511
     title: Notch4 binds FLT4 gene promoter
     findings: []
+core_functions:
+  - molecular_function:
+      id: GO:0003713
+      label: transcription coactivator activity
+    description: >-
+      MAML1 is a nuclear transcriptional coactivator for Notch intracellular
+      domain-RBPJ/CSL complexes. It forms a DNA-bound transcriptional activation
+      complex that promotes HES1-class Notch target gene transcription, and it
+      also has direct evidence for p53 coactivator activity.
+    directly_involved_in:
+      - id: GO:0007221
+        label: positive regulation of transcription of Notch receptor target
+      - id: GO:0045944
+        label: positive regulation of transcription by RNA polymerase II
+    locations:
+      - id: GO:0005634
+        label: nucleus
+      - id: GO:0005654
+        label: nucleoplasm
+    supported_by:
+      - reference_id: PMID:11101851
+        supporting_text: >-
+          MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH
+          receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and
+          amplifies NOTCH-induced transcription of HES1.
+      - reference_id: PMID:17317671
+        supporting_text: >-
+          Overexpression of wild-type MAML1 as well as a mutant, defective in
+          Notch signaling, enhanced the p53-dependent gene induction in
+          mammalian cells, whereas MAML1 knockdown reduced the p53-dependent
+          gene expression.
+      - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+        supporting_text: >-
+          MAML1 is better captured by Notch transcription
+          coactivator/complex-associated terms than by a broad “protein
+          binding” annotation alone.
+  - molecular_function:
+      id: GO:0019901
+      label: protein kinase binding
+    description: >-
+      MAML1 directly binds/recruits CDK8 in the Notch transcription complex,
+      coupling Notch transcriptional activation to Notch intracellular domain
+      phosphorylation and turnover. This is a specific binding function and
+      should not be collapsed into generic protein binding.
+    directly_involved_in:
+      - id: GO:0045859
+        label: regulation of protein kinase activity
+    locations:
+      - id: GO:0005634
+        label: nucleus
+      - id: GO:0005654
+        label: nucleoplasm
+    supported_by:
+      - reference_id: PMID:15546612
+        supporting_text: >-
+          MAM interacts directly with CDK8 and can cause it to localize to
+          subnuclear foci.
+      - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
+        supporting_text: >-
+          Mediator kinase module recruitment and NICD phosphorylation/turnover.
+proposed_new_terms: []
+suggested_questions:
+  - question: >-
+      Which MAML1 developmental annotations are directly supported by human
+      MAML1-specific experiments rather than pan-MAML or Notch pathway
+      perturbation?
+  - question: >-
+      Are endogenous MAML1 nuclear bodies equivalent to nuclear specks in the
+      contexts represented by GOA annotations?
+suggested_experiments:
+  - description: >-
+      Use endogenous-tagged MAML1 with Notch activation time courses to map
+      nuclear subcompartment localization and distinguish nucleoplasm, nuclear
+      body, and nuclear speck assignments.
+  - description: >-
+      Perform MAML1-specific rescue after knockout at representative Notch,
+      p53, and myogenic target genes to separate direct MAML1 functions from
+      broader Notch pathway or paralog-redundant effects.

--- a/genes/human/MAML1/MAML1-ai-review.yaml
+++ b/genes/human/MAML1/MAML1-ai-review.yaml
@@ -27,9 +27,9 @@ existing_annotations:
       supported_by:
         - reference_id: PMID:11101851
           supporting_text: >-
-            MAML1 binds to the ankyrin repeat domain of all four mammalian
-            NOTCH receptors, forms a DNA-binding complex with ICN and
-            RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1.
+            Here we clone MAML1, a human homologue of the Drosophila gene
+            Mastermind, and show that it encodes a protein of 130 kD
+            localizing to nuclear bodies.
         - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
           supporting_text: >-
             Nuclear localization is well supported; “nucleoplasm” is
@@ -652,27 +652,21 @@ existing_annotations:
     original_reference_id: PMID:16510869
     review:
       summary: >-
-        MISANNOTATION: MAML1 is a transcriptional coactivator, NOT a kinase. The cited
-        paper PMID:16510869 describes MAML1 as a "coactivator for MEF2C-mediated transcription"
-        and "required for normal myogenesis" - no phosphorylation activity is described.
-        PMID:15546612 shows MAML1 "recruits CycC:CDK8 to phosphorylate the Notch ICD"
-        - meaning
-        MAML1 brings the kinase to its substrate, it doesn't perform phosphorylation
-        itself.
-        UniProt also shows MAML1 is phosphorylated at Ser-314 and Ser-360 (substrate).
-        MAML1's role in phosphorylation is regulatory (recruiting kinases), not catalytic.
-      action: MODIFY
-      proposed_replacement_terms:
-        - id: GO:0045859
-          label: regulation of protein kinase activity
+        MISANNOTATION: MAML1 is a transcriptional coactivator, not a kinase,
+        and the cited PMID:16510869 supports MEF2C coactivation/myogenesis
+        rather than protein phosphorylation.
+      action: REMOVE
+      reason: >-
+        The essence of the annotation is not sound: MAML1 does not catalyze
+        protein phosphorylation in this paper. MAML1's non-catalytic CDK8
+        recruitment role is already captured separately by the accepted
+        GO:0019901 protein kinase binding row based on PMID:15546612.
       supported_by:
-        - reference_id: PMID:15546612
+        - reference_id: PMID:16510869
           supporting_text: >-
-            MAM interacts directly with CDK8 and can cause it to localize to
-            subnuclear foci.
-        - reference_id: file:human/MAML1/MAML1-deep-research-falcon.md
-          supporting_text: >-
-            Mediator kinase module recruitment and NICD phosphorylation/turnover.
+            Our study thus reveals novel and nonredundant functions for MAML1:
+            It acts as a coactivator for MEF2C transcription and is essential
+            for proper muscle development.
   - term:
       id: GO:0010831
       label: positive regulation of myotube differentiation
@@ -1112,9 +1106,6 @@ core_functions:
       coupling Notch transcriptional activation to Notch intracellular domain
       phosphorylation and turnover. This is a specific binding function and
       should not be collapsed into generic protein binding.
-    directly_involved_in:
-      - id: GO:0045859
-        label: regulation of protein kinase activity
     locations:
       - id: GO:0005634
         label: nucleus

--- a/genes/human/MAML1/MAML1-deep-research-falcon.md
+++ b/genes/human/MAML1/MAML1-deep-research-falcon.md
@@ -1,0 +1,206 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-12T16:03:15.806817'
+end_time: '2026-05-12T16:34:44.985399'
+duration_seconds: 1889.18
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 38
+---
+
+## Question
+
+Concise GO annotation research for human MAML1 / UniProt Q92585. Focus only on GO-relevant evidence for MAML1/Mastermind-like protein 1: transcription coactivator activity in the NOTCH intracellular domain-CSL/RBPJ/RBPSUH transcriptional activation complex; positive regulation of transcription of Notch receptor target genes (for example HES1) versus broader Notch signaling pathway terms; nuclear/nucleoplasm/nuclear speck localization and the specific MAML1-RBP-Jkappa-ICN1 complex; interactions with NOTCH1-4, RBPJ/RBPSUH, CREBBP/CBP, CDK8/Cyclin C, TP53 and whether these support specific terms over generic protein binding; roles in phosphorylation/turnover of NOTCH intracellular domain, chromatin/nucleosome acetylation at Notch enhancers, p53 coactivation, myogenic differentiation, heart/atrioventricular node development, and any caveats for over-broad developmental annotations or high-throughput protein binding. Include PMID/DOI citations and keep under 1500 words.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+Concise GO annotation research for human MAML1 / UniProt Q92585. Focus only on GO-relevant evidence for MAML1/Mastermind-like protein 1: transcription coactivator activity in the NOTCH intracellular domain-CSL/RBPJ/RBPSUH transcriptional activation complex; positive regulation of transcription of Notch receptor target genes (for example HES1) versus broader Notch signaling pathway terms; nuclear/nucleoplasm/nuclear speck localization and the specific MAML1-RBP-Jkappa-ICN1 complex; interactions with NOTCH1-4, RBPJ/RBPSUH, CREBBP/CBP, CDK8/Cyclin C, TP53 and whether these support specific terms over generic protein binding; roles in phosphorylation/turnover of NOTCH intracellular domain, chromatin/nucleosome acetylation at Notch enhancers, p53 coactivation, myogenic differentiation, heart/atrioventricular node development, and any caveats for over-broad developmental annotations or high-throughput protein binding. Include PMID/DOI citations and keep under 1500 words.
+
+## Concise GO annotation research report: Human **MAML1** (Mastermind-like protein 1), UniProt **Q92585**
+
+### Scope and intent
+This report summarizes **GO-relevant** evidence for MAML1, emphasizing (i) its **specific transcription coactivator role** in the **nuclear NOTCH intracellular domain (NICD/ICN)–CSL/RBPJ** activation complex, (ii) **positive regulation of transcription of canonical Notch target genes** (e.g., HES family), (iii) **nuclear subcompartment localization** evidence, (iv) recruitment of **EP300/CREBBP (p300/CBP)** and **Mediator kinase module (CDK8–Cyclin C)**, and (v) evidence/caveats for broader developmental or high-throughput “binding” style annotations.
+
+### Key concepts and GO-relevant definitions (current understanding)
+
+**Canonical Notch transcription activation complex (NTC).** After Notch receptor activation and cleavage, NICD enters the nucleus and forms a **DNA-bound ternary complex** with **RBPJ/CSL** and **Mastermind-like (MAML)** proteins; this complex recruits coactivators and enables transcription of Notch target genes. Primary and review sources emphasize that MAML proteins act as **core coactivators** of NICD–RBPJ complexes rather than generic interactors. (wu2000maml1ahuman pages 2-3, wu2002identificationofa pages 2-3, hall2022thestructurebinding pages 1-2)
+
+**GO emphasis: “positive regulation of transcription of Notch target genes” vs broad “Notch signaling.”** The strongest direct evidence for MAML1 typically reads out **transcriptional activation** (HES/HES4/DTX1 reporters; chromatin templates; ChIP-linked acetylation changes), supporting specific transcriptional regulation terms rather than broad pathway-level terms (which can be context- and tissue-dependent). (wu2000maml1ahuman pages 2-3, rogers2020maml1dependentnotchresponsivegenes pages 1-2)
+
+**Coactivator recruitment at chromatin.** MAML1 is a scaffold-like coactivator that supports Notch-driven transcription by recruiting/activating histone acetyltransferases (**p300/CBP**) and linking to Mediator kinase module components (**CDK8–Cyclin C**), coupling transcriptional activation with **NICD phosphorylation and turnover**. (ribeiro2009transcriptionalmechanismsby pages 3-4, hansson2009thetranscriptionalcoactivator pages 1-1, ribeiro2009gsk3βisa pages 1-2, hall2022thestructurebinding pages 1-2)
+
+### Molecular function (MF): specific coactivator activity in the NICD–RBPJ/CSL complex
+
+**Ternary complex assembly and specificity.** Seminal work demonstrated that MAML1 forms a **DNA-binding complex** with **ICN (NICD)** and **RBP-Jκ (RBPJ/CSL)** and functions as a **transcriptional co-activator** for Notch receptors; it enhances Notch-induced transcription from a HES1 promoter reporter, and dominant-negative MAML1 reduces activation. (Wu et al., 2000, *Nat Genet*, Dec 2000, DOI: https://doi.org/10.1038/82644) (wu2000maml1ahuman pages 2-3)
+
+**NOTCH1–4 interaction breadth.** Wu et al. reported that MAML1 can bind ICN1 and also interacts with ICN2–4 in vitro, supporting annotations consistent with coactivator activity across mammalian Notch intracellular domains in canonical transcriptional activation contexts (carefully: intracellular domains, not membrane receptors). (wu2000maml1ahuman pages 2-3)
+
+**Prefer complex/coactivator terms over generic “protein binding.”** Because the core evidence is **functional (reporter activation) + mechanistic (ternary complex formation)**, MAML1 is better captured by Notch transcription coactivator/complex-associated terms than by a broad “protein binding” annotation alone. (wu2000maml1ahuman pages 2-3, wu2002identificationofa pages 2-3)
+
+### Biological process (BP): positive regulation of transcription of Notch target genes (e.g., HES family)
+
+**HES1-class transcriptional outcomes.** In the original characterization, MAML1 amplified NOTCH-induced transcription and specifically enhanced HES1 promoter activation, while dominant-negative MAML1 reduced it—direct functional support for **positive regulation of transcription of Notch target genes**. (wu2000maml1ahuman pages 2-3)
+
+**Genetic requirement for Notch-responsive target gene induction.** In Jurkat T-ALL cells, **MAML1 knockout** eliminated Notch-responsive activation of representative targets (HES4, DTX1) and mapped essential regions for Notch-dependent induction; reduced transcription associated with reduced histone acetylation at targets (see below). (Rogers et al., 2020, *Mol Cell Biol*, May 2020, DOI: https://doi.org/10.1128/mcb.00014-20) (rogers2020maml1dependentnotchresponsivegenes pages 1-2)
+
+**Caveat: promoter vs enhancer dependencies.** The same study showed promoter-proximal and enhancer-regulated targets can have different cofactor requirements (e.g., p300-HAT fusion rescue at one locus but not another), arguing for careful selection of GO BP terms focused on transcriptional regulation rather than over-generalizing to all Notch pathway outputs. (rogers2020varyingcofactorrequirements pages 1-5, rogers2020maml1dependentnotchresponsivegenes pages 1-2)
+
+### Cellular component (CC): nucleus, nucleoplasm, nuclear bodies/speckles, and complex localization
+
+**Nuclear localization is robust.** MAML proteins are nuclear and contain an NLS; nuclear localization is consistent with their role in DNA-bound NICD–RBPJ transcriptional activation. (ribeiro2009transcriptionalmechanismsby pages 2-3)
+
+**Nuclear bodies / PML-associated structures (with caveats).** MAML1 was observed to localize to nuclear bodies and to relocalize ICN1 (and, in other work, p300 and acetylated histones) to nuclear bodies. However, several observations rely on overexpression and nuclear-body composition can vary (e.g., not always PML-positive), so “nuclear speck/PML body” annotations should be conservative unless supported by endogenous localization. (wu2000maml1ahuman pages 2-3, hansson2009thetranscriptionalcoactivator pages 1-1, wu2002identificationofa pages 2-3)
+
+**Specific complex membership: NICD–RBPJ–MAML1.** Evidence supports MAML1 as a component of the **Notch transcription activation complex** rather than a generic nuclear complex, including biochemical purification/complex assembly logic in foundational work. (wu2002identificationofa pages 2-3, hall2022thestructurebinding pages 1-2)
+
+### Chromatin and transcriptional machinery: EP300/CREBBP and Mediator kinase module (CDK8–Cyclin C)
+
+**Recruitment/activation of p300/CBP and histone acetylation.** Primary experimental evidence indicates MAML1 recruits p300 to DNA–CSL–NICD complexes, binds p300 (C/H3 domain), and that p300–MAML1 complexes acetylate histone H3/H4 tails on chromatin in vitro; MAML1 also potentiates p300 autoacetylation and HAT activity, with correlated localization of MAML1/p300/acetylated histones to nuclear bodies. (Hansson et al., 2009, *Nucleic Acids Res*, Mar 2009, DOI: https://doi.org/10.1093/nar/gkp163) (hansson2009thetranscriptionalcoactivator pages 1-1, hansson2009thetranscriptionalcoactivator pages 9-10)
+
+**H3K27 acetylation at Notch-responsive loci.** In Jurkat T-ALL, loss of MAML1 reduced Notch target gene expression together with decreased H3K27 acetylation, consistent with MAML1-dependent acetyltransferase activity at Notch-responsive chromatin. (rogers2020varyingcofactorrequirements pages 1-5, rogers2020maml1dependentnotchresponsivegenes pages 1-2)
+
+**Mediator kinase module recruitment and NICD phosphorylation/turnover.** Multiple sources support that MAML1 interacts with/recruits **CDK8** (often discussed with Cyclin C as the Mediator kinase module), which phosphorylates serines in the NICD PEST domain and promotes proteasomal turnover linked to FBW7-mediated degradation—supporting GO BP terms around regulation of NICD stability/turnover in the transcription complex context. (ribeiro2009transcriptionalmechanismsby pages 3-4, ribeiro2009gsk3βisa pages 1-2, hall2022thestructurebinding pages 1-2)
+
+### Notch-independent but GO-relevant transcriptional coactivation: TP53
+
+**Direct p53 coactivator function.** Zhao et al. showed MAML1 interacts with p53 (N-terminus of MAML1 with p53 DNA-binding domain), occupies native p53 response elements (ChIP), enhances p53-dependent gene induction, and knockdown reduces p53-dependent gene expression; MAML1 also increased p53 half-life and enhanced phosphorylation/acetylation after DNA damage. (Zhao et al., 2007, *J Biol Chem*, Apr 2007, DOI: https://doi.org/10.1074/jbc.M608974200) (zhao2007thenotchregulator pages 1-2)
+
+**GO implication.** These data support **specific “transcription coactivator activity” in a p53 context**, but curators should not conflate this with Notch complex membership; separate MF/BP annotations are warranted. (zhao2007thenotchregulator pages 1-2)
+
+### Recent developments (2023–2024) and real-world implementation context
+
+**Therapeutic targeting of the Notch transcription complex (NTC).** A 2023 T-ALL review lists agents that disrupt the Notch transcription complex via MAML1/NTC interference, including **SAHM1** (stapled peptide interfering with MAML1 binding to the NTC) and **NADI-351** (described as disrupting the NTC). While not providing new mechanistic data itself, it reflects expert synthesis of an application direction: targeting **NICD–RBPJ–MAML1** transcriptional output rather than upstream cleavage. (Toribio & González-García, 2023, *Int J Mol Sci*, Jan 2023, DOI: https://doi.org/10.3390/ijms24021383) (toribio2023notchpartnersin pages 5-6)
+
+**Pharmacologic modulation of Notch loss-of-function phenotypes (HDAC axis).** In a 2024 in vivo intestinal context, Dai et al. showed that the HDAC inhibitor **valproic acid** could prevent intestinal consequences caused by Notch dimerization deficiency and by gamma-secretase inhibitors, highlighting real-world translational interplay between Notch transcriptional output and chromatin repression machinery. (Dai et al., 2024, *PLOS Genet*, Dec 2024, DOI: https://doi.org/10.1371/journal.pgen.1011486) (dai2024lossofnotch pages 1-2)
+
+**Quantitative transcription-hub model (2024) with Mediator CDK module recruitment.** Live-imaging work in 2024 (Drosophila Mastermind, the orthologous coactivator class) provides a modern mechanistic model consistent with MAML1’s GO-relevant role: Mastermind-containing complexes promote formation of Notch transcription hubs that concentrate factors including the Mediator CDK module; importantly, only a subset of hubs become transcriptionally productive (reported ~37%), and a second signal can raise activation probability (~70%). This supports the idea that coactivator-driven assemblies regulate the probability of transcriptional initiation, and it offers a conceptual framework for how Mediator kinase module recruitment might shape Notch target transcription dynamics. (DeHaro-Arbona et al., 2024, *eLife*, May 2024, DOI: https://doi.org/10.7554/eLife.92083.3) (deharoarbona2024dynamicmodesof pages 1-2, deharoarbona2024dynamicmodesof pages 15-17)
+
+### Annotation caveats (avoid over-broad terms; avoid HTP-only binding)
+
+1. **Prefer “Notch target gene transcription” over broad “Notch signaling pathway”** unless direct pathway-level phenotypes are tied specifically to human MAML1 (not dnMAML pan-inhibition, not paralog redundancy). (rogers2020maml1dependentnotchresponsivegenes pages 1-2)
+2. **Nuclear bodies/specks:** nuclear-body localization is supported but is **often overexpression-linked**; annotate cautiously at specific subnuclear compartments. (wu2002identificationofa pages 2-3, ribeiro2009transcriptionalmechanismsby pages 2-3)
+3. **Complex vs binding:** many interactions (NOTCH1-4 ICD, RBPJ, p300/CBP, CDK8) are best captured as **functional complex membership/coactivator recruitment** rather than generic “protein binding,” because functional readouts (reporters, chromatin transcription, acetylation, KO) exist. (wu2000maml1ahuman pages 2-3, hansson2009thetranscriptionalcoactivator pages 1-1)
+
+### Evidence-to-annotation map (summary)
+| GO aspect (MF/BP/CC) | Suggested GO term label (not GO ID) | Evidence summary (1 sentence) | Key experimental system/assay | Representative paper (authors, year, journal) | DOI/URL | Caveats for annotation breadth/HTP |
+|---|---|---|---|---|---|---|
+| MF | transcription coactivator activity, RNA polymerase II transcription factor binding | Human MAML1 binds NICD and RBPJ/CSL to form the canonical Notch ternary complex and amplifies HES1-class reporter activation, supporting a specific coactivator role rather than generic protein binding. (wu2000maml1ahuman pages 2-3, wu2002identificationofa pages 2-3) | GST pulldown, co-IP, EMSA/co-shift, luciferase reporter | Wu et al., 2000, *Nature Genetics*; Wu et al., 2002, *MCB* | https://doi.org/10.1038/82644 ; https://doi.org/10.1128/MCB.22.21.7688-7700.2002 | Prefer specific Notch transcription-complex/coactivator terms over broad “protein binding”; avoid inferring noncanonical coactivator functions from Notch assays alone. |
+| BP | positive regulation of transcription of Notch receptor target genes | MAML1 is required for activation of canonical Notch targets (HES1/HES4/DTX1 contexts), and knockout or dominant-negative constructs block induction. (wu2000maml1ahuman pages 2-3, rogers2020maml1dependentnotchresponsivegenes pages 1-2) | Jagged/NICD-responsive reporters, Jurkat MAML1 knockout and rescue | Wu et al., 2000, *Nature Genetics*; Rogers et al., 2020, *MCB* | https://doi.org/10.1038/82644 ; https://doi.org/10.1128/MCB.00014-20 | Strongest support is for positive regulation of transcription of Notch target genes, not necessarily for every broader “Notch signaling pathway” child term. |
+| CC | nucleus / nucleoplasm | MAML1 is a nuclear protein with an NLS and functions in nuclear Notch transcription complexes on DNA/chromatin. (ribeiro2009transcriptionalmechanismsby pages 2-3) | Localization studies, domain analysis, chromatin transcription assays | Ribeiro & Wallberg, 2009, *Current Protein & Peptide Science* | https://doi.org/10.2174/138920309789630543 | Nuclear localization is well supported; “nucleoplasm” is reasonable, but exact subnuclear assignment depends on assay context. |
+| CC | nuclear body / nuclear speck / PML body-associated localization | MAML1 localizes to nuclear bodies and can relocalize ICN1, p300, and acetylated histones there, but much of this evidence uses overexpression and not all bodies are PML-positive. (wu2000maml1ahuman pages 2-3, hansson2009thetranscriptionalcoactivator pages 1-1, wu2002identificationofa pages 2-3) | Fluorescence colocalization, overexpression microscopy | Wu et al., 2000, *Nature Genetics*; Hansson et al., 2009, *NAR* | https://doi.org/10.1038/82644 ; https://doi.org/10.1093/nar/gkp163 | Use caution with “nuclear speck” or “PML body” annotations because nuclear-body formation is partly overexpression-based and may not reflect a constitutive endogenous compartment. |
+| CC | Notch transcription activation complex | Endogenous and reconstituted data support MAML1 as a component of the DNA-bound NICD–RBPJ/CSL activation complex, including ICN1 and also ICN2-4 binding. (wu2000maml1ahuman pages 2-3, wu2002identificationofa pages 2-3) | Size-exclusion chromatography, co-IP, in vitro complex assembly | Wu et al., 2002, *MCB* | https://doi.org/10.1128/MCB.22.21.7688-7700.2002 | This is stronger than generic “protein-containing complex”; annotate the specific Notch activation complex when possible. |
+| MF/BP | NOTCH1-4 intracellular domain binding in activation complex context | MAML1 directly interacts with ICN1 and can bind ICN2-4, supporting receptor-family breadth within canonical Notch transcriptional activation. (wu2000maml1ahuman pages 2-3, wu2002identificationofa pages 2-3) | GST pulldown, reporter assays across ICN1-4 | Wu et al., 2000, *Nature Genetics*; Wu et al., 2002, *MCB* | https://doi.org/10.1038/82644 ; https://doi.org/10.1128/MCB.22.21.7688-7700.2002 | Binding evidence is strongest for intracellular domains in canonical transcription assays; avoid overextending to all receptor contexts or surface-signaling steps. |
+| MF/BP | CREBBP/EP300 recruitment and chromatin acetylation at Notch-regulated loci | MAML1 recruits p300/CBP to DNA-CSL-NICD complexes, stimulates p300 autoacetylation/HAT activity, and supports H3/H4 acetylation and H3K27ac at Notch-responsive promoters/enhancers. (rogers2020varyingcofactorrequirements pages 1-5, ribeiro2009transcriptionalmechanismsby pages 3-4, hansson2009thetranscriptionalcoactivator pages 1-1) | In vitro chromatin transcription, HAT assays, ChIP/acetylation readouts, KO-rescue | Hansson et al., 2009, *NAR*; Rogers et al., 2020, *MCB* | https://doi.org/10.1093/nar/gkp163 ; https://doi.org/10.1128/MCB.00014-20 | Strong support for coactivator-mediated recruitment/activation of acetyltransferase activity; do not over-annotate MAML1 itself as the acetyltransferase. |
+| BP | regulation of Notch intracellular domain phosphorylation / turnover | MAML1 recruits CDK8/cyclin C-associated machinery that promotes NICD PEST phosphorylation and subsequent FBW7-linked degradation, coupling transcriptional activation to NICD turnover. (ribeiro2009transcriptionalmechanismsby pages 3-4, ribeiro2009gsk3βisa pages 1-2, rogers2020maml1dependentnotchresponsivegenes pages 1-2) | Biochemical interaction studies, chromatin assays, mechanistic genetics/review synthesis | Hansson et al., 2009, *NAR*; Rogers et al., 2020, *MCB* | https://doi.org/10.1093/nar/gkp163 ; https://doi.org/10.1128/MCB.00014-20 | Best treated as regulation of NICD stability/turnover in the Notch transcription complex; evidence is partly mechanistic synthesis rather than a single direct human loss-of-function experiment. |
+| MF/BP | TP53 coactivator activity / positive regulation of p53 target gene transcription | MAML1 directly interacts with p53, occupies p53-response elements, increases p53 half-life and phosphorylation/acetylation, and enhances p53-dependent transcription independently of Notch. (zhao2007thenotchregulator pages 1-2, ribeiro2009transcriptionalmechanismsby pages 4-5) | ChIP, p53 reporter assays, knockdown/overexpression, DNA damage assays | Zhao et al., 2007, *JBC* | https://doi.org/10.1074/jbc.M608974200 | This supports specific p53 coactivator terms, not generic protein binding; keep separate from canonical Notch annotations. |
+| BP | positive regulation of myogenic differentiation | MAML1 has reported Notch-independent coactivator activity with MEF2C in myogenesis, supporting a possible myogenic BP annotation if direct human evidence is curated. (ribeiro2009transcriptionalmechanismsby pages 3-4, ribeiro2009transcriptionalmechanismsby pages 1-2) | Biochemical interaction/function studies summarized in review | Ribeiro & Wallberg, 2009, *Current Protein & Peptide Science* | https://doi.org/10.2174/138920309789630543 | Evidence here is largely review-level and cross-species/contextual; weaker than canonical Notch evidence and should be curated conservatively. |
+| BP | heart / atrioventricular node development | Cardiac phenotypes from dominant-negative MAML or pathway-level studies implicate MAML-dependent Notch signaling in AV node development, but direct attribution to human MAML1 is indirect. (dai2024lossofnotch pages 1-2, toribio2023notchpartnersin pages 5-6) | Mouse developmental genetics, pathway perturbation, review synthesis | MacGrogan et al., 2018, *Nat Rev Cardiol*; Zhou & Liu, 2013, *Braz J Med Biol Res* | https://doi.org/10.1038/s41569-018-0100-2 ; https://doi.org/10.1590/1414-431X20133177 | Avoid over-broad human MAML1 developmental annotations unless supported by direct gene-specific experiments; dnMAML affects multiple MAML paralogs/pathway output. |
+
+
+*Table: This table maps the strongest GO-relevant candidate annotations for human MAML1 to representative evidence and highlights where annotations should remain specific rather than broad. It is useful for distinguishing well-supported canonical Notch coactivator functions from weaker or context-dependent developmental and localization claims.*
+
+### Representative publications (with dates and URLs)
+- Wu et al. “MAML1… transcriptional co-activator for NOTCH receptors.” *Nature Genetics* (Dec 2000). https://doi.org/10.1038/82644 (wu2000maml1ahuman pages 2-3)
+- Wu et al. “Identification of a family of Mastermind-like transcriptional coactivators…” *Molecular and Cellular Biology* (Nov 2002). https://doi.org/10.1128/MCB.22.21.7688-7700.2002 (wu2002identificationofa pages 2-3)
+- Hansson et al. “MAML1 regulates p300 autoacetylation and HAT activity.” *Nucleic Acids Research* (Mar 2009). https://doi.org/10.1093/nar/gkp163 (hansson2009thetranscriptionalcoactivator pages 1-1)
+- Zhao et al. “MAML1 interacts with p53 and functions as a coactivator.” *J Biol Chem* (Apr 2007). https://doi.org/10.1074/jbc.M608974200 (zhao2007thenotchregulator pages 1-2)
+- Rogers et al. “MAML1-dependent Notch-responsive genes…” *Molecular and Cellular Biology* (May 2020). https://doi.org/10.1128/mcb.00014-20 (rogers2020maml1dependentnotchresponsivegenes pages 1-2)
+- Toribio & González-García. “Notch partners in T-ALL pathogenesis.” *Int J Mol Sci* (Jan 2023). https://doi.org/10.3390/ijms24021383 (toribio2023notchpartnersin pages 5-6)
+- DeHaro-Arbona et al. “Dynamic modes of Notch transcription hubs…” *eLife* (May 2024). https://doi.org/10.7554/eLife.92083.3 (deharoarbona2024dynamicmodesof pages 1-2, deharoarbona2024dynamicmodesof pages 15-17)
+- Dai et al. “Loss of Notch dimerization perturbs intestinal homeostasis…” *PLOS Genetics* (Dec 2024). https://doi.org/10.1371/journal.pgen.1011486 (dai2024lossofnotch pages 1-2)
+
+
+References
+
+1. (wu2000maml1ahuman pages 2-3): Lizi Wu, Jon C. Aster, Stephen C. Blacklow, Robert Lake, Spyros Artavanis-Tsakonas, and James D. Griffin. Maml1, a human homologue of drosophila mastermind, is a transcriptional co-activator for notch receptors. Nature Genetics, 26:484-489, Dec 2000. URL: https://doi.org/10.1038/82644, doi:10.1038/82644. This article has 757 citations and is from a highest quality peer-reviewed journal.
+
+2. (wu2002identificationofa pages 2-3): Lizi Wu, Tao Sun, Karla Kobayashi, Ping Gao, and James D. Griffin. Identification of a family of mastermind-like transcriptional coactivators for mammalian notch receptors. Molecular and Cellular Biology, 22:7688-7700, Nov 2002. URL: https://doi.org/10.1128/mcb.22.21.7688-7700.2002, doi:10.1128/mcb.22.21.7688-7700.2002. This article has 365 citations and is from a domain leading peer-reviewed journal.
+
+3. (hall2022thestructurebinding pages 1-2): Daniel Hall, Benedetto Daniele Giaimo, Sung-Soo Park, Wiebke Hemmer, Tobias Friedrich, Francesca Ferrante, Marek Bartkuhn, Zhenyu Yuan, Franz Oswald, Tilman Borggrefe, Jean-François Rual, and Rhett A. Kovall. The structure, binding and function of a notch transcription complex involving rbpj and the epigenetic reader protein l3mbtl3. Nucleic Acids Research, 50:13083-13099, Feb 2022. URL: https://doi.org/10.1093/nar/gkac1137, doi:10.1093/nar/gkac1137. This article has 10 citations and is from a highest quality peer-reviewed journal.
+
+4. (rogers2020maml1dependentnotchresponsivegenes pages 1-2): Julia M. Rogers, Bingqian Guo, Emily D. Egan, Jon C. Aster, Karen Adelman, and Stephen C. Blacklow. Maml1-dependent notch-responsive genes exhibit differing cofactor requirements for transcriptional activation. May 2020. URL: https://doi.org/10.1128/mcb.00014-20, doi:10.1128/mcb.00014-20. This article has 12 citations and is from a domain leading peer-reviewed journal.
+
+5. (ribeiro2009transcriptionalmechanismsby pages 3-4): M. Saint Just Ribeiro and A. Wallberg. Transcriptional mechanisms by the coregulator maml1. Current Protein &amp; Peptide Science, 10:570-576, Dec 2009. URL: https://doi.org/10.2174/138920309789630543, doi:10.2174/138920309789630543. This article has 32 citations and is from a peer-reviewed journal.
+
+6. (hansson2009thetranscriptionalcoactivator pages 1-1): Magnus L. Hansson, Anita E. Popko-Ścibor, Mariana Saint Just Ribeiro, Beverley M. Dancy, Mikael J. Lindberg, Philip A. Cole, and Annika E. Wallberg. The transcriptional coactivator maml1 regulates p300 autoacetylation and hat activity. Nucleic Acids Research, 37:2996-3006, Mar 2009. URL: https://doi.org/10.1093/nar/gkp163, doi:10.1093/nar/gkp163. This article has 76 citations and is from a highest quality peer-reviewed journal.
+
+7. (ribeiro2009gsk3βisa pages 1-2): M. Saint Just Ribeiro, M. L. Hansson, M. J. Lindberg, A. E. Popko-Scibor, and A. E. Wallberg. Gsk3β is a negative regulator of the transcriptional coactivator maml1. Nucleic Acids Research, 37:6691-6700, Sep 2009. URL: https://doi.org/10.1093/nar/gkp724, doi:10.1093/nar/gkp724. This article has 45 citations and is from a highest quality peer-reviewed journal.
+
+8. (rogers2020varyingcofactorrequirements pages 1-5): Julia M. Rogers, Bingqian Guo, Emily D. Egan, Jon C. Aster, Karen Adelman, and Stephen C. Blacklow. Varying co-factor requirements for maml1-dependent transcription at different notch-responsive target genes. bioRxiv, Jan 2020. URL: https://doi.org/10.1101/2020.01.13.905612, doi:10.1101/2020.01.13.905612. This article has 0 citations.
+
+9. (ribeiro2009transcriptionalmechanismsby pages 2-3): M. Saint Just Ribeiro and A. Wallberg. Transcriptional mechanisms by the coregulator maml1. Current Protein &amp; Peptide Science, 10:570-576, Dec 2009. URL: https://doi.org/10.2174/138920309789630543, doi:10.2174/138920309789630543. This article has 32 citations and is from a peer-reviewed journal.
+
+10. (hansson2009thetranscriptionalcoactivator pages 9-10): Magnus L. Hansson, Anita E. Popko-Ścibor, Mariana Saint Just Ribeiro, Beverley M. Dancy, Mikael J. Lindberg, Philip A. Cole, and Annika E. Wallberg. The transcriptional coactivator maml1 regulates p300 autoacetylation and hat activity. Nucleic Acids Research, 37:2996-3006, Mar 2009. URL: https://doi.org/10.1093/nar/gkp163, doi:10.1093/nar/gkp163. This article has 76 citations and is from a highest quality peer-reviewed journal.
+
+11. (zhao2007thenotchregulator pages 1-2): Yongtong Zhao, Rebecca B. Katzman, Laurie M. Delmolino, Ishfaq Bhat, Ying Zhang, Channabasavaiah B. Gurumurthy, Aleksandra Germaniuk-Kurowska, Honey V. Reddi, Aharon Solomon, Mu-Sheng Zeng, Aisha Kung, Hui Ma, Qingshen Gao, Goberdhan Dimri, Adina Stanculescu, Lucio Miele, Lizi Wu, James D. Griffin, David E. Wazer, Hamid Band, and Vimla Band. The notch regulator maml1 interacts with p53 and functions as a coactivator*. Journal of Biological Chemistry, 282:11969-11981, Apr 2007. URL: https://doi.org/10.1074/jbc.m608974200, doi:10.1074/jbc.m608974200. This article has 105 citations and is from a domain leading peer-reviewed journal.
+
+12. (toribio2023notchpartnersin pages 5-6): María Luisa Toribio and Sara González-García. Notch partners in the long journey of t-all pathogenesis. International Journal of Molecular Sciences, 24:1383, Jan 2023. URL: https://doi.org/10.3390/ijms24021383, doi:10.3390/ijms24021383. This article has 23 citations.
+
+13. (dai2024lossofnotch pages 1-2): Quanhui Dai, Kristina Preusse, Danni Yu, Rhett A. Kovall, Konrad Thorner, Xinhua Lin, and Raphael Kopan. Loss of notch dimerization perturbs intestinal homeostasis by a mechanism involving hdac activity. PLOS Genetics, 20:e1011486, Dec 2024. URL: https://doi.org/10.1371/journal.pgen.1011486, doi:10.1371/journal.pgen.1011486. This article has 2 citations and is from a domain leading peer-reviewed journal.
+
+14. (deharoarbona2024dynamicmodesof pages 1-2): F Javier DeHaro-Arbona, Charalambos Roussos, Sarah Baloul, Jonathan Townson, María J Gómez Lamarca, and Sarah Bray. Dynamic modes of notch transcription hubs conferring memory and stochastic activation revealed by live imaging the co-activator mastermind. eLife, May 2024. URL: https://doi.org/10.7554/elife.92083.3, doi:10.7554/elife.92083.3. This article has 22 citations and is from a domain leading peer-reviewed journal.
+
+15. (deharoarbona2024dynamicmodesof pages 15-17): F Javier DeHaro-Arbona, Charalambos Roussos, Sarah Baloul, Jonathan Townson, María J Gómez Lamarca, and Sarah Bray. Dynamic modes of notch transcription hubs conferring memory and stochastic activation revealed by live imaging the co-activator mastermind. eLife, May 2024. URL: https://doi.org/10.7554/elife.92083.3, doi:10.7554/elife.92083.3. This article has 22 citations and is from a domain leading peer-reviewed journal.
+
+16. (ribeiro2009transcriptionalmechanismsby pages 4-5): M. Saint Just Ribeiro and A. Wallberg. Transcriptional mechanisms by the coregulator maml1. Current Protein &amp; Peptide Science, 10:570-576, Dec 2009. URL: https://doi.org/10.2174/138920309789630543, doi:10.2174/138920309789630543. This article has 32 citations and is from a peer-reviewed journal.
+
+17. (ribeiro2009transcriptionalmechanismsby pages 1-2): M. Saint Just Ribeiro and A. Wallberg. Transcriptional mechanisms by the coregulator maml1. Current Protein &amp; Peptide Science, 10:570-576, Dec 2009. URL: https://doi.org/10.2174/138920309789630543, doi:10.2174/138920309789630543. This article has 32 citations and is from a peer-reviewed journal.
+
+## Citations
+
+1. ribeiro2009transcriptionalmechanismsby pages 2-3
+2. zhao2007thenotchregulator pages 1-2
+3. toribio2023notchpartnersin pages 5-6
+4. dai2024lossofnotch pages 1-2
+5. wu2002identificationofa pages 2-3
+6. hansson2009thetranscriptionalcoactivator pages 1-1
+7. hall2022thestructurebinding pages 1-2
+8. ribeiro2009transcriptionalmechanismsby pages 3-4
+9. rogers2020varyingcofactorrequirements pages 1-5
+10. hansson2009thetranscriptionalcoactivator pages 9-10
+11. deharoarbona2024dynamicmodesof pages 1-2
+12. deharoarbona2024dynamicmodesof pages 15-17
+13. ribeiro2009transcriptionalmechanismsby pages 4-5
+14. ribeiro2009transcriptionalmechanismsby pages 1-2
+15. https://doi.org/10.1038/82644
+16. https://doi.org/10.1128/mcb.00014-20
+17. https://doi.org/10.1093/nar/gkp163
+18. https://doi.org/10.1074/jbc.M608974200
+19. https://doi.org/10.3390/ijms24021383
+20. https://doi.org/10.1371/journal.pgen.1011486
+21. https://doi.org/10.7554/eLife.92083.3
+22. https://doi.org/10.1128/MCB.22.21.7688-7700.2002
+23. https://doi.org/10.1128/MCB.00014-20
+24. https://doi.org/10.2174/138920309789630543
+25. https://doi.org/10.1038/s41569-018-0100-2
+26. https://doi.org/10.1590/1414-431X20133177
+27. https://doi.org/10.1038/82644,
+28. https://doi.org/10.1128/mcb.22.21.7688-7700.2002,
+29. https://doi.org/10.1093/nar/gkac1137,
+30. https://doi.org/10.1128/mcb.00014-20,
+31. https://doi.org/10.2174/138920309789630543,
+32. https://doi.org/10.1093/nar/gkp163,
+33. https://doi.org/10.1093/nar/gkp724,
+34. https://doi.org/10.1101/2020.01.13.905612,
+35. https://doi.org/10.1074/jbc.m608974200,
+36. https://doi.org/10.3390/ijms24021383,
+37. https://doi.org/10.1371/journal.pgen.1011486,
+38. https://doi.org/10.7554/elife.92083.3,

--- a/genes/human/MAML1/MAML1-notes.md
+++ b/genes/human/MAML1/MAML1-notes.md
@@ -1,0 +1,9 @@
+# MAML1 notes
+
+## Falcon integration, 2026-05-12
+
+- Falcon supports MAML1 as a nuclear transcriptional coactivator in the Notch intracellular domain-RBPJ/CSL activation complex, with direct HES1 transcriptional activation evidence [PMID:11101851 "MAML1 binds to the ankyrin repeat domain of all four mammalian NOTCH receptors, forms a DNA-binding complex with ICN and RBP-Jkappa, and amplifies NOTCH-induced transcription of HES1."].
+- The review should prefer Notch target-gene transcription terms over a broad pathway-only framing: [file:human/MAML1/MAML1-deep-research-falcon.md "**Prefer “Notch target gene transcription” over broad “Notch signaling pathway”** unless direct pathway-level phenotypes are tied specifically to human MAML1 (not dnMAML pan-inhibition, not paralog redundancy)."].
+- Generic protein binding rows are less informative than the specific coactivator, complex-membership, and CDK8-binding evidence. CDK8 binding is supported directly [PMID:15546612 "MAM interacts directly with CDK8 and can cause it to localize to subnuclear foci."].
+- The PMID:17317671 peptide antigen binding annotation appears erroneous: the paper supports p53 coactivator activity, not antigen binding [PMID:17317671 "MAML1-p53 interaction involves the N-terminal region of MAML1 and the DNA-binding domain of p53, and we use a chromatin immunoprecipitation assay to show that MAML1 is part of the activator complex that binds to native p53-response elements within the promoter of the p53 target genes."].
+- Nuclear/nucleoplasm localization is solid as context, but nuclear speck or nuclear-body assignments should be conservative because Falcon notes that the evidence is often overexpression-linked [file:human/MAML1/MAML1-deep-research-falcon.md "**Nuclear bodies/specks:** nuclear-body localization is supported but is **often overexpression-linked**; annotate cautiously at specific subnuclear compartments."].


### PR DESCRIPTION
## Summary\n- add Falcon deep research for human MAML1\n- incorporate Falcon/direct evidence into the review description, references, notes, and core functions\n- resolve high-confidence Notch transcription, CDK8-binding, nuclear localization, and p53/peptide-antigen rows while leaving inherited unresolved rows as PENDING\n- render the updated HTML\n\n## Validation\n- uv run python scripts/validate_deep_research.py genes/human/MAML1/MAML1-deep-research-falcon.md\n- exact supporting_text audit against cached PMIDs/Falcon file\n- just validate human MAML1 (passes with expected warning: 52 inherited PENDING annotations remain)\n- just render human MAML1\n- git diff --check