### PR TITLE
Add Falcon deep research for MAPK1

### DIFF
--- a/genes/human/MAPK1/MAPK1-ai-review.html
+++ b/genes/human/MAPK1/MAPK1-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>MAPK1</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/P28482" target="_blank" class="term-link">
                         P28482
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Homo sapiens</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-initialized">
                     INITIALIZED
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,24 +728,24 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
-            <span class="vote-buttons" data-g="P28482" data-a="DESCRIPTION: TODO: Add description for MAPK1..." data-r="" data-act="DESCRIPTION">
+            <span class="vote-buttons" data-g="P28482" data-a="DESCRIPTION: MAPK1 (ERK2) is an ATP-dependent, proline-directed..." data-r="" data-act="DESCRIPTION">
                 <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>TODO: Add description for MAPK1</p>
+        <p>MAPK1 (ERK2) is an ATP-dependent, proline-directed serine/threonine MAP kinase in the canonical Ras-RAF-MEK-ERK cascade. It is activated by MEK1/2 dual phosphorylation, phosphorylates cytosolic and nuclear substrates, and shuttles between cytoplasmic/cytosolic and nuclear compartments after stimulation. Distal proliferation, differentiation, apoptosis, migration, transcriptional, and disease phenotypes are context-dependent ERK pathway outputs rather than the core MAPK1 molecular function.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,502 +758,791 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005634" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 localizes to the nucleus after stimulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Nuclear localization is supported, but should be interpreted as stimulus-dependent rather than constitutive.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear accumulation can be partially uncoupled from TEY phosphorylation and depends on docking interactions and anchors.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005737" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is cytoplasmic in quiescent cells.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytoplasmic localization is a core supported localization for ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035556" target="_blank" class="term-link">
                                     GO:0035556
                                 </a>
                             </span>
                             <span class="term-label">intracellular signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0035556" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0035556" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 functions in intracellular signal transduction downstream of extracellular cues.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Intracellular signal transduction is a supported core process for MAPK1 as the ERK2 kinase in the canonical MAPK cascade.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
                                     GO:0004674
                                 </a>
                             </span>
                             <span class="term-label">protein serine/threonine kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="GO_REF:0000033" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Serine/threonine protein kinase activity is a core molecular function of MAPK1; the more specific MAP kinase activity term should also be retained where present.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007166" target="_blank" class="term-link">
                                     GO:0007166
                                 </a>
                             </span>
                             <span class="term-label">cell surface receptor signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0007166" data-r="GO_REF:0000033" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0007166" data-r="GO_REF:0000033" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 responds to cell-surface receptor inputs, but its core role is the downstream intracellular ERK/MAPK cascade.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cell surface receptor signaling is too broad and upstream-oriented for the MAPK1 core function; ERK/MAPK cascade terms are more specific.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070371" target="_blank" class="term-link">
+                                    ERK1 and ERK2 cascade
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000165" target="_blank" class="term-link">
+                                    MAPK cascade
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004672" target="_blank" class="term-link">
                                     GO:0004672
                                 </a>
                             </span>
                             <span class="term-label">protein kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004672" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004672" data-r="GO_REF:0000120" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 is a protein kinase, but this term is less specific than the supported serine/threonine MAP kinase terms.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The generic protein kinase term should be replaced by protein serine/threonine kinase activity and MAP kinase activity, which capture MAPK1 specificity.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                                    protein serine/threonine kinase activity
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004707" target="_blank" class="term-link">
+                                    MAP kinase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004707" target="_blank" class="term-link">
                                     GO:0004707
                                 </a>
                             </span>
                             <span class="term-label">MAP kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004707" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004707" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 has MAP kinase activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005524" data-r="GO_REF:0000002" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 binds ATP as the phosphoryl donor for kinase catalysis.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ATP binding is integral to the active-site chemistry of ERK2 kinase activity.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005634" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005634" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 localizes to the nucleus after stimulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Nuclear localization is supported, but should be interpreted as stimulus-dependent rather than constitutive.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear accumulation can be partially uncoupled from TEY phosphorylation and depends on docking interactions and anchors.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005737" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005737" data-r="GO_REF:0000120" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is cytoplasmic in quiescent cells.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytoplasmic localization is a core supported localization for ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005769" target="_blank" class="term-link">
                                     GO:0005769
                                 </a>
                             </span>
                             <span class="term-label">early endosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1265,42 +1554,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005770" target="_blank" class="term-link">
                                     GO:0005770
                                 </a>
                             </span>
                             <span class="term-label">late endosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1312,42 +1601,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005794" target="_blank" class="term-link">
                                     GO:0005794
                                 </a>
                             </span>
                             <span class="term-label">Golgi apparatus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1359,42 +1648,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005813" target="_blank" class="term-link">
                                     GO:0005813
                                 </a>
                             </span>
                             <span class="term-label">centrosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1406,42 +1695,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005819" target="_blank" class="term-link">
                                     GO:0005819
                                 </a>
                             </span>
                             <span class="term-label">spindle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1453,42 +1742,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005901" target="_blank" class="term-link">
                                     GO:0005901
                                 </a>
                             </span>
                             <span class="term-label">caveola</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1500,42 +1789,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005925" target="_blank" class="term-link">
                                     GO:0005925
                                 </a>
                             </span>
                             <span class="term-label">focal adhesion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1547,183 +1836,254 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006357" target="_blank" class="term-link">
                                     GO:0006357
                                 </a>
                             </span>
                             <span class="term-label">regulation of transcription by RNA polymerase II</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000108
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0006357" data-r="GO_REF:0000108" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0006357" data-r="GO_REF:0000108" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 can affect transcriptional programs through downstream substrates, but broad regulation of RNA polymerase II transcription overstates the direct function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The direct MAPK1 function is kinase activity and ERK/MAPK cascade signaling; broad transcriptional regulation should not be inferred from pathway membership alone.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007173" target="_blank" class="term-link">
                                     GO:0007173
                                 </a>
                             </span>
                             <span class="term-label">epidermal growth factor receptor signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0007173" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0007173" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 is activated in receptor and growth-factor signaling contexts, but these are stimulus-specific pathway contexts rather than the core conserved ERK2 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Growth-factor and receptor-specific signaling annotations can be retained as non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010759" target="_blank" class="term-link">
                                     GO:0010759
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of macrophage chemotaxis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0010759" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0010759" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a context-dependent downstream process linked to ERK signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The process may be retained as non-core where the source evidence supports a specific context, but it should not be treated as the core conserved MAPK1 function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032206" target="_blank" class="term-link">
                                     GO:0032206
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of telomere maintenance</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1735,136 +2095,198 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032872" target="_blank" class="term-link">
                                     GO:0032872
                                 </a>
                             </span>
                             <span class="term-label">regulation of stress-activated MAPK cascade</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0032872" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0032872" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a stress-context signaling annotation for MAPK1.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Stress-context annotations are secondary to the canonical ERK/MAPK cascade role and should remain non-core unless a later source-level review shows they are central for MAPK1.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034198" target="_blank" class="term-link">
                                     GO:0034198
                                 </a>
                             </span>
                             <span class="term-label">cellular response to amino acid starvation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0034198" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0034198" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a stress-context signaling annotation for MAPK1.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Stress-context annotations are secondary to the canonical ERK/MAPK cascade role and should remain non-core unless a later source-level review shows they are central for MAPK1.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045202" target="_blank" class="term-link">
                                     GO:0045202
                                 </a>
                             </span>
                             <span class="term-label">synapse</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000108
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1876,89 +2298,120 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051403" target="_blank" class="term-link">
                                     GO:0051403
                                 </a>
                             </span>
                             <span class="term-label">stress-activated MAPK cascade</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0051403" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0051403" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a stress-context signaling annotation for MAPK1.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Stress-context annotations are secondary to the canonical ERK/MAPK cascade role and should remain non-core unless a later source-level review shows they are central for MAPK1.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051493" target="_blank" class="term-link">
                                     GO:0051493
                                 </a>
                             </span>
                             <span class="term-label">regulation of cytoskeleton organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -1970,183 +2423,265 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061514" target="_blank" class="term-link">
                                     GO:0061514
                                 </a>
                             </span>
                             <span class="term-label">interleukin-34-mediated signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0061514" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0061514" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a context-dependent downstream process linked to ERK signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The process may be retained as non-core where the source evidence supports a specific context, but it should not be treated as the core conserved MAPK1 function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070371" target="_blank" class="term-link">
                                     GO:0070371
                                 </a>
                             </span>
                             <span class="term-label">ERK1 and ERK2 cascade</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0070371" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0070371" data-r="GO_REF:0000117" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is a central component of the ERK1 and ERK2 cascade.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ERK1 and ERK2 cascade is a core pathway term for MAPK1 and is more specific than generic signaling process terms.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070849" target="_blank" class="term-link">
                                     GO:0070849
                                 </a>
                             </span>
                             <span class="term-label">response to epidermal growth factor</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0070849" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0070849" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 is activated in receptor and growth-factor signaling contexts, but these are stimulus-specific pathway contexts rather than the core conserved ERK2 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Growth-factor and receptor-specific signaling annotations can be retained as non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072584" target="_blank" class="term-link">
                                     GO:0072584
                                 </a>
                             </span>
                             <span class="term-label">caveolin-mediated endocytosis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2158,42 +2693,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090170" target="_blank" class="term-link">
                                     GO:0090170
                                 </a>
                             </span>
                             <span class="term-label">regulation of Golgi inheritance</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2205,42 +2740,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0097542" target="_blank" class="term-link">
                                     GO:0097542
                                 </a>
                             </span>
                             <span class="term-label">ciliary tip</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2252,136 +2787,193 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0106310" target="_blank" class="term-link">
                                     GO:0106310
                                 </a>
                             </span>
                             <span class="term-label">protein serine kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000116
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0106310" data-r="GO_REF:0000116" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0106310" data-r="GO_REF:0000116" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 can phosphorylate serine residues, but the serine-only term is incomplete for ERK2.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ERK2 is a proline-directed serine/threonine MAP kinase; GO:0004674 and GO:0004707 better capture the supported activity than a serine-only activity term.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                                    protein serine/threonine kinase activity
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004707" target="_blank" class="term-link">
+                                    MAP kinase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120041" target="_blank" class="term-link">
                                     GO:0120041
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of macrophage proliferation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0120041" data-r="GO_REF:0000117" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0120041" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a context-dependent downstream process linked to ERK signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The process may be retained as non-core where the source evidence supports a specific context, but it should not be treated as the core conserved MAPK1 function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2000641" target="_blank" class="term-link">
                                     GO:2000641
                                 </a>
                             </span>
                             <span class="term-label">regulation of early endosome to late endosome transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000117
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2393,53 +2985,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10415025" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10415025
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Direct suppression of TCR-mediated activation of extracellul...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2451,53 +3043,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10601328" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10601328
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A novel regulatory mechanism of MAP kinases activation and n...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2509,53 +3101,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12592337" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12592337
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The protein tyrosine phosphatase HePTP regulates nuclear tra...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2567,53 +3159,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12840032" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12840032
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Constitutive induction of p-Erk1/2 accompanied by reduced ac...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2625,53 +3217,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15713638" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15713638
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Specific inactivation and nuclear anchoring of extracellular...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2683,53 +3275,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16038800" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16038800
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Conditional expression of MAP kinase phosphatase-2 protects ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2741,53 +3333,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16286470" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16286470
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Cooperation of ERK and SCFSkp2 for MKP-1 destruction provide...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2799,53 +3391,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16288922" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16288922
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     New insights into the catalytic activation of the MAPK phosp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2857,53 +3449,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17255944" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17255944
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A MAPK docking site is critical for downregulation of Capicu...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2915,53 +3507,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/17255949" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:17255949
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mxi2 promotes stimulus-independent ERK nuclear translocation...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -2973,53 +3565,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18060821" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18060821
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structural insights into the enzymatic mechanism of the path...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3031,53 +3623,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18084305" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18084305
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structural basis for the catalytic mechanism of phosphothreo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3089,53 +3681,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18463290" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18463290
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Human biliverdin reductase is an ERK activator; hBVR is an E...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3147,53 +3739,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18616943" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18616943
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphorylation of U24 from Human Herpes Virus type 6 (HHV-6...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3205,53 +3797,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19494114" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19494114
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tumor suppressor density-enhanced phosphatase-1 (DEP-1) inhi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3263,53 +3855,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21826244" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21826244
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     TRAPPC4-ERK2 interaction activates ERK1/2, modulates its nuc...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3321,53 +3913,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21908610" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21908610
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphorylation of the kinase interaction motif in mitogen-a...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3379,53 +3971,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21988832
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Toward an understanding of the protein interaction network o...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3437,53 +4029,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22521293" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22521293
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ETS-dependent p16INK4a and p21waf1/cip1 gene expression upon...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3495,53 +4087,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23241949" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23241949
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MEK1 inactivates Myt1 to regulate Golgi membrane fragmentati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3553,53 +4145,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23455922" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23455922
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interlaboratory reproducibility of large-scale human protein...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3611,53 +4203,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23519423" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23519423
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protein-peptide complex crystallization: a case study on the...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3669,53 +4261,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23560844" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23560844
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Metal-dependent protein phosphatase 1A functions as an extra...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3727,53 +4319,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23575685" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23575685
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structure of ERK2 bound to PEA-15 reveals a mechanism for ra...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3785,53 +4377,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23584453" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23584453
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interaction with Shc prevents aberrant Erk activation in the...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3843,53 +4435,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23602568" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23602568
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The protein interaction landscape of the human CMGC kinase g...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3901,53 +4493,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25241761" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25241761
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Using an in situ proximity ligation assay to systematically ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -3959,53 +4551,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25852190" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25852190
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Integrative analysis of kinase networks in TRAIL-induced apo...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4017,53 +4609,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26267535" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26267535
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ERK2-Dependent Phosphorylation of CSN6 Is Critical in Colore...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4075,53 +4667,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26733474" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26733474
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Identification of allosteric ERK2 inhibitors through in sili...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4133,53 +4725,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27880917" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27880917
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phenotypic and Interaction Profiling of the Human Phosphatas...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4191,53 +4783,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/29997244" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:29997244
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     LuTHy: a double-readout bioluminescence-based two-hybrid tec...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4249,53 +4841,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/31980649" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:31980649
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extensive rewiring of the EGFR network in colorectal cancer ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4307,53 +4899,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32296183
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A reference map of the human binary protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4365,53 +4957,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32707033" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32707033
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Kinase Interaction Network Expands Functional and Disease Ro...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4423,53 +5015,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32814053
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Interactome Mapping Provides a Network of Neurodegenerative ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4481,53 +5073,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:33961781
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dual proteome-scale networks reveal cell-specific remodeling...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4539,53 +5131,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/34591642" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:34591642
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A protein network map of head and neck cancer reveals PIK3CA...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4597,53 +5189,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35271311
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     OpenCell: Endogenous tagging for the cartography of human ce...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4655,53 +5247,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/38884001" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:38884001
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mapping adipocyte interactome networks by HaloTag-enrichment...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4713,53 +5305,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:40205054
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Multimodal cell maps as a foundation for structural and func...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4771,53 +5363,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9632734" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9632734
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Activation of extracellular signal-regulated kinase 2 by a n...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4829,53 +5421,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/9788880" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:9788880
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Isolation of the human genes encoding the pyst1 and Pyst2 ph...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4887,53 +5479,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16627622" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16627622
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Direct phosphorylation and regulation of poly(ADP-ribose) po...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -4945,53 +5537,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26267534" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26267534
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Small Molecule Inhibition of ERK Dimerization Prevents Tumor...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -5003,42 +5595,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0001784" target="_blank" class="term-link">
                                     GO:0001784
                                 </a>
                             </span>
                             <span class="term-label">phosphotyrosine residue binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -5050,89 +5642,109 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
                                     GO:0004674
                                 </a>
                             </span>
                             <span class="term-label">protein serine/threonine kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="GO_REF:0000107" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Serine/threonine protein kinase activity is a core molecular function of MAPK1; the more specific MAP kinase activity term should also be retained where present.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -5144,136 +5756,187 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005829" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005829" data-r="GO_REF:0000107" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is present in the cytosolic/cytoplasmic compartment.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytosolic localization is consistent with ERK2 being predominantly cytoplasmic in quiescent cells before stimulus-dependent nuclear accumulation.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008286" target="_blank" class="term-link">
                                     GO:0008286
                                 </a>
                             </span>
                             <span class="term-label">insulin receptor signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0008286" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0008286" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 is activated in receptor and growth-factor signaling contexts, but these are stimulus-specific pathway contexts rather than the core conserved ERK2 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Growth-factor and receptor-specific signaling annotations can be retained as non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008353" target="_blank" class="term-link">
                                     GO:0008353
                                 </a>
                             </span>
                             <span class="term-label">RNA polymerase II CTD heptapeptide repeat kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -5285,183 +5948,260 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0014044" target="_blank" class="term-link">
                                     GO:0014044
                                 </a>
                             </span>
                             <span class="term-label">Schwann cell development</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0014044" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0014044" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The available synthesis supports ERK/MAPK cascade membership as core, but warns against promoting broad developmental or disease-associated outcomes to core MAPK1 functions without direct MAPK1-specific evidence.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016301" target="_blank" class="term-link">
                                     GO:0016301
                                 </a>
                             </span>
                             <span class="term-label">kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0016301" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0016301" data-r="GO_REF:0000107" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 is a kinase, but this term is too broad for ERK2.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The broad kinase activity annotation should use the more informative serine/threonine MAP kinase terms.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                                    protein serine/threonine kinase activity
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004707" target="_blank" class="term-link">
+                                    MAP kinase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019902" target="_blank" class="term-link">
                                     GO:0019902
                                 </a>
                             </span>
                             <span class="term-label">phosphatase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0019902" data-r="GO_REF:0000120" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0019902" data-r="GO_REF:0000120" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 binds MAP kinase phosphatases such as DUSP6/MKP-3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Phosphatase binding is a supported regulatory interaction, but it is not the primary catalytic function of MAPK1.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">DUSP6/MKP-3 as cytoplasmic tether:** MKP-3/DUSP6 binds ERK2 and can dephosphorylate and tether inactive ERK2 in the cytoplasm; mutating MKP-3 NES or KIM abolishes cytoplasmic anchoring.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0031143" target="_blank" class="term-link">
                                     GO:0031143
                                 </a>
                             </span>
                             <span class="term-label">pseudopodium</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -5473,42 +6213,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035094" target="_blank" class="term-link">
                                     GO:0035094
                                 </a>
                             </span>
                             <span class="term-label">response to nicotine</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -5520,136 +6260,187 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038133" target="_blank" class="term-link">
                                     GO:0038133
                                 </a>
                             </span>
                             <span class="term-label">ERBB2-ERBB3 signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0038133" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0038133" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 is activated in receptor and growth-factor signaling contexts, but these are stimulus-specific pathway contexts rather than the core conserved ERK2 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Growth-factor and receptor-specific signaling annotations can be retained as non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042552" target="_blank" class="term-link">
                                     GO:0042552
                                 </a>
                             </span>
                             <span class="term-label">myelination</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0042552" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0042552" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The available synthesis supports ERK/MAPK cascade membership as core, but warns against promoting broad developmental or disease-associated outcomes to core MAPK1 functions without direct MAPK1-specific evidence.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -5661,451 +6452,650 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043415" target="_blank" class="term-link">
                                     GO:0043415
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of skeletal muscle tissue regeneration</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0043415" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0043415" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The available synthesis supports ERK/MAPK cascade membership as core, but warns against promoting broad developmental or disease-associated outcomes to core MAPK1 functions without direct MAPK1-specific evidence.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0048009" target="_blank" class="term-link">
                                     GO:0048009
                                 </a>
                             </span>
                             <span class="term-label">insulin-like growth factor receptor signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0048009" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0048009" data-r="GO_REF:0000107" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 is activated in receptor and growth-factor signaling contexts, but these are stimulus-specific pathway contexts rather than the core conserved ERK2 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Growth-factor and receptor-specific signaling annotations can be retained as non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0150078" target="_blank" class="term-link">
                                     GO:0150078
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of neuroinflammatory response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000107
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0150078" data-r="GO_REF:0000107" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0150078" data-r="GO_REF:0000107" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The available synthesis supports ERK/MAPK cascade membership as core, but warns against promoting broad developmental or disease-associated outcomes to core MAPK1 functions without direct MAPK1-specific evidence.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004707" target="_blank" class="term-link">
                                     GO:0004707
                                 </a>
                             </span>
                             <span class="term-label">MAP kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004707" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004707" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 has MAP kinase activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22451653" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22451653
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Siglec-15 protein regulates formation of functional osteocla...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005829" data-r="PMID:22451653" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005829" data-r="PMID:22451653" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is present in the cytosolic/cytoplasmic compartment.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytosolic localization is consistent with ERK2 being predominantly cytoplasmic in quiescent cells before stimulus-dependent nuclear accumulation.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043415" target="_blank" class="term-link">
                                     GO:0043415
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of skeletal muscle tissue regeneration</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0043415" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0043415" data-r="GO_REF:0000024" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The available synthesis supports ERK/MAPK cascade membership as core, but warns against promoting broad developmental or disease-associated outcomes to core MAPK1 functions without direct MAPK1-specific evidence.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0106310" target="_blank" class="term-link">
                                     GO:0106310
                                 </a>
                             </span>
                             <span class="term-label">protein serine kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0106310" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0106310" data-r="GO_REF:0000024" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 can phosphorylate serine residues, but the serine-only term is incomplete for ERK2.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ERK2 is a proline-directed serine/threonine MAP kinase; GO:0004674 and GO:0004707 better capture the supported activity than a serine-only activity term.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
+                                    protein serine/threonine kinase activity
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004707" target="_blank" class="term-link">
+                                    MAP kinase activity
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
                                     GO:0004674
                                 </a>
                             </span>
                             <span class="term-label">protein serine/threonine kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35831023" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35831023
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ERK2 MAP kinase regulates SUFU binding by multisite phosphor...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="PMID:35831023" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="PMID:35831023" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Serine/threonine protein kinase activity is a core molecular function of MAPK1; the more specific MAP kinase activity term should also be retained where present.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045880" target="_blank" class="term-link">
                                     GO:0045880
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of smoothened signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/35831023" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:35831023
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ERK2 MAP kinase regulates SUFU binding by multisite phosphor...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -6117,451 +7107,666 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005654" data-r="GO_REF:0000052" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005654" data-r="GO_REF:0000052" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 can accumulate in the nuclear compartment after stimulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Nucleoplasmic localization is compatible with the supported stimulus-dependent nuclear accumulation of ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear accumulation can be partially uncoupled from TEY phosphorylation and depends on docking interactions and anchors.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000052
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005829" data-r="GO_REF:0000052" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is present in the cytosolic/cytoplasmic compartment.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytosolic localization is consistent with ERK2 being predominantly cytoplasmic in quiescent cells before stimulus-dependent nuclear accumulation.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004707" target="_blank" class="term-link">
                                     GO:0004707
                                 </a>
                             </span>
                             <span class="term-label">MAP kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-111898
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004707" data-r="Reactome:R-HSA-111898" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004707" data-r="Reactome:R-HSA-111898" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 has MAP kinase activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004707" target="_blank" class="term-link">
                                     GO:0004707
                                 </a>
                             </span>
                             <span class="term-label">MAP kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-445079
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004707" data-r="Reactome:R-HSA-445079" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004707" data-r="Reactome:R-HSA-445079" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 has MAP kinase activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
                                     GO:0004674
                                 </a>
                             </span>
                             <span class="term-label">protein serine/threonine kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/38503280" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:38503280
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A gut-derived hormone regulates cholesterol metabolism.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="PMID:38503280" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="PMID:38503280" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Serine/threonine protein kinase activity is a core molecular function of MAPK1; the more specific MAP kinase activity term should also be retained where present.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070371" target="_blank" class="term-link">
                                     GO:0070371
                                 </a>
                             </span>
                             <span class="term-label">ERK1 and ERK2 cascade</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15850461" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15850461
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The phosphorylation of CapZ-interacting protein (CapZIP) by ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0070371" data-r="PMID:15850461" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0070371" data-r="PMID:15850461" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is a central component of the ERK1 and ERK2 cascade.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ERK1 and ERK2 cascade is a core pathway term for MAPK1 and is more specific than generic signaling process terms.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0150078" target="_blank" class="term-link">
                                     GO:0150078
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of neuroinflammatory response</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0150078" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0150078" data-r="GO_REF:0000024" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The available synthesis supports ERK/MAPK cascade membership as core, but warns against promoting broad developmental or disease-associated outcomes to core MAPK1 functions without direct MAPK1-specific evidence.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004707" target="_blank" class="term-link">
                                     GO:0004707
                                 </a>
                             </span>
                             <span class="term-label">MAP kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/38503280" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:38503280
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A gut-derived hormone regulates cholesterol metabolism.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004707" data-r="PMID:38503280" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004707" data-r="PMID:38503280" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 has MAP kinase activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070098" target="_blank" class="term-link">
                                     GO:0070098
                                 </a>
                             </span>
                             <span class="term-label">chemokine-mediated signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -6573,285 +7778,398 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000165" target="_blank" class="term-link">
                                     GO:0000165
                                 </a>
                             </span>
                             <span class="term-label">MAPK cascade</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15850461" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15850461
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The phosphorylation of CapZ-interacting protein (CapZIP) by ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0000165" data-r="PMID:15850461" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0000165" data-r="PMID:15850461" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 functions in the canonical MAPK cascade.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> MAPK cascade membership is a core biological process for ERK2, downstream of Ras-RAF-MEK signaling.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0061514" target="_blank" class="term-link">
                                     GO:0061514
                                 </a>
                             </span>
                             <span class="term-label">interleukin-34-mediated signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26754294" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26754294
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     miR-28-5p-IL-34-macrophage feedback loop modulates hepatocel...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0061514" data-r="PMID:26754294" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0061514" data-r="PMID:26754294" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a context-dependent downstream process linked to ERK signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The process may be retained as non-core where the source evidence supports a specific context, but it should not be treated as the core conserved MAPK1 function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000165" target="_blank" class="term-link">
                                     GO:0000165
                                 </a>
                             </span>
                             <span class="term-label">MAPK cascade</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24854121" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24854121
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Endophilin-1 regulates blood-brain barrier permeability by c...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0000165" data-r="PMID:24854121" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0000165" data-r="PMID:24854121" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 functions in the canonical MAPK cascade.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> MAPK cascade membership is a core biological process for ERK2, downstream of Ras-RAF-MEK signaling.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007173" target="_blank" class="term-link">
                                     GO:0007173
                                 </a>
                             </span>
                             <span class="term-label">epidermal growth factor receptor signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24854121" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24854121
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Endophilin-1 regulates blood-brain barrier permeability by c...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0007173" data-r="PMID:24854121" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0007173" data-r="PMID:24854121" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 is activated in receptor and growth-factor signaling contexts, but these are stimulus-specific pathway contexts rather than the core conserved ERK2 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Growth-factor and receptor-specific signaling annotations can be retained as non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26942675
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Mitochondria-Translocated PGK1 Functions as a Protein Kinase...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -6863,53 +8181,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032206" target="_blank" class="term-link">
                                     GO:0032206
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of telomere maintenance</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21531765" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21531765
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     High-throughput RNAi screening reveals novel regulators of t...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -6921,53 +8239,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045542" target="_blank" class="term-link">
                                     GO:0045542
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of cholesterol biosynthetic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/38503280" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:38503280
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A gut-derived hormone regulates cholesterol metabolism.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -6979,53 +8297,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11489891" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11489891
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MKP-7, a novel mitogen-activated protein kinase phosphatase,...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -7037,53 +8355,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32721402" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32721402
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Enhanced MAPK1 Function Causes a Neurodevelopmental Disorder...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -7095,169 +8413,220 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32721402" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32721402
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Enhanced MAPK1 Function Causes a Neurodevelopmental Disorder...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005634" data-r="PMID:32721402" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005634" data-r="PMID:32721402" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 localizes to the nucleus after stimulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Nuclear localization is supported, but should be interpreted as stimulus-dependent rather than constitutive.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear accumulation can be partially uncoupled from TEY phosphorylation and depends on docking interactions and anchors.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32721402" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32721402
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Enhanced MAPK1 Function Causes a Neurodevelopmental Disorder...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005737" data-r="PMID:32721402" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005737" data-r="PMID:32721402" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is cytoplasmic in quiescent cells.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytoplasmic localization is a core supported localization for ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32051553" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32051553
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The EGFR-ZNF263 signaling axis silences SIX3 in glioblastoma...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -7269,227 +8638,287 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
                                     GO:0004674
                                 </a>
                             </span>
                             <span class="term-label">protein serine/threonine kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/7588608" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:7588608
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     ERF: an ETS domain protein with strong transcriptional repre...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="PMID:7588608" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="PMID:7588608" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Serine/threonine protein kinase activity is a core molecular function of MAPK1; the more specific MAP kinase activity term should also be retained where present.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010759" target="_blank" class="term-link">
                                     GO:0010759
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of macrophage chemotaxis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26754294" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26754294
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     miR-28-5p-IL-34-macrophage feedback loop modulates hepatocel...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0010759" data-r="PMID:26754294" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0010759" data-r="PMID:26754294" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a context-dependent downstream process linked to ERK signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The process may be retained as non-core where the source evidence supports a specific context, but it should not be treated as the core conserved MAPK1 function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0120041" target="_blank" class="term-link">
                                     GO:0120041
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of macrophage proliferation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26754294" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26754294
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     miR-28-5p-IL-34-macrophage feedback loop modulates hepatocel...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0120041" data-r="PMID:26754294" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0120041" data-r="PMID:26754294" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a context-dependent downstream process linked to ERK signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The process may be retained as non-core where the source evidence supports a specific context, but it should not be treated as the core conserved MAPK1 function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15133037" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15133037
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The major vault protein is a novel substrate for the tyrosin...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -7501,42 +8930,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9652816
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -7548,89 +8977,120 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005788" target="_blank" class="term-link">
                                     GO:0005788
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9636296
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005788" data-r="Reactome:R-HSA-9636296" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005788" data-r="Reactome:R-HSA-9636296" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is not a supported core MAPK1 localization in this review.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Falcon synthesis supports cytoplasmic/cytosolic and stimulus-dependent nuclear localization; secretory or granule-lumen locations are likely pathway-context over-annotations for soluble ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Prefer cytoplasm/nucleus over highly specific compartments unless direct localization evidence exists for MAPK1 itself in that context.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9635739
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -7642,100 +9102,120 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
                                     GO:0004674
                                 </a>
                             </span>
                             <span class="term-label">protein serine/threonine kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26996940" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26996940
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Regulation of Microtubule Assembly by Tau and not by Pin1.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="PMID:26996940" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="PMID:26996940" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Serine/threonine protein kinase activity is a core molecular function of MAPK1; the more specific MAP kinase activity term should also be retained where present.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005886" target="_blank" class="term-link">
                                     GO:0005886
                                 </a>
                             </span>
                             <span class="term-label">plasma membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -7747,42 +9227,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005901" target="_blank" class="term-link">
                                     GO:0005901
                                 </a>
                             </span>
                             <span class="term-label">caveola</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -7794,100 +9274,120 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007611" target="_blank" class="term-link">
                                     GO:0007611
                                 </a>
                             </span>
                             <span class="term-label">learning or memory</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11404397" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11404397
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Beta-amyloid activates the mitogen-activated protein kinase ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0007611" data-r="PMID:11404397" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0007611" data-r="PMID:11404397" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a context-dependent downstream process linked to ERK signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The process may be retained as non-core where the source evidence supports a specific context, but it should not be treated as the core conserved MAPK1 function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035094" target="_blank" class="term-link">
                                     GO:0035094
                                 </a>
                             </span>
                             <span class="term-label">response to nicotine</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -7899,357 +9399,543 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034198" target="_blank" class="term-link">
                                     GO:0034198
                                 </a>
                             </span>
                             <span class="term-label">cellular response to amino acid starvation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11096076" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11096076
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Glutamine-dependent antiapoptotic interaction of human gluta...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0034198" data-r="PMID:11096076" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0034198" data-r="PMID:11096076" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a stress-context signaling annotation for MAPK1.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Stress-context annotations are secondary to the canonical ERK/MAPK cascade role and should remain non-core unless a later source-level review shows they are central for MAPK1.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051403" target="_blank" class="term-link">
                                     GO:0051403
                                 </a>
                             </span>
                             <span class="term-label">stress-activated MAPK cascade</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11096076" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11096076
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Glutamine-dependent antiapoptotic interaction of human gluta...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0051403" data-r="PMID:11096076" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0051403" data-r="PMID:11096076" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a stress-context signaling annotation for MAPK1.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Stress-context annotations are secondary to the canonical ERK/MAPK cascade role and should remain non-core unless a later source-level review shows they are central for MAPK1.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6798751
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005576" data-r="Reactome:R-HSA-6798751" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005576" data-r="Reactome:R-HSA-6798751" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is not a supported core MAPK1 localization in this review.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Falcon synthesis supports cytoplasmic/cytosolic and stimulus-dependent nuclear localization; secretory or granule-lumen locations are likely pathway-context over-annotations for soluble ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Prefer cytoplasm/nucleus over highly specific compartments unless direct localization evidence exists for MAPK1 itself in that context.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005576" target="_blank" class="term-link">
                                     GO:0005576
                                 </a>
                             </span>
                             <span class="term-label">extracellular region</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6800434
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005576" data-r="Reactome:R-HSA-6800434" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005576" data-r="Reactome:R-HSA-6800434" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is not a supported core MAPK1 localization in this review.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Falcon synthesis supports cytoplasmic/cytosolic and stimulus-dependent nuclear localization; secretory or granule-lumen locations are likely pathway-context over-annotations for soluble ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Prefer cytoplasm/nucleus over highly specific compartments unless direct localization evidence exists for MAPK1 itself in that context.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035578" target="_blank" class="term-link">
                                     GO:0035578
                                 </a>
                             </span>
                             <span class="term-label">azurophil granule lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6798751
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0035578" data-r="Reactome:R-HSA-6798751" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0035578" data-r="Reactome:R-HSA-6798751" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is not a supported core MAPK1 localization in this review.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Falcon synthesis supports cytoplasmic/cytosolic and stimulus-dependent nuclear localization; secretory or granule-lumen locations are likely pathway-context over-annotations for soluble ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Prefer cytoplasm/nucleus over highly specific compartments unless direct localization evidence exists for MAPK1 itself in that context.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:1904813" target="_blank" class="term-link">
                                     GO:1904813
                                 </a>
                             </span>
                             <span class="term-label">ficolin-1-rich granule lumen</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6800434
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:1904813" data-r="Reactome:R-HSA-6800434" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:1904813" data-r="Reactome:R-HSA-6800434" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is not a supported core MAPK1 localization in this review.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Falcon synthesis supports cytoplasmic/cytosolic and stimulus-dependent nuclear localization; secretory or granule-lumen locations are likely pathway-context over-annotations for soluble ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Prefer cytoplasm/nucleus over highly specific compartments unless direct localization evidence exists for MAPK1 itself in that context.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24735981" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24735981
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     MFAP3L activation promotes colorectal cancer cell invasion a...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -8261,263 +9947,365 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006468" target="_blank" class="term-link">
                                     GO:0006468
                                 </a>
                             </span>
                             <span class="term-label">protein phosphorylation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23184662" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23184662
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Phosphorylation of eukaryotic elongation factor 2 (eEF2) by ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0006468" data-r="PMID:23184662" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0006468" data-r="PMID:23184662" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 directly phosphorylates protein substrates.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Protein phosphorylation is the direct biochemical output of the MAPK1 kinase activity.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 directly phosphorylates defined downstream targets such as Elk-1/ETS-family and other transcription-factor substrates in vitro and in cells; docking motifs/exosites help determine substrate recognition.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16791210" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16791210
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dynamic proteomics in individual human cells uncovers widesp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005634" data-r="PMID:16791210" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005634" data-r="PMID:16791210" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 localizes to the nucleus after stimulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Nuclear localization is supported, but should be interpreted as stimulus-dependent rather than constitutive.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear accumulation can be partially uncoupled from TEY phosphorylation and depends on docking interactions and anchors.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16791210" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16791210
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Dynamic proteomics in individual human cells uncovers widesp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005737" data-r="PMID:16791210" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005737" data-r="PMID:16791210" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is cytoplasmic in quiescent cells.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytoplasmic localization is a core supported localization for ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005737" data-r="GO_REF:0000024" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005737" data-r="GO_REF:0000024" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is cytoplasmic in quiescent cells.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytoplasmic localization is a core supported localization for ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072686" target="_blank" class="term-link">
                                     GO:0072686
                                 </a>
                             </span>
                             <span class="term-label">mitotic spindle</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -8529,53 +10317,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/23847209" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:23847209
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Pseudophosphatase STYX modulates cell-fate decisions and cel...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -8587,42 +10375,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-198746
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -8634,42 +10422,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-198756
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -8681,42 +10469,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-199959
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -8728,42 +10516,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-203797
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -8775,42 +10563,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3132737
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -8822,42 +10610,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3857329
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -8869,42 +10657,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-450325
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -8916,42 +10704,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5674387
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -8963,42 +10751,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5675373
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9010,42 +10798,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9032751
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9057,42 +10845,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9610166
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9104,42 +10892,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9632910
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9151,42 +10939,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9725030
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9198,42 +10986,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9765960
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9245,42 +11033,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005654" target="_blank" class="term-link">
                                     GO:0005654
                                 </a>
                             </span>
                             <span class="term-label">nucleoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-NUL-9009236
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9292,42 +11080,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-109858
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9339,42 +11127,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-109862
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9386,42 +11174,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-109864
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9433,42 +11221,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-111898
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9480,42 +11268,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-1168459
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9527,42 +11315,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-2029469
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9574,42 +11362,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-3371531
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9621,42 +11409,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-418158
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9668,42 +11456,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-418163
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9715,42 +11503,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-418170
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9762,42 +11550,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-418176
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9809,42 +11597,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-418200
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9856,42 +11644,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-445079
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9903,42 +11691,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5654560
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9950,42 +11738,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5654562
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -9997,42 +11785,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5654565
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10044,42 +11832,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5654566
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10091,42 +11879,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5672972
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10138,42 +11926,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5672973
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10185,42 +11973,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5672978
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10232,42 +12020,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5672980
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10279,42 +12067,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5674130
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10326,42 +12114,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5674132
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10373,42 +12161,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5674366
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10420,42 +12208,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5674373
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10467,42 +12255,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5674385
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10514,42 +12302,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5674387
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10561,42 +12349,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5674496
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10608,42 +12396,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5675194
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10655,42 +12443,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5675198
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10702,42 +12490,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5675206
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10749,42 +12537,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-5675376
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10796,42 +12584,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802910
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10843,42 +12631,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802911
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10890,42 +12678,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802912
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10937,42 +12725,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802914
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -10984,42 +12772,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802918
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11031,42 +12819,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802919
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11078,42 +12866,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802921
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11125,42 +12913,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802922
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11172,42 +12960,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802925
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11219,42 +13007,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802926
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11266,42 +13054,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802932
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11313,42 +13101,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802933
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11360,42 +13148,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802934
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11407,42 +13195,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802935
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11454,42 +13242,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802942
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11501,42 +13289,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6802943
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11548,42 +13336,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6803227
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11595,42 +13383,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6803230
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11642,42 +13430,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6803233
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11689,42 +13477,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6803234
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11736,42 +13524,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6811454
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11783,42 +13571,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-6811472
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11830,42 +13618,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9610152
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11877,42 +13665,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9610153
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11924,42 +13712,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9610154
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -11971,42 +13759,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9610156
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12018,42 +13806,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9610166
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12065,42 +13853,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9626832
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12112,42 +13900,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9627089
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12159,42 +13947,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9632910
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12206,42 +13994,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9635743
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12253,42 +14041,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9636296
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12300,42 +14088,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9652165
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12347,42 +14135,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9656209
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12394,42 +14182,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9656211
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12441,42 +14229,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9656214
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12488,42 +14276,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9656215
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12535,42 +14323,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9657599
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12582,42 +14370,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9657603
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12629,42 +14417,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9657606
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12676,42 +14464,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9657608
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12723,42 +14511,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9731111
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12770,42 +14558,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9732753
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12817,42 +14605,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9734547
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12864,42 +14652,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9824582
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12911,42 +14699,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9824977
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -12958,42 +14746,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9825759
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -13005,42 +14793,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-HSA-9845033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -13052,42 +14840,42 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-NUL-9619973
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -13099,169 +14887,220 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0038127" target="_blank" class="term-link">
                                     GO:0038127
                                 </a>
                             </span>
                             <span class="term-label">ERBB signaling pathway</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15133037" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15133037
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The major vault protein is a novel substrate for the tyrosin...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0038127" data-r="PMID:15133037" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0038127" data-r="PMID:15133037" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 is activated in receptor and growth-factor signaling contexts, but these are stimulus-specific pathway contexts rather than the core conserved ERK2 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Growth-factor and receptor-specific signaling annotations can be retained as non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
                                     GO:0004674
                                 </a>
                             </span>
                             <span class="term-label">protein serine/threonine kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18794356" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18794356
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extracellular signal-regulated kinase 2 (ERK2) phosphorylati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="PMID:18794356" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="PMID:18794356" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Serine/threonine protein kinase activity is a core molecular function of MAPK1; the more specific MAP kinase activity term should also be retained where present.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18794356" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18794356
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extracellular signal-regulated kinase 2 (ERK2) phosphorylati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -13273,227 +15112,309 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18794356" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18794356
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extracellular signal-regulated kinase 2 (ERK2) phosphorylati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005634" data-r="PMID:18794356" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005634" data-r="PMID:18794356" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 localizes to the nucleus after stimulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Nuclear localization is supported, but should be interpreted as stimulus-dependent rather than constitutive.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear accumulation can be partially uncoupled from TEY phosphorylation and depends on docking interactions and anchors.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18794356" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18794356
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extracellular signal-regulated kinase 2 (ERK2) phosphorylati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005737" data-r="PMID:18794356" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005737" data-r="PMID:18794356" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is cytoplasmic in quiescent cells.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytoplasmic localization is a core supported localization for ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070849" target="_blank" class="term-link">
                                     GO:0070849
                                 </a>
                             </span>
                             <span class="term-label">response to epidermal growth factor</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18794356" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18794356
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extracellular signal-regulated kinase 2 (ERK2) phosphorylati...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0070849" data-r="PMID:18794356" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0070849" data-r="PMID:18794356" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 is activated in receptor and growth-factor signaling contexts, but these are stimulus-specific pathway contexts rather than the core conserved ERK2 function.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Growth-factor and receptor-specific signaling annotations can be retained as non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22253824" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22253824
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Localization of nucleoporin Tpr to the nuclear pore complex ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -13505,169 +15426,220 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004674" target="_blank" class="term-link">
                                     GO:0004674
                                 </a>
                             </span>
                             <span class="term-label">protein serine/threonine kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/15850461" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:15850461
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The phosphorylation of CapZ-interacting protein (CapZIP) by ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="PMID:15850461" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004674" data-r="PMID:15850461" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Serine/threonine protein kinase activity is a core molecular function of MAPK1; the more specific MAP kinase activity term should also be retained where present.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
                                     GO:0005634
                                 </a>
                             </span>
                             <span class="term-label">nucleus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19565474" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19565474
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ERK signaling cascade--views from different subcellular ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005634" data-r="PMID:19565474" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005634" data-r="PMID:19565474" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 localizes to the nucleus after stimulation.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Nuclear localization is supported, but should be interpreted as stimulus-dependent rather than constitutive.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">**Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear accumulation can be partially uncoupled from TEY phosphorylation and depends on docking interactions and anchors.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005739" target="_blank" class="term-link">
                                     GO:0005739
                                 </a>
                             </span>
                             <span class="term-label">mitochondrion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19565474" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19565474
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ERK signaling cascade--views from different subcellular ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -13679,53 +15651,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005769" target="_blank" class="term-link">
                                     GO:0005769
                                 </a>
                             </span>
                             <span class="term-label">early endosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19565474" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19565474
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ERK signaling cascade--views from different subcellular ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -13737,53 +15709,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005770" target="_blank" class="term-link">
                                     GO:0005770
                                 </a>
                             </span>
                             <span class="term-label">late endosome</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19565474" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19565474
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ERK signaling cascade--views from different subcellular ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -13795,53 +15767,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005794" target="_blank" class="term-link">
                                     GO:0005794
                                 </a>
                             </span>
                             <span class="term-label">Golgi apparatus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19565474" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19565474
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ERK signaling cascade--views from different subcellular ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -13853,111 +15825,131 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19565474" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19565474
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ERK signaling cascade--views from different subcellular ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005829" data-r="PMID:19565474" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0005829" data-r="PMID:19565474" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is present in the cytosolic/cytoplasmic compartment.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Cytosolic localization is consistent with ERK2 being predominantly cytoplasmic in quiescent cells before stimulus-dependent nuclear accumulation.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005856" target="_blank" class="term-link">
                                     GO:0005856
                                 </a>
                             </span>
                             <span class="term-label">cytoskeleton</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19565474" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19565474
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ERK signaling cascade--views from different subcellular ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -13969,53 +15961,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005901" target="_blank" class="term-link">
                                     GO:0005901
                                 </a>
                             </span>
                             <span class="term-label">caveola</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19565474" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19565474
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ERK signaling cascade--views from different subcellular ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -14027,53 +16019,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005925" target="_blank" class="term-link">
                                     GO:0005925
                                 </a>
                             </span>
                             <span class="term-label">focal adhesion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19565474" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19565474
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ERK signaling cascade--views from different subcellular ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -14085,111 +16077,142 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032872" target="_blank" class="term-link">
                                     GO:0032872
                                 </a>
                             </span>
                             <span class="term-label">regulation of stress-activated MAPK cascade</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19565474" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19565474
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ERK signaling cascade--views from different subcellular ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0032872" data-r="PMID:19565474" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0032872" data-r="PMID:19565474" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a stress-context signaling annotation for MAPK1.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Stress-context annotations are secondary to the canonical ERK/MAPK cascade role and should remain non-core unless a later source-level review shows they are central for MAPK1.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051493" target="_blank" class="term-link">
                                     GO:0051493
                                 </a>
                             </span>
                             <span class="term-label">regulation of cytoskeleton organization</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19565474" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19565474
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ERK signaling cascade--views from different subcellular ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -14201,53 +16224,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0072584" target="_blank" class="term-link">
                                     GO:0072584
                                 </a>
                             </span>
                             <span class="term-label">caveolin-mediated endocytosis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19565474" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19565474
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ERK signaling cascade--views from different subcellular ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -14259,53 +16282,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0090170" target="_blank" class="term-link">
                                     GO:0090170
                                 </a>
                             </span>
                             <span class="term-label">regulation of Golgi inheritance</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19565474" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19565474
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ERK signaling cascade--views from different subcellular ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -14317,53 +16340,53 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:2000641" target="_blank" class="term-link">
                                     GO:2000641
                                 </a>
                             </span>
                             <span class="term-label">regulation of early endosome to late endosome transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19565474" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19565474
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The ERK signaling cascade--views from different subcellular ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -14375,216 +16398,298 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010800" target="_blank" class="term-link">
                                     GO:0010800
                                 </a>
                             </span>
                             <span class="term-label">positive regulation of peptidyl-threonine phosphorylation</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16314496" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16314496
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Activation of TRAP/mediator subunit TRAP220/Med1 is regulate...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0010800" data-r="PMID:16314496" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0010800" data-r="PMID:16314496" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 can increase phosphorylation of downstream threonine-containing protein substrates.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The term is consistent with ERK2 substrate phosphorylation, but it is less central than the direct kinase activity and ERK/MAPK cascade annotations.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 directly phosphorylates defined downstream targets such as Elk-1/ETS-family and other transcription-factor substrates in vitro and in cells; docking motifs/exosites help determine substrate recognition.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070371" target="_blank" class="term-link">
                                     GO:0070371
                                 </a>
                             </span>
                             <span class="term-label">ERK1 and ERK2 cascade</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16314496" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16314496
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Activation of TRAP/mediator subunit TRAP220/Med1 is regulate...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0070371" data-r="PMID:16314496" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0070371" data-r="PMID:16314496" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 is a central component of the ERK1 and ERK2 cascade.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> ERK1 and ERK2 cascade is a core pathway term for MAPK1 and is more specific than generic signaling process terms.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019902" target="_blank" class="term-link">
                                     GO:0019902
                                 </a>
                             </span>
                             <span class="term-label">phosphatase binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19494114" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19494114
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tumor suppressor density-enhanced phosphatase-1 (DEP-1) inhi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0019902" data-r="PMID:19494114" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0019902" data-r="PMID:19494114" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 binds MAP kinase phosphatases such as DUSP6/MKP-3.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Phosphatase binding is a supported regulatory interaction, but it is not the primary catalytic function of MAPK1.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">DUSP6/MKP-3 as cytoplasmic tether:** MKP-3/DUSP6 binds ERK2 and can dephosphorylate and tether inactive ERK2 in the cytoplasm; mutating MKP-3 NES or KIM abolishes cytoplasmic anchoring.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008353" target="_blank" class="term-link">
                                     GO:0008353
                                 </a>
                             </span>
                             <span class="term-label">RNA polymerase II CTD heptapeptide repeat kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">ISS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000024
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-pending">
@@ -14596,3021 +16701,3835 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> TODO: Review this GOA annotation
                         </div>
-                        
-                        
-                        
-                        
+
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004707" target="_blank" class="term-link">
                                     GO:0004707
                                 </a>
                             </span>
                             <span class="term-label">MAP kinase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10706854" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10706854
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Eotaxin induces degranulation and chemotaxis of eosinophils ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004707" data-r="PMID:10706854" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0004707" data-r="PMID:10706854" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1/ERK2 has MAP kinase activity.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006915" target="_blank" class="term-link">
                                     GO:0006915
                                 </a>
                             </span>
                             <span class="term-label">apoptotic process</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10958679" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10958679
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Hsp72-mediated suppression of c-Jun N-terminal kinase is imp...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0006915" data-r="PMID:10958679" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0006915" data-r="PMID:10958679" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a context-dependent downstream process linked to ERK signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The process may be retained as non-core where the source evidence supports a specific context, but it should not be treated as the core conserved MAPK1 function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006935" target="_blank" class="term-link">
                                     GO:0006935
                                 </a>
                             </span>
                             <span class="term-label">chemotaxis</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10706854" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10706854
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Eotaxin induces degranulation and chemotaxis of eosinophils ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0006935" data-r="PMID:10706854" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0006935" data-r="PMID:10706854" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a context-dependent downstream process linked to ERK signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The process may be retained as non-core where the source evidence supports a specific context, but it should not be treated as the core conserved MAPK1 function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007165" target="_blank" class="term-link">
                                     GO:0007165
                                 </a>
                             </span>
                             <span class="term-label">signal transduction</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/1540184" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:1540184
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Extracellular signal-regulated kinases in T cells: character...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-modify">
+                            MODIFY
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0007165" data-r="PMID:1540184" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0007165" data-r="PMID:1540184" data-act="MODIFY">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> MAPK1 participates in signal transduction, but the generic term should be replaced by more specific intracellular MAPK/ERK signaling terms.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> Generic signal transduction underspecifies MAPK1; intracellular signal transduction and ERK/MAPK cascade terms capture the supported biology more accurately.
+                        </div>
+
+
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0035556" target="_blank" class="term-link">
+                                    intracellular signal transduction
+                                </a>
+                            </span>
+
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070371" target="_blank" class="term-link">
+                                    ERK1 and ERK2 cascade
+                                </a>
+                            </span>
+
+                        </div>
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                            </div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0007268" target="_blank" class="term-link">
                                     GO:0007268
                                 </a>
                             </span>
                             <span class="term-label">chemical synaptic transmission</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/10051431" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:10051431
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Regulation of extracellular-signal regulated kinase and c-Ju...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0007268" data-r="PMID:10051431" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0007268" data-r="PMID:10051431" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> This is a context-dependent downstream process linked to ERK signaling.
                         </div>
-                        
-                        
-                        
-                        
+
+
+                        <div>
+                            <strong>Reason:</strong> The process may be retained as non-core where the source evidence supports a specific context, but it should not be treated as the core conserved MAPK1 function.
+                        </div>
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>MAPK1/ERK2 is an ATP-dependent, proline-directed serine/threonine MAP kinase. After MEK1/2-mediated activation, ERK2 phosphorylates protein substrates and transmits canonical Ras-RAF-MEK-ERK signals to cytosolic and nuclear targets.</h3>
+                <span class="vote-buttons" data-g="P28482" data-a="FUNCTION: MAPK1/ERK2 is an ATP-dependent, proline-directed s..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0004707" target="_blank" class="term-link">
+                            MAP kinase activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0070371" target="_blank" class="term-link">
+                                ERK1 and ERK2 cascade
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000165" target="_blank" class="term-link">
+                                MAPK cascade
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006468" target="_blank" class="term-link">
+                                protein phosphorylation
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
+                                cytoplasm
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro.</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>ATP binding is a core active-site function of MAPK1 because ATP/MgATP provides the phosphoryl group used for ERK2 serine/threonine protein kinase catalysis.</h3>
+                <span class="vote-buttons" data-g="P28482" data-a="FUNCTION: ATP binding is a core active-site function of MAPK..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
+                            ATP binding
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006468" target="_blank" class="term-link">
+                                protein phosphorylation
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005634" target="_blank" class="term-link">
+                                nucleus
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">ERK2 is a Ser/Thr MAPK that transfers phosphate from ATP/MgATP to Ser/Thr-Pro motifs; ATP binds in the active site, with N-lobe/glycine-rich loop contributions to nucleotide binding and catalysis.</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
                             GO_REF:0000024
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000052.md" target="_blank" class="term-link">
                             GO_REF:0000052
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000107.md" target="_blank" class="term-link">
                             GO_REF:0000107
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
                             GO_REF:0000108
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000116.md" target="_blank" class="term-link">
                             GO_REF:0000116
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000117.md" target="_blank" class="term-link">
                             GO_REF:0000117
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10051431" target="_blank" class="term-link">
                             PMID:10051431
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Regulation of extracellular-signal regulated kinase and c-Jun N-terminal kinase by G-protein-linked muscarinic acetylcholine receptors.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10415025" target="_blank" class="term-link">
                             PMID:10415025
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Direct suppression of TCR-mediated activation of extracellular signal-regulated kinase by leukocyte protein tyrosine phosphatase, a tyrosine-specific phosphatase.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10601328" target="_blank" class="term-link">
                             PMID:10601328
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A novel regulatory mechanism of MAP kinases activation and nuclear translocation mediated by PKA and the PTP-SL tyrosine phosphatase.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10706854" target="_blank" class="term-link">
                             PMID:10706854
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Eotaxin induces degranulation and chemotaxis of eosinophils through the activation of ERK2 and p38 mitogen-activated protein kinases.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/10958679" target="_blank" class="term-link">
                             PMID:10958679
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Hsp72-mediated suppression of c-Jun N-terminal kinase is implicated in development of tolerance to caspase-independent cell death.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11096076" target="_blank" class="term-link">
                             PMID:11096076
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Glutamine-dependent antiapoptotic interaction of human glutaminyl-tRNA synthetase with apoptosis signal-regulating kinase 1.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11404397" target="_blank" class="term-link">
                             PMID:11404397
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Beta-amyloid activates the mitogen-activated protein kinase cascade via hippocampal alpha7 nicotinic acetylcholine receptors: In vitro and in vivo mechanisms related to Alzheimer</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11489891" target="_blank" class="term-link">
                             PMID:11489891
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MKP-7, a novel mitogen-activated protein kinase phosphatase, functions as a shuttle protein.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12592337" target="_blank" class="term-link">
                             PMID:12592337
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The protein tyrosine phosphatase HePTP regulates nuclear translocation of ERK2 and can modulate megakaryocytic differentiation of K562 cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12840032" target="_blank" class="term-link">
                             PMID:12840032
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Constitutive induction of p-Erk1/2 accompanied by reduced activities of protein phosphatases 1 and 2A and MKP3 due to reactive oxygen species during cellular senescence.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15133037" target="_blank" class="term-link">
                             PMID:15133037
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The major vault protein is a novel substrate for the tyrosine phosphatase SHP-2 and scaffold protein in epidermal growth factor signaling.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/1540184" target="_blank" class="term-link">
                             PMID:1540184
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Extracellular signal-regulated kinases in T cells: characterization of human ERK1 and ERK2 cDNAs.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15713638" target="_blank" class="term-link">
                             PMID:15713638
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Specific inactivation and nuclear anchoring of extracellular signal-regulated kinase 2 by the inducible dual-specificity protein phosphatase DUSP5.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/15850461" target="_blank" class="term-link">
                             PMID:15850461
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The phosphorylation of CapZ-interacting protein (CapZIP) by stress-activated protein kinases triggers its dissociation from CapZ.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16038800" target="_blank" class="term-link">
                             PMID:16038800
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Conditional expression of MAP kinase phosphatase-2 protects against genotoxic stress-induced apoptosis by binding and selective dephosphorylation of nuclear activated c-jun N-terminal kinase.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16286470" target="_blank" class="term-link">
                             PMID:16286470
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Cooperation of ERK and SCFSkp2 for MKP-1 destruction provides a positive feedback regulation of proliferating signaling.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16288922" target="_blank" class="term-link">
                             PMID:16288922
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">New insights into the catalytic activation of the MAPK phosphatase PAC-1 induced by its substrate MAPK ERK2 binding.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16314496" target="_blank" class="term-link">
                             PMID:16314496
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Activation of TRAP/mediator subunit TRAP220/Med1 is regulated by mitogen-activated protein kinase-dependent phosphorylation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16627622" target="_blank" class="term-link">
                             PMID:16627622
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Direct phosphorylation and regulation of poly(ADP-ribose) polymerase-1 by extracellular signal-regulated kinases 1/2.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16791210" target="_blank" class="term-link">
                             PMID:16791210
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dynamic proteomics in individual human cells uncovers widespread cell-cycle dependence of nuclear proteins.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17255944" target="_blank" class="term-link">
                             PMID:17255944
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A MAPK docking site is critical for downregulation of Capicua by Torso and EGFR RTK signaling.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/17255949" target="_blank" class="term-link">
                             PMID:17255949
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mxi2 promotes stimulus-independent ERK nuclear translocation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18060821" target="_blank" class="term-link">
                             PMID:18060821
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structural insights into the enzymatic mechanism of the pathogenic MAPK phosphothreonine lyase.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18084305" target="_blank" class="term-link">
                             PMID:18084305
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structural basis for the catalytic mechanism of phosphothreonine lyase.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18463290" target="_blank" class="term-link">
                             PMID:18463290
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Human biliverdin reductase is an ERK activator; hBVR is an ERK nuclear transporter and is required for MAPK signaling.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18616943" target="_blank" class="term-link">
                             PMID:18616943
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Phosphorylation of U24 from Human Herpes Virus type 6 (HHV-6) and its potential role in mimicking myelin basic protein (MBP) in multiple sclerosis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18794356" target="_blank" class="term-link">
                             PMID:18794356
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Extracellular signal-regulated kinase 2 (ERK2) phosphorylation sites and docking domain on the nuclear pore complex protein Tpr cooperatively regulate ERK2-Tpr interaction.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19494114" target="_blank" class="term-link">
                             PMID:19494114
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tumor suppressor density-enhanced phosphatase-1 (DEP-1) inhibits the RAS pathway by direct dephosphorylation of ERK1/2 kinases.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19565474" target="_blank" class="term-link">
                             PMID:19565474
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The ERK signaling cascade--views from different subcellular compartments.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21531765" target="_blank" class="term-link">
                             PMID:21531765
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">High-throughput RNAi screening reveals novel regulators of telomerase.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21826244" target="_blank" class="term-link">
                             PMID:21826244
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TRAPPC4-ERK2 interaction activates ERK1/2, modulates its nuclear localization and regulates proliferation and apoptosis of colorectal cancer cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21908610" target="_blank" class="term-link">
                             PMID:21908610
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Phosphorylation of the kinase interaction motif in mitogen-activated protein (MAP) kinase phosphatase-4 mediates cross-talk between protein kinase A and MAP kinase signaling pathways.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21988832" target="_blank" class="term-link">
                             PMID:21988832
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Toward an understanding of the protein interaction network of the human liver.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22253824" target="_blank" class="term-link">
                             PMID:22253824
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Localization of nucleoporin Tpr to the nuclear pore complex is essential for Tpr mediated regulation of the export of unspliced RNA.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22451653" target="_blank" class="term-link">
                             PMID:22451653
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Siglec-15 protein regulates formation of functional osteoclasts in concert with DNAX-activating protein of 12 kDa (DAP12).</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22521293" target="_blank" class="term-link">
                             PMID:22521293
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ETS-dependent p16INK4a and p21waf1/cip1 gene expression upon endothelin-1 stimulation in malignant versus and non-malignant proximal tubule cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23184662" target="_blank" class="term-link">
                             PMID:23184662
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Phosphorylation of eukaryotic elongation factor 2 (eEF2) by cyclin A-cyclin-dependent kinase 2 regulates its inhibition by eEF2 kinase.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23241949" target="_blank" class="term-link">
                             PMID:23241949
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MEK1 inactivates Myt1 to regulate Golgi membrane fragmentation and mitotic entry in mammalian cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23455922" target="_blank" class="term-link">
                             PMID:23455922
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interlaboratory reproducibility of large-scale human protein-complex analysis by standardized AP-MS.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23519423" target="_blank" class="term-link">
                             PMID:23519423
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Protein-peptide complex crystallization: a case study on the ERK2 mitogen-activated protein kinase.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23560844" target="_blank" class="term-link">
                             PMID:23560844
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Metal-dependent protein phosphatase 1A functions as an extracellular signal-regulated kinase phosphatase.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23575685" target="_blank" class="term-link">
                             PMID:23575685
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structure of ERK2 bound to PEA-15 reveals a mechanism for rapid release of activated MAPK.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23584453" target="_blank" class="term-link">
                             PMID:23584453
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interaction with Shc prevents aberrant Erk activation in the absence of extracellular stimuli.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23602568" target="_blank" class="term-link">
                             PMID:23602568
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The protein interaction landscape of the human CMGC kinase group.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/23847209" target="_blank" class="term-link">
                             PMID:23847209
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Pseudophosphatase STYX modulates cell-fate decisions and cell migration by spatiotemporal regulation of ERK1/2.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24735981" target="_blank" class="term-link">
                             PMID:24735981
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">MFAP3L activation promotes colorectal cancer cell invasion and metastasis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24854121" target="_blank" class="term-link">
                             PMID:24854121
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Endophilin-1 regulates blood-brain barrier permeability by controlling ZO-1 and occludin expression via the EGFR-ERK1/2 pathway.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25241761" target="_blank" class="term-link">
                             PMID:25241761
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Using an in situ proximity ligation assay to systematically profile endogenous protein-protein interactions in a pathway network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25852190" target="_blank" class="term-link">
                             PMID:25852190
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Integrative analysis of kinase networks in TRAIL-induced apoptosis provides a source of potential targets for combination therapy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26267534" target="_blank" class="term-link">
                             PMID:26267534
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Small Molecule Inhibition of ERK Dimerization Prevents Tumorigenesis by RAS-ERK Pathway Oncogenes.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26267535" target="_blank" class="term-link">
                             PMID:26267535
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ERK2-Dependent Phosphorylation of CSN6 Is Critical in Colorectal Cancer Development.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26733474" target="_blank" class="term-link">
                             PMID:26733474
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Identification of allosteric ERK2 inhibitors through in silico biased screening and competitive binding assay.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26754294" target="_blank" class="term-link">
                             PMID:26754294
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">miR-28-5p-IL-34-macrophage feedback loop modulates hepatocellular carcinoma metastasis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26942675" target="_blank" class="term-link">
                             PMID:26942675
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mitochondria-Translocated PGK1 Functions as a Protein Kinase to Coordinate Glycolysis and the TCA Cycle in Tumorigenesis.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26996940" target="_blank" class="term-link">
                             PMID:26996940
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Regulation of Microtubule Assembly by Tau and not by Pin1.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27880917" target="_blank" class="term-link">
                             PMID:27880917
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Phenotypic and Interaction Profiling of the Human Phosphatases Identifies Diverse Mitotic Regulators.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/29997244" target="_blank" class="term-link">
                             PMID:29997244
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">LuTHy: a double-readout bioluminescence-based two-hybrid technology for quantitative mapping of protein-protein interactions in mammalian cells.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/31980649" target="_blank" class="term-link">
                             PMID:31980649
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Extensive rewiring of the EGFR network in colorectal cancer cells expressing transforming levels of KRAS(G13D).</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32051553" target="_blank" class="term-link">
                             PMID:32051553
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The EGFR-ZNF263 signaling axis silences SIX3 in glioblastoma epigenetically.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32296183" target="_blank" class="term-link">
                             PMID:32296183
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A reference map of the human binary protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32707033" target="_blank" class="term-link">
                             PMID:32707033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Kinase Interaction Network Expands Functional and Disease Roles of Human Kinases.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32721402" target="_blank" class="term-link">
                             PMID:32721402
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Enhanced MAPK1 Function Causes a Neurodevelopmental Disorder within the RASopathy Clinical Spectrum.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32814053" target="_blank" class="term-link">
                             PMID:32814053
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Interactome Mapping Provides a Network of Neurodegenerative Disease Proteins and Uncovers Widespread Protein Aggregation in Affected Brains.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/33961781" target="_blank" class="term-link">
                             PMID:33961781
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/34591642" target="_blank" class="term-link">
                             PMID:34591642
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A protein network map of head and neck cancer reveals PIK3CA mutant drug sensitivity.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35271311" target="_blank" class="term-link">
                             PMID:35271311
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">OpenCell: Endogenous tagging for the cartography of human cellular organization.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/35831023" target="_blank" class="term-link">
                             PMID:35831023
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ERK2 MAP kinase regulates SUFU binding by multisite phosphorylation of GLI1.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/38503280" target="_blank" class="term-link">
                             PMID:38503280
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A gut-derived hormone regulates cholesterol metabolism.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/38884001" target="_blank" class="term-link">
                             PMID:38884001
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Mapping adipocyte interactome networks by HaloTag-enrichment-mass spectrometry.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/40205054" target="_blank" class="term-link">
                             PMID:40205054
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Multimodal cell maps as a foundation for structural and functional genomics.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/7588608" target="_blank" class="term-link">
                             PMID:7588608
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">ERF: an ETS domain protein with strong transcriptional repressor activity, can suppress ets-associated tumorigenesis and is regulated by phosphorylation during cell cycle and mitogenic stimulation.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9632734" target="_blank" class="term-link">
                             PMID:9632734
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Activation of extracellular signal-regulated kinase 2 by a novel Abl-binding protein, ST5.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/9788880" target="_blank" class="term-link">
                             PMID:9788880
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Isolation of the human genes encoding the pyst1 and Pyst2 phosphatases: characterisation of Pyst2 as a cytosolic dual-specificity MAP kinase phosphatase and its catalytic activation by both MAP and SAP kinases.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-109858
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-109862
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-109864
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-111898
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-1168459
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-198746
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-198756
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-199959
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-2029469
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-203797
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3132737
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3371531
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-3857329
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-418158
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-418163
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-418170
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-418176
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-418200
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-445079
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-450325
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5654560
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5654562
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5654565
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5654566
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5672972
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5672973
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5672978
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5672980
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5674130
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5674132
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5674366
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5674373
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5674385
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5674387
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5674496
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5675194
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5675198
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5675206
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5675373
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-5675376
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6798751
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6800434
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802910
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802911
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802912
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802914
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802918
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802919
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802921
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802922
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802925
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802926
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802932
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802933
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802934
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802935
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802942
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6802943
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6803227
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6803230
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6803233
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6803234
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6811454
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-6811472
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9032751
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9610152
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9610153
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9610154
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9610156
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9610166
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9626832
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9627089
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9632910
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9635739
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9635743
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9636296
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9652165
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9652816
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9656209
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9656211
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9656214
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9656215
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9657599
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9657603
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9657606
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9657608
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9725030
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9731111
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9732753
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9734547
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9765960
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9824582
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9824977
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9825759
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-HSA-9845033
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-NUL-9009236
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-NUL-9619973
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">TODO: Fetch title</div>
-                
-                
+
+
             </div>
-            
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:human/MAPK1/MAPK1-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report on MAPK1</div>
+
+
+            </div>
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which generic protein-binding annotations correspond to direct MAPK1 docking, substrate, scaffold, or phosphatase interactions that should be curated with more specific terms?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P28482" data-a="Q: Which generic protein-binding annotations correspo..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Which downstream proliferation, apoptosis, migration, immune, neuronal, or developmental annotations have direct MAPK1-specific evidence rather than general ERK pathway membership?</p>
+
+                </div>
+                <span class="vote-buttons" data-g="P28482" data-a="Q: Which downstream proliferation, apoptosis, migrati..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Prioritize source-level review of MAPK1-specific substrate phosphorylation papers to separate direct ERK2 substrates from phosphoproteomics or inhibitor-based pathway effects.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P28482" data-a="EXPERIMENT: Prioritize source-level review of MAPK1-specific s..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+
+                    <p><strong>Experiment:</strong> Review compartment-specific MAPK1 localization evidence with stimulus and cell-type context, especially endosome, Golgi, mitochondrion, focal adhesion, and caveola annotations.</p>
+
+
+
+                </div>
+                <span class="vote-buttons" data-g="P28482" data-a="EXPERIMENT: Review compartment-specific MAPK1 localization evi..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MAPK1-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P28482" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-12T21:28:55.391359'<br />
+end_time: '2026-05-12T21:47:01.793924'<br />
+duration_seconds: 1086.4<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 31</p>
+<hr />
+<h2 id="question">Question</h2>
+<p>Concise GO annotation research for human MAPK1 / UniProt P28482 (mitogen-activated protein kinase 1, ERK2). Focus only on GO-relevant evidence: core molecular function as a serine/threonine protein kinase/MAP kinase with ATP binding and phosphotransfer activity; activation by dual phosphorylation by MEK1/2; core roles in MAPK cascade, ERK1/ERK2 cascade, intracellular signal transduction, response to growth factors; nuclear/cytoplasmic localization and stimulus-dependent nuclear translocation; substrates and downstream processes including transcription factor phosphorylation, cell proliferation/differentiation, apoptosis/senescence, cell migration, and whether these should be core or non-core; scaffold/protein binding annotations; over-annotation risks for generic protein binding, broad development/cancer/cell cycle/transcription terms, high-throughput substrate claims, and phenotypes from inhibitor/overexpression studies. Include caveats distinguishing direct MAPK1 kinase activity from downstream pathway outcomes. Include PMID/DOI citations and keep under 1500 words.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<p>Concise GO annotation research for human MAPK1 / UniProt P28482 (mitogen-activated protein kinase 1, ERK2). Focus only on GO-relevant evidence: core molecular function as a serine/threonine protein kinase/MAP kinase with ATP binding and phosphotransfer activity; activation by dual phosphorylation by MEK1/2; core roles in MAPK cascade, ERK1/ERK2 cascade, intracellular signal transduction, response to growth factors; nuclear/cytoplasmic localization and stimulus-dependent nuclear translocation; substrates and downstream processes including transcription factor phosphorylation, cell proliferation/differentiation, apoptosis/senescence, cell migration, and whether these should be core or non-core; scaffold/protein binding annotations; over-annotation risks for generic protein binding, broad development/cancer/cell cycle/transcription terms, high-throughput substrate claims, and phenotypes from inhibitor/overexpression studies. Include caveats distinguishing direct MAPK1 kinase activity from downstream pathway outcomes. Include PMID/DOI citations and keep under 1500 words.</p>
+<h2 id="concise-go-annotation-research-report-human-mapk1-erk2-uniprot-p28482">Concise GO annotation research report: human MAPK1 / ERK2 (UniProt P28482)</h2>
+<h3 id="scope-and-principles-go-relevant-evidence-only">Scope and principles (GO-relevant evidence only)</h3>
+<p>MAPK1 (ERK2) is best annotated in GO by (i) conserved biochemical activity (ATP-dependent, proline-directed Ser/Thr protein kinase), (ii) conserved activation mechanism (MEK1/2 dual phosphorylation of the activation loop), (iii) conserved pathway placement (MAPK/ERK cascade downstream of Ras–Raf–MEK), (iv) experimentally supported subcellular distribution (cytoplasm↔nucleus shuttling with stimulus-dependent nuclear accumulation), and (v) motif/exosite-mediated docking interactions that govern partner binding and spatial regulation. Downstream phenotypes (proliferation, differentiation, apoptosis, senescence, migration) are frequently ERK-pathway outcomes and are high risk for over-annotation unless direct MAPK1-specific causality is demonstrated. (novak2023mutationinthe pages 1-2, karlsson2006spatiotemporalregulationof pages 1-2, caunt2010stimulusinduceduncouplingof pages 1-2)</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-core-molecular-function-mf">1.1 Core Molecular Function (MF)</h4>
+<p><strong>Protein serine/threonine kinase activity (MAP kinase) + ATP binding.</strong> ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro. (rainey2004astructurefunctionanalysis pages 20-24, rainey2004astructurefunctionanalysis pages 24-29, waas2003physiologicalconcentrationsof pages 1-2)</p>
+<p><strong>Mechanistic detail useful for MF curation.</strong> Structural/biophysical descriptions emphasize ATP binding by the N-lobe (β strands and glycine-rich loop) and ATP/substrate engagement by both lobes; this supports annotating “ATP binding” and “protein serine/threonine kinase activity” as core MF terms. (novak2023mutationinthe pages 1-2)</p>
+<p><strong>Data/quantitative note.</strong> Dual phosphorylation causes an extremely large increase in catalytic efficiency (reported as ~600,000-fold in one mechanistic source), emphasizing that “active ERK2 kinase activity” is conditional on upstream activation. (rainey2004astructurefunctionanalysis pages 24-29)</p>
+<h4 id="12-activation-mechanism-upstream-regulation">1.2 Activation mechanism (upstream regulation)</h4>
+<p><strong>Dual phosphorylation by MEK1/2.</strong> ERK activation requires phosphorylation on one threonine and one tyrosine in the activation loop by the dual-specificity kinase MEK (MAPKK/ERK kinase). This is described in biochemical/structural terms and is central to GO BP annotation for MAPK cascade. (butch1996characterizationoferk1 pages 1-2, novak2023mutationinthe pages 1-2)</p>
+<p><strong>Site mapping (ERK2).</strong> Recent ERK2-focused biochemical work explicitly identifies the ERK2 activation loop residues as Thr185 and Tyr187 (ERK1: Thr202/Tyr204), phosphorylated by MEK1/2. (novak2023mutationinthe pages 1-2)</p>
+<p><strong>Specificity note (curation relevance).</strong> MEK is described as highly specific for ERK (“only known substrate for MEK” in the cited source), supporting a conservative upstream relationship (MAPKK→MAPK) rather than broad “protein kinase regulator activity” claims. (butch1996characterizationoferk1 pages 1-2)</p>
+<h3 id="2-core-biological-process-bp-annotations-conservative-evidence-driven">2) Core Biological Process (BP) annotations (conservative, evidence-driven)</h3>
+<h4 id="21-mapk-cascade-erk1-erk2-cascade-intracellular-signal-transduction">2.1 MAPK cascade / ERK1-ERK2 cascade / intracellular signal transduction</h4>
+<p>ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses. (novak2023mutationinthe pages 1-2, rainey2004astructurefunctionanalysis pages 20-24, waas2003physiologicalconcentrationsof pages 1-2)</p>
+<p><strong>GO-relevant framing:</strong> annotate ERK2 to <strong>MAPK cascade / ERK1 and ERK2 cascade</strong> and <strong>intracellular signal transduction</strong>; optionally include <strong>response to growth factor</strong> where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes. (waas2003physiologicalconcentrationsof pages 1-2, karlsson2006spatiotemporalregulationof pages 1-2)</p>
+<h4 id="22-downstream-outcomes-core-vs-non-core">2.2 Downstream outcomes: core vs non-core</h4>
+<p>Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions. For example, ERK signaling is described as converting stimuli into proliferation/differentiation and being implicated in oncogenic transformation when deregulated. These statements support pathway-level BP terms, but <strong>do not automatically justify</strong> GO terms like “cell cycle,” “transcription,” “cancer,” or broad developmental processes as core MAPK1 BPs. (novak2023mutationinthe pages 1-2, butch1996characterizationoferk1 pages 1-2)</p>
+<h3 id="3-cellular-component-cc-localization-and-stimulus-dependent-translocation">3) Cellular Component (CC): localization and stimulus-dependent translocation</h3>
+<h4 id="31-basal-distribution-and-stimulus-dependent-nuclear-accumulation">3.1 Basal distribution and stimulus-dependent nuclear accumulation</h4>
+<p>ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs. (karlsson2006spatiotemporalregulationof pages 1-2)</p>
+<h4 id="32-erk-lacks-obvious-intrinsic-nlsnes-partner-mediated-trafficking">3.2 ERK lacks obvious intrinsic NLS/NES → partner-mediated trafficking</h4>
+<p>ERK lacks obvious intrinsic NLS/NES elements, implying nuclear-cytoplasmic trafficking depends on binding partners that carry localization motifs (e.g., MEK, DUSPs, scaffolds). (karlsson2006spatiotemporalregulationof pages 1-2, caunt2006seventransmembranereceptorsignalling pages 2-3, caunt2010stimulusinduceduncouplingof pages 1-2)</p>
+<h4 id="33-cytoplasmic-anchoring-and-nuclear-sequestration-directly-relevant-regulators">3.3 Cytoplasmic anchoring and nuclear sequestration (directly relevant regulators)</h4>
+<ul>
+<li><strong>MEK as cytoplasmic anchor:</strong> MEK contains a leucine-rich NES and an ERK-binding site that anchors inactive ERK in the cytoplasm; activation dissociates the MEK–ERK complex and enables ERK nuclear translocation. (karlsson2006spatiotemporalregulationof pages 1-2, karlsson2006spatiotemporalregulationof pages 2-3)</li>
+<li><strong>DUSP6/MKP-3 as cytoplasmic tether:</strong> MKP-3/DUSP6 binds ERK2 and can dephosphorylate and tether inactive ERK2 in the cytoplasm; mutating MKP-3 NES or KIM abolishes cytoplasmic anchoring. (karlsson2006spatiotemporalregulationof pages 2-3, karlsson2006spatiotemporalregulationof pages 1-2)</li>
+<li><strong>DUSP5 as nuclear sequestration factor:</strong> DUSP5 contains an NLS; co-expression experiments show DUSP5 can inactivate and sequester ERK2 in the nucleus in an NLS- and KIM-dependent manner. (karlsson2006spatiotemporalregulationof pages 2-3)</li>
+</ul>
+<h4 id="34-docking-domain-dependence-of-nuclear-localization-caution">3.4 Docking-domain dependence of nuclear localization (caution)</h4>
+<p>Stimulus-induced nuclear localization is <strong>not always proportional</strong> to TEY phosphorylation; a phosphorylation-independent component of nuclear accumulation can depend on D-domain docking interactions (e.g., reduced by ERK2 D319N affecting the D-domain binding interface). This supports annotating “stimulus-dependent nuclear translocation” cautiously and discourages inferring nuclear localization solely from phospho-ERK immunoblot signals. (caunt2010stimulusinduceduncouplingof pages 1-2, caunt2010stimulusinduceduncouplingof pages 2-3)</p>
+<h3 id="4-protein-binding-scaffold-docking-annotations-avoid-generic-binding">4) Protein binding / scaffold &amp; docking annotations (avoid generic binding)</h3>
+<h4 id="41-motifexosite-mediated-docking-is-central-to-erk-specificity">4.1 Motif/exosite-mediated docking is central to ERK specificity</h4>
+<p>ERK docking is mediated by defined motifs and complementary exosites: D-domains/KIMs and DEF/FXFP motifs on partners bind ERK CD/FRS-related surfaces and other exosites. Biochemical peptide-competition experiments show docking-site peptides from MEK/MKPs/Elk-1 can inhibit MEK2–ERK2 binding and ERK2 phosphorylation of Elk-1-like substrates, indicating docking interactions are crucial for enzymatic function. (bardwell2003dockingsiteson pages 5-6, rainey2004astructurefunctionanalysis pages 24-29)</p>
+<h4 id="42-avoid-over-annotation-to-protein-binding">4.2 Avoid over-annotation to “protein binding”</h4>
+<p>Because docking is motif-driven and structurally/biochemically dissectable, using only “protein binding” is typically uninformative and risks over-annotation. Additionally, yeast two-hybrid and peptide-based assays may capture indirect interactions or partial interfaces, so direct “binding” annotations should be limited to partners with orthogonal support. (rainey2004astructurefunctionanalysis pages 29-33, rainey2004astructurefunctionanalysis pages 24-29)</p>
+<h3 id="5-substrates-and-downstream-processes-direct-vs-indirect-20232024-developments">5) Substrates and downstream processes: direct vs indirect; 2023–2024 developments</h3>
+<h4 id="51-direct-phosphorylation-what-is-strong-enough-for-go-use">5.1 Direct phosphorylation: what is strong enough for GO use?</h4>
+<p><strong>Strongest direct evidence</strong> comes from direct biochemical phosphorylation assays and/or site-level validation. Examples in the evidence set include:<br />
+- ERK2 phosphorylation of an ETS-derived substrate (EtsΔ138) at Thr-38 in vitro (example of direct Ser/Thr-Pro phosphorylation). (waas2003physiologicalconcentrationsof pages 1-2)<br />
+- ERK2 phosphorylation of Elk-1–derived peptide/protein substrates in vitro assays using purified, dually phosphorylated ERK2. (bardwell2003dockingsiteson pages 5-6)</p>
+<p>A later review compiles additional site-level candidates (e.g., PKM2 Ser37; PAK1 Thr212; PFAS Thr619) but also notes that some are based on global phosphoproteomics and context-dependent signaling; these are useful for hypothesis generation but should not all be elevated to “direct substrate” GO annotations without independent validation. (martin–vega2025erk12mapksignalingmetabolic pages 3-5)</p>
+<h4 id="52-2024-mechanistic-advance-kinase-independent-erk2-function-via-direct-binding">5.2 2024 mechanistic advance: kinase-independent ERK2 function via direct binding</h4>
+<p>A major 2024 development relevant to GO curation is <strong>direct structural and functional evidence</strong> for an ERK2 binding interaction that regulates a process <strong>independently of ERK kinase activity</strong>. Becker et al. (Cell Reports, 2024-10; DOI:10.1016/j.celrep.2024.114831; URL: https://doi.org/10.1016/j.celrep.2024.114831) report a cryo-EM DHPS–ERK2 complex in which ERK2 physically occludes access to the DHPS active site, inhibiting deoxyhypusination in vitro, and show the interaction can be regulated by ERK2 regions outside the catalytic site (including an ERK2 Ser-Pro-Ser motif). This supports a careful “protein binding”/complex annotation for a specific partner (DHPS) and highlights that not all ERK2-associated biological outcomes are mediated by phosphorylation. (becker2024erk12interactionwith pages 1-3, becker2024erk12interactionwith media 4b826433, becker2024erk12interactionwith media dca6815c)</p>
+<h4 id="53-processes-like-proliferationmigrationapoptosissenescence-typically-non-core-for-mapk1">5.3 Processes like proliferation/migration/apoptosis/senescence: typically non-core for MAPK1</h4>
+<p>While ERK pathway activity is frequently associated with proliferation, differentiation, apoptosis/senescence, and migration, these are often downstream, cell-type- and stimulus-dependent outcomes mediated by networks of effectors and feedback loops. GO BP annotation for MAPK1 should therefore prioritize <strong>cascade membership and signal transduction</strong>, and use downstream process terms only when MAPK1-specific, direct mechanistic links (not only inhibitor/overexpression phenotypes) are demonstrated. (novak2023mutationinthe pages 1-2, caunt2010stimulusinduceduncouplingof pages 1-2, martin–vega2025erk12mapksignalingmetabolic pages 3-5)</p>
+<h3 id="6-current-applications-and-real-world-implementations-annotation-relevant">6) Current applications and real-world implementations (annotation-relevant)</h3>
+<p>ERK pathway components are major drug targets; however, therapeutic studies primarily inform <strong>pathway perturbation phenotypes</strong> rather than MAPK1 core GO functions. In a 2024 cardiovascular-focused review, ERK dimerization/autophosphorylation and nuclear shuttling mechanisms are discussed alongside peptide tools that perturb ERK dimerization or ERK–Importin7 interaction, illustrating how localization/complex formation is a practical intervention axis. These are useful as mechanistic context for CC annotations (nuclear translocation) but should not be used to assert broad disease-process GO terms for MAPK1. (mohammed2024mekinhibitorsa pages 2-3)</p>
+<h3 id="7-recommended-conservative-go-annotation-set-with-over-annotation-warnings">7) Recommended conservative GO annotation set (with over-annotation warnings)</h3>
+<p>The table below summarizes the most defensible GO scope from the evidence.</p>
+<table>
+<thead>
+<tr>
+<th>GO aspect</th>
+<th>Recommended core GO term(s)</th>
+<th>Evidence type</th>
+<th>Key supporting statements</th>
+<th>Key citation IDs</th>
+<th>Over-annotation caveat</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>MF</td>
+<td>protein serine/threonine kinase activity; mitogen-activated protein kinase activity; ATP binding</td>
+<td>direct biochemical</td>
+<td>ERK2 is a Ser/Thr MAPK that transfers phosphate from ATP/MgATP to Ser/Thr-Pro motifs; ATP binds in the active site, with N-lobe/glycine-rich loop contributions to nucleotide binding and catalysis.</td>
+<td>(rainey2004astructurefunctionanalysis pages 20-24, rainey2004astructurefunctionanalysis pages 24-29, waas2003physiologicalconcentrationsof pages 1-2, novak2023mutationinthe pages 1-2)</td>
+<td>Do not infer tyrosine kinase activity, broad “catalytic activity,” or substrate-level specificity beyond supported proline-directed Ser/Thr phosphorylation.</td>
+</tr>
+<tr>
+<td>MF</td>
+<td>MAP kinase kinase activity toward protein substrates</td>
+<td>direct biochemical</td>
+<td>Catalytic efficiency rises dramatically after dual phosphorylation; purified dually phosphorylated ERK2 phosphorylates peptide/protein substrates, including Elk-1-derived peptides and ETS/Runx-related transcription factor substrates in biochemical assays.</td>
+<td>(rainey2004astructurefunctionanalysis pages 24-29, bardwell2003dockingsiteson pages 5-6, waas2003physiologicalconcentrationsof pages 1-2)</td>
+<td>Do not treat every phosphoproteomics hit or motif-containing protein as a direct MAPK1 substrate.</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>ERK1 and ERK2 cascade; MAPK cascade; intracellular signal transduction; response to growth factor</td>
+<td>review/mechanistic plus direct pathway evidence</td>
+<td>ERK2 is a principal effector downstream of Ras-Raf-MEK; activated by extracellular stimuli including serum/growth factors and mediates canonical MAPK/ERK signaling.</td>
+<td>(novak2023mutationinthe pages 1-2, waas2003physiologicalconcentrationsof pages 1-2, rainey2004astructurefunctionanalysis pages 20-24)</td>
+<td>Keep pathway terms close to the conserved cascade; avoid annotating broad disease, cancer, development, or generic transcription terms from pathway membership alone.</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>positive regulation of protein phosphorylation of direct substrates; phosphorylation of transcription factors</td>
+<td>direct biochemical</td>
+<td>ERK2 directly phosphorylates defined downstream targets such as Elk-1/ETS-family and other transcription-factor substrates in vitro and in cells; docking motifs/exosites help determine substrate recognition.</td>
+<td>(bardwell2003dockingsiteson pages 5-6, waas2003physiologicalconcentrationsof pages 1-2, rainey2004astructurefunctionanalysis pages 24-29)</td>
+<td>Direct substrate phosphorylation can support narrower process terms only when the substrate/process link is demonstrated; do not infer all downstream transcriptional programs as direct MAPK1 functions.</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>regulation of cell proliferation/differentiation; apoptosis/senescence; cell migration</td>
+<td>review/mechanistic, usually non-core</td>
+<td>Literature links ERK2 signaling to proliferation, differentiation, survival/death decisions, and motility, often through many downstream effectors and context-specific scaffolds.</td>
+<td>(novak2023mutationinthe pages 1-2, martin–vega2025erk12mapksignalingmetabolic pages 3-5, butch1996characterizationoferk1 pages 1-2)</td>
+<td>These are often pathway outcomes, not direct MAPK1 actions; avoid making them core GO annotations unless supported by direct loss-of-function/rescue and mechanistic evidence specific to MAPK1.</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>cytoplasm; nucleus</td>
+<td>cell biology localization</td>
+<td>In quiescent cells ERK is mainly cytoplasmic; after activation it accumulates in the nucleus. ERK lacks clear intrinsic NLS/NES and relies on partner-mediated trafficking.</td>
+<td>(karlsson2006spatiotemporalregulationof pages 1-2, caunt2006seventransmembranereceptorsignalling pages 2-3, caunt2010stimulusinduceduncouplingof pages 1-2, caunt2010stimulusinduceduncouplingof pages 2-3)</td>
+<td>Prefer cytoplasm/nucleus over highly specific compartments unless direct localization evidence exists for MAPK1 itself in that context.</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>cytoplasm to nucleus translocation upon stimulation</td>
+<td>cell biology localization</td>
+<td>MEK binds inactive ERK in the cytoplasm; TEY phosphorylation and release from anchors permit nuclear accumulation. Nuclear localization depends on phosphorylation but can also require D-domain interactions beyond phosphorylation alone.</td>
+<td>(karlsson2006spatiotemporalregulationof pages 1-2, caunt2010stimulusinduceduncouplingof pages 1-2, caunt2010stimulusinduceduncouplingof pages 2-3)</td>
+<td>Do not annotate constitutive nuclear localization; stimulus dependence matters, and nuclear entry should not be inferred solely from ERK phosphorylation readouts.</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>cytoplasmic anchoring complex with MEK/DUSP6-like regulators; nuclear sequestration with DUSP5-like regulators</td>
+<td>cell biology localization; review/mechanistic</td>
+<td>MEK NES helps anchor inactive ERK in cytoplasm; DUSP6/MKP-3 tethers inactive ERK2 in cytoplasm; DUSP5 contains an NLS and can inactivate/sequester ERK2 in the nucleus.</td>
+<td>(karlsson2006spatiotemporalregulationof pages 2-3, karlsson2006spatiotemporalregulationof pages 1-2, caunt2010stimulusinduceduncouplingof pages 11-11)</td>
+<td>These support localization regulation and specific complexes, not broad stable residence in every compartment or all phosphatase-binding annotations.</td>
+</tr>
+<tr>
+<td>MF</td>
+<td>sequence-specific protein docking / scaffold-mediated binding</td>
+<td>direct biochemical; review/mechanistic</td>
+<td>ERK2 recognizes D-domain/KIM and DEF/FXFP docking motifs through common-docking and exosite regions; these interactions are crucial for MEK, MKP, Elk-1 and scaffold/substrate binding.</td>
+<td>(rainey2004astructurefunctionanalysis pages 24-29, bardwell2003dockingsiteson pages 5-6, rainey2004astructurefunctionanalysis pages 29-33)</td>
+<td>Avoid generic “protein binding” if a more informative docking/scaffold interaction term can be used; also avoid inferring direct binding from yeast two-hybrid or peptide competition alone without orthogonal support.</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>scaffold-mediated spatial regulation of MAPK signaling</td>
+<td>review/mechanistic</td>
+<td>Scaffold and anchoring proteins such as β-arrestin, Naf1, paxillin/GIT1/IQGAP1/KSR1 shape where ERK signals and which outputs are engaged.</td>
+<td>(rainey2004astructurefunctionanalysis pages 29-33, martin–vega2025erk12mapksignalingmetabolic pages 3-5)</td>
+<td>Scaffold-dependent localization does not automatically justify annotating MAPK1 to every scaffold’s biological process or cellular site.</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>nuclear transcription factor phosphorylation leading to gene expression changes</td>
+<td>direct substrate plus mechanistic</td>
+<td>ERK nuclear translocation enables phosphorylation of nuclear substrates such as Elk-1 and related transcription factors that contribute to induced gene expression.</td>
+<td>(caunt2006seventransmembranereceptorsignalling pages 2-3, bardwell2003dockingsiteson pages 5-6, butch1996characterizationoferk1 pages 1-2)</td>
+<td>Annotate the direct phosphorylation event or upstream signaling role rather than broad “regulation of transcription” unless MAPK1-specific causality is directly established.</td>
+</tr>
+<tr>
+<td>General guidance</td>
+<td>core set should emphasize kinase activity, MEK-dependent activation, MAPK/ERK cascade role, intracellular signaling, and cytoplasm/nucleus shuttling</td>
+<td>synthesis</td>
+<td>Best-supported core annotations are those nearest to direct chemistry, canonical pathway position, and experimentally observed localization dynamics.</td>
+<td>(novak2023mutationinthe pages 1-2, karlsson2006spatiotemporalregulationof pages 1-2, caunt2010stimulusinduceduncouplingof pages 1-2)</td>
+<td>Be cautious with inhibitor/overexpression phenotypes, cancer-context reviews, and high-throughput substrate claims; distinguish direct MAPK1 action from downstream pathway outcomes.</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes GO-relevant evidence and annotation boundaries for human MAPK1/ERK2 using only the provided evidence contexts. It highlights the strongest core annotations and flags common over-annotation risks for downstream phenotypes, generic binding, and indirect pathway outcomes.</em></p>
+<h3 id="key-caveats-for-curators-high-priority">Key caveats for curators (high priority)</h3>
+<ol>
+<li><strong>Do not infer “nuclear” localization from phospho-ERK alone.</strong> Nuclear accumulation can be partially uncoupled from TEY phosphorylation and depends on docking interactions and anchors. (caunt2010stimulusinduceduncouplingof pages 1-2, caunt2010stimulusinduceduncouplingof pages 2-3)</li>
+<li><strong>Avoid broad BP terms (cancer, development, cell cycle, transcription) from pathway membership.</strong> Prefer “MAPK/ERK cascade” and “intracellular signal transduction,” and only add downstream BPs with direct MAPK1 evidence. (novak2023mutationinthe pages 1-2, butch1996characterizationoferk1 pages 1-2)</li>
+<li><strong>Be conservative with high-throughput substrate claims.</strong> Motif presence is insufficient; only a minority of Ser/Thr-Pro sites are bona fide MAPK substrates in vivo, and phosphoproteomics hits need orthogonal validation. (rainey2004astructurefunctionanalysis pages 24-29, martin–vega2025erk12mapksignalingmetabolic pages 3-5)</li>
+<li><strong>Use specific docking/scaffold language rather than generic binding when possible.</strong> Docking is mediated by defined motifs (KIM/D-domain, DEF/FXFP) and ERK exosites; peptide/yeast assays can be indirect. (bardwell2003dockingsiteson pages 5-6, rainey2004astructurefunctionanalysis pages 29-33)</li>
+<li><strong>Distinguish kinase-dependent vs kinase-independent ERK functions.</strong> The DHPS–ERK2 interaction demonstrates direct binding-mediated regulation independent of ERK catalytic activity, warning against attributing every ERK-associated outcome to “protein phosphorylation.” (becker2024erk12interactionwith pages 1-3, becker2024erk12interactionwith media 4b826433)</li>
+</ol>
+<h3 id="references-urls-dates-identifiers">References (URLs, dates, identifiers)</h3>
+<ul>
+<li>Novak L. et al. <em>Cancers</em> (2023-05). “Mutation in the Common Docking Domain Affects MAP Kinase ERK2 Catalysis and Stability.” DOI:10.3390/cancers15112938. URL: https://doi.org/10.3390/cancers15112938 (novak2023mutationinthe pages 1-2)</li>
+<li>Becker A.E. et al. <em>Cell Reports</em> (2024-10). “ERK1/2 interaction with DHPS regulates eIF5A deoxyhypusination independently of ERK kinase activity.” DOI:10.1016/j.celrep.2024.114831. URL: https://doi.org/10.1016/j.celrep.2024.114831 (becker2024erk12interactionwith pages 1-3, becker2024erk12interactionwith media 4b826433)</li>
+<li>Mohammed K.A.K. et al. <em>Frontiers in Cardiovascular Medicine</em> (2024-07). “MEK inhibitors: a promising targeted therapy for cardiovascular disease.” DOI:10.3389/fcvm.2024.1404253. URL: https://doi.org/10.3389/fcvm.2024.1404253 (mohammed2024mekinhibitorsa pages 2-3)</li>
+<li>Karlsson M. et al. <em>Biochemical Society Transactions</em> (2006-10). “Spatio-temporal regulation of MAPK signalling by protein phosphatases.” DOI:10.1042/bst0340842. URL: https://doi.org/10.1042/bst0340842 (karlsson2006spatiotemporalregulationof pages 1-2)</li>
+<li>Caunt C.J. et al. <em>Trends Endocrinol Metab</em> (2006-09). “Seven-transmembrane receptor signalling and ERK compartmentalization.” DOI:10.1016/j.tem.2006.07.008. URL: https://doi.org/10.1016/j.tem.2006.07.008 (caunt2006seventransmembranereceptorsignalling pages 2-3)</li>
+<li>Caunt C.J. &amp; McArdle C.A. <em>J Cell Sci</em> (2010-12). “Stimulus-induced uncoupling of ERK phosphorylation from nuclear localization…” DOI:10.1242/jcs.076349. URL: https://doi.org/10.1242/jcs.076349 (caunt2010stimulusinduceduncouplingof pages 1-2, caunt2010stimulusinduceduncouplingof pages 2-3)</li>
+<li>Waas W.F. &amp; Dalby K.N. <em>Biochemistry</em> (2003-03). “Physiological concentrations of divalent magnesium ion activate… ERK2.” DOI:10.1021/bi027171w. URL: https://doi.org/10.1021/bi027171w (waas2003physiologicalconcentrationsof pages 1-2)</li>
+<li>Bardwell A.J. et al. <em>Biochem J</em> (2003-03). “Docking sites… compete for MAPK binding and are crucial for enzymic activity.” DOI:10.1042/bj20021806. URL: https://doi.org/10.1042/bj20021806 (bardwell2003dockingsiteson pages 5-6)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(novak2023mutationinthe pages 1-2): Leonore Novak, Maria Petrosino, Alessandra Pasquo, Apirat Chaikuad, Roberta Chiaraluce, Stefan Knapp, and Valerio Consalvi. Mutation in the common docking domain affects map kinase erk2 catalysis and stability. Cancers, 15:2938, May 2023. URL: https://doi.org/10.3390/cancers15112938, doi:10.3390/cancers15112938. This article has 7 citations.</p>
+</li>
+<li>
+<p>(karlsson2006spatiotemporalregulationof pages 1-2): M. Karlsson, M. Mandl, and S.M. Keyse. Spatio-temporal regulation of mitogen-activated protein kinase (mapk) signalling by protein phosphatases. Biochemical Society transactions, 34 Pt 5:842-5, Oct 2006. URL: https://doi.org/10.1042/bst0340842, doi:10.1042/bst0340842. This article has 35 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(caunt2010stimulusinduceduncouplingof pages 1-2): Christopher J. Caunt and Craig A. McArdle. Stimulus-induced uncoupling of extracellular signal-regulated kinase phosphorylation from nuclear localization is dependent on docking domain interactions. Journal of Cell Science, 123:4310-4320, Dec 2010. URL: https://doi.org/10.1242/jcs.076349, doi:10.1242/jcs.076349. This article has 34 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rainey2004astructurefunctionanalysis pages 20-24): MA Rainey. A structure/function analysis of macromolecular recognition by the protein kinase erk2. Unknown journal, 2004.</p>
+</li>
+<li>
+<p>(rainey2004astructurefunctionanalysis pages 24-29): MA Rainey. A structure/function analysis of macromolecular recognition by the protein kinase erk2. Unknown journal, 2004.</p>
+</li>
+<li>
+<p>(waas2003physiologicalconcentrationsof pages 1-2): William F. Waas and Kevin N. Dalby. Physiological concentrations of divalent magnesium ion activate the serine/threonine specific protein kinase erk2. Biochemistry, 42 10:2960-70, Mar 2003. URL: https://doi.org/10.1021/bi027171w, doi:10.1021/bi027171w. This article has 60 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(butch1996characterizationoferk1 pages 1-2): Elizabeth R. Butch and Kun-Liang Guan. Characterization of erk1 activation site mutants and the effect on recognition by mek1 and mek2 (*). The Journal of Biological Chemistry, 271:4230-4235, Feb 1996. URL: https://doi.org/10.1074/jbc.271.8.4230, doi:10.1074/jbc.271.8.4230. This article has 77 citations.</p>
+</li>
+<li>
+<p>(caunt2006seventransmembranereceptorsignalling pages 2-3): Christopher J. Caunt, Ann R. Finch, Kathleen R. Sedgley, and Craig A. McArdle. Seven-transmembrane receptor signalling and erk compartmentalization. Trends in Endocrinology &amp; Metabolism, 17:276-283, Sep 2006. URL: https://doi.org/10.1016/j.tem.2006.07.008, doi:10.1016/j.tem.2006.07.008. This article has 115 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(karlsson2006spatiotemporalregulationof pages 2-3): M. Karlsson, M. Mandl, and S.M. Keyse. Spatio-temporal regulation of mitogen-activated protein kinase (mapk) signalling by protein phosphatases. Biochemical Society transactions, 34 Pt 5:842-5, Oct 2006. URL: https://doi.org/10.1042/bst0340842, doi:10.1042/bst0340842. This article has 35 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(caunt2010stimulusinduceduncouplingof pages 2-3): Christopher J. Caunt and Craig A. McArdle. Stimulus-induced uncoupling of extracellular signal-regulated kinase phosphorylation from nuclear localization is dependent on docking domain interactions. Journal of Cell Science, 123:4310-4320, Dec 2010. URL: https://doi.org/10.1242/jcs.076349, doi:10.1242/jcs.076349. This article has 34 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(bardwell2003dockingsiteson pages 5-6): A. Jane BARDWELL, Mahsa ABDOLLAHI, and Lee BARDWELL. Docking sites on mitogen-activated protein kinase (mapk) kinases, mapk phosphatases and the elk-1 transcription factor compete for mapk binding and are crucial for enzymic activity. Biochemical Journal, 370:1077-1085, Mar 2003. URL: https://doi.org/10.1042/bj20021806, doi:10.1042/bj20021806. This article has 150 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(rainey2004astructurefunctionanalysis pages 29-33): MA Rainey. A structure/function analysis of macromolecular recognition by the protein kinase erk2. Unknown journal, 2004.</p>
+</li>
+<li>
+<p>(martin–vega2025erk12mapksignalingmetabolic pages 3-5): Ana Martin–Vega and Melanie H. Cobb. Erk1/2-mapk signaling: metabolic, organellar, and cytoskeletal interactions. Current Opinion in Cell Biology, 95:102526, Aug 2025. URL: https://doi.org/10.1016/j.ceb.2025.102526, doi:10.1016/j.ceb.2025.102526. This article has 12 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(becker2024erk12interactionwith pages 1-3): Andrew E. Becker, Paweł Kochanowski, Pui-Kei Wu, Elżbieta Wątor, Wenjing Chen, Koushik Guchhait, Artur P. Biela, Przemysław Grudnik, and Jong-In Park. Erk1/2 interaction with dhps regulates eif5a deoxyhypusination independently of erk kinase activity. Cell reports, 43:114831-114831, Oct 2024. URL: https://doi.org/10.1016/j.celrep.2024.114831, doi:10.1016/j.celrep.2024.114831. This article has 4 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(becker2024erk12interactionwith media 4b826433): Andrew E. Becker, Paweł Kochanowski, Pui-Kei Wu, Elżbieta Wątor, Wenjing Chen, Koushik Guchhait, Artur P. Biela, Przemysław Grudnik, and Jong-In Park. Erk1/2 interaction with dhps regulates eif5a deoxyhypusination independently of erk kinase activity. Cell reports, 43:114831-114831, Oct 2024. URL: https://doi.org/10.1016/j.celrep.2024.114831, doi:10.1016/j.celrep.2024.114831. This article has 4 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(becker2024erk12interactionwith media dca6815c): Andrew E. Becker, Paweł Kochanowski, Pui-Kei Wu, Elżbieta Wątor, Wenjing Chen, Koushik Guchhait, Artur P. Biela, Przemysław Grudnik, and Jong-In Park. Erk1/2 interaction with dhps regulates eif5a deoxyhypusination independently of erk kinase activity. Cell reports, 43:114831-114831, Oct 2024. URL: https://doi.org/10.1016/j.celrep.2024.114831, doi:10.1016/j.celrep.2024.114831. This article has 4 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mohammed2024mekinhibitorsa pages 2-3): Khaled A. K. Mohammed, Paolo Madeddu, and Elisa Avolio. Mek inhibitors: a promising targeted therapy for cardiovascular disease. Frontiers in Cardiovascular Medicine, Jul 2024. URL: https://doi.org/10.3389/fcvm.2024.1404253, doi:10.3389/fcvm.2024.1404253. This article has 17 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(caunt2010stimulusinduceduncouplingof pages 11-11): Christopher J. Caunt and Craig A. McArdle. Stimulus-induced uncoupling of extracellular signal-regulated kinase phosphorylation from nuclear localization is dependent on docking domain interactions. Journal of Cell Science, 123:4310-4320, Dec 2010. URL: https://doi.org/10.1242/jcs.076349, doi:10.1242/jcs.076349. This article has 34 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>novak2023mutationinthe pages 1-2</li>
+<li>rainey2004astructurefunctionanalysis pages 24-29</li>
+<li>karlsson2006spatiotemporalregulationof pages 1-2</li>
+<li>karlsson2006spatiotemporalregulationof pages 2-3</li>
+<li>waas2003physiologicalconcentrationsof pages 1-2</li>
+<li>bardwell2003dockingsiteson pages 5-6</li>
+<li>mohammed2024mekinhibitorsa pages 2-3</li>
+<li>caunt2006seventransmembranereceptorsignalling pages 2-3</li>
+<li>caunt2010stimulusinduceduncouplingof pages 1-2</li>
+<li>rainey2004astructurefunctionanalysis pages 20-24</li>
+<li>caunt2010stimulusinduceduncouplingof pages 2-3</li>
+<li>rainey2004astructurefunctionanalysis pages 29-33</li>
+<li>caunt2010stimulusinduceduncouplingof pages 11-11</li>
+<li>https://doi.org/10.1016/j.celrep.2024.114831</li>
+<li>https://doi.org/10.3390/cancers15112938</li>
+<li>https://doi.org/10.3389/fcvm.2024.1404253</li>
+<li>https://doi.org/10.1042/bst0340842</li>
+<li>https://doi.org/10.1016/j.tem.2006.07.008</li>
+<li>https://doi.org/10.1242/jcs.076349</li>
+<li>https://doi.org/10.1021/bi027171w</li>
+<li>https://doi.org/10.1042/bj20021806</li>
+<li>https://doi.org/10.3390/cancers15112938,</li>
+<li>https://doi.org/10.1042/bst0340842,</li>
+<li>https://doi.org/10.1242/jcs.076349,</li>
+<li>https://doi.org/10.1021/bi027171w,</li>
+<li>https://doi.org/10.1074/jbc.271.8.4230,</li>
+<li>https://doi.org/10.1016/j.tem.2006.07.008,</li>
+<li>https://doi.org/10.1042/bj20021806,</li>
+<li>https://doi.org/10.1016/j.ceb.2025.102526,</li>
+<li>https://doi.org/10.1016/j.celrep.2024.114831,</li>
+<li>https://doi.org/10.3389/fcvm.2024.1404253,</li>
+</ol>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(MAPK1-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="P28482" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="mapk1-notes">MAPK1 notes</h1>
+<p>Initial Falcon pass, 2026-05-12. MAPK1/ERK2 started as a fully pending review<br />
+with 276 existing annotations, so this pass focuses on the safest term-level<br />
+curation rather than attempting a primary-source review of every substrate,<br />
+interaction, Reactome, and phenotype annotation.</p>
+<p>Core molecular function: MAPK1 is ERK2, an ATP-dependent serine/threonine MAP<br />
+kinase. Falcon summarizes the core enzymology as direct ATP-dependent<br />
+phosphotransfer [file:human/MAPK1/MAPK1-deep-research-falcon.md "ERK2 is a<br />
+Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like<br />
+other protein kinases it binds ATP in an active-site cleft, with MgATP2−<br />
+serving as the relevant phosphoryl donor in vitro."]. I therefore accepted MAP<br />
+kinase activity, protein serine/threonine kinase activity, ATP binding, and<br />
+protein phosphorylation, while modifying broader or incomplete kinase terms to<br />
+the specific MAP kinase/serine-threonine kinase terms.</p>
+<p>Core process: the most defensible biological process is canonical ERK/MAPK<br />
+cascade signal transduction. Falcon places ERK2 downstream of Ras-RAF-MEK and<br />
+growth-factor inputs [file:human/MAPK1/MAPK1-deep-research-falcon.md "ERK2 is<br />
+consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal<br />
+transduction cascade, converting extracellular cues (including growth<br />
+factors/serum) into intracellular phosphorylation events and responses."]. I<br />
+accepted ERK1 and ERK2 cascade, MAPK cascade, and intracellular signal<br />
+transduction, and kept receptor-specific contexts such as EGFR/ERBB/insulin<br />
+signaling as non-core.</p>
+<p>Core localization: the best-supported localizations are cytoplasmic/cytosolic<br />
+localization in unstimulated cells plus stimulus-dependent nuclear<br />
+accumulation. Falcon states that ERK is mainly cytoplasmic in quiescent cells<br />
+and accumulates in the nucleus after activation<br />
+[file:human/MAPK1/MAPK1-deep-research-falcon.md "ERK is predominantly<br />
+cytoplasmic in quiescent cells and accumulates in the nucleus after activation<br />
+by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes<br />
+to induced gene expression programs."]. I accepted cytoplasm, cytosol, nucleus,<br />
+and one nucleoplasm row with this stimulus-dependent caveat. Most repetitive<br />
+Reactome cytosol/nucleoplasm rows and more specific compartments remain pending<br />
+unless later primary-source review supports a stronger decision.</p>
+<p>Over-annotation cautions: Falcon explicitly warns that downstream proliferation,<br />
+differentiation, apoptosis, migration, developmental, transcriptional, and<br />
+disease terms are often ERK pathway outcomes rather than direct MAPK1<br />
+functions [file:human/MAPK1/MAPK1-deep-research-falcon.md "Many sources link<br />
+ERK signaling to proliferation/differentiation and disease contexts, but these<br />
+are typically emergent outcomes of the pathway rather than direct MAPK1<br />
+enzymatic functions."]. I marked a small set of automated broad developmental<br />
+or transcriptional annotations as over-annotated and retained some source-backed<br />
+downstream processes as non-core.</p>
+<p>Protein binding: MAPK1 has many reported interacting partners, but the generic<br />
+GO:0005515 term is not useful for this gene. Falcon notes that ERK docking is<br />
+motif/exosite-mediated and that generic protein binding risks over-annotation<br />
+[file:human/MAPK1/MAPK1-deep-research-falcon.md "Because docking is<br />
+motif-driven and structurally/biochemically dissectable, using only “protein<br />
+binding” is typically uninformative and risks over-annotation."]. I left the<br />
+generic protein-binding rows pending for partner-specific follow-up, while<br />
+keeping the more informative phosphatase-binding term as non-core.</p>
+<p>Left for later: a source-level review should triage individual substrates,<br />
+protein interactions, Reactome location rows, and old TAS/NAS phenotype rows.<br />
+Several annotations remain PENDING where I did not inspect the primary<br />
+publication.</p>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -17626,7 +20545,14 @@ status: INITIALIZED
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: &#39;TODO: Add description for MAPK1&#39;
+description: &gt;-
+  MAPK1 (ERK2) is an ATP-dependent, proline-directed serine/threonine MAP kinase
+  in the canonical Ras-RAF-MEK-ERK cascade. It is activated by MEK1/2 dual
+  phosphorylation, phosphorylates cytosolic and nuclear substrates, and shuttles
+  between cytoplasmic/cytosolic and nuclear compartments after stimulation.
+  Distal proliferation, differentiation, apoptosis, migration, transcriptional,
+  and disease phenotypes are context-dependent ERK pathway outputs rather than
+  the core MAPK1 molecular function.
 alternative_products:
 - name: &#39;1&#39;
   id: P28482-1
@@ -17640,80 +20566,216 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 localizes to the nucleus after stimulation.
+    action: ACCEPT
+    reason: &gt;-
+      Nuclear localization is supported, but should be interpreted as stimulus-dependent
+      rather than constitutive.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        **Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear
+        accumulation can be partially uncoupled from TEY phosphorylation and depends on
+        docking interactions and anchors.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is cytoplasmic in quiescent cells.
+    action: ACCEPT
+    reason: &gt;-
+      Cytoplasmic localization is a core supported localization for ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0035556
     label: intracellular signal transduction
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 functions in intracellular signal transduction downstream of extracellular
+      cues.
+    action: ACCEPT
+    reason: &gt;-
+      Intracellular signal transduction is a supported core process for MAPK1 as the
+      ERK2 kinase in the canonical MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0004674
     label: protein serine/threonine kinase activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: &gt;-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0007166
     label: cell surface receptor signaling pathway
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 responds to cell-surface receptor inputs, but its core role is the
+      downstream intracellular ERK/MAPK cascade.
+    action: MODIFY
+    reason: &gt;-
+      Cell surface receptor signaling is too broad and upstream-oriented for the MAPK1
+      core function; ERK/MAPK cascade terms are more specific.
+    proposed_replacement_terms:
+    - id: GO:0070371
+      label: ERK1 and ERK2 cascade
+    - id: GO:0000165
+      label: MAPK cascade
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0004672
     label: protein kinase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 is a protein kinase, but this term is less specific than the supported
+      serine/threonine MAP kinase terms.
+    action: MODIFY
+    reason: &gt;-
+      The generic protein kinase term should be replaced by protein serine/threonine
+      kinase activity and MAP kinase activity, which capture MAPK1 specificity.
+    proposed_replacement_terms:
+    - id: GO:0004674
+      label: protein serine/threonine kinase activity
+    - id: GO:0004707
+      label: MAP kinase activity
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0004707
     label: MAP kinase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 has MAP kinase activity.
+    action: ACCEPT
+    reason: &gt;-
+      MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
 - term:
     id: GO:0005524
     label: ATP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 binds ATP as the phosphoryl donor for kinase catalysis.
+    action: ACCEPT
+    reason: &gt;-
+      ATP binding is integral to the active-site chemistry of ERK2 kinase activity.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 localizes to the nucleus after stimulation.
+    action: ACCEPT
+    reason: &gt;-
+      Nuclear localization is supported, but should be interpreted as stimulus-dependent
+      rather than constitutive.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        **Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear
+        accumulation can be partially uncoupled from TEY phosphorylation and depends on
+        docking interactions and anchors.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is cytoplasmic in quiescent cells.
+    action: ACCEPT
+    reason: &gt;-
+      Cytoplasmic localization is a core supported localization for ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0005769
     label: early endosome
@@ -17776,24 +20838,63 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000108
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 can affect transcriptional programs through downstream substrates, but broad
+      regulation of RNA polymerase II transcription overstates the direct function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The direct MAPK1 function is kinase activity and ERK/MAPK cascade signaling; broad
+      transcriptional regulation should not be inferred from pathway membership alone.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0007173
     label: epidermal growth factor receptor signaling pathway
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0010759
     label: positive regulation of macrophage chemotaxis
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0032206
     label: positive regulation of telomere maintenance
@@ -17808,16 +20909,48 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a stress-context signaling annotation for MAPK1.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
+      and should remain non-core unless a later source-level review shows they are
+      central for MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0034198
     label: cellular response to amino acid starvation
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a stress-context signaling annotation for MAPK1.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
+      and should remain non-core unless a later source-level review shows they are
+      central for MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0045202
     label: synapse
@@ -17832,8 +20965,24 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a stress-context signaling annotation for MAPK1.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
+      and should remain non-core unless a later source-level review shows they are
+      central for MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0051493
     label: regulation of cytoskeleton organization
@@ -17848,24 +20997,68 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0070371
     label: ERK1 and ERK2 cascade
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is a central component of the ERK1 and ERK2 cascade.
+    action: ACCEPT
+    reason: &gt;-
+      ERK1 and ERK2 cascade is a core pathway term for MAPK1 and is more specific than
+      generic signaling process terms.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0070849
     label: response to epidermal growth factor
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0072584
     label: caveolin-mediated endocytosis
@@ -17896,16 +21089,43 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000116
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 can phosphorylate serine residues, but the serine-only term is incomplete
+      for ERK2.
+    action: MODIFY
+    reason: &gt;-
+      ERK2 is a proline-directed serine/threonine MAP kinase; GO:0004674 and GO:0004707
+      better capture the supported activity than a serine-only activity term.
+    proposed_replacement_terms:
+    - id: GO:0004674
+      label: protein serine/threonine kinase activity
+    - id: GO:0004707
+      label: MAP kinase activity
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0120041
     label: positive regulation of macrophage proliferation
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:2000641
     label: regulation of early endosome to late endosome transport
@@ -18288,8 +21508,18 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: &gt;-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0005739
     label: mitochondrion
@@ -18304,16 +21534,43 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is present in the cytosolic/cytoplasmic compartment.
+    action: ACCEPT
+    reason: &gt;-
+      Cytosolic localization is consistent with ERK2 being predominantly cytoplasmic in
+      quiescent cells before stimulus-dependent nuclear accumulation.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0008286
     label: insulin receptor signaling pathway
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0008353
     label: RNA polymerase II CTD heptapeptide repeat kinase activity
@@ -18328,24 +21585,60 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The available synthesis supports ERK/MAPK cascade membership as core, but warns
+      against promoting broad developmental or disease-associated outcomes to core MAPK1
+      functions without direct MAPK1-specific evidence.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0016301
     label: kinase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 is a kinase, but this term is too broad for ERK2.
+    action: MODIFY
+    reason: &gt;-
+      The broad kinase activity annotation should use the more informative
+      serine/threonine MAP kinase terms.
+    proposed_replacement_terms:
+    - id: GO:0004674
+      label: protein serine/threonine kinase activity
+    - id: GO:0004707
+      label: MAP kinase activity
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0019902
     label: phosphatase binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 binds MAP kinase phosphatases such as DUSP6/MKP-3.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Phosphatase binding is a supported regulatory interaction, but it is not the
+      primary catalytic function of MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        DUSP6/MKP-3 as cytoplasmic tether:** MKP-3/DUSP6 binds ERK2 and can
+        dephosphorylate and tether inactive ERK2 in the cytoplasm; mutating MKP-3 NES or
+        KIM abolishes cytoplasmic anchoring.
 - term:
     id: GO:0031143
     label: pseudopodium
@@ -18368,16 +21661,44 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0042552
     label: myelination
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The available synthesis supports ERK/MAPK cascade membership as core, but warns
+      against promoting broad developmental or disease-associated outcomes to core MAPK1
+      functions without direct MAPK1-specific evidence.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0042802
     label: identical protein binding
@@ -18392,64 +21713,164 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The available synthesis supports ERK/MAPK cascade membership as core, but warns
+      against promoting broad developmental or disease-associated outcomes to core MAPK1
+      functions without direct MAPK1-specific evidence.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0048009
     label: insulin-like growth factor receptor signaling pathway
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0150078
     label: positive regulation of neuroinflammatory response
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The available synthesis supports ERK/MAPK cascade membership as core, but warns
+      against promoting broad developmental or disease-associated outcomes to core MAPK1
+      functions without direct MAPK1-specific evidence.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0004707
     label: MAP kinase activity
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 has MAP kinase activity.
+    action: ACCEPT
+    reason: &gt;-
+      MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: IDA
   original_reference_id: PMID:22451653
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is present in the cytosolic/cytoplasmic compartment.
+    action: ACCEPT
+    reason: &gt;-
+      Cytosolic localization is consistent with ERK2 being predominantly cytoplasmic in
+      quiescent cells before stimulus-dependent nuclear accumulation.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0043415
     label: positive regulation of skeletal muscle tissue regeneration
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The available synthesis supports ERK/MAPK cascade membership as core, but warns
+      against promoting broad developmental or disease-associated outcomes to core MAPK1
+      functions without direct MAPK1-specific evidence.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0106310
     label: protein serine kinase activity
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 can phosphorylate serine residues, but the serine-only term is incomplete
+      for ERK2.
+    action: MODIFY
+    reason: &gt;-
+      ERK2 is a proline-directed serine/threonine MAP kinase; GO:0004674 and GO:0004707
+      better capture the supported activity than a serine-only activity term.
+    proposed_replacement_terms:
+    - id: GO:0004674
+      label: protein serine/threonine kinase activity
+    - id: GO:0004707
+      label: MAP kinase activity
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0004674
     label: protein serine/threonine kinase activity
   evidence_type: IDA
   original_reference_id: PMID:35831023
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: &gt;-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0045880
     label: positive regulation of smoothened signaling pathway
@@ -18464,64 +21885,168 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 can accumulate in the nuclear compartment after stimulation.
+    action: ACCEPT
+    reason: &gt;-
+      Nucleoplasmic localization is compatible with the supported stimulus-dependent
+      nuclear accumulation of ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        **Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear
+        accumulation can be partially uncoupled from TEY phosphorylation and depends on
+        docking interactions and anchors.
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is present in the cytosolic/cytoplasmic compartment.
+    action: ACCEPT
+    reason: &gt;-
+      Cytosolic localization is consistent with ERK2 being predominantly cytoplasmic in
+      quiescent cells before stimulus-dependent nuclear accumulation.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0004707
     label: MAP kinase activity
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-111898
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 has MAP kinase activity.
+    action: ACCEPT
+    reason: &gt;-
+      MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
 - term:
     id: GO:0004707
     label: MAP kinase activity
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-445079
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 has MAP kinase activity.
+    action: ACCEPT
+    reason: &gt;-
+      MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
 - term:
     id: GO:0004674
     label: protein serine/threonine kinase activity
   evidence_type: IDA
   original_reference_id: PMID:38503280
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: &gt;-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0070371
     label: ERK1 and ERK2 cascade
   evidence_type: IDA
   original_reference_id: PMID:15850461
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is a central component of the ERK1 and ERK2 cascade.
+    action: ACCEPT
+    reason: &gt;-
+      ERK1 and ERK2 cascade is a core pathway term for MAPK1 and is more specific than
+      generic signaling process terms.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0150078
     label: positive regulation of neuroinflammatory response
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      The available synthesis supports ERK/MAPK cascade membership as core, but warns
+      against promoting broad developmental or disease-associated outcomes to core MAPK1
+      functions without direct MAPK1-specific evidence.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0004707
     label: MAP kinase activity
   evidence_type: IDA
   original_reference_id: PMID:38503280
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 has MAP kinase activity.
+    action: ACCEPT
+    reason: &gt;-
+      MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
 - term:
     id: GO:0070098
     label: chemokine-mediated signaling pathway
@@ -18536,32 +22061,92 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:15850461
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 functions in the canonical MAPK cascade.
+    action: ACCEPT
+    reason: &gt;-
+      MAPK cascade membership is a core biological process for ERK2, downstream of
+      Ras-RAF-MEK signaling.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0061514
     label: interleukin-34-mediated signaling pathway
   evidence_type: IGI
   original_reference_id: PMID:26754294
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0000165
     label: MAPK cascade
   evidence_type: IDA
   original_reference_id: PMID:24854121
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 functions in the canonical MAPK cascade.
+    action: ACCEPT
+    reason: &gt;-
+      MAPK cascade membership is a core biological process for ERK2, downstream of
+      Ras-RAF-MEK signaling.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0007173
     label: epidermal growth factor receptor signaling pathway
   evidence_type: IDA
   original_reference_id: PMID:24854121
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0005515
     label: protein binding
@@ -18608,16 +22193,40 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:32721402
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 localizes to the nucleus after stimulation.
+    action: ACCEPT
+    reason: &gt;-
+      Nuclear localization is supported, but should be interpreted as stimulus-dependent
+      rather than constitutive.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        **Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear
+        accumulation can be partially uncoupled from TEY phosphorylation and depends on
+        docking interactions and anchors.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:32721402
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is cytoplasmic in quiescent cells.
+    action: ACCEPT
+    reason: &gt;-
+      Cytoplasmic localization is a core supported localization for ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0005515
     label: protein binding
@@ -18632,24 +22241,56 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:7588608
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: &gt;-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0010759
     label: positive regulation of macrophage chemotaxis
   evidence_type: IGI
   original_reference_id: PMID:26754294
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0120041
     label: positive regulation of macrophage proliferation
   evidence_type: IGI
   original_reference_id: PMID:26754294
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0005515
     label: protein binding
@@ -18672,8 +22313,23 @@ existing_annotations:
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9636296
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is not a supported core MAPK1 localization in this review.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Falcon synthesis supports cytoplasmic/cytosolic and stimulus-dependent nuclear
+      localization; secretory or granule-lumen locations are likely pathway-context
+      over-annotations for soluble ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Prefer cytoplasm/nucleus over highly specific compartments unless direct
+        localization evidence exists for MAPK1 itself in that context.
 - term:
     id: GO:0005829
     label: cytosol
@@ -18688,8 +22344,18 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:26996940
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: &gt;-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0005886
     label: plasma membrane
@@ -18712,8 +22378,19 @@ existing_annotations:
   evidence_type: NAS
   original_reference_id: PMID:11404397
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0035094
     label: response to nicotine
@@ -18728,48 +22405,140 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:11096076
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a stress-context signaling annotation for MAPK1.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
+      and should remain non-core unless a later source-level review shows they are
+      central for MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0051403
     label: stress-activated MAPK cascade
   evidence_type: IDA
   original_reference_id: PMID:11096076
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a stress-context signaling annotation for MAPK1.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
+      and should remain non-core unless a later source-level review shows they are
+      central for MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0005576
     label: extracellular region
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6798751
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is not a supported core MAPK1 localization in this review.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Falcon synthesis supports cytoplasmic/cytosolic and stimulus-dependent nuclear
+      localization; secretory or granule-lumen locations are likely pathway-context
+      over-annotations for soluble ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Prefer cytoplasm/nucleus over highly specific compartments unless direct
+        localization evidence exists for MAPK1 itself in that context.
 - term:
     id: GO:0005576
     label: extracellular region
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6800434
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is not a supported core MAPK1 localization in this review.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Falcon synthesis supports cytoplasmic/cytosolic and stimulus-dependent nuclear
+      localization; secretory or granule-lumen locations are likely pathway-context
+      over-annotations for soluble ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Prefer cytoplasm/nucleus over highly specific compartments unless direct
+        localization evidence exists for MAPK1 itself in that context.
 - term:
     id: GO:0035578
     label: azurophil granule lumen
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6798751
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is not a supported core MAPK1 localization in this review.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Falcon synthesis supports cytoplasmic/cytosolic and stimulus-dependent nuclear
+      localization; secretory or granule-lumen locations are likely pathway-context
+      over-annotations for soluble ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Prefer cytoplasm/nucleus over highly specific compartments unless direct
+        localization evidence exists for MAPK1 itself in that context.
 - term:
     id: GO:1904813
     label: ficolin-1-rich granule lumen
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6800434
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is not a supported core MAPK1 localization in this review.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: &gt;-
+      Falcon synthesis supports cytoplasmic/cytosolic and stimulus-dependent nuclear
+      localization; secretory or granule-lumen locations are likely pathway-context
+      over-annotations for soluble ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Prefer cytoplasm/nucleus over highly specific compartments unless direct
+        localization evidence exists for MAPK1 itself in that context.
 - term:
     id: GO:0005515
     label: protein binding
@@ -18784,32 +22553,80 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:23184662
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 directly phosphorylates protein substrates.
+    action: ACCEPT
+    reason: &gt;-
+      Protein phosphorylation is the direct biochemical output of the MAPK1 kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 directly phosphorylates defined downstream targets such as Elk-1/ETS-family
+        and other transcription-factor substrates in vitro and in cells; docking
+        motifs/exosites help determine substrate recognition.
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: HDA
   original_reference_id: PMID:16791210
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 localizes to the nucleus after stimulation.
+    action: ACCEPT
+    reason: &gt;-
+      Nuclear localization is supported, but should be interpreted as stimulus-dependent
+      rather than constitutive.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        **Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear
+        accumulation can be partially uncoupled from TEY phosphorylation and depends on
+        docking interactions and anchors.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:16791210
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is cytoplasmic in quiescent cells.
+    action: ACCEPT
+    reason: &gt;-
+      Cytoplasmic localization is a core supported localization for ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is cytoplasmic in quiescent cells.
+    action: ACCEPT
+    reason: &gt;-
+      Cytoplasmic localization is a core supported localization for ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0072686
     label: mitotic spindle
@@ -19600,16 +23417,43 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:15133037
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0004674
     label: protein serine/threonine kinase activity
   evidence_type: IDA
   original_reference_id: PMID:18794356
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: &gt;-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0005515
     label: protein binding
@@ -19624,24 +23468,65 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:18794356
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 localizes to the nucleus after stimulation.
+    action: ACCEPT
+    reason: &gt;-
+      Nuclear localization is supported, but should be interpreted as stimulus-dependent
+      rather than constitutive.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        **Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear
+        accumulation can be partially uncoupled from TEY phosphorylation and depends on
+        docking interactions and anchors.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:18794356
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is cytoplasmic in quiescent cells.
+    action: ACCEPT
+    reason: &gt;-
+      Cytoplasmic localization is a core supported localization for ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0070849
     label: response to epidermal growth factor
   evidence_type: IDA
   original_reference_id: PMID:18794356
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0005515
     label: protein binding
@@ -19656,16 +23541,41 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:15850461
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: &gt;-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: TAS
   original_reference_id: PMID:19565474
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 localizes to the nucleus after stimulation.
+    action: ACCEPT
+    reason: &gt;-
+      Nuclear localization is supported, but should be interpreted as stimulus-dependent
+      rather than constitutive.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        **Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear
+        accumulation can be partially uncoupled from TEY phosphorylation and depends on
+        docking interactions and anchors.
 - term:
     id: GO:0005739
     label: mitochondrion
@@ -19704,8 +23614,18 @@ existing_annotations:
   evidence_type: TAS
   original_reference_id: PMID:19565474
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is present in the cytosolic/cytoplasmic compartment.
+    action: ACCEPT
+    reason: &gt;-
+      Cytosolic localization is consistent with ERK2 being predominantly cytoplasmic in
+      quiescent cells before stimulus-dependent nuclear accumulation.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0005856
     label: cytoskeleton
@@ -19736,8 +23656,24 @@ existing_annotations:
   evidence_type: TAS
   original_reference_id: PMID:19565474
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a stress-context signaling annotation for MAPK1.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
+      and should remain non-core unless a later source-level review shows they are
+      central for MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0051493
     label: regulation of cytoskeleton organization
@@ -19776,24 +23712,66 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:16314496
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 can increase phosphorylation of downstream threonine-containing protein
+      substrates.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The term is consistent with ERK2 substrate phosphorylation, but it is less central
+      than the direct kinase activity and ERK/MAPK cascade annotations.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 directly phosphorylates defined downstream targets such as Elk-1/ETS-family
+        and other transcription-factor substrates in vitro and in cells; docking
+        motifs/exosites help determine substrate recognition.
 - term:
     id: GO:0070371
     label: ERK1 and ERK2 cascade
   evidence_type: IDA
   original_reference_id: PMID:16314496
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 is a central component of the ERK1 and ERK2 cascade.
+    action: ACCEPT
+    reason: &gt;-
+      ERK1 and ERK2 cascade is a core pathway term for MAPK1 and is more specific than
+      generic signaling process terms.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0019902
     label: phosphatase binding
   evidence_type: IPI
   original_reference_id: PMID:19494114
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 binds MAP kinase phosphatases such as DUSP6/MKP-3.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      Phosphatase binding is a supported regulatory interaction, but it is not the
+      primary catalytic function of MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        DUSP6/MKP-3 as cytoplasmic tether:** MKP-3/DUSP6 binds ERK2 and can
+        dephosphorylate and tether inactive ERK2 in the cytoplasm; mutating MKP-3 NES or
+        KIM abolishes cytoplasmic anchoring.
 - term:
     id: GO:0008353
     label: RNA polymerase II CTD heptapeptide repeat kinase activity
@@ -19808,40 +23786,110 @@ existing_annotations:
   evidence_type: TAS
   original_reference_id: PMID:10706854
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1/ERK2 has MAP kinase activity.
+    action: ACCEPT
+    reason: &gt;-
+      MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
 - term:
     id: GO:0006915
     label: apoptotic process
   evidence_type: TAS
   original_reference_id: PMID:10958679
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0006935
     label: chemotaxis
   evidence_type: TAS
   original_reference_id: PMID:10706854
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0007165
     label: signal transduction
   evidence_type: TAS
   original_reference_id: PMID:1540184
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      MAPK1 participates in signal transduction, but the generic term should be replaced
+      by more specific intracellular MAPK/ERK signaling terms.
+    action: MODIFY
+    reason: &gt;-
+      Generic signal transduction underspecifies MAPK1; intracellular signal
+      transduction and ERK/MAPK cascade terms capture the supported biology more
+      accurately.
+    proposed_replacement_terms:
+    - id: GO:0035556
+      label: intracellular signal transduction
+    - id: GO:0070371
+      label: ERK1 and ERK2 cascade
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0007268
     label: chemical synaptic transmission
   evidence_type: TAS
   original_reference_id: PMID:10051431
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: &gt;-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 references:
 - id: GO_REF:0000002
   title: &#39;TODO: Fetch title&#39;
@@ -20413,13 +24461,90 @@ references:
 - id: Reactome:R-NUL-9619973
   title: &#39;TODO: Fetch title&#39;
   findings: []
+- id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+  title: Falcon deep research report on MAPK1
+  findings: []
+core_functions:
+- molecular_function:
+    id: GO:0004707
+    label: MAP kinase activity
+  description: &gt;-
+    MAPK1/ERK2 is an ATP-dependent, proline-directed serine/threonine MAP
+    kinase. After MEK1/2-mediated activation, ERK2 phosphorylates protein
+    substrates and transmits canonical Ras-RAF-MEK-ERK signals to cytosolic and
+    nuclear targets.
+  directly_involved_in:
+  - id: GO:0070371
+    label: ERK1 and ERK2 cascade
+  - id: GO:0000165
+    label: MAPK cascade
+  - id: GO:0006468
+    label: protein phosphorylation
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  - id: GO:0005737
+    label: cytoplasm
+  - id: GO:0005634
+    label: nucleus
+  supported_by:
+  - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+    supporting_text: &gt;-
+      ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+      motifs; like other protein kinases it binds ATP in an active-site cleft, with
+      MgATP2− serving as the relevant phosphoryl donor in vitro.
+  - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+    supporting_text: &gt;-
+      ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+      signal transduction cascade, converting extracellular cues (including growth
+      factors/serum) into intracellular phosphorylation events and responses.
+- molecular_function:
+    id: GO:0005524
+    label: ATP binding
+  description: &gt;-
+    ATP binding is a core active-site function of MAPK1 because ATP/MgATP
+    provides the phosphoryl group used for ERK2 serine/threonine protein kinase
+    catalysis.
+  directly_involved_in:
+  - id: GO:0006468
+    label: protein phosphorylation
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  - id: GO:0005634
+    label: nucleus
+  supported_by:
+  - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+    supporting_text: &gt;-
+      ERK2 is a Ser/Thr MAPK that transfers phosphate from ATP/MgATP to Ser/Thr-Pro
+      motifs; ATP binds in the active site, with N-lobe/glycine-rich loop contributions
+      to nucleotide binding and catalysis.
+proposed_new_terms: []
+suggested_questions:
+- question: &gt;-
+    Which generic protein-binding annotations correspond to direct MAPK1
+    docking, substrate, scaffold, or phosphatase interactions that should be
+    curated with more specific terms?
+- question: &gt;-
+    Which downstream proliferation, apoptosis, migration, immune, neuronal, or
+    developmental annotations have direct MAPK1-specific evidence rather than
+    general ERK pathway membership?
+suggested_experiments:
+- description: &gt;-
+    Prioritize source-level review of MAPK1-specific substrate phosphorylation
+    papers to separate direct ERK2 substrates from phosphoproteomics or
+    inhibitor-based pathway effects.
+- description: &gt;-
+    Review compartment-specific MAPK1 localization evidence with stimulus and
+    cell-type context, especially endosome, Golgi, mitochondrion, focal
+    adhesion, and caveola annotations.
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/human/MAPK1/MAPK1-ai-review.html
+++ b/genes/human/MAPK1/MAPK1-ai-review.html
@@ -2133,10 +2133,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0032872" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0032872" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2144,42 +2144,15 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This is a stress-context signaling annotation for MAPK1.
+                            <strong>Summary:</strong> This automated annotation places canonical ERK2 in a stress-activated MAPK cascade context.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Stress-context annotations are secondary to the canonical ERK/MAPK cascade role and should remain non-core unless a later source-level review shows they are central for MAPK1.
+                            <strong>Reason:</strong> GO:0032872 is a stress-activated MAPK cascade term associated with JNK/p38 signaling, whereas MAPK1/ERK2 is curated here as the canonical ERK/MAPK cascade kinase. The automated inference overstates the evidence.
                         </div>
 
 
-
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
-
-                            </div>
-
-                        </div>
 
                     </td>
                 </tr>
@@ -2222,12 +2195,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This is a stress-context signaling annotation for MAPK1.
+                            <strong>Summary:</strong> This is an amino-acid-starvation response annotation linked to ERK signaling context.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Stress-context annotations are secondary to the canonical ERK/MAPK cascade role and should remain non-core unless a later source-level review shows they are central for MAPK1.
+                            <strong>Reason:</strong> The starvation-response annotation may be retained as non-core where the source evidence supports this context, but it should not be treated as the core conserved MAPK1 function.
                         </div>
 
 
@@ -2336,10 +2309,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0051403" data-r="GO_REF:0000117" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0051403" data-r="GO_REF:0000117" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -2347,42 +2320,15 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This is a stress-context signaling annotation for MAPK1.
+                            <strong>Summary:</strong> This automated annotation places canonical ERK2 in the stress-activated MAPK cascade.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Stress-context annotations are secondary to the canonical ERK/MAPK cascade role and should remain non-core unless a later source-level review shows they are central for MAPK1.
+                            <strong>Reason:</strong> GO:0051403 refers to stress-activated MAPK cascade biology associated with JNK/p38 signaling, not the canonical ERK1/ERK2 cascade. The automated inference should not be retained as a valid non-core MAPK1 annotation.
                         </div>
 
 
-
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
-
-                            </div>
-
-                        </div>
 
                     </td>
                 </tr>
@@ -7098,10 +7044,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-pending">
-                            PENDING
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0045880" data-r="PMID:35831023" data-act="PENDING">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0045880" data-r="PMID:35831023" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -7109,9 +7055,13 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> TODO: Review this GOA annotation
+                            <strong>Summary:</strong> ERK2 phosphorylation of GLI1 links MAPK1 to Smoothened/Hedgehog pathway output in this specific context.
                         </div>
 
+
+                        <div>
+                            <strong>Reason:</strong> This is a supported pathway-specific downstream role from PMID:35831023, but the core MAPK1 function remains ERK2 serine/threonine MAP kinase activity in the ERK/MAPK cascade.
+                        </div>
 
 
 
@@ -9459,12 +9409,12 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This is a stress-context signaling annotation for MAPK1.
+                            <strong>Summary:</strong> This is an amino-acid-starvation response annotation linked to ERK signaling context.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Stress-context annotations are secondary to the canonical ERK/MAPK cascade role and should remain non-core unless a later source-level review shows they are central for MAPK1.
+                            <strong>Reason:</strong> The starvation-response annotation may be retained as non-core where the source evidence supports this context, but it should not be treated as the core conserved MAPK1 function.
                         </div>
 
 
@@ -9537,10 +9487,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0051403" data-r="PMID:11096076" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0051403" data-r="PMID:11096076" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -9548,42 +9498,15 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This is a stress-context signaling annotation for MAPK1.
+                            <strong>Summary:</strong> This paper-level stress-activated MAPK cascade annotation needs source-level review before a term-level decision.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Stress-context annotations are secondary to the canonical ERK/MAPK cascade role and should remain non-core unless a later source-level review shows they are central for MAPK1.
+                            <strong>Reason:</strong> GO:0051403 is normally associated with JNK/p38 stress-activated MAPK cascades. PMID:11096076 appears to focus on ASK1/stress signaling, and this review did not verify that it supports MAPK1/ERK2 as part of the stress-activated MAPK cascade.
                         </div>
 
 
-
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
-
-                            </div>
-
-                        </div>
 
                     </td>
                 </tr>
@@ -16126,10 +16049,10 @@
 
                     </td>
                     <td>
-                        <span class="action-badge action-keepasnoncore">
-                            KEEP AS NON CORE
+                        <span class="action-badge action-undecided">
+                            UNDECIDED
                         </span>
-                        <span class="vote-buttons" data-g="P28482" data-a="GO:0032872" data-r="PMID:19565474" data-act="KEEP_AS_NON_CORE">
+                        <span class="vote-buttons" data-g="P28482" data-a="GO:0032872" data-r="PMID:19565474" data-act="UNDECIDED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -16137,42 +16060,15 @@
                     <td>
 
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> This is a stress-context signaling annotation for MAPK1.
+                            <strong>Summary:</strong> This TAS annotation that MAPK1 regulates the stress-activated MAPK cascade needs source-level review.
                         </div>
 
 
                         <div>
-                            <strong>Reason:</strong> Stress-context annotations are secondary to the canonical ERK/MAPK cascade role and should remain non-core unless a later source-level review shows they are central for MAPK1.
+                            <strong>Reason:</strong> GO:0032872 is atypical for canonical ERK2 biology and should not be kept as non-core without checking PMID:19565474 directly.
                         </div>
 
 
-
-                        <div class="supported-by">
-                            <div class="supported-by-title">Supporting Evidence:</div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses.</div>
-
-                            </div>
-
-                            <div class="support-item">
-                                <span class="support-ref">
-
-                                    file:human/MAPK1/MAPK1-deep-research-falcon.md
-
-                                </span>
-
-                                <div class="support-text">Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions.</div>
-
-                            </div>
-
-                        </div>
 
                     </td>
                 </tr>
@@ -20513,6 +20409,11 @@ are typically emergent outcomes of the pathway rather than direct MAPK1<br />
 enzymatic functions."]. I marked a small set of automated broad developmental<br />
 or transcriptional annotations as over-annotated and retained some source-backed<br />
 downstream processes as non-core.</p>
+<p>Review follow-up: stress-activated MAPK cascade terms should not be treated as<br />
+valid non-core ERK2 biology, because GO:0051403/GO:0032872 are JNK/p38-oriented<br />
+stress MAPK terms rather than canonical ERK cascade terms. I marked the<br />
+automated stress-cascade rows as over-annotated and left the PMID-backed rows<br />
+UNDECIDED pending source-level review.</p>
 <p>Protein binding: MAPK1 has many reported interacting partners, but the generic<br />
 GO:0005515 term is not useful for this gene. Falcon notes that ERK docking is<br />
 motif/exosite-mediated and that generic protein binding risks over-annotation<br />
@@ -20910,23 +20811,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: &gt;-
-      This is a stress-context signaling annotation for MAPK1.
-    action: KEEP_AS_NON_CORE
+      This automated annotation places canonical ERK2 in a stress-activated
+      MAPK cascade context.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
-      and should remain non-core unless a later source-level review shows they are
-      central for MAPK1.
-    supported_by:
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: &gt;-
-        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
-        signal transduction cascade, converting extracellular cues (including growth
-        factors/serum) into intracellular phosphorylation events and responses.
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: &gt;-
-        Many sources link ERK signaling to proliferation/differentiation and disease
-        contexts, but these are typically emergent outcomes of the pathway rather than
-        direct MAPK1 enzymatic functions.
+      GO:0032872 is a stress-activated MAPK cascade term associated with
+      JNK/p38 signaling, whereas MAPK1/ERK2 is curated here as the canonical
+      ERK/MAPK cascade kinase. The automated inference overstates the evidence.
 - term:
     id: GO:0034198
     label: cellular response to amino acid starvation
@@ -20934,12 +20825,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: &gt;-
-      This is a stress-context signaling annotation for MAPK1.
+      This is an amino-acid-starvation response annotation linked to ERK signaling
+      context.
     action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
-      and should remain non-core unless a later source-level review shows they are
-      central for MAPK1.
+      The starvation-response annotation may be retained as non-core where the source
+      evidence supports this context, but it should not be treated as the core conserved
+      MAPK1 function.
     supported_by:
     - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
       supporting_text: &gt;-
@@ -20966,23 +20858,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: &gt;-
-      This is a stress-context signaling annotation for MAPK1.
-    action: KEEP_AS_NON_CORE
+      This automated annotation places canonical ERK2 in the stress-activated MAPK
+      cascade.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
-      and should remain non-core unless a later source-level review shows they are
-      central for MAPK1.
-    supported_by:
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: &gt;-
-        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
-        signal transduction cascade, converting extracellular cues (including growth
-        factors/serum) into intracellular phosphorylation events and responses.
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: &gt;-
-        Many sources link ERK signaling to proliferation/differentiation and disease
-        contexts, but these are typically emergent outcomes of the pathway rather than
-        direct MAPK1 enzymatic functions.
+      GO:0051403 refers to stress-activated MAPK cascade biology associated with JNK/p38
+      signaling, not the canonical ERK1/ERK2 cascade. The automated inference should not
+      be retained as a valid non-core MAPK1 annotation.
 - term:
     id: GO:0051493
     label: regulation of cytoskeleton organization
@@ -21877,8 +21759,14 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:35831023
   review:
-    summary: &#39;TODO: Review this GOA annotation&#39;
-    action: PENDING
+    summary: &gt;-
+      ERK2 phosphorylation of GLI1 links MAPK1 to Smoothened/Hedgehog pathway
+      output in this specific context.
+    action: KEEP_AS_NON_CORE
+    reason: &gt;-
+      This is a supported pathway-specific downstream role from PMID:35831023,
+      but the core MAPK1 function remains ERK2 serine/threonine MAP kinase
+      activity in the ERK/MAPK cascade.
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -22406,12 +22294,13 @@ existing_annotations:
   original_reference_id: PMID:11096076
   review:
     summary: &gt;-
-      This is a stress-context signaling annotation for MAPK1.
+      This is an amino-acid-starvation response annotation linked to ERK signaling
+      context.
     action: KEEP_AS_NON_CORE
     reason: &gt;-
-      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
-      and should remain non-core unless a later source-level review shows they are
-      central for MAPK1.
+      The starvation-response annotation may be retained as non-core where the source
+      evidence supports this context, but it should not be treated as the core conserved
+      MAPK1 function.
     supported_by:
     - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
       supporting_text: &gt;-
@@ -22430,23 +22319,13 @@ existing_annotations:
   original_reference_id: PMID:11096076
   review:
     summary: &gt;-
-      This is a stress-context signaling annotation for MAPK1.
-    action: KEEP_AS_NON_CORE
+      This paper-level stress-activated MAPK cascade annotation needs source-level
+      review before a term-level decision.
+    action: UNDECIDED
     reason: &gt;-
-      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
-      and should remain non-core unless a later source-level review shows they are
-      central for MAPK1.
-    supported_by:
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: &gt;-
-        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
-        signal transduction cascade, converting extracellular cues (including growth
-        factors/serum) into intracellular phosphorylation events and responses.
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: &gt;-
-        Many sources link ERK signaling to proliferation/differentiation and disease
-        contexts, but these are typically emergent outcomes of the pathway rather than
-        direct MAPK1 enzymatic functions.
+      GO:0051403 is normally associated with JNK/p38 stress-activated MAPK cascades.
+      PMID:11096076 appears to focus on ASK1/stress signaling, and this review did not
+      verify that it supports MAPK1/ERK2 as part of the stress-activated MAPK cascade.
 - term:
     id: GO:0005576
     label: extracellular region
@@ -23657,23 +23536,12 @@ existing_annotations:
   original_reference_id: PMID:19565474
   review:
     summary: &gt;-
-      This is a stress-context signaling annotation for MAPK1.
-    action: KEEP_AS_NON_CORE
+      This TAS annotation that MAPK1 regulates the stress-activated MAPK
+      cascade needs source-level review.
+    action: UNDECIDED
     reason: &gt;-
-      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
-      and should remain non-core unless a later source-level review shows they are
-      central for MAPK1.
-    supported_by:
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: &gt;-
-        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
-        signal transduction cascade, converting extracellular cues (including growth
-        factors/serum) into intracellular phosphorylation events and responses.
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: &gt;-
-        Many sources link ERK signaling to proliferation/differentiation and disease
-        contexts, but these are typically emergent outcomes of the pathway rather than
-        direct MAPK1 enzymatic functions.
+      GO:0032872 is atypical for canonical ERK2 biology and should not be kept
+      as non-core without checking PMID:19565474 directly.
 - term:
     id: GO:0051493
     label: regulation of cytoskeleton organization

--- a/genes/human/MAPK1/MAPK1-ai-review.yaml
+++ b/genes/human/MAPK1/MAPK1-ai-review.yaml
@@ -5,7 +5,14 @@ status: INITIALIZED
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for MAPK1'
+description: >-
+  MAPK1 (ERK2) is an ATP-dependent, proline-directed serine/threonine MAP kinase
+  in the canonical Ras-RAF-MEK-ERK cascade. It is activated by MEK1/2 dual
+  phosphorylation, phosphorylates cytosolic and nuclear substrates, and shuttles
+  between cytoplasmic/cytosolic and nuclear compartments after stimulation.
+  Distal proliferation, differentiation, apoptosis, migration, transcriptional,
+  and disease phenotypes are context-dependent ERK pathway outputs rather than
+  the core MAPK1 molecular function.
 alternative_products:
 - name: '1'
   id: P28482-1
@@ -19,80 +26,216 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 localizes to the nucleus after stimulation.
+    action: ACCEPT
+    reason: >-
+      Nuclear localization is supported, but should be interpreted as stimulus-dependent
+      rather than constitutive.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        **Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear
+        accumulation can be partially uncoupled from TEY phosphorylation and depends on
+        docking interactions and anchors.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is cytoplasmic in quiescent cells.
+    action: ACCEPT
+    reason: >-
+      Cytoplasmic localization is a core supported localization for ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0035556
     label: intracellular signal transduction
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 functions in intracellular signal transduction downstream of extracellular
+      cues.
+    action: ACCEPT
+    reason: >-
+      Intracellular signal transduction is a supported core process for MAPK1 as the
+      ERK2 kinase in the canonical MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0004674
     label: protein serine/threonine kinase activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: >-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0007166
     label: cell surface receptor signaling pathway
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 responds to cell-surface receptor inputs, but its core role is the
+      downstream intracellular ERK/MAPK cascade.
+    action: MODIFY
+    reason: >-
+      Cell surface receptor signaling is too broad and upstream-oriented for the MAPK1
+      core function; ERK/MAPK cascade terms are more specific.
+    proposed_replacement_terms:
+    - id: GO:0070371
+      label: ERK1 and ERK2 cascade
+    - id: GO:0000165
+      label: MAPK cascade
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0004672
     label: protein kinase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 is a protein kinase, but this term is less specific than the supported
+      serine/threonine MAP kinase terms.
+    action: MODIFY
+    reason: >-
+      The generic protein kinase term should be replaced by protein serine/threonine
+      kinase activity and MAP kinase activity, which capture MAPK1 specificity.
+    proposed_replacement_terms:
+    - id: GO:0004674
+      label: protein serine/threonine kinase activity
+    - id: GO:0004707
+      label: MAP kinase activity
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0004707
     label: MAP kinase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 has MAP kinase activity.
+    action: ACCEPT
+    reason: >-
+      MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
 - term:
     id: GO:0005524
     label: ATP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 binds ATP as the phosphoryl donor for kinase catalysis.
+    action: ACCEPT
+    reason: >-
+      ATP binding is integral to the active-site chemistry of ERK2 kinase activity.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 localizes to the nucleus after stimulation.
+    action: ACCEPT
+    reason: >-
+      Nuclear localization is supported, but should be interpreted as stimulus-dependent
+      rather than constitutive.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        **Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear
+        accumulation can be partially uncoupled from TEY phosphorylation and depends on
+        docking interactions and anchors.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is cytoplasmic in quiescent cells.
+    action: ACCEPT
+    reason: >-
+      Cytoplasmic localization is a core supported localization for ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0005769
     label: early endosome
@@ -155,24 +298,63 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000108
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 can affect transcriptional programs through downstream substrates, but broad
+      regulation of RNA polymerase II transcription overstates the direct function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The direct MAPK1 function is kinase activity and ERK/MAPK cascade signaling; broad
+      transcriptional regulation should not be inferred from pathway membership alone.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0007173
     label: epidermal growth factor receptor signaling pathway
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0010759
     label: positive regulation of macrophage chemotaxis
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0032206
     label: positive regulation of telomere maintenance
@@ -187,16 +369,48 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a stress-context signaling annotation for MAPK1.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
+      and should remain non-core unless a later source-level review shows they are
+      central for MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0034198
     label: cellular response to amino acid starvation
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a stress-context signaling annotation for MAPK1.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
+      and should remain non-core unless a later source-level review shows they are
+      central for MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0045202
     label: synapse
@@ -211,8 +425,24 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a stress-context signaling annotation for MAPK1.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
+      and should remain non-core unless a later source-level review shows they are
+      central for MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0051493
     label: regulation of cytoskeleton organization
@@ -227,24 +457,68 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0070371
     label: ERK1 and ERK2 cascade
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is a central component of the ERK1 and ERK2 cascade.
+    action: ACCEPT
+    reason: >-
+      ERK1 and ERK2 cascade is a core pathway term for MAPK1 and is more specific than
+      generic signaling process terms.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0070849
     label: response to epidermal growth factor
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0072584
     label: caveolin-mediated endocytosis
@@ -275,16 +549,43 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000116
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 can phosphorylate serine residues, but the serine-only term is incomplete
+      for ERK2.
+    action: MODIFY
+    reason: >-
+      ERK2 is a proline-directed serine/threonine MAP kinase; GO:0004674 and GO:0004707
+      better capture the supported activity than a serine-only activity term.
+    proposed_replacement_terms:
+    - id: GO:0004674
+      label: protein serine/threonine kinase activity
+    - id: GO:0004707
+      label: MAP kinase activity
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0120041
     label: positive regulation of macrophage proliferation
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:2000641
     label: regulation of early endosome to late endosome transport
@@ -667,8 +968,18 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: >-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0005739
     label: mitochondrion
@@ -683,16 +994,43 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is present in the cytosolic/cytoplasmic compartment.
+    action: ACCEPT
+    reason: >-
+      Cytosolic localization is consistent with ERK2 being predominantly cytoplasmic in
+      quiescent cells before stimulus-dependent nuclear accumulation.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0008286
     label: insulin receptor signaling pathway
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0008353
     label: RNA polymerase II CTD heptapeptide repeat kinase activity
@@ -707,24 +1045,60 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The available synthesis supports ERK/MAPK cascade membership as core, but warns
+      against promoting broad developmental or disease-associated outcomes to core MAPK1
+      functions without direct MAPK1-specific evidence.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0016301
     label: kinase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 is a kinase, but this term is too broad for ERK2.
+    action: MODIFY
+    reason: >-
+      The broad kinase activity annotation should use the more informative
+      serine/threonine MAP kinase terms.
+    proposed_replacement_terms:
+    - id: GO:0004674
+      label: protein serine/threonine kinase activity
+    - id: GO:0004707
+      label: MAP kinase activity
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0019902
     label: phosphatase binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 binds MAP kinase phosphatases such as DUSP6/MKP-3.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Phosphatase binding is a supported regulatory interaction, but it is not the
+      primary catalytic function of MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        DUSP6/MKP-3 as cytoplasmic tether:** MKP-3/DUSP6 binds ERK2 and can
+        dephosphorylate and tether inactive ERK2 in the cytoplasm; mutating MKP-3 NES or
+        KIM abolishes cytoplasmic anchoring.
 - term:
     id: GO:0031143
     label: pseudopodium
@@ -747,16 +1121,44 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0042552
     label: myelination
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The available synthesis supports ERK/MAPK cascade membership as core, but warns
+      against promoting broad developmental or disease-associated outcomes to core MAPK1
+      functions without direct MAPK1-specific evidence.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0042802
     label: identical protein binding
@@ -771,64 +1173,164 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The available synthesis supports ERK/MAPK cascade membership as core, but warns
+      against promoting broad developmental or disease-associated outcomes to core MAPK1
+      functions without direct MAPK1-specific evidence.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0048009
     label: insulin-like growth factor receptor signaling pathway
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0150078
     label: positive regulation of neuroinflammatory response
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The available synthesis supports ERK/MAPK cascade membership as core, but warns
+      against promoting broad developmental or disease-associated outcomes to core MAPK1
+      functions without direct MAPK1-specific evidence.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0004707
     label: MAP kinase activity
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 has MAP kinase activity.
+    action: ACCEPT
+    reason: >-
+      MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: IDA
   original_reference_id: PMID:22451653
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is present in the cytosolic/cytoplasmic compartment.
+    action: ACCEPT
+    reason: >-
+      Cytosolic localization is consistent with ERK2 being predominantly cytoplasmic in
+      quiescent cells before stimulus-dependent nuclear accumulation.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0043415
     label: positive regulation of skeletal muscle tissue regeneration
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The available synthesis supports ERK/MAPK cascade membership as core, but warns
+      against promoting broad developmental or disease-associated outcomes to core MAPK1
+      functions without direct MAPK1-specific evidence.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0106310
     label: protein serine kinase activity
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 can phosphorylate serine residues, but the serine-only term is incomplete
+      for ERK2.
+    action: MODIFY
+    reason: >-
+      ERK2 is a proline-directed serine/threonine MAP kinase; GO:0004674 and GO:0004707
+      better capture the supported activity than a serine-only activity term.
+    proposed_replacement_terms:
+    - id: GO:0004674
+      label: protein serine/threonine kinase activity
+    - id: GO:0004707
+      label: MAP kinase activity
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0004674
     label: protein serine/threonine kinase activity
   evidence_type: IDA
   original_reference_id: PMID:35831023
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: >-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0045880
     label: positive regulation of smoothened signaling pathway
@@ -843,64 +1345,168 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 can accumulate in the nuclear compartment after stimulation.
+    action: ACCEPT
+    reason: >-
+      Nucleoplasmic localization is compatible with the supported stimulus-dependent
+      nuclear accumulation of ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        **Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear
+        accumulation can be partially uncoupled from TEY phosphorylation and depends on
+        docking interactions and anchors.
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is present in the cytosolic/cytoplasmic compartment.
+    action: ACCEPT
+    reason: >-
+      Cytosolic localization is consistent with ERK2 being predominantly cytoplasmic in
+      quiescent cells before stimulus-dependent nuclear accumulation.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0004707
     label: MAP kinase activity
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-111898
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 has MAP kinase activity.
+    action: ACCEPT
+    reason: >-
+      MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
 - term:
     id: GO:0004707
     label: MAP kinase activity
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-445079
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 has MAP kinase activity.
+    action: ACCEPT
+    reason: >-
+      MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
 - term:
     id: GO:0004674
     label: protein serine/threonine kinase activity
   evidence_type: IDA
   original_reference_id: PMID:38503280
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: >-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0070371
     label: ERK1 and ERK2 cascade
   evidence_type: IDA
   original_reference_id: PMID:15850461
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is a central component of the ERK1 and ERK2 cascade.
+    action: ACCEPT
+    reason: >-
+      ERK1 and ERK2 cascade is a core pathway term for MAPK1 and is more specific than
+      generic signaling process terms.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0150078
     label: positive regulation of neuroinflammatory response
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a distal or cell-type-specific outcome rather than a core MAPK1 function.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      The available synthesis supports ERK/MAPK cascade membership as core, but warns
+      against promoting broad developmental or disease-associated outcomes to core MAPK1
+      functions without direct MAPK1-specific evidence.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0004707
     label: MAP kinase activity
   evidence_type: IDA
   original_reference_id: PMID:38503280
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 has MAP kinase activity.
+    action: ACCEPT
+    reason: >-
+      MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
 - term:
     id: GO:0070098
     label: chemokine-mediated signaling pathway
@@ -915,32 +1521,92 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:15850461
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 functions in the canonical MAPK cascade.
+    action: ACCEPT
+    reason: >-
+      MAPK cascade membership is a core biological process for ERK2, downstream of
+      Ras-RAF-MEK signaling.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0061514
     label: interleukin-34-mediated signaling pathway
   evidence_type: IGI
   original_reference_id: PMID:26754294
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0000165
     label: MAPK cascade
   evidence_type: IDA
   original_reference_id: PMID:24854121
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 functions in the canonical MAPK cascade.
+    action: ACCEPT
+    reason: >-
+      MAPK cascade membership is a core biological process for ERK2, downstream of
+      Ras-RAF-MEK signaling.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0007173
     label: epidermal growth factor receptor signaling pathway
   evidence_type: IDA
   original_reference_id: PMID:24854121
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0005515
     label: protein binding
@@ -987,16 +1653,40 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:32721402
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 localizes to the nucleus after stimulation.
+    action: ACCEPT
+    reason: >-
+      Nuclear localization is supported, but should be interpreted as stimulus-dependent
+      rather than constitutive.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        **Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear
+        accumulation can be partially uncoupled from TEY phosphorylation and depends on
+        docking interactions and anchors.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:32721402
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is cytoplasmic in quiescent cells.
+    action: ACCEPT
+    reason: >-
+      Cytoplasmic localization is a core supported localization for ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0005515
     label: protein binding
@@ -1011,24 +1701,56 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:7588608
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: >-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0010759
     label: positive regulation of macrophage chemotaxis
   evidence_type: IGI
   original_reference_id: PMID:26754294
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0120041
     label: positive regulation of macrophage proliferation
   evidence_type: IGI
   original_reference_id: PMID:26754294
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0005515
     label: protein binding
@@ -1051,8 +1773,23 @@ existing_annotations:
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9636296
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is not a supported core MAPK1 localization in this review.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Falcon synthesis supports cytoplasmic/cytosolic and stimulus-dependent nuclear
+      localization; secretory or granule-lumen locations are likely pathway-context
+      over-annotations for soluble ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Prefer cytoplasm/nucleus over highly specific compartments unless direct
+        localization evidence exists for MAPK1 itself in that context.
 - term:
     id: GO:0005829
     label: cytosol
@@ -1067,8 +1804,18 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:26996940
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: >-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0005886
     label: plasma membrane
@@ -1091,8 +1838,19 @@ existing_annotations:
   evidence_type: NAS
   original_reference_id: PMID:11404397
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0035094
     label: response to nicotine
@@ -1107,48 +1865,140 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:11096076
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a stress-context signaling annotation for MAPK1.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
+      and should remain non-core unless a later source-level review shows they are
+      central for MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0051403
     label: stress-activated MAPK cascade
   evidence_type: IDA
   original_reference_id: PMID:11096076
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a stress-context signaling annotation for MAPK1.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
+      and should remain non-core unless a later source-level review shows they are
+      central for MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0005576
     label: extracellular region
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6798751
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is not a supported core MAPK1 localization in this review.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Falcon synthesis supports cytoplasmic/cytosolic and stimulus-dependent nuclear
+      localization; secretory or granule-lumen locations are likely pathway-context
+      over-annotations for soluble ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Prefer cytoplasm/nucleus over highly specific compartments unless direct
+        localization evidence exists for MAPK1 itself in that context.
 - term:
     id: GO:0005576
     label: extracellular region
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6800434
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is not a supported core MAPK1 localization in this review.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Falcon synthesis supports cytoplasmic/cytosolic and stimulus-dependent nuclear
+      localization; secretory or granule-lumen locations are likely pathway-context
+      over-annotations for soluble ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Prefer cytoplasm/nucleus over highly specific compartments unless direct
+        localization evidence exists for MAPK1 itself in that context.
 - term:
     id: GO:0035578
     label: azurophil granule lumen
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6798751
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is not a supported core MAPK1 localization in this review.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Falcon synthesis supports cytoplasmic/cytosolic and stimulus-dependent nuclear
+      localization; secretory or granule-lumen locations are likely pathway-context
+      over-annotations for soluble ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Prefer cytoplasm/nucleus over highly specific compartments unless direct
+        localization evidence exists for MAPK1 itself in that context.
 - term:
     id: GO:1904813
     label: ficolin-1-rich granule lumen
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6800434
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is not a supported core MAPK1 localization in this review.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: >-
+      Falcon synthesis supports cytoplasmic/cytosolic and stimulus-dependent nuclear
+      localization; secretory or granule-lumen locations are likely pathway-context
+      over-annotations for soluble ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Prefer cytoplasm/nucleus over highly specific compartments unless direct
+        localization evidence exists for MAPK1 itself in that context.
 - term:
     id: GO:0005515
     label: protein binding
@@ -1163,32 +2013,80 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:23184662
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 directly phosphorylates protein substrates.
+    action: ACCEPT
+    reason: >-
+      Protein phosphorylation is the direct biochemical output of the MAPK1 kinase
+      activity.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 directly phosphorylates defined downstream targets such as Elk-1/ETS-family
+        and other transcription-factor substrates in vitro and in cells; docking
+        motifs/exosites help determine substrate recognition.
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: HDA
   original_reference_id: PMID:16791210
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 localizes to the nucleus after stimulation.
+    action: ACCEPT
+    reason: >-
+      Nuclear localization is supported, but should be interpreted as stimulus-dependent
+      rather than constitutive.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        **Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear
+        accumulation can be partially uncoupled from TEY phosphorylation and depends on
+        docking interactions and anchors.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: HDA
   original_reference_id: PMID:16791210
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is cytoplasmic in quiescent cells.
+    action: ACCEPT
+    reason: >-
+      Cytoplasmic localization is a core supported localization for ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is cytoplasmic in quiescent cells.
+    action: ACCEPT
+    reason: >-
+      Cytoplasmic localization is a core supported localization for ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0072686
     label: mitotic spindle
@@ -1979,16 +2877,43 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:15133037
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0004674
     label: protein serine/threonine kinase activity
   evidence_type: IDA
   original_reference_id: PMID:18794356
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: >-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0005515
     label: protein binding
@@ -2003,24 +2928,65 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:18794356
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 localizes to the nucleus after stimulation.
+    action: ACCEPT
+    reason: >-
+      Nuclear localization is supported, but should be interpreted as stimulus-dependent
+      rather than constitutive.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        **Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear
+        accumulation can be partially uncoupled from TEY phosphorylation and depends on
+        docking interactions and anchors.
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IDA
   original_reference_id: PMID:18794356
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is cytoplasmic in quiescent cells.
+    action: ACCEPT
+    reason: >-
+      Cytoplasmic localization is a core supported localization for ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0070849
     label: response to epidermal growth factor
   evidence_type: IDA
   original_reference_id: PMID:18794356
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 is activated in receptor and growth-factor signaling contexts, but these are
+      stimulus-specific pathway contexts rather than the core conserved ERK2 function.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Growth-factor and receptor-specific signaling annotations can be retained as
+      non-core contexts; the core MAPK1 process is the intracellular ERK/MAPK cascade.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0005515
     label: protein binding
@@ -2035,16 +3001,41 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:15850461
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is an ATP-dependent protein serine/threonine kinase.
+    action: ACCEPT
+    reason: >-
+      Serine/threonine protein kinase activity is a core molecular function of MAPK1;
+      the more specific MAP kinase activity term should also be retained where present.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: TAS
   original_reference_id: PMID:19565474
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 localizes to the nucleus after stimulation.
+    action: ACCEPT
+    reason: >-
+      Nuclear localization is supported, but should be interpreted as stimulus-dependent
+      rather than constitutive.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        **Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear
+        accumulation can be partially uncoupled from TEY phosphorylation and depends on
+        docking interactions and anchors.
 - term:
     id: GO:0005739
     label: mitochondrion
@@ -2083,8 +3074,18 @@ existing_annotations:
   evidence_type: TAS
   original_reference_id: PMID:19565474
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is present in the cytosolic/cytoplasmic compartment.
+    action: ACCEPT
+    reason: >-
+      Cytosolic localization is consistent with ERK2 being predominantly cytoplasmic in
+      quiescent cells before stimulus-dependent nuclear accumulation.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK is predominantly cytoplasmic in quiescent cells and accumulates in the
+        nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear
+        targets and contributes to induced gene expression programs.
 - term:
     id: GO:0005856
     label: cytoskeleton
@@ -2115,8 +3116,24 @@ existing_annotations:
   evidence_type: TAS
   original_reference_id: PMID:19565474
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a stress-context signaling annotation for MAPK1.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
+      and should remain non-core unless a later source-level review shows they are
+      central for MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0051493
     label: regulation of cytoskeleton organization
@@ -2155,24 +3172,66 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:16314496
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 can increase phosphorylation of downstream threonine-containing protein
+      substrates.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The term is consistent with ERK2 substrate phosphorylation, but it is less central
+      than the direct kinase activity and ERK/MAPK cascade annotations.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 directly phosphorylates defined downstream targets such as Elk-1/ETS-family
+        and other transcription-factor substrates in vitro and in cells; docking
+        motifs/exosites help determine substrate recognition.
 - term:
     id: GO:0070371
     label: ERK1 and ERK2 cascade
   evidence_type: IDA
   original_reference_id: PMID:16314496
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 is a central component of the ERK1 and ERK2 cascade.
+    action: ACCEPT
+    reason: >-
+      ERK1 and ERK2 cascade is a core pathway term for MAPK1 and is more specific than
+      generic signaling process terms.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0019902
     label: phosphatase binding
   evidence_type: IPI
   original_reference_id: PMID:19494114
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 binds MAP kinase phosphatases such as DUSP6/MKP-3.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      Phosphatase binding is a supported regulatory interaction, but it is not the
+      primary catalytic function of MAPK1.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        DUSP6/MKP-3 as cytoplasmic tether:** MKP-3/DUSP6 binds ERK2 and can
+        dephosphorylate and tether inactive ERK2 in the cytoplasm; mutating MKP-3 NES or
+        KIM abolishes cytoplasmic anchoring.
 - term:
     id: GO:0008353
     label: RNA polymerase II CTD heptapeptide repeat kinase activity
@@ -2187,40 +3246,110 @@ existing_annotations:
   evidence_type: TAS
   original_reference_id: PMID:10706854
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1/ERK2 has MAP kinase activity.
+    action: ACCEPT
+    reason: >-
+      MAP kinase activity is the most specific core catalytic function for MAPK1/ERK2.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+        motifs; like other protein kinases it binds ATP in an active-site cleft, with
+        MgATP2− serving as the relevant phosphoryl donor in vitro.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
 - term:
     id: GO:0006915
     label: apoptotic process
   evidence_type: TAS
   original_reference_id: PMID:10958679
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0006935
     label: chemotaxis
   evidence_type: TAS
   original_reference_id: PMID:10706854
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 - term:
     id: GO:0007165
     label: signal transduction
   evidence_type: TAS
   original_reference_id: PMID:1540184
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      MAPK1 participates in signal transduction, but the generic term should be replaced
+      by more specific intracellular MAPK/ERK signaling terms.
+    action: MODIFY
+    reason: >-
+      Generic signal transduction underspecifies MAPK1; intracellular signal
+      transduction and ERK/MAPK cascade terms capture the supported biology more
+      accurately.
+    proposed_replacement_terms:
+    - id: GO:0035556
+      label: intracellular signal transduction
+    - id: GO:0070371
+      label: ERK1 and ERK2 cascade
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+        signal transduction cascade, converting extracellular cues (including growth
+        factors/serum) into intracellular phosphorylation events and responses.
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular
+        signal transduction**; optionally include **response to growth factor** where
+        the evidence is directly about upstream stimuli triggering ERK
+        activation/translocation rather than downstream phenotypes.
 - term:
     id: GO:0007268
     label: chemical synaptic transmission
   evidence_type: TAS
   original_reference_id: PMID:10051431
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      This is a context-dependent downstream process linked to ERK signaling.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      The process may be retained as non-core where the source evidence supports a
+      specific context, but it should not be treated as the core conserved MAPK1
+      function.
+    supported_by:
+    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+      supporting_text: >-
+        Many sources link ERK signaling to proliferation/differentiation and disease
+        contexts, but these are typically emergent outcomes of the pathway rather than
+        direct MAPK1 enzymatic functions.
 references:
 - id: GO_REF:0000002
   title: 'TODO: Fetch title'
@@ -2792,3 +3921,80 @@ references:
 - id: Reactome:R-NUL-9619973
   title: 'TODO: Fetch title'
   findings: []
+- id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+  title: Falcon deep research report on MAPK1
+  findings: []
+core_functions:
+- molecular_function:
+    id: GO:0004707
+    label: MAP kinase activity
+  description: >-
+    MAPK1/ERK2 is an ATP-dependent, proline-directed serine/threonine MAP
+    kinase. After MEK1/2-mediated activation, ERK2 phosphorylates protein
+    substrates and transmits canonical Ras-RAF-MEK-ERK signals to cytosolic and
+    nuclear targets.
+  directly_involved_in:
+  - id: GO:0070371
+    label: ERK1 and ERK2 cascade
+  - id: GO:0000165
+    label: MAPK cascade
+  - id: GO:0006468
+    label: protein phosphorylation
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  - id: GO:0005737
+    label: cytoplasm
+  - id: GO:0005634
+    label: nucleus
+  supported_by:
+  - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+    supporting_text: >-
+      ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro
+      motifs; like other protein kinases it binds ATP in an active-site cleft, with
+      MgATP2− serving as the relevant phosphoryl donor in vitro.
+  - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+    supporting_text: >-
+      ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
+      signal transduction cascade, converting extracellular cues (including growth
+      factors/serum) into intracellular phosphorylation events and responses.
+- molecular_function:
+    id: GO:0005524
+    label: ATP binding
+  description: >-
+    ATP binding is a core active-site function of MAPK1 because ATP/MgATP
+    provides the phosphoryl group used for ERK2 serine/threonine protein kinase
+    catalysis.
+  directly_involved_in:
+  - id: GO:0006468
+    label: protein phosphorylation
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  - id: GO:0005634
+    label: nucleus
+  supported_by:
+  - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
+    supporting_text: >-
+      ERK2 is a Ser/Thr MAPK that transfers phosphate from ATP/MgATP to Ser/Thr-Pro
+      motifs; ATP binds in the active site, with N-lobe/glycine-rich loop contributions
+      to nucleotide binding and catalysis.
+proposed_new_terms: []
+suggested_questions:
+- question: >-
+    Which generic protein-binding annotations correspond to direct MAPK1
+    docking, substrate, scaffold, or phosphatase interactions that should be
+    curated with more specific terms?
+- question: >-
+    Which downstream proliferation, apoptosis, migration, immune, neuronal, or
+    developmental annotations have direct MAPK1-specific evidence rather than
+    general ERK pathway membership?
+suggested_experiments:
+- description: >-
+    Prioritize source-level review of MAPK1-specific substrate phosphorylation
+    papers to separate direct ERK2 substrates from phosphoproteomics or
+    inhibitor-based pathway effects.
+- description: >-
+    Review compartment-specific MAPK1 localization evidence with stimulus and
+    cell-type context, especially endosome, Golgi, mitochondrion, focal
+    adhesion, and caveola annotations.

--- a/genes/human/MAPK1/MAPK1-ai-review.yaml
+++ b/genes/human/MAPK1/MAPK1-ai-review.yaml
@@ -370,23 +370,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: >-
-      This is a stress-context signaling annotation for MAPK1.
-    action: KEEP_AS_NON_CORE
+      This automated annotation places canonical ERK2 in a stress-activated
+      MAPK cascade context.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
-      and should remain non-core unless a later source-level review shows they are
-      central for MAPK1.
-    supported_by:
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: >-
-        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
-        signal transduction cascade, converting extracellular cues (including growth
-        factors/serum) into intracellular phosphorylation events and responses.
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: >-
-        Many sources link ERK signaling to proliferation/differentiation and disease
-        contexts, but these are typically emergent outcomes of the pathway rather than
-        direct MAPK1 enzymatic functions.
+      GO:0032872 is a stress-activated MAPK cascade term associated with
+      JNK/p38 signaling, whereas MAPK1/ERK2 is curated here as the canonical
+      ERK/MAPK cascade kinase. The automated inference overstates the evidence.
 - term:
     id: GO:0034198
     label: cellular response to amino acid starvation
@@ -394,12 +384,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: >-
-      This is a stress-context signaling annotation for MAPK1.
+      This is an amino-acid-starvation response annotation linked to ERK signaling
+      context.
     action: KEEP_AS_NON_CORE
     reason: >-
-      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
-      and should remain non-core unless a later source-level review shows they are
-      central for MAPK1.
+      The starvation-response annotation may be retained as non-core where the source
+      evidence supports this context, but it should not be treated as the core conserved
+      MAPK1 function.
     supported_by:
     - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
       supporting_text: >-
@@ -426,23 +417,13 @@ existing_annotations:
   original_reference_id: GO_REF:0000117
   review:
     summary: >-
-      This is a stress-context signaling annotation for MAPK1.
-    action: KEEP_AS_NON_CORE
+      This automated annotation places canonical ERK2 in the stress-activated MAPK
+      cascade.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
-      and should remain non-core unless a later source-level review shows they are
-      central for MAPK1.
-    supported_by:
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: >-
-        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
-        signal transduction cascade, converting extracellular cues (including growth
-        factors/serum) into intracellular phosphorylation events and responses.
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: >-
-        Many sources link ERK signaling to proliferation/differentiation and disease
-        contexts, but these are typically emergent outcomes of the pathway rather than
-        direct MAPK1 enzymatic functions.
+      GO:0051403 refers to stress-activated MAPK cascade biology associated with JNK/p38
+      signaling, not the canonical ERK1/ERK2 cascade. The automated inference should not
+      be retained as a valid non-core MAPK1 annotation.
 - term:
     id: GO:0051493
     label: regulation of cytoskeleton organization
@@ -1337,8 +1318,14 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:35831023
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: >-
+      ERK2 phosphorylation of GLI1 links MAPK1 to Smoothened/Hedgehog pathway
+      output in this specific context.
+    action: KEEP_AS_NON_CORE
+    reason: >-
+      This is a supported pathway-specific downstream role from PMID:35831023,
+      but the core MAPK1 function remains ERK2 serine/threonine MAP kinase
+      activity in the ERK/MAPK cascade.
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1866,12 +1853,13 @@ existing_annotations:
   original_reference_id: PMID:11096076
   review:
     summary: >-
-      This is a stress-context signaling annotation for MAPK1.
+      This is an amino-acid-starvation response annotation linked to ERK signaling
+      context.
     action: KEEP_AS_NON_CORE
     reason: >-
-      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
-      and should remain non-core unless a later source-level review shows they are
-      central for MAPK1.
+      The starvation-response annotation may be retained as non-core where the source
+      evidence supports this context, but it should not be treated as the core conserved
+      MAPK1 function.
     supported_by:
     - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
       supporting_text: >-
@@ -1890,23 +1878,13 @@ existing_annotations:
   original_reference_id: PMID:11096076
   review:
     summary: >-
-      This is a stress-context signaling annotation for MAPK1.
-    action: KEEP_AS_NON_CORE
+      This paper-level stress-activated MAPK cascade annotation needs source-level
+      review before a term-level decision.
+    action: UNDECIDED
     reason: >-
-      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
-      and should remain non-core unless a later source-level review shows they are
-      central for MAPK1.
-    supported_by:
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: >-
-        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
-        signal transduction cascade, converting extracellular cues (including growth
-        factors/serum) into intracellular phosphorylation events and responses.
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: >-
-        Many sources link ERK signaling to proliferation/differentiation and disease
-        contexts, but these are typically emergent outcomes of the pathway rather than
-        direct MAPK1 enzymatic functions.
+      GO:0051403 is normally associated with JNK/p38 stress-activated MAPK cascades.
+      PMID:11096076 appears to focus on ASK1/stress signaling, and this review did not
+      verify that it supports MAPK1/ERK2 as part of the stress-activated MAPK cascade.
 - term:
     id: GO:0005576
     label: extracellular region
@@ -3117,23 +3095,12 @@ existing_annotations:
   original_reference_id: PMID:19565474
   review:
     summary: >-
-      This is a stress-context signaling annotation for MAPK1.
-    action: KEEP_AS_NON_CORE
+      This TAS annotation that MAPK1 regulates the stress-activated MAPK
+      cascade needs source-level review.
+    action: UNDECIDED
     reason: >-
-      Stress-context annotations are secondary to the canonical ERK/MAPK cascade role
-      and should remain non-core unless a later source-level review shows they are
-      central for MAPK1.
-    supported_by:
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: >-
-        ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK
-        signal transduction cascade, converting extracellular cues (including growth
-        factors/serum) into intracellular phosphorylation events and responses.
-    - reference_id: file:human/MAPK1/MAPK1-deep-research-falcon.md
-      supporting_text: >-
-        Many sources link ERK signaling to proliferation/differentiation and disease
-        contexts, but these are typically emergent outcomes of the pathway rather than
-        direct MAPK1 enzymatic functions.
+      GO:0032872 is atypical for canonical ERK2 biology and should not be kept
+      as non-core without checking PMID:19565474 directly.
 - term:
     id: GO:0051493
     label: regulation of cytoskeleton organization

--- a/genes/human/MAPK1/MAPK1-deep-research-falcon.md
+++ b/genes/human/MAPK1/MAPK1-deep-research-falcon.md
@@ -1,0 +1,220 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-12T21:28:55.391359'
+end_time: '2026-05-12T21:47:01.793924'
+duration_seconds: 1086.4
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 31
+---
+
+## Question
+
+Concise GO annotation research for human MAPK1 / UniProt P28482 (mitogen-activated protein kinase 1, ERK2). Focus only on GO-relevant evidence: core molecular function as a serine/threonine protein kinase/MAP kinase with ATP binding and phosphotransfer activity; activation by dual phosphorylation by MEK1/2; core roles in MAPK cascade, ERK1/ERK2 cascade, intracellular signal transduction, response to growth factors; nuclear/cytoplasmic localization and stimulus-dependent nuclear translocation; substrates and downstream processes including transcription factor phosphorylation, cell proliferation/differentiation, apoptosis/senescence, cell migration, and whether these should be core or non-core; scaffold/protein binding annotations; over-annotation risks for generic protein binding, broad development/cancer/cell cycle/transcription terms, high-throughput substrate claims, and phenotypes from inhibitor/overexpression studies. Include caveats distinguishing direct MAPK1 kinase activity from downstream pathway outcomes. Include PMID/DOI citations and keep under 1500 words.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+Concise GO annotation research for human MAPK1 / UniProt P28482 (mitogen-activated protein kinase 1, ERK2). Focus only on GO-relevant evidence: core molecular function as a serine/threonine protein kinase/MAP kinase with ATP binding and phosphotransfer activity; activation by dual phosphorylation by MEK1/2; core roles in MAPK cascade, ERK1/ERK2 cascade, intracellular signal transduction, response to growth factors; nuclear/cytoplasmic localization and stimulus-dependent nuclear translocation; substrates and downstream processes including transcription factor phosphorylation, cell proliferation/differentiation, apoptosis/senescence, cell migration, and whether these should be core or non-core; scaffold/protein binding annotations; over-annotation risks for generic protein binding, broad development/cancer/cell cycle/transcription terms, high-throughput substrate claims, and phenotypes from inhibitor/overexpression studies. Include caveats distinguishing direct MAPK1 kinase activity from downstream pathway outcomes. Include PMID/DOI citations and keep under 1500 words.
+
+## Concise GO annotation research report: human MAPK1 / ERK2 (UniProt P28482)
+
+### Scope and principles (GO-relevant evidence only)
+MAPK1 (ERK2) is best annotated in GO by (i) conserved biochemical activity (ATP-dependent, proline-directed Ser/Thr protein kinase), (ii) conserved activation mechanism (MEK1/2 dual phosphorylation of the activation loop), (iii) conserved pathway placement (MAPK/ERK cascade downstream of Ras–Raf–MEK), (iv) experimentally supported subcellular distribution (cytoplasm↔nucleus shuttling with stimulus-dependent nuclear accumulation), and (v) motif/exosite-mediated docking interactions that govern partner binding and spatial regulation. Downstream phenotypes (proliferation, differentiation, apoptosis, senescence, migration) are frequently ERK-pathway outcomes and are high risk for over-annotation unless direct MAPK1-specific causality is demonstrated. (novak2023mutationinthe pages 1-2, karlsson2006spatiotemporalregulationof pages 1-2, caunt2010stimulusinduceduncouplingof pages 1-2)
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 Core Molecular Function (MF)
+**Protein serine/threonine kinase activity (MAP kinase) + ATP binding.** ERK2 is a Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like other protein kinases it binds ATP in an active-site cleft, with MgATP2− serving as the relevant phosphoryl donor in vitro. (rainey2004astructurefunctionanalysis pages 20-24, rainey2004astructurefunctionanalysis pages 24-29, waas2003physiologicalconcentrationsof pages 1-2)
+
+**Mechanistic detail useful for MF curation.** Structural/biophysical descriptions emphasize ATP binding by the N-lobe (β strands and glycine-rich loop) and ATP/substrate engagement by both lobes; this supports annotating “ATP binding” and “protein serine/threonine kinase activity” as core MF terms. (novak2023mutationinthe pages 1-2)
+
+**Data/quantitative note.** Dual phosphorylation causes an extremely large increase in catalytic efficiency (reported as ~600,000-fold in one mechanistic source), emphasizing that “active ERK2 kinase activity” is conditional on upstream activation. (rainey2004astructurefunctionanalysis pages 24-29)
+
+#### 1.2 Activation mechanism (upstream regulation)
+**Dual phosphorylation by MEK1/2.** ERK activation requires phosphorylation on one threonine and one tyrosine in the activation loop by the dual-specificity kinase MEK (MAPKK/ERK kinase). This is described in biochemical/structural terms and is central to GO BP annotation for MAPK cascade. (butch1996characterizationoferk1 pages 1-2, novak2023mutationinthe pages 1-2)
+
+**Site mapping (ERK2).** Recent ERK2-focused biochemical work explicitly identifies the ERK2 activation loop residues as Thr185 and Tyr187 (ERK1: Thr202/Tyr204), phosphorylated by MEK1/2. (novak2023mutationinthe pages 1-2)
+
+**Specificity note (curation relevance).** MEK is described as highly specific for ERK (“only known substrate for MEK” in the cited source), supporting a conservative upstream relationship (MAPKK→MAPK) rather than broad “protein kinase regulator activity” claims. (butch1996characterizationoferk1 pages 1-2)
+
+### 2) Core Biological Process (BP) annotations (conservative, evidence-driven)
+
+#### 2.1 MAPK cascade / ERK1-ERK2 cascade / intracellular signal transduction
+ERK2 is consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal transduction cascade, converting extracellular cues (including growth factors/serum) into intracellular phosphorylation events and responses. (novak2023mutationinthe pages 1-2, rainey2004astructurefunctionanalysis pages 20-24, waas2003physiologicalconcentrationsof pages 1-2)
+
+**GO-relevant framing:** annotate ERK2 to **MAPK cascade / ERK1 and ERK2 cascade** and **intracellular signal transduction**; optionally include **response to growth factor** where the evidence is directly about upstream stimuli triggering ERK activation/translocation rather than downstream phenotypes. (waas2003physiologicalconcentrationsof pages 1-2, karlsson2006spatiotemporalregulationof pages 1-2)
+
+#### 2.2 Downstream outcomes: core vs non-core
+Many sources link ERK signaling to proliferation/differentiation and disease contexts, but these are typically emergent outcomes of the pathway rather than direct MAPK1 enzymatic functions. For example, ERK signaling is described as converting stimuli into proliferation/differentiation and being implicated in oncogenic transformation when deregulated. These statements support pathway-level BP terms, but **do not automatically justify** GO terms like “cell cycle,” “transcription,” “cancer,” or broad developmental processes as core MAPK1 BPs. (novak2023mutationinthe pages 1-2, butch1996characterizationoferk1 pages 1-2)
+
+### 3) Cellular Component (CC): localization and stimulus-dependent translocation
+
+#### 3.1 Basal distribution and stimulus-dependent nuclear accumulation
+ERK is predominantly cytoplasmic in quiescent cells and accumulates in the nucleus after activation by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes to induced gene expression programs. (karlsson2006spatiotemporalregulationof pages 1-2)
+
+#### 3.2 ERK lacks obvious intrinsic NLS/NES → partner-mediated trafficking
+ERK lacks obvious intrinsic NLS/NES elements, implying nuclear-cytoplasmic trafficking depends on binding partners that carry localization motifs (e.g., MEK, DUSPs, scaffolds). (karlsson2006spatiotemporalregulationof pages 1-2, caunt2006seventransmembranereceptorsignalling pages 2-3, caunt2010stimulusinduceduncouplingof pages 1-2)
+
+#### 3.3 Cytoplasmic anchoring and nuclear sequestration (directly relevant regulators)
+- **MEK as cytoplasmic anchor:** MEK contains a leucine-rich NES and an ERK-binding site that anchors inactive ERK in the cytoplasm; activation dissociates the MEK–ERK complex and enables ERK nuclear translocation. (karlsson2006spatiotemporalregulationof pages 1-2, karlsson2006spatiotemporalregulationof pages 2-3)
+- **DUSP6/MKP-3 as cytoplasmic tether:** MKP-3/DUSP6 binds ERK2 and can dephosphorylate and tether inactive ERK2 in the cytoplasm; mutating MKP-3 NES or KIM abolishes cytoplasmic anchoring. (karlsson2006spatiotemporalregulationof pages 2-3, karlsson2006spatiotemporalregulationof pages 1-2)
+- **DUSP5 as nuclear sequestration factor:** DUSP5 contains an NLS; co-expression experiments show DUSP5 can inactivate and sequester ERK2 in the nucleus in an NLS- and KIM-dependent manner. (karlsson2006spatiotemporalregulationof pages 2-3)
+
+#### 3.4 Docking-domain dependence of nuclear localization (caution)
+Stimulus-induced nuclear localization is **not always proportional** to TEY phosphorylation; a phosphorylation-independent component of nuclear accumulation can depend on D-domain docking interactions (e.g., reduced by ERK2 D319N affecting the D-domain binding interface). This supports annotating “stimulus-dependent nuclear translocation” cautiously and discourages inferring nuclear localization solely from phospho-ERK immunoblot signals. (caunt2010stimulusinduceduncouplingof pages 1-2, caunt2010stimulusinduceduncouplingof pages 2-3)
+
+### 4) Protein binding / scaffold & docking annotations (avoid generic binding)
+
+#### 4.1 Motif/exosite-mediated docking is central to ERK specificity
+ERK docking is mediated by defined motifs and complementary exosites: D-domains/KIMs and DEF/FXFP motifs on partners bind ERK CD/FRS-related surfaces and other exosites. Biochemical peptide-competition experiments show docking-site peptides from MEK/MKPs/Elk-1 can inhibit MEK2–ERK2 binding and ERK2 phosphorylation of Elk-1-like substrates, indicating docking interactions are crucial for enzymatic function. (bardwell2003dockingsiteson pages 5-6, rainey2004astructurefunctionanalysis pages 24-29)
+
+#### 4.2 Avoid over-annotation to “protein binding”
+Because docking is motif-driven and structurally/biochemically dissectable, using only “protein binding” is typically uninformative and risks over-annotation. Additionally, yeast two-hybrid and peptide-based assays may capture indirect interactions or partial interfaces, so direct “binding” annotations should be limited to partners with orthogonal support. (rainey2004astructurefunctionanalysis pages 29-33, rainey2004astructurefunctionanalysis pages 24-29)
+
+### 5) Substrates and downstream processes: direct vs indirect; 2023–2024 developments
+
+#### 5.1 Direct phosphorylation: what is strong enough for GO use?
+**Strongest direct evidence** comes from direct biochemical phosphorylation assays and/or site-level validation. Examples in the evidence set include:
+- ERK2 phosphorylation of an ETS-derived substrate (EtsΔ138) at Thr-38 in vitro (example of direct Ser/Thr-Pro phosphorylation). (waas2003physiologicalconcentrationsof pages 1-2)
+- ERK2 phosphorylation of Elk-1–derived peptide/protein substrates in vitro assays using purified, dually phosphorylated ERK2. (bardwell2003dockingsiteson pages 5-6)
+
+A later review compiles additional site-level candidates (e.g., PKM2 Ser37; PAK1 Thr212; PFAS Thr619) but also notes that some are based on global phosphoproteomics and context-dependent signaling; these are useful for hypothesis generation but should not all be elevated to “direct substrate” GO annotations without independent validation. (martin–vega2025erk12mapksignalingmetabolic pages 3-5)
+
+#### 5.2 2024 mechanistic advance: kinase-independent ERK2 function via direct binding
+A major 2024 development relevant to GO curation is **direct structural and functional evidence** for an ERK2 binding interaction that regulates a process **independently of ERK kinase activity**. Becker et al. (Cell Reports, 2024-10; DOI:10.1016/j.celrep.2024.114831; URL: https://doi.org/10.1016/j.celrep.2024.114831) report a cryo-EM DHPS–ERK2 complex in which ERK2 physically occludes access to the DHPS active site, inhibiting deoxyhypusination in vitro, and show the interaction can be regulated by ERK2 regions outside the catalytic site (including an ERK2 Ser-Pro-Ser motif). This supports a careful “protein binding”/complex annotation for a specific partner (DHPS) and highlights that not all ERK2-associated biological outcomes are mediated by phosphorylation. (becker2024erk12interactionwith pages 1-3, becker2024erk12interactionwith media 4b826433, becker2024erk12interactionwith media dca6815c)
+
+#### 5.3 Processes like proliferation/migration/apoptosis/senescence: typically non-core for MAPK1
+While ERK pathway activity is frequently associated with proliferation, differentiation, apoptosis/senescence, and migration, these are often downstream, cell-type- and stimulus-dependent outcomes mediated by networks of effectors and feedback loops. GO BP annotation for MAPK1 should therefore prioritize **cascade membership and signal transduction**, and use downstream process terms only when MAPK1-specific, direct mechanistic links (not only inhibitor/overexpression phenotypes) are demonstrated. (novak2023mutationinthe pages 1-2, caunt2010stimulusinduceduncouplingof pages 1-2, martin–vega2025erk12mapksignalingmetabolic pages 3-5)
+
+### 6) Current applications and real-world implementations (annotation-relevant)
+ERK pathway components are major drug targets; however, therapeutic studies primarily inform **pathway perturbation phenotypes** rather than MAPK1 core GO functions. In a 2024 cardiovascular-focused review, ERK dimerization/autophosphorylation and nuclear shuttling mechanisms are discussed alongside peptide tools that perturb ERK dimerization or ERK–Importin7 interaction, illustrating how localization/complex formation is a practical intervention axis. These are useful as mechanistic context for CC annotations (nuclear translocation) but should not be used to assert broad disease-process GO terms for MAPK1. (mohammed2024mekinhibitorsa pages 2-3)
+
+### 7) Recommended conservative GO annotation set (with over-annotation warnings)
+The table below summarizes the most defensible GO scope from the evidence.
+
+| GO aspect | Recommended core GO term(s) | Evidence type | Key supporting statements | Key citation IDs | Over-annotation caveat |
+|---|---|---|---|---|---|
+| MF | protein serine/threonine kinase activity; mitogen-activated protein kinase activity; ATP binding | direct biochemical | ERK2 is a Ser/Thr MAPK that transfers phosphate from ATP/MgATP to Ser/Thr-Pro motifs; ATP binds in the active site, with N-lobe/glycine-rich loop contributions to nucleotide binding and catalysis. | (rainey2004astructurefunctionanalysis pages 20-24, rainey2004astructurefunctionanalysis pages 24-29, waas2003physiologicalconcentrationsof pages 1-2, novak2023mutationinthe pages 1-2) | Do not infer tyrosine kinase activity, broad “catalytic activity,” or substrate-level specificity beyond supported proline-directed Ser/Thr phosphorylation. |
+| MF | MAP kinase kinase activity toward protein substrates | direct biochemical | Catalytic efficiency rises dramatically after dual phosphorylation; purified dually phosphorylated ERK2 phosphorylates peptide/protein substrates, including Elk-1-derived peptides and ETS/Runx-related transcription factor substrates in biochemical assays. | (rainey2004astructurefunctionanalysis pages 24-29, bardwell2003dockingsiteson pages 5-6, waas2003physiologicalconcentrationsof pages 1-2) | Do not treat every phosphoproteomics hit or motif-containing protein as a direct MAPK1 substrate. |
+| BP | ERK1 and ERK2 cascade; MAPK cascade; intracellular signal transduction; response to growth factor | review/mechanistic plus direct pathway evidence | ERK2 is a principal effector downstream of Ras-Raf-MEK; activated by extracellular stimuli including serum/growth factors and mediates canonical MAPK/ERK signaling. | (novak2023mutationinthe pages 1-2, waas2003physiologicalconcentrationsof pages 1-2, rainey2004astructurefunctionanalysis pages 20-24) | Keep pathway terms close to the conserved cascade; avoid annotating broad disease, cancer, development, or generic transcription terms from pathway membership alone. |
+| BP | positive regulation of protein phosphorylation of direct substrates; phosphorylation of transcription factors | direct biochemical | ERK2 directly phosphorylates defined downstream targets such as Elk-1/ETS-family and other transcription-factor substrates in vitro and in cells; docking motifs/exosites help determine substrate recognition. | (bardwell2003dockingsiteson pages 5-6, waas2003physiologicalconcentrationsof pages 1-2, rainey2004astructurefunctionanalysis pages 24-29) | Direct substrate phosphorylation can support narrower process terms only when the substrate/process link is demonstrated; do not infer all downstream transcriptional programs as direct MAPK1 functions. |
+| BP | regulation of cell proliferation/differentiation; apoptosis/senescence; cell migration | review/mechanistic, usually non-core | Literature links ERK2 signaling to proliferation, differentiation, survival/death decisions, and motility, often through many downstream effectors and context-specific scaffolds. | (novak2023mutationinthe pages 1-2, martin–vega2025erk12mapksignalingmetabolic pages 3-5, butch1996characterizationoferk1 pages 1-2) | These are often pathway outcomes, not direct MAPK1 actions; avoid making them core GO annotations unless supported by direct loss-of-function/rescue and mechanistic evidence specific to MAPK1. |
+| CC | cytoplasm; nucleus | cell biology localization | In quiescent cells ERK is mainly cytoplasmic; after activation it accumulates in the nucleus. ERK lacks clear intrinsic NLS/NES and relies on partner-mediated trafficking. | (karlsson2006spatiotemporalregulationof pages 1-2, caunt2006seventransmembranereceptorsignalling pages 2-3, caunt2010stimulusinduceduncouplingof pages 1-2, caunt2010stimulusinduceduncouplingof pages 2-3) | Prefer cytoplasm/nucleus over highly specific compartments unless direct localization evidence exists for MAPK1 itself in that context. |
+| CC | cytoplasm to nucleus translocation upon stimulation | cell biology localization | MEK binds inactive ERK in the cytoplasm; TEY phosphorylation and release from anchors permit nuclear accumulation. Nuclear localization depends on phosphorylation but can also require D-domain interactions beyond phosphorylation alone. | (karlsson2006spatiotemporalregulationof pages 1-2, caunt2010stimulusinduceduncouplingof pages 1-2, caunt2010stimulusinduceduncouplingof pages 2-3) | Do not annotate constitutive nuclear localization; stimulus dependence matters, and nuclear entry should not be inferred solely from ERK phosphorylation readouts. |
+| CC | cytoplasmic anchoring complex with MEK/DUSP6-like regulators; nuclear sequestration with DUSP5-like regulators | cell biology localization; review/mechanistic | MEK NES helps anchor inactive ERK in cytoplasm; DUSP6/MKP-3 tethers inactive ERK2 in cytoplasm; DUSP5 contains an NLS and can inactivate/sequester ERK2 in the nucleus. | (karlsson2006spatiotemporalregulationof pages 2-3, karlsson2006spatiotemporalregulationof pages 1-2, caunt2010stimulusinduceduncouplingof pages 11-11) | These support localization regulation and specific complexes, not broad stable residence in every compartment or all phosphatase-binding annotations. |
+| MF | sequence-specific protein docking / scaffold-mediated binding | direct biochemical; review/mechanistic | ERK2 recognizes D-domain/KIM and DEF/FXFP docking motifs through common-docking and exosite regions; these interactions are crucial for MEK, MKP, Elk-1 and scaffold/substrate binding. | (rainey2004astructurefunctionanalysis pages 24-29, bardwell2003dockingsiteson pages 5-6, rainey2004astructurefunctionanalysis pages 29-33) | Avoid generic “protein binding” if a more informative docking/scaffold interaction term can be used; also avoid inferring direct binding from yeast two-hybrid or peptide competition alone without orthogonal support. |
+| BP | scaffold-mediated spatial regulation of MAPK signaling | review/mechanistic | Scaffold and anchoring proteins such as β-arrestin, Naf1, paxillin/GIT1/IQGAP1/KSR1 shape where ERK signals and which outputs are engaged. | (rainey2004astructurefunctionanalysis pages 29-33, martin–vega2025erk12mapksignalingmetabolic pages 3-5) | Scaffold-dependent localization does not automatically justify annotating MAPK1 to every scaffold’s biological process or cellular site. |
+| BP | nuclear transcription factor phosphorylation leading to gene expression changes | direct substrate plus mechanistic | ERK nuclear translocation enables phosphorylation of nuclear substrates such as Elk-1 and related transcription factors that contribute to induced gene expression. | (caunt2006seventransmembranereceptorsignalling pages 2-3, bardwell2003dockingsiteson pages 5-6, butch1996characterizationoferk1 pages 1-2) | Annotate the direct phosphorylation event or upstream signaling role rather than broad “regulation of transcription” unless MAPK1-specific causality is directly established. |
+| General guidance | core set should emphasize kinase activity, MEK-dependent activation, MAPK/ERK cascade role, intracellular signaling, and cytoplasm/nucleus shuttling | synthesis | Best-supported core annotations are those nearest to direct chemistry, canonical pathway position, and experimentally observed localization dynamics. | (novak2023mutationinthe pages 1-2, karlsson2006spatiotemporalregulationof pages 1-2, caunt2010stimulusinduceduncouplingof pages 1-2) | Be cautious with inhibitor/overexpression phenotypes, cancer-context reviews, and high-throughput substrate claims; distinguish direct MAPK1 action from downstream pathway outcomes. |
+
+
+*Table: This table summarizes GO-relevant evidence and annotation boundaries for human MAPK1/ERK2 using only the provided evidence contexts. It highlights the strongest core annotations and flags common over-annotation risks for downstream phenotypes, generic binding, and indirect pathway outcomes.*
+
+### Key caveats for curators (high priority)
+1. **Do not infer “nuclear” localization from phospho-ERK alone.** Nuclear accumulation can be partially uncoupled from TEY phosphorylation and depends on docking interactions and anchors. (caunt2010stimulusinduceduncouplingof pages 1-2, caunt2010stimulusinduceduncouplingof pages 2-3)
+2. **Avoid broad BP terms (cancer, development, cell cycle, transcription) from pathway membership.** Prefer “MAPK/ERK cascade” and “intracellular signal transduction,” and only add downstream BPs with direct MAPK1 evidence. (novak2023mutationinthe pages 1-2, butch1996characterizationoferk1 pages 1-2)
+3. **Be conservative with high-throughput substrate claims.** Motif presence is insufficient; only a minority of Ser/Thr-Pro sites are bona fide MAPK substrates in vivo, and phosphoproteomics hits need orthogonal validation. (rainey2004astructurefunctionanalysis pages 24-29, martin–vega2025erk12mapksignalingmetabolic pages 3-5)
+4. **Use specific docking/scaffold language rather than generic binding when possible.** Docking is mediated by defined motifs (KIM/D-domain, DEF/FXFP) and ERK exosites; peptide/yeast assays can be indirect. (bardwell2003dockingsiteson pages 5-6, rainey2004astructurefunctionanalysis pages 29-33)
+5. **Distinguish kinase-dependent vs kinase-independent ERK functions.** The DHPS–ERK2 interaction demonstrates direct binding-mediated regulation independent of ERK catalytic activity, warning against attributing every ERK-associated outcome to “protein phosphorylation.” (becker2024erk12interactionwith pages 1-3, becker2024erk12interactionwith media 4b826433)
+
+### References (URLs, dates, identifiers)
+- Novak L. et al. *Cancers* (2023-05). “Mutation in the Common Docking Domain Affects MAP Kinase ERK2 Catalysis and Stability.” DOI:10.3390/cancers15112938. URL: https://doi.org/10.3390/cancers15112938 (novak2023mutationinthe pages 1-2)
+- Becker A.E. et al. *Cell Reports* (2024-10). “ERK1/2 interaction with DHPS regulates eIF5A deoxyhypusination independently of ERK kinase activity.” DOI:10.1016/j.celrep.2024.114831. URL: https://doi.org/10.1016/j.celrep.2024.114831 (becker2024erk12interactionwith pages 1-3, becker2024erk12interactionwith media 4b826433)
+- Mohammed K.A.K. et al. *Frontiers in Cardiovascular Medicine* (2024-07). “MEK inhibitors: a promising targeted therapy for cardiovascular disease.” DOI:10.3389/fcvm.2024.1404253. URL: https://doi.org/10.3389/fcvm.2024.1404253 (mohammed2024mekinhibitorsa pages 2-3)
+- Karlsson M. et al. *Biochemical Society Transactions* (2006-10). “Spatio-temporal regulation of MAPK signalling by protein phosphatases.” DOI:10.1042/bst0340842. URL: https://doi.org/10.1042/bst0340842 (karlsson2006spatiotemporalregulationof pages 1-2)
+- Caunt C.J. et al. *Trends Endocrinol Metab* (2006-09). “Seven-transmembrane receptor signalling and ERK compartmentalization.” DOI:10.1016/j.tem.2006.07.008. URL: https://doi.org/10.1016/j.tem.2006.07.008 (caunt2006seventransmembranereceptorsignalling pages 2-3)
+- Caunt C.J. & McArdle C.A. *J Cell Sci* (2010-12). “Stimulus-induced uncoupling of ERK phosphorylation from nuclear localization…” DOI:10.1242/jcs.076349. URL: https://doi.org/10.1242/jcs.076349 (caunt2010stimulusinduceduncouplingof pages 1-2, caunt2010stimulusinduceduncouplingof pages 2-3)
+- Waas W.F. & Dalby K.N. *Biochemistry* (2003-03). “Physiological concentrations of divalent magnesium ion activate… ERK2.” DOI:10.1021/bi027171w. URL: https://doi.org/10.1021/bi027171w (waas2003physiologicalconcentrationsof pages 1-2)
+- Bardwell A.J. et al. *Biochem J* (2003-03). “Docking sites… compete for MAPK binding and are crucial for enzymic activity.” DOI:10.1042/bj20021806. URL: https://doi.org/10.1042/bj20021806 (bardwell2003dockingsiteson pages 5-6)
+
+
+
+References
+
+1. (novak2023mutationinthe pages 1-2): Leonore Novak, Maria Petrosino, Alessandra Pasquo, Apirat Chaikuad, Roberta Chiaraluce, Stefan Knapp, and Valerio Consalvi. Mutation in the common docking domain affects map kinase erk2 catalysis and stability. Cancers, 15:2938, May 2023. URL: https://doi.org/10.3390/cancers15112938, doi:10.3390/cancers15112938. This article has 7 citations.
+
+2. (karlsson2006spatiotemporalregulationof pages 1-2): M. Karlsson, M. Mandl, and S.M. Keyse. Spatio-temporal regulation of mitogen-activated protein kinase (mapk) signalling by protein phosphatases. Biochemical Society transactions, 34 Pt 5:842-5, Oct 2006. URL: https://doi.org/10.1042/bst0340842, doi:10.1042/bst0340842. This article has 35 citations and is from a peer-reviewed journal.
+
+3. (caunt2010stimulusinduceduncouplingof pages 1-2): Christopher J. Caunt and Craig A. McArdle. Stimulus-induced uncoupling of extracellular signal-regulated kinase phosphorylation from nuclear localization is dependent on docking domain interactions. Journal of Cell Science, 123:4310-4320, Dec 2010. URL: https://doi.org/10.1242/jcs.076349, doi:10.1242/jcs.076349. This article has 34 citations and is from a domain leading peer-reviewed journal.
+
+4. (rainey2004astructurefunctionanalysis pages 20-24): MA Rainey. A structure/function analysis of macromolecular recognition by the protein kinase erk2. Unknown journal, 2004.
+
+5. (rainey2004astructurefunctionanalysis pages 24-29): MA Rainey. A structure/function analysis of macromolecular recognition by the protein kinase erk2. Unknown journal, 2004.
+
+6. (waas2003physiologicalconcentrationsof pages 1-2): William F. Waas and Kevin N. Dalby. Physiological concentrations of divalent magnesium ion activate the serine/threonine specific protein kinase erk2. Biochemistry, 42 10:2960-70, Mar 2003. URL: https://doi.org/10.1021/bi027171w, doi:10.1021/bi027171w. This article has 60 citations and is from a peer-reviewed journal.
+
+7. (butch1996characterizationoferk1 pages 1-2): Elizabeth R. Butch and Kun-Liang Guan. Characterization of erk1 activation site mutants and the effect on recognition by mek1 and mek2 (*). The Journal of Biological Chemistry, 271:4230-4235, Feb 1996. URL: https://doi.org/10.1074/jbc.271.8.4230, doi:10.1074/jbc.271.8.4230. This article has 77 citations.
+
+8. (caunt2006seventransmembranereceptorsignalling pages 2-3): Christopher J. Caunt, Ann R. Finch, Kathleen R. Sedgley, and Craig A. McArdle. Seven-transmembrane receptor signalling and erk compartmentalization. Trends in Endocrinology & Metabolism, 17:276-283, Sep 2006. URL: https://doi.org/10.1016/j.tem.2006.07.008, doi:10.1016/j.tem.2006.07.008. This article has 115 citations and is from a domain leading peer-reviewed journal.
+
+9. (karlsson2006spatiotemporalregulationof pages 2-3): M. Karlsson, M. Mandl, and S.M. Keyse. Spatio-temporal regulation of mitogen-activated protein kinase (mapk) signalling by protein phosphatases. Biochemical Society transactions, 34 Pt 5:842-5, Oct 2006. URL: https://doi.org/10.1042/bst0340842, doi:10.1042/bst0340842. This article has 35 citations and is from a peer-reviewed journal.
+
+10. (caunt2010stimulusinduceduncouplingof pages 2-3): Christopher J. Caunt and Craig A. McArdle. Stimulus-induced uncoupling of extracellular signal-regulated kinase phosphorylation from nuclear localization is dependent on docking domain interactions. Journal of Cell Science, 123:4310-4320, Dec 2010. URL: https://doi.org/10.1242/jcs.076349, doi:10.1242/jcs.076349. This article has 34 citations and is from a domain leading peer-reviewed journal.
+
+11. (bardwell2003dockingsiteson pages 5-6): A. Jane BARDWELL, Mahsa ABDOLLAHI, and Lee BARDWELL. Docking sites on mitogen-activated protein kinase (mapk) kinases, mapk phosphatases and the elk-1 transcription factor compete for mapk binding and are crucial for enzymic activity. Biochemical Journal, 370:1077-1085, Mar 2003. URL: https://doi.org/10.1042/bj20021806, doi:10.1042/bj20021806. This article has 150 citations and is from a domain leading peer-reviewed journal.
+
+12. (rainey2004astructurefunctionanalysis pages 29-33): MA Rainey. A structure/function analysis of macromolecular recognition by the protein kinase erk2. Unknown journal, 2004.
+
+13. (martin–vega2025erk12mapksignalingmetabolic pages 3-5): Ana Martin–Vega and Melanie H. Cobb. Erk1/2-mapk signaling: metabolic, organellar, and cytoskeletal interactions. Current Opinion in Cell Biology, 95:102526, Aug 2025. URL: https://doi.org/10.1016/j.ceb.2025.102526, doi:10.1016/j.ceb.2025.102526. This article has 12 citations and is from a peer-reviewed journal.
+
+14. (becker2024erk12interactionwith pages 1-3): Andrew E. Becker, Paweł Kochanowski, Pui-Kei Wu, Elżbieta Wątor, Wenjing Chen, Koushik Guchhait, Artur P. Biela, Przemysław Grudnik, and Jong-In Park. Erk1/2 interaction with dhps regulates eif5a deoxyhypusination independently of erk kinase activity. Cell reports, 43:114831-114831, Oct 2024. URL: https://doi.org/10.1016/j.celrep.2024.114831, doi:10.1016/j.celrep.2024.114831. This article has 4 citations and is from a highest quality peer-reviewed journal.
+
+15. (becker2024erk12interactionwith media 4b826433): Andrew E. Becker, Paweł Kochanowski, Pui-Kei Wu, Elżbieta Wątor, Wenjing Chen, Koushik Guchhait, Artur P. Biela, Przemysław Grudnik, and Jong-In Park. Erk1/2 interaction with dhps regulates eif5a deoxyhypusination independently of erk kinase activity. Cell reports, 43:114831-114831, Oct 2024. URL: https://doi.org/10.1016/j.celrep.2024.114831, doi:10.1016/j.celrep.2024.114831. This article has 4 citations and is from a highest quality peer-reviewed journal.
+
+16. (becker2024erk12interactionwith media dca6815c): Andrew E. Becker, Paweł Kochanowski, Pui-Kei Wu, Elżbieta Wątor, Wenjing Chen, Koushik Guchhait, Artur P. Biela, Przemysław Grudnik, and Jong-In Park. Erk1/2 interaction with dhps regulates eif5a deoxyhypusination independently of erk kinase activity. Cell reports, 43:114831-114831, Oct 2024. URL: https://doi.org/10.1016/j.celrep.2024.114831, doi:10.1016/j.celrep.2024.114831. This article has 4 citations and is from a highest quality peer-reviewed journal.
+
+17. (mohammed2024mekinhibitorsa pages 2-3): Khaled A. K. Mohammed, Paolo Madeddu, and Elisa Avolio. Mek inhibitors: a promising targeted therapy for cardiovascular disease. Frontiers in Cardiovascular Medicine, Jul 2024. URL: https://doi.org/10.3389/fcvm.2024.1404253, doi:10.3389/fcvm.2024.1404253. This article has 17 citations and is from a peer-reviewed journal.
+
+18. (caunt2010stimulusinduceduncouplingof pages 11-11): Christopher J. Caunt and Craig A. McArdle. Stimulus-induced uncoupling of extracellular signal-regulated kinase phosphorylation from nuclear localization is dependent on docking domain interactions. Journal of Cell Science, 123:4310-4320, Dec 2010. URL: https://doi.org/10.1242/jcs.076349, doi:10.1242/jcs.076349. This article has 34 citations and is from a domain leading peer-reviewed journal.
+
+## Citations
+
+1. novak2023mutationinthe pages 1-2
+2. rainey2004astructurefunctionanalysis pages 24-29
+3. karlsson2006spatiotemporalregulationof pages 1-2
+4. karlsson2006spatiotemporalregulationof pages 2-3
+5. waas2003physiologicalconcentrationsof pages 1-2
+6. bardwell2003dockingsiteson pages 5-6
+7. mohammed2024mekinhibitorsa pages 2-3
+8. caunt2006seventransmembranereceptorsignalling pages 2-3
+9. caunt2010stimulusinduceduncouplingof pages 1-2
+10. rainey2004astructurefunctionanalysis pages 20-24
+11. caunt2010stimulusinduceduncouplingof pages 2-3
+12. rainey2004astructurefunctionanalysis pages 29-33
+13. caunt2010stimulusinduceduncouplingof pages 11-11
+14. https://doi.org/10.1016/j.celrep.2024.114831
+15. https://doi.org/10.3390/cancers15112938
+16. https://doi.org/10.3389/fcvm.2024.1404253
+17. https://doi.org/10.1042/bst0340842
+18. https://doi.org/10.1016/j.tem.2006.07.008
+19. https://doi.org/10.1242/jcs.076349
+20. https://doi.org/10.1021/bi027171w
+21. https://doi.org/10.1042/bj20021806
+22. https://doi.org/10.3390/cancers15112938,
+23. https://doi.org/10.1042/bst0340842,
+24. https://doi.org/10.1242/jcs.076349,
+25. https://doi.org/10.1021/bi027171w,
+26. https://doi.org/10.1074/jbc.271.8.4230,
+27. https://doi.org/10.1016/j.tem.2006.07.008,
+28. https://doi.org/10.1042/bj20021806,
+29. https://doi.org/10.1016/j.ceb.2025.102526,
+30. https://doi.org/10.1016/j.celrep.2024.114831,
+31. https://doi.org/10.3389/fcvm.2024.1404253,

--- a/genes/human/MAPK1/MAPK1-notes.md
+++ b/genes/human/MAPK1/MAPK1-notes.md
@@ -1,0 +1,62 @@
+# MAPK1 notes
+
+Initial Falcon pass, 2026-05-12. MAPK1/ERK2 started as a fully pending review
+with 276 existing annotations, so this pass focuses on the safest term-level
+curation rather than attempting a primary-source review of every substrate,
+interaction, Reactome, and phenotype annotation.
+
+Core molecular function: MAPK1 is ERK2, an ATP-dependent serine/threonine MAP
+kinase. Falcon summarizes the core enzymology as direct ATP-dependent
+phosphotransfer [file:human/MAPK1/MAPK1-deep-research-falcon.md "ERK2 is a
+Ser/Thr MAPK that transfers the γ-phosphate of ATP to Ser/Thr-Pro motifs; like
+other protein kinases it binds ATP in an active-site cleft, with MgATP2−
+serving as the relevant phosphoryl donor in vitro."]. I therefore accepted MAP
+kinase activity, protein serine/threonine kinase activity, ATP binding, and
+protein phosphorylation, while modifying broader or incomplete kinase terms to
+the specific MAP kinase/serine-threonine kinase terms.
+
+Core process: the most defensible biological process is canonical ERK/MAPK
+cascade signal transduction. Falcon places ERK2 downstream of Ras-RAF-MEK and
+growth-factor inputs [file:human/MAPK1/MAPK1-deep-research-falcon.md "ERK2 is
+consistently positioned as a downstream effector in the Ras–Raf–MEK–ERK signal
+transduction cascade, converting extracellular cues (including growth
+factors/serum) into intracellular phosphorylation events and responses."]. I
+accepted ERK1 and ERK2 cascade, MAPK cascade, and intracellular signal
+transduction, and kept receptor-specific contexts such as EGFR/ERBB/insulin
+signaling as non-core.
+
+Core localization: the best-supported localizations are cytoplasmic/cytosolic
+localization in unstimulated cells plus stimulus-dependent nuclear
+accumulation. Falcon states that ERK is mainly cytoplasmic in quiescent cells
+and accumulates in the nucleus after activation
+[file:human/MAPK1/MAPK1-deep-research-falcon.md "ERK is predominantly
+cytoplasmic in quiescent cells and accumulates in the nucleus after activation
+by certain stimuli; nuclear ERK phosphorylates nuclear targets and contributes
+to induced gene expression programs."]. I accepted cytoplasm, cytosol, nucleus,
+and one nucleoplasm row with this stimulus-dependent caveat. Most repetitive
+Reactome cytosol/nucleoplasm rows and more specific compartments remain pending
+unless later primary-source review supports a stronger decision.
+
+Over-annotation cautions: Falcon explicitly warns that downstream proliferation,
+differentiation, apoptosis, migration, developmental, transcriptional, and
+disease terms are often ERK pathway outcomes rather than direct MAPK1
+functions [file:human/MAPK1/MAPK1-deep-research-falcon.md "Many sources link
+ERK signaling to proliferation/differentiation and disease contexts, but these
+are typically emergent outcomes of the pathway rather than direct MAPK1
+enzymatic functions."]. I marked a small set of automated broad developmental
+or transcriptional annotations as over-annotated and retained some source-backed
+downstream processes as non-core.
+
+Protein binding: MAPK1 has many reported interacting partners, but the generic
+GO:0005515 term is not useful for this gene. Falcon notes that ERK docking is
+motif/exosite-mediated and that generic protein binding risks over-annotation
+[file:human/MAPK1/MAPK1-deep-research-falcon.md "Because docking is
+motif-driven and structurally/biochemically dissectable, using only “protein
+binding” is typically uninformative and risks over-annotation."]. I left the
+generic protein-binding rows pending for partner-specific follow-up, while
+keeping the more informative phosphatase-binding term as non-core.
+
+Left for later: a source-level review should triage individual substrates,
+protein interactions, Reactome location rows, and old TAS/NAS phenotype rows.
+Several annotations remain PENDING where I did not inspect the primary
+publication.

--- a/genes/human/MAPK1/MAPK1-notes.md
+++ b/genes/human/MAPK1/MAPK1-notes.md
@@ -47,6 +47,12 @@ enzymatic functions."]. I marked a small set of automated broad developmental
 or transcriptional annotations as over-annotated and retained some source-backed
 downstream processes as non-core.
 
+Review follow-up: stress-activated MAPK cascade terms should not be treated as
+valid non-core ERK2 biology, because GO:0051403/GO:0032872 are JNK/p38-oriented
+stress MAPK terms rather than canonical ERK cascade terms. I marked the
+automated stress-cascade rows as over-annotated and left the PMID-backed rows
+UNDECIDED pending source-level review.
+
 Protein binding: MAPK1 has many reported interacting partners, but the generic
 GO:0005515 term is not useful for this gene. Falcon notes that ERK docking is
 motif/exosite-mediated and that generic protein binding risks over-annotation


### PR DESCRIPTION
## Summary
- add Falcon deep research and notes for human MAPK1 / ERK2
- curate a conservative first pass of core MAPK1 kinase, ERK/MAPK signaling, and cytoplasm/nucleus localization annotations
- add core_functions for MAP kinase activity and ATP binding, leaving 192 annotations pending for source-level follow-up
- render the updated MAPK1 review HTML

## Validation
- exact support-text audit: checked 129 supporting_text entries, all found exactly after whitespace normalization
- uv run python scripts/validate_deep_research.py genes/human/MAPK1/MAPK1-deep-research-falcon.md
- just validate human MAPK1 (passes with expected warning: 192 annotations marked as PENDING)
- just render human MAPK1
- perl -pi -e 's/[ \t]+$//' genes/human/MAPK1/MAPK1-ai-review.html
- git diff --check