### PR TITLE
RB1: ACCEPT 6 canonical nuclear-localization rows (batch 10 of #347)

### DIFF
--- a/genes/human/RB1/RB1-ai-review.yaml
+++ b/genes/human/RB1/RB1-ai-review.yaml
@@ -1067,16 +1067,18 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'IDA annotation for nucleoplasmic localization sourced from the Human Protein Atlas immunofluorescence curation (GO_REF:0000052). RB1 is a canonical nuclear/nucleoplasmic protein; hypophosphorylated active RB1 occupies E2F-target gene promoters in the nucleoplasm and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis). Nucleoplasmic localization is also independently supported by 17 Reactome TAS rows on GO:0005654 already ACCEPTed in PR #444 and by IEA propagations ACCEPTed in PR #461.'
+    action: ACCEPT
+    reason: 'Canonical RB1 localization, well supported by experimental evidence already present in this file (PMID:7923370 RB-BRG1 cooperation; 17 Reactome TAS nucleoplasm rows ACCEPTed in PR #444) and by HPA immunofluorescence curation (GO_REF:0000052). Mechanical canonical-nuclear-localization batch (batch 10 of #347).'
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IDA
   original_reference_id: PMID:1531329
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'IDA annotation for nuclear localization sourced from the RB-E2F interaction paper (Hiebert et al. 1992 Genes Dev, PMID:1531329). The paper demonstrates that RB1 interacts with E2F in a complex that inhibits E2F transcriptional activity, with the in vivo biochemistry performed on nuclear extracts. Nuclear localization is the canonical compartment for active hypophosphorylated RB1 and is independently supported by 17 Reactome TAS rows on GO:0005654 nucleoplasm previously ACCEPTed (PR #444), by IEA propagations ACCEPTed in PR #461, and by the IDA nucleoplasm row from PMID:17540172 ACCEPTed in PR #499.'
+    action: ACCEPT
+    reason: 'Canonical RB1 localization, well supported by experimental evidence already present in this file (PMID:7923370 RB-BRG1 cooperation; 17 Reactome TAS nucleoplasm rows ACCEPTed in PR #444). The Hiebert et al. 1992 paper is the canonical RB-E2F interaction paper and directly supports nuclear localization of RB1. Mechanical canonical-nuclear-localization batch (batch 10 of #347).'
 - term:
     id: GO:0006355
     label: regulation of DNA-templated transcription
@@ -1099,8 +1101,9 @@ existing_annotations:
   evidence_type: EXP
   original_reference_id: PMID:20940255
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'EXP annotation for nuclear localization sourced from Pickard et al. 2010 (PMID:20940255), "Acetylation of Rb by PCAF is required for nuclear localization and keratinocyte differentiation." The paper directly characterizes RB1 nuclear localization and shows that PCAF-mediated acetylation of Rb is required for its retention in the nucleus during keratinocyte differentiation. Nuclear localization is the canonical compartment for active hypophosphorylated RB1 and is independently supported by 17 Reactome TAS rows on GO:0005654 nucleoplasm previously ACCEPTed (PR #444) and by IEA propagations ACCEPTed in PR #461.'
+    action: ACCEPT
+    reason: 'Canonical RB1 localization, directly characterized by the cited paper (PMID:20940255) — RB1 nuclear localization is the explicit subject of the Pickard et al. 2010 study. Also independently supported by 17 Reactome TAS nucleoplasm rows ACCEPTed in PR #444 and by canonical IEA propagations. Mechanical canonical-nuclear-localization batch (batch 10 of #347).'
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -1238,8 +1241,9 @@ existing_annotations:
   evidence_type: TAS
   original_reference_id: PMID:3657987
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'TAS annotation for nuclear localization sourced from Lee et al. 1987 Nature (PMID:3657987), the foundational paper that identified the retinoblastoma gene product as a nuclear phosphoprotein. The paper explicitly states that "biochemical fractionation and immunofluorescence studies demonstrate that the majority of the protein is located within the nucleus." This is the original characterization of RB1 as a nuclear protein and is independently corroborated by 17 Reactome TAS rows on GO:0005654 nucleoplasm previously ACCEPTed (PR #444), IDA evidence (PMID:17540172 in PR #499, PMID:1531329, PMID:20940255 in this batch), and canonical IEA propagations ACCEPTed in PR #461.'
+    action: ACCEPT
+    reason: 'Canonical RB1 localization established in the foundational Lee et al. 1987 Nature paper (PMID:3657987), which directly demonstrates nuclear localization by both biochemical fractionation and immunofluorescence. Nuclear localization is one of the defining features of RB1 from the moment the gene was cloned. Mechanical canonical-nuclear-localization batch (batch 10 of #347).'
 - term:
     id: GO:0030308
     label: negative regulation of cell growth
@@ -1352,8 +1356,9 @@ existing_annotations:
   evidence_type: NAS
   original_reference_id: PMID:2730637
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'NAS annotation for nuclear localization derived from Taya et al. 1989 (PMID:2730637), a paper primarily about homology between the RB1 gene and L1 family repetitive sequences. The paper discusses DNA-binding properties of RB1 (which implicitly involves nuclear localization) but does not directly characterize subcellular localization. The NAS evidence is weak as a primary source, but the annotated function (nuclear localization) is independently and robustly supported by IDA evidence (PMID:1531329, PMID:20940255, PMID:17540172), TAS evidence (PMID:3657987 — the original Lee et al. 1987 nuclear-phosphoprotein paper), and 17 Reactome TAS rows on GO:0005654 nucleoplasm previously ACCEPTed (PR #444).'
+    action: ACCEPT
+    reason: 'The underlying annotation (nuclear localization) is one of the most robustly established RB1 facts, independently supported by multiple IDA/EXP/TAS rows from the foundational literature. The specific NAS source (PMID:2730637) is weak provenance individually, but consistent with the broader literature and not biologically wrong. Mechanical canonical-nuclear-localization batch (batch 10 of #347).'
 - term:
     id: GO:0006355
     label: regulation of DNA-templated transcription
@@ -1376,8 +1381,9 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:8245034
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'IDA annotation for nucleoplasmic localization sourced from Pahel et al. 1993 (PMID:8245034), an HPV16 E7 biochemistry paper. E7 is a "nuclear phosphoprotein" that binds RB1 "avidly and specifically" and can dissociate the E2F transcription factor from RB1 in vitro. The biochemistry of the E7–RB1 interaction is performed on nuclear RB1, supporting RB1 nucleoplasmic localization. Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is independently supported by 17 Reactome TAS rows on GO:0005654 already ACCEPTed (PR #444), by IDA evidence (PMID:17540172 in PR #499, GO_REF:0000052 HPA in this batch), and by canonical IEA propagations ACCEPTed in PR #461.'
+    action: ACCEPT
+    reason: 'Canonical RB1 nucleoplasmic localization, well supported by experimental evidence already present in this file (17 Reactome TAS rows ACCEPTed in PR #444; IDA from PMID:17540172 ACCEPTed in PR #499). The E7-RB1 interaction characterized in PMID:8245034 is well established to occur in the nucleus where RB1 binds chromatin. Mechanical canonical-nuclear-localization batch (batch 10 of #347).'
 - term:
     id: GO:0035189
     label: Rb-E2F complex


### PR DESCRIPTION
## Summary

Mechanically consolidates the **6 PENDING canonical nuclear/nucleoplasmic localization rows** in `RB1-ai-review.yaml` to `ACCEPT` with a uniform per-source template, following the same pattern as BRAF PR #505 (4 canonical localization rows) and the prior RB1 nucleoplasm batches.

RB1 nuclear/nucleoplasmic localization is one of the defining facts about the protein — established in the foundational Lee et al. 1987 Nature paper (PMID:3657987) and supported across every evidence tier in this file. All six rows in this batch are independently corroborated by:

- **17 Reactome TAS nucleoplasm rows** ACCEPTed in PR #444
- **IDA nucleus/nucleoplasm** from PMID:17540172 (chromatin lock complex) ACCEPTed in PR #499
- **Canonical IEA propagations** ACCEPTed in PR #461
- **Multiple cross-referenced sources** within this batch itself

## What's in this PR

| Term | Evidence | Reference | Notes |
|------|----------|-----------|-------|
| `GO:0005654` nucleoplasm | IDA | GO_REF:0000052 | Human Protein Atlas immunofluorescence |
| `GO:0005634` nucleus | IDA | PMID:1531329 | Hiebert 1992 — RB-E2F interaction (Genes Dev) |
| `GO:0005634` nucleus | EXP | PMID:20940255 | Pickard 2010 — "Acetylation of Rb by PCAF is required for **nuclear localization**" (direct subject) |
| `GO:0005634` nucleus | TAS | PMID:3657987 | Lee 1987 Nature — foundational nuclear-phosphoprotein characterization |
| `GO:0005634` nucleus | NAS | PMID:2730637 | Taya 1989 — weaker primary source but underlying fact robustly supported elsewhere |
| `GO:0005654` nucleoplasm | IDA | PMID:8245034 | Pahel 1993 — HPV16 E7-RB1 nucleoplasmic interaction |

### NAS row (PMID:2730637)
The Taya et al. 1989 paper is primarily about L1 family homology in the RB1 gene, not subcellular localization — NAS is a weak primary source for the GO:0005634 nucleus annotation. Kept as `ACCEPT` (not `MARK_AS_OVER_ANNOTATED`) because the underlying fact (RB1 is nuclear) is robustly established by every other IDA/EXP/TAS source in this batch and elsewhere in the file. The summary explicitly flags the weak provenance.

## Diff stats

- `+18 / -12` lines on `RB1-ai-review.yaml`
- **PENDING count: 49 → 43 (−6)**
- `just validate human RB1` → ✓ Valid (only the 2 pre-existing warnings — unchanged PENDING count warning and the unused deep-research-file note)

## What remains after this batch (43 PENDING)

Same shape as the [batch 9 PR #516 carryover](https://github.com/ai4curation/ai-gene-review/pull/516), minus the 6 canonical-localization rows resolved here:

- ~12 IEA `GO_REF:0000107` rows (mixed canonical / tissue-specific — needs split per-row review)
- ~7 IPI rows on `GO:0042802` / `GO:0035189` / `GO:0140297` / `GO:0061676` / `GO:0097718` / `GO:0051219` self-interaction & RB-E2F complex variants (analogous to BRAF #493 dimerization-IPI batch)
- ~9 IDA/EXP/IMP canonical rows on PMID:1531329 / PMID:8245034 / PMID:19223331 / PMID:12065415 / PMID:20940255 / PMID:20551165 / PMID:10783144 / PMID:25100735 / PMID:12037672 — drive `core_functions[1+]` block expansion
- ~6 PMID:20551165 IMP mitotic / chromosome-organization cluster (single paper batch candidate, defines a non-core mitotic role)
- ~6 ISS rows
- 1 NAS PMID:2730637 GO:0006355 (paired with the NAS nucleus row resolved here), 1 EXP PMID:16360038 GO:0060090 adaptor activity, 1 IEP PMID:9054499 GO:0007265 Ras signal transduction, plus singletons

## Test plan

- [x] `just validate human RB1` → ✓ Valid
- [x] PENDING count verified: 49 → 43 (−6)
- [x] All 6 changed rows use ACCEPT, no other action types in this batch
- [x] References for all 5 PMIDs already in the `references:` block (lines 1892, 1994, 2072, 2093, 2123) — no new references added
- [x] All 5 cached publication files present (`publications/PMID_*.md`)

*(Automated curation scanner — single-target run on RB1 #347; BRAF #344 has an open draft batch-9 PR (#518) so stacking another batch there would conflict. Mechanical canonical-localization batch, no `core_functions` decisions made.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)