### PR TITLE
Add Falcon deep research for GET3

### DIFF
--- a/genes/yeast/GET3/GET3-ai-review.html
+++ b/genes/yeast/GET3/GET3-ai-review.html
@@ -671,33 +671,33 @@
     <div class="header">
         <h1>GET3</h1>
         <div class="gene-info">
-            
+
             <div class="info-item">
-                
+
                 <span class="info-label">UniProt ID:</span>
                 <span>
                     <a href="https://www.uniprot.org/uniprotkb/Q12154" target="_blank" class="term-link">
                         Q12154
                     </a>
                 </span>
-                
+
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Organism:</span>
                 <span>Saccharomyces cerevisiae</span>
             </div>
-            
-            
+
+
             <div class="info-item">
                 <span class="info-label">Review Status:</span>
                 <span class="status-badge status-draft">
                     DRAFT
                 </span>
             </div>
-            
-            
+
+
         </div>
         <div style="margin-top: 1rem; text-align: center;">
             <a id="feedback-form-link"
@@ -728,7 +728,7 @@
         </div>
     </div>
 
-    
+
     <div class="description-card">
         <div style="display: flex; justify-content: space-between; align-items: center;">
             <h2>Gene Description</h2>
@@ -739,13 +739,13 @@
         </div>
         <p>GET3 encodes an ATPase that is the central targeting factor in the GET (Guided Entry of Tail-anchored proteins) pathway. As a homodimer, Get3p recognizes and binds the transmembrane domain of newly synthesized tail-anchored (TA) membrane proteins in the cytosol, shielding the hydrophobic segment from aqueous solvent. ATP binding drives a closed dimer conformation that facilitates TA substrate capture, and the Get3p-substrate complex is then delivered to the ER membrane via the Get1p/Get2p receptor, where ATP hydrolysis triggers substrate release and membrane insertion. Get3p also cooperates with the HDEL receptor Erd2p in ATP-dependent retrograde retrieval of ER-resident proteins from the Golgi, and functions as a guanine nucleotide exchange factor for Gpa1p in pheromone signaling. Under oxidative stress with ATP depletion, Get3p undergoes a conformational switch to act as a holdase chaperone. Orthologous to human GET3/TRC40.</p>
     </div>
-    
 
-    
 
-    
 
-    
+
+
+
+
     <div class="section">
         <h2 class="section-title">Existing Annotations Review</h2>
         <table class="annotations-table">
@@ -758,32 +758,32 @@
                 </tr>
             </thead>
             <tbody>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043529" target="_blank" class="term-link">
                                     GO:0043529
                                 </a>
                             </span>
                             <span class="term-label">GET complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -795,46 +795,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: GET complex is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is ATP-sensitive and reversible</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -846,46 +862,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: ATP hydrolysis activity is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Functionally, ATP hydrolysis is required for productive insertion because a hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071816" target="_blank" class="term-link">
                                     GO:0071816
                                 </a>
                             </span>
                             <span class="term-label">tail-anchored membrane protein insertion into ER membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IBA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000033
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -897,46 +929,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: tail-anchored membrane protein insertion into ER membrane is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and **Get1 driving ATPase-dependent substrate release** for insertion</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006457" target="_blank" class="term-link">
                                     GO:0006457
                                 </a>
                             </span>
                             <span class="term-label">protein folding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000108
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -948,46 +996,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein folding may be context-dependent or peripheral for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000166" target="_blank" class="term-link">
                                     GO:0000166
                                 </a>
                             </span>
                             <span class="term-label">nucleotide binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -999,46 +1047,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: nucleotide binding is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005524" target="_blank" class="term-link">
                                     GO:0005524
                                 </a>
                             </span>
                             <span class="term-label">ATP binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000120
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1050,46 +1098,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: ATP binding is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005737" target="_blank" class="term-link">
                                     GO:0005737
                                 </a>
                             </span>
                             <span class="term-label">cytoplasm</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1101,46 +1149,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: cytoplasm is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is ATP-sensitive and reversible</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1152,46 +1216,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: endoplasmic reticulum is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is ATP-sensitive and reversible</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005794" target="_blank" class="term-link">
                                     GO:0005794
                                 </a>
                             </span>
                             <span class="term-label">Golgi apparatus</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000044
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1203,46 +1283,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: Golgi apparatus may be context-dependent or peripheral for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016192" target="_blank" class="term-link">
                                     GO:0016192
                                 </a>
                             </span>
                             <span class="term-label">vesicle-mediated transport</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1254,46 +1334,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: vesicle-mediated transport may be context-dependent or peripheral for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016787" target="_blank" class="term-link">
                                     GO:0016787
                                 </a>
                             </span>
                             <span class="term-label">hydrolase activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1305,46 +1385,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: hydrolase activity may be context-dependent or peripheral for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000002
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1356,46 +1436,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: ATP hydrolysis activity is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Functionally, ATP hydrolysis is required for productive insertion because a hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043529" target="_blank" class="term-link">
                                     GO:0043529
                                 </a>
                             </span>
                             <span class="term-label">GET complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000104
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1407,46 +1503,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: GET complex is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is ATP-sensitive and reversible</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045048" target="_blank" class="term-link">
                                     GO:0045048
                                 </a>
                             </span>
                             <span class="term-label">protein insertion into ER membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000104
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -1458,46 +1570,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein insertion into ER membrane is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and **Get1 driving ATPase-dependent substrate release** for insertion</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046685" target="_blank" class="term-link">
                                     GO:0046685
                                 </a>
                             </span>
                             <span class="term-label">response to arsenic-containing substance</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1509,46 +1637,46 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: response to arsenic-containing substance may be context-dependent or peripheral for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0046872" target="_blank" class="term-link">
                                     GO:0046872
                                 </a>
                             </span>
                             <span class="term-label">metal ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IEA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             GO_REF:0000043
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -1560,57 +1688,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: metal ion binding may be context-dependent or peripheral for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11283351" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11283351
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A comprehensive two-hybrid analysis to explore the yeast pro...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1622,57 +1750,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/11805837" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:11805837
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Systematic identification of protein complexes in Saccharomy...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1684,57 +1812,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16260785" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16260785
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The yeast Arr4p ATPase binds the chloride transporter Gef1p ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1746,57 +1874,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16269340" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16269340
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Exploration of the function and organization of the yeast ea...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1808,57 +1936,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16429126" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16429126
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Proteome survey reveals modularity of the yeast cell machine...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1870,57 +1998,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16554755
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global landscape of protein complexes in the yeast Saccharom...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1932,57 +2060,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16816426" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16816426
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The conserved ATPase Get3/Arr4 modulates the activity of mem...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -1994,57 +2122,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18467557" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18467557
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An in vivo map of the yeast protein interactome.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2056,57 +2184,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18719252" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18719252
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     High-quality binary protein interaction map of the yeast int...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2118,57 +2246,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18724936" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18724936
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The GET complex mediates insertion of tail-anchored proteins...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2180,57 +2308,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19675567" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19675567
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The structural basis of tail-anchored membrane protein recog...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2242,57 +2370,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20106980" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20106980
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Crystal structure of Get4-Get5 complex and its interactions ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2304,57 +2432,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20850366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20850366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A chaperone cascade sorts proteins for posttranslational mem...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2366,57 +2494,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21866104" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21866104
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The mechanism of membrane-associated steps in tail-anchored ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2428,57 +2556,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24727835" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24727835
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Crystal structure of ATP-bound Get3-Get4-Get5 complex reveal...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2490,57 +2618,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25745174" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25745174
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protein targeting. Structure of the Get3 targeting factor in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2552,57 +2680,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:27107014
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     An inter-species protein-protein interaction network across ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2614,57 +2742,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
                                     GO:0005515
                                 </a>
                             </span>
                             <span class="term-label">protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:37968396
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The social and structural architecture of the yeast protein ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-markasoverannotated">
@@ -2676,429 +2804,525 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein binding is too generic or over-extended for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16260785" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16260785
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The yeast Arr4p ATPase binds the chloride transporter Gef1p ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0042802" data-r="PMID:16260785" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0042802" data-r="PMID:16260785" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: identical protein binding is too generic or over-extended for GET3.
+                            <strong>Summary:</strong> Manual review: identical protein binding captures the obligate Get3 homodimer that forms the tail-anchored protein binding groove.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic groove that binds and shields tail-anchored protein transmembrane domains.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide dependent</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19675567" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19675567
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The structural basis of tail-anchored membrane protein recog...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0042802" data-r="PMID:19675567" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0042802" data-r="PMID:19675567" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: identical protein binding is too generic or over-extended for GET3.
+                            <strong>Summary:</strong> Manual review: identical protein binding captures the obligate Get3 homodimer that forms the tail-anchored protein binding groove.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic groove that binds and shields tail-anchored protein transmembrane domains.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide dependent</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/19706470" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:19706470
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Model for eukaryotic tail-anchored protein binding based on ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0042802" data-r="PMID:19706470" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0042802" data-r="PMID:19706470" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: identical protein binding is too generic or over-extended for GET3.
+                            <strong>Summary:</strong> Manual review: identical protein binding captures the obligate Get3 homodimer that forms the tail-anchored protein binding groove.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic groove that binds and shields tail-anchored protein transmembrane domains.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide dependent</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/22124326" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:22124326
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Tail-anchor targeting by a Get3 tetramer: the structure of a...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0042802" data-r="PMID:22124326" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0042802" data-r="PMID:22124326" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: identical protein binding is too generic or over-extended for GET3.
+                            <strong>Summary:</strong> Manual review: identical protein binding captures the obligate Get3 homodimer that forms the tail-anchored protein binding groove.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic groove that binds and shields tail-anchored protein transmembrane domains.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide dependent</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/24727835" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:24727835
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Crystal structure of ATP-bound Get3-Get4-Get5 complex reveal...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0042802" data-r="PMID:24727835" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0042802" data-r="PMID:24727835" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: identical protein binding is too generic or over-extended for GET3.
+                            <strong>Summary:</strong> Manual review: identical protein binding captures the obligate Get3 homodimer that forms the tail-anchored protein binding groove.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic groove that binds and shields tail-anchored protein transmembrane domains.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide dependent</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0042802" target="_blank" class="term-link">
                                     GO:0042802
                                 </a>
                             </span>
                             <span class="term-label">identical protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25745174" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25745174
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Protein targeting. Structure of the Get3 targeting factor in...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-accept">
+                            ACCEPT
                         </span>
-                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0042802" data-r="PMID:25745174" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0042802" data-r="PMID:25745174" data-act="ACCEPT">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: identical protein binding is too generic or over-extended for GET3.
+                            <strong>Summary:</strong> Manual review: identical protein binding captures the obligate Get3 homodimer that forms the tail-anchored protein binding groove.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic groove that binds and shields tail-anchored protein transmembrane domains.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide dependent</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
                                     GO:0005789
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">NAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32910895" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32910895
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structural Basis of Tail-Anchored Membrane Protein Biogenesi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3110,57 +3334,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: endoplasmic reticulum membrane is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is ATP-sensitive and reversible</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0045048" target="_blank" class="term-link">
                                     GO:0045048
                                 </a>
                             </span>
                             <span class="term-label">protein insertion into ER membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/21866104" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:21866104
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The mechanism of membrane-associated steps in tail-anchored ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3172,46 +3412,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: protein insertion into ER membrane is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and **Get1 driving ATPase-dependent substrate release** for insertion</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-SCE-9628646
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3223,57 +3479,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: ATP hydrolysis activity is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Functionally, ATP hydrolysis is required for productive insertion because a hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071816" target="_blank" class="term-link">
                                     GO:0071816
                                 </a>
                             </span>
                             <span class="term-label">tail-anchored membrane protein insertion into ER membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18724936" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18724936
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The GET complex mediates insertion of tail-anchored proteins...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3285,57 +3557,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: tail-anchored membrane protein insertion into ER membrane is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and **Get1 driving ATPase-dependent substrate release** for insertion</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0008270" target="_blank" class="term-link">
                                     GO:0008270
                                 </a>
                             </span>
                             <span class="term-label">zinc ion binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">RCA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:30358795
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The cellular economy of the Saccharomyces cerevisiae zinc pr...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3347,119 +3635,135 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: zinc ion binding may be context-dependent or peripheral for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0044183" target="_blank" class="term-link">
                                     GO:0044183
                                 </a>
                             </span>
                             <span class="term-label">protein folding chaperone</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25242142" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25242142
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The protein targeting factor Get3 functions as ATP-independe...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-markasoverannotated">
-                            MARK AS OVER ANNOTATED
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0044183" data-r="PMID:25242142" data-act="MARK_AS_OVER_ANNOTATED">
+                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0044183" data-r="PMID:25242142" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: protein folding chaperone is too generic or over-extended for GET3.
+                            <strong>Summary:</strong> Manual review: protein folding chaperone activity is supported under oxidative or ATP-depleting stress but is not the core GET-pathway function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Marked over-annotated because more specific terms capture the biology more accurately.
+                            <strong>Reason:</strong> Keep as non-core because Get3 has a regulated ATP-independent holdase role during oxidative stress, while the primary function remains ATP-dependent tail-anchored protein targeting to the ER.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">under oxidative stress or ATP depletion, Get3 is converted from ATPase targeting factor into an **ATP-independent holdase chaperone**.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043529" target="_blank" class="term-link">
                                     GO:0043529
                                 </a>
                             </span>
                             <span class="term-label">GET complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/32910895" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:32910895
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Structural Basis of Tail-Anchored Membrane Protein Biogenesi...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3471,57 +3775,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: GET complex is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is ATP-sensitive and reversible</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:26928762
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     One library to make them all: streamlining the creation of y...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3533,57 +3853,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: cytosol is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is ATP-sensitive and reversible</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005783" target="_blank" class="term-link">
                                     GO:0005783
                                 </a>
                             </span>
                             <span class="term-label">endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">HDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:14562095
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Global analysis of protein localization in budding yeast.
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3595,46 +3931,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: endoplasmic reticulum is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is ATP-sensitive and reversible</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-SCE-9628640
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3646,46 +3998,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: cytosol is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is ATP-sensitive and reversible</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-SCE-9628646
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3697,46 +4065,62 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: cytosol is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is ATP-sensitive and reversible</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
                                     GO:0005829
                                 </a>
                             </span>
                             <span class="term-label">cytosol</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">TAS</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             Reactome:R-SCE-9629050
-                            
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -3748,57 +4132,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: cytosol is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is ATP-sensitive and reversible</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0034599" target="_blank" class="term-link">
                                     GO:0034599
                                 </a>
                             </span>
                             <span class="term-label">cellular response to oxidative stress</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25242142" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25242142
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The protein targeting factor Get3 functions as ATP-independe...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3810,130 +4210,135 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: cellular response to oxidative stress may be context-dependent or peripheral for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0051082" target="_blank" class="term-link">
                                     GO:0051082
                                 </a>
                             </span>
                             <span class="term-label">unfolded protein binding</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/25242142" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:25242142
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The protein targeting factor Get3 functions as ATP-independe...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
-                        <span class="action-badge action-modify">
-                            MODIFY
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
                         </span>
-                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0051082" data-r="PMID:25242142" data-act="MODIFY">
+                        <span class="vote-buttons" data-g="Q12154" data-a="GO:0051082" data-r="PMID:25242142" data-act="KEEP_AS_NON_CORE">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: unfolded protein binding is better represented by a more specific replacement term for GET3.
+                            <strong>Summary:</strong> Manual review: unfolded protein binding is supported for the oxidative-stress holdase state of Get3 but is condition-specific.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Modified to align with current curation guidance and improve term specificity.
+                            <strong>Reason:</strong> Keep as non-core rather than replacing it; Falcon and the source literature support unfolded-protein binding during stress-induced Get3 holdase activity, distinct from the core GET targeting ATPase cycle.
                         </div>
-                        
-                        
-                        <div style="margin-top: 0.5rem;">
-                            <strong>Proposed replacements:</strong>
-                            
-                            <span class="badge">
-                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140597" target="_blank" class="term-link">
-                                    protein carrier chaperone
-                                </a>
-                            </span>
-                            
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">under oxidative stress or ATP depletion, Get3 is converted from ATPase targeting factor into an **ATP-independent holdase chaperone**.</div>
+
+                            </div>
+
                         </div>
-                        
-                        
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0000750" target="_blank" class="term-link">
                                     GO:0000750
                                 </a>
                             </span>
                             <span class="term-label">pheromone-dependent signal transduction involved in conjugation with cellular fusion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18261907" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18261907
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Coactivation of G protein signaling by cell-surface receptor...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -3945,57 +4350,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: pheromone-dependent signal transduction involved in conjugation with cellular fusion may be context-dependent or peripheral for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005085" target="_blank" class="term-link">
                                     GO:0005085
                                 </a>
                             </span>
                             <span class="term-label">guanyl-nucleotide exchange factor activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/18261907" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:18261907
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Coactivation of G protein signaling by cell-surface receptor...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4007,57 +4412,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: guanyl-nucleotide exchange factor activity may be context-dependent or peripheral for GET3.
+                            <strong>Summary:</strong> Manual review: guanyl-nucleotide exchange factor activity for Gpa1 is directly reported but remains context-specific relative to the canonical GET pathway.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Keep as non-core because one quantitative source supports Arr4/Get3 GEF activity in pheromone signaling, but this role is less integrated with later GET-pathway mechanistic literature than TA-protein targeting.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">A 2008 study reported that Arr4 is a **non-receptor GEF for Gpa1** and indicates that **Arr4 is an alias of Get3**</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006620" target="_blank" class="term-link">
                                     GO:0006620
                                 </a>
                             </span>
                             <span class="term-label">post-translational protein targeting to endoplasmic reticulum membrane</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/20850366" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:20850366
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     A chaperone cascade sorts proteins for posttranslational mem...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4069,57 +4490,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: post-translational protein targeting to endoplasmic reticulum membrane is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and **Get1 driving ATPase-dependent substrate release** for insertion</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006890" target="_blank" class="term-link">
                                     GO:0006890
                                 </a>
                             </span>
                             <span class="term-label">retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16269340" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16269340
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Exploration of the function and organization of the yeast ea...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4131,57 +4568,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum may be context-dependent or peripheral for GET3.
+                            <strong>Summary:</strong> Manual review: Golgi-to-ER retrograde transport evidence appears indirect for GET3 and should not be treated as core function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Keep as non-core because the reviewed GET-pathway literature does not provide direct Erd2/HDEL-mediated retrograde-transport evidence for Get3; trafficking effects may be secondary to TA-client targeting or proteostasis defects.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">No direct evidence for Erd2/HDEL-mediated retrograde transport involvement was found in the retrieved primary mechanistic GET literature.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006890" target="_blank" class="term-link">
                                     GO:0006890
                                 </a>
                             </span>
                             <span class="term-label">retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16269340" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16269340
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Exploration of the function and organization of the yeast ea...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4193,57 +4646,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum may be context-dependent or peripheral for GET3.
+                            <strong>Summary:</strong> Manual review: Golgi-to-ER retrograde transport evidence appears indirect for GET3 and should not be treated as core function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Keep as non-core because the reviewed GET-pathway literature does not provide direct Erd2/HDEL-mediated retrograde-transport evidence for Get3; trafficking effects may be secondary to TA-client targeting or proteostasis defects.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">No direct evidence for Erd2/HDEL-mediated retrograde transport involvement was found in the retrieved primary mechanistic GET literature.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006890" target="_blank" class="term-link">
                                     GO:0006890
                                 </a>
                             </span>
                             <span class="term-label">retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IGI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16269340" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16269340
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Exploration of the function and organization of the yeast ea...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4255,57 +4724,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> Manual review: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum may be context-dependent or peripheral for GET3.
+                            <strong>Summary:</strong> Manual review: Golgi-to-ER retrograde transport evidence appears indirect for GET3 and should not be treated as core function.
                         </div>
-                        
-                        
+
+
                         <div>
-                            <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+                            <strong>Reason:</strong> Keep as non-core because the reviewed GET-pathway literature does not provide direct Erd2/HDEL-mediated retrograde-transport evidence for Get3; trafficking effects may be secondary to TA-client targeting or proteostasis defects.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">No direct evidence for Erd2/HDEL-mediated retrograde transport involvement was found in the retrieved primary mechanistic GET literature.</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009408" target="_blank" class="term-link">
                                     GO:0009408
                                 </a>
                             </span>
                             <span class="term-label">response to heat</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12680698" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12680698
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Saccharomyces cerevisiae Arr4p is involved in metal and ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4317,57 +4802,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: response to heat may be context-dependent or peripheral for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0010038" target="_blank" class="term-link">
                                     GO:0010038
                                 </a>
                             </span>
                             <span class="term-label">response to metal ion</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IMP</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12680698" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12680698
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Saccharomyces cerevisiae Arr4p is involved in metal and ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-keepasnoncore">
@@ -4379,57 +4864,57 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: response to metal ion may be context-dependent or peripheral for GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
                         </div>
-                        
-                        
-                        
+
+
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
                                     GO:0016887
                                 </a>
                             </span>
                             <span class="term-label">ATP hydrolysis activity</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IDA</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/12680698" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:12680698
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     The Saccharomyces cerevisiae Arr4p is involved in metal and ...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4441,57 +4926,73 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: ATP hydrolysis activity is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Functionally, ATP hydrolysis is required for productive insertion because a hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
                 <tr>
                     <td>
                         <div class="term-info">
-                            
+
                             <span class="term-id">
                                 <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0043529" target="_blank" class="term-link">
                                     GO:0043529
                                 </a>
                             </span>
                             <span class="term-label">GET complex</span>
-                            
+
                         </div>
                     </td>
                     <td>
                         <span class="evidence-code">IPI</span>
-                        
-                        
-                        
+
+
+
                         <br>
                         <span style="font-size: 0.75rem;">
-                            
+
                             <a href="https://pubmed.ncbi.nlm.nih.gov/16269340" target="_blank" class="term-link" style="font-size: 0.75rem;">
                                 PMID:16269340
                             </a>
-                            
-                                
-                                
+
+
+
                                 <br>
                                 <span style="font-size: 0.7rem; color: #666; font-style: italic;">
                                     Exploration of the function and organization of the yeast ea...
                                 </span>
-                                
-                            
-                            
+
+
+
                         </span>
-                        
+
                     </td>
                     <td>
                         <span class="action-badge action-accept">
@@ -4503,635 +5004,1165 @@
                         </span>
                     </td>
                     <td>
-                        
+
                         <div style="margin-bottom: 0.5rem;">
                             <strong>Summary:</strong> Manual review: GET complex is consistent with known biology of GET3.
                         </div>
-                        
-                        
+
+
                         <div>
                             <strong>Reason:</strong> Retained as supported or plausible for this gene and evidence context.
                         </div>
-                        
-                        
-                        
+
+
+
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+
+                            <div class="support-item">
+                                <span class="support-ref">
+
+                                    file:yeast/GET3/GET3-deep-research-falcon.md
+
+                                </span>
+
+                                <div class="support-text">Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is ATP-sensitive and reversible</div>
+
+                            </div>
+
+                        </div>
+
                     </td>
                 </tr>
-                
+
             </tbody>
         </table>
     </div>
-    
 
-    
 
-    
+
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+
+        <div class="core-function-card">
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Get3 is the central ATPase of the yeast GET pathway. As a cytosolic homodimer, it binds and shields tail-anchored protein transmembrane domains, delivers the client to the ER Get1/Get2 receptor/insertase, and uses ATP hydrolysis to drive productive release and insertion into the ER membrane.</h3>
+                <span class="vote-buttons" data-g="Q12154" data-a="FUNCTION: Get3 is the central ATPase of the yeast GET pathwa..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+
+
+            <div class="core-function-terms">
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016887" target="_blank" class="term-link">
+                            ATP hydrolysis activity
+                        </a>
+                    </span>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0071816" target="_blank" class="term-link">
+                                tail-anchored membrane protein insertion into ER membrane
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006620" target="_blank" class="term-link">
+                                post-translational protein targeting to endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005829" target="_blank" class="term-link">
+                                cytosol
+                            </a>
+                        </span>
+
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005789" target="_blank" class="term-link">
+                                endoplasmic reticulum membrane
+                            </a>
+                        </span>
+
+                    </div>
+                </div>
+
+
+
+
+
+            </div>
+
+
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/GET3/GET3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Functionally, ATP hydrolysis is required for productive insertion because a hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/GET3/GET3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide dependent</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/GET3/GET3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and **Get1 driving ATPase-dependent substrate release** for insertion</div>
+
+                    </li>
+
+                    <li class="finding-item">
+                        <span class="reference-id">
+
+                            file:yeast/GET3/GET3-deep-research-falcon.md
+
+                        </span>
+
+                        <div class="finding-text">Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is ATP-sensitive and reversible</div>
+
+                    </li>
+
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class="section">
         <h2 class="section-title collapsible">References</h2>
         <div class="collapse-content">
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
+                        file:yeast/GET3/GET3-deep-research-falcon.md
+
+                    </span>
+                </div>
+
+                <div class="reference-title">Falcon deep research report for GET3</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
+                        file:yeast/GET3/GET3-uniprot.txt
+
+                    </span>
+                </div>
+
+                <div class="reference-title">UniProt record for yeast GET3</div>
+
+
+            </div>
+
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000002.md" target="_blank" class="term-link">
                             GO_REF:0000002
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation through association of InterPro records with GO terms</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000033.md" target="_blank" class="term-link">
                             GO_REF:0000033
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Annotation inferences using phylogenetic trees</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000043.md" target="_blank" class="term-link">
                             GO_REF:0000043
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
                             GO_REF:0000044
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000104.md" target="_blank" class="term-link">
                             GO_REF:0000104
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Electronic Gene Ontology annotations created by transferring manual GO annotations between related proteins based on shared sequence features</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000108.md" target="_blank" class="term-link">
                             GO_REF:0000108
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Automatic assignment of GO terms using logical inference, based on on inter-ontology links</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000120.md" target="_blank" class="term-link">
                             GO_REF:0000120
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Combined Automated Annotation using Multiple IEA Methods</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11283351" target="_blank" class="term-link">
                             PMID:11283351
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A comprehensive two-hybrid analysis to explore the yeast protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/11805837" target="_blank" class="term-link">
                             PMID:11805837
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Systematic identification of protein complexes in Saccharomyces cerevisiae by mass spectrometry.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/12680698" target="_blank" class="term-link">
                             PMID:12680698
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The Saccharomyces cerevisiae Arr4p is involved in metal and heat tolerance.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/14562095" target="_blank" class="term-link">
                             PMID:14562095
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global analysis of protein localization in budding yeast.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16260785" target="_blank" class="term-link">
                             PMID:16260785
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The yeast Arr4p ATPase binds the chloride transporter Gef1p when copper is available in the cytosol.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16269340" target="_blank" class="term-link">
                             PMID:16269340
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Exploration of the function and organization of the yeast early secretory pathway through an epistatic miniarray profile.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16429126" target="_blank" class="term-link">
                             PMID:16429126
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Proteome survey reveals modularity of the yeast cell machinery.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16554755" target="_blank" class="term-link">
                             PMID:16554755
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Global landscape of protein complexes in the yeast Saccharomyces cerevisiae.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/16816426" target="_blank" class="term-link">
                             PMID:16816426
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The conserved ATPase Get3/Arr4 modulates the activity of membrane-associated proteins in Saccharomyces cerevisiae.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18261907" target="_blank" class="term-link">
                             PMID:18261907
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Coactivation of G protein signaling by cell-surface receptors and an intracellular exchange factor.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18467557" target="_blank" class="term-link">
                             PMID:18467557
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An in vivo map of the yeast protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18719252" target="_blank" class="term-link">
                             PMID:18719252
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">High-quality binary protein interaction map of the yeast interactome network.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/18724936" target="_blank" class="term-link">
                             PMID:18724936
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The GET complex mediates insertion of tail-anchored proteins into the ER membrane.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19675567" target="_blank" class="term-link">
                             PMID:19675567
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The structural basis of tail-anchored membrane protein recognition by Get3.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/19706470" target="_blank" class="term-link">
                             PMID:19706470
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Model for eukaryotic tail-anchored protein binding based on the structure of Get3.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20106980" target="_blank" class="term-link">
                             PMID:20106980
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Crystal structure of Get4-Get5 complex and its interactions with Sgt2, Get3, and Ydj1.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/20850366" target="_blank" class="term-link">
                             PMID:20850366
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">A chaperone cascade sorts proteins for posttranslational membrane insertion into the endoplasmic reticulum.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/21866104" target="_blank" class="term-link">
                             PMID:21866104
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The mechanism of membrane-associated steps in tail-anchored protein insertion.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/22124326" target="_blank" class="term-link">
                             PMID:22124326
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Tail-anchor targeting by a Get3 tetramer: the structure of an archaeal homologue.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/24727835" target="_blank" class="term-link">
                             PMID:24727835
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Crystal structure of ATP-bound Get3-Get4-Get5 complex reveals regulation of Get3 by Get4.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25242142" target="_blank" class="term-link">
                             PMID:25242142
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The protein targeting factor Get3 functions as ATP-independent chaperone under oxidative stress conditions.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/25745174" target="_blank" class="term-link">
                             PMID:25745174
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Protein targeting. Structure of the Get3 targeting factor in complex with its membrane protein cargo.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/26928762" target="_blank" class="term-link">
                             PMID:26928762
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/27107014" target="_blank" class="term-link">
                             PMID:27107014
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">An inter-species protein-protein interaction network across vast evolutionary distance.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/30358795" target="_blank" class="term-link">
                             PMID:30358795
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The cellular economy of the Saccharomyces cerevisiae zinc proteome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/32910895" target="_blank" class="term-link">
                             PMID:32910895
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">Structural Basis of Tail-Anchored Membrane Protein Biogenesis by the GET Insertase Complex.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         <a href="https://pubmed.ncbi.nlm.nih.gov/37968396" target="_blank" class="term-link">
                             PMID:37968396
                         </a>
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">The social and structural architecture of the yeast protein interactome.</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-SCE-9628640
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">SBH1:GET3:ADP:GET1:GET2 dissociates yielding SBH1 in the endoplasmic reticulum membrane</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-SCE-9628646
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">SBH1:GET3:ADP binds GET1:GET2</div>
-                
-                
+
+
             </div>
-            
+
             <div class="reference-item">
                 <div class="reference-header">
                     <span class="reference-id">
-                        
+
                         Reactome:R-SCE-9629050
-                        
+
                     </span>
                 </div>
-                
+
                 <div class="reference-title">SBH1:GET3:ATP:GET4:MDY2:SGT2 dissociates and GET3 hydrolyzes ATP yielding SBH1:GET3:ADP</div>
-                
-                
+
+
             </div>
-            
+
         </div>
     </div>
-    
 
 
-    
 
-    
 
-    
+
+
+
+
 
     <!-- Computational Predictions Section -->
-    
+
 
     <!-- Additional Documentation Sections -->
-    
+
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(GET3-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q12154" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <hr />
+<p>provider: falcon<br />
+model: Edison Scientific Literature<br />
+cached: false<br />
+start_time: '2026-05-13T03:01:39.869307'<br />
+end_time: '2026-05-13T03:18:20.507928'<br />
+duration_seconds: 1000.64<br />
+provider_config:<br />
+  timeout: 600<br />
+  max_retries: 3<br />
+  parameters:<br />
+    allowed_domains: []<br />
+    temperature: 0.1<br />
+citation_count: 46</p>
+<hr />
+<h2 id="question">Question</h2>
+<p>GO annotation research for Saccharomyces cerevisiae GET3/ARR4 (UniProt Q12154). Focus on GO evidence for core functions: ATPase/ATP hydrolysis and ATP binding, homodimeric GET3 as cytosolic targeting factor for tail-anchored membrane proteins, binding/shielding TA protein transmembrane domains, delivery to the ER membrane GET1/GET2 insertase/receptor, tail-anchored membrane protein insertion into ER membrane, GET complex, cytosol/cytoplasm and ER membrane localization. Evaluate non-core or context-specific roles: oxidative-stress ATP-independent holdase/chaperone, protein folding/unfolded protein binding, heat/metal/arsenite response, Golgi-to-ER retrograde transport with Erd2/HDEL receptor, guanyl-nucleotide exchange factor activity for Gpa1/pheromone signaling, generic protein binding and identical protein binding. Include PMID/DOI citations and keep under 1200 words.</p>
+<h2 id="output">Output</h2>
+<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
+<p>Provide detailed information focusing on:<br />
+1. Key concepts and definitions with current understanding<br />
+2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
+3. Current applications and real-world implementations<br />
+4. Expert opinions and analysis from authoritative sources<br />
+5. Relevant statistics and data from recent studies</p>
+<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
+<p>GO annotation research for Saccharomyces cerevisiae GET3/ARR4 (UniProt Q12154). Focus on GO evidence for core functions: ATPase/ATP hydrolysis and ATP binding, homodimeric GET3 as cytosolic targeting factor for tail-anchored membrane proteins, binding/shielding TA protein transmembrane domains, delivery to the ER membrane GET1/GET2 insertase/receptor, tail-anchored membrane protein insertion into ER membrane, GET complex, cytosol/cytoplasm and ER membrane localization. Evaluate non-core or context-specific roles: oxidative-stress ATP-independent holdase/chaperone, protein folding/unfolded protein binding, heat/metal/arsenite response, Golgi-to-ER retrograde transport with Erd2/HDEL receptor, guanyl-nucleotide exchange factor activity for Gpa1/pheromone signaling, generic protein binding and identical protein binding. Include PMID/DOI citations and keep under 1200 words.</p>
+<h2 id="research-report-go-annotation-evidence-for-s-cerevisiae-get3arr4-uniprot-q12154">Research report: GO-annotation evidence for <em>S. cerevisiae</em> Get3/Arr4 (UniProt Q12154)</h2>
+<h3 id="scope-and-sources">Scope and sources</h3>
+<p>This report summarizes Gene Ontology (GO)-relevant experimental evidence for Get3/Arr4, emphasizing core Guided Entry of Tail-anchored proteins (GET) pathway roles and evaluating proposed non-core/context-specific roles. Priority is given to recent 2023–2024 work when available, complemented by high-confidence mechanistic primary studies.</p>
+<p>A compact evidence map is provided in the table artifact below.</p>
+<table>
+<thead>
+<tr>
+<th>GO aspect</th>
+<th>Proposed GO term/concept</th>
+<th>Evidence summary</th>
+<th>Key quantitative data</th>
+<th>Strongest supporting citations with year/DOI/URL</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>MF</td>
+<td>ATPase activity / ATP hydrolysis</td>
+<td>Get3 is a SIMIBI-class ATPase whose nucleotide cycle drives conformational switching needed for TA-client release at the ER; hydrolysis-defective mutants remain substrate-bound and insertion-defective.</td>
+<td>Get2 binds ATP-bound Get3 with Kd ~190 nM; Get1 binds post-release apo-Get3 with Kd ~50 nM.</td>
+<td>Mariappan et al., 2011, doi:10.1038/nature10362, https://doi.org/10.1038/nature10362; Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334 (mariappan2011themechanismof pages 22-25, denic2013endoplasmicreticulumtargeting pages 5-7)</td>
+</tr>
+<tr>
+<td>MF</td>
+<td>ATP binding</td>
+<td>Structural states with AMPPNP, ADP, and ADP·AlF4− show ATP-dependent open/closed Get3 dimer conformations required for substrate capture and receptor engagement.</td>
+<td>ATP-bound state preferentially engages Get4/Get5; Get4/Get5 has ~10-fold lower affinity for ADP-bound Get3.</td>
+<td>Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334; Jennrich, 2024, doi:10.53846/goediss-10715, https://doi.org/10.53846/goediss-10715 (denic2013endoplasmicreticulumtargeting pages 5-7, jennrich2024characterizationofstressinduced pages 20-23)</td>
+</tr>
+<tr>
+<td>MF</td>
+<td>Tail-anchored membrane protein binding / TMD shielding</td>
+<td>Zn2+-stabilized homodimeric Get3 forms a composite hydrophobic groove that binds and shields α-helical TA transmembrane domains in the cytosol.</td>
+<td>Hydrophilizing groove mutations reduce TA binding; hydrolysis-deficient D57N/D57E mutants trap substrate-bound states.</td>
+<td>Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334; Mariappan et al., 2011, doi:10.1038/nature10362, https://doi.org/10.1038/nature10362 (denic2013endoplasmicreticulumtargeting pages 5-7, mariappan2011themechanismof pages 22-25)</td>
+</tr>
+<tr>
+<td>MF</td>
+<td>Identical protein binding / homodimerization</td>
+<td>Get3 functions as an obligate homodimer, and dimer closure generates the TA-binding site central to GET-pathway activity.</td>
+<td>Obligatory Zn2+-coordinated homodimer; tetramers also observed under oxidizing/stress conditions.</td>
+<td>Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334; Jennrich, 2024, doi:10.53846/goediss-10715, https://doi.org/10.53846/goediss-10715 (denic2013endoplasmicreticulumtargeting pages 5-7, jennrich2024characterizationofstressinduced pages 20-23)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>Cytosolic targeting factor for TA proteins</td>
+<td>Get3 receives TA clients from the Sgt2/Get4/Get5 pretargeting machinery and escorts them post-translationally from the cytosol to the ER receptor.</td>
+<td>Reconstituted Get3–Sec22 complexes are insertion-competent.</td>
+<td>Wang et al., 2011, doi:10.1016/j.molcel.2011.07.020, https://doi.org/10.1016/j.molcel.2011.07.020; Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334 (wang2011themechanismof pages 1-2, denic2013endoplasmicreticulumtargeting pages 4-5)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>Delivery to ER membrane Get1/Get2 receptor/insertase</td>
+<td>Get2 first tethers the Get3-TA complex to the ER, then Get1 binds and wedges open Get3 to trigger cargo release for membrane insertion.</td>
+<td>Minimal functional membrane machinery is Get1/Get2; ATP disrupts Get1–Get3 complex for recycling.</td>
+<td>Mariappan et al., 2011, doi:10.1038/nature10362, https://doi.org/10.1038/nature10362; Wang et al., 2011, doi:10.1016/j.molcel.2011.07.020, https://doi.org/10.1016/j.molcel.2011.07.020 (mariappan2011themechanismof pages 22-25, wang2011themechanismof pages 1-2)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>Tail-anchored protein insertion into ER membrane</td>
+<td>Get1/Get2 constitute the ER insertase/receptor complex, and Get3 ATPase cycling is essential for productive TA insertion rather than mere docking.</td>
+<td>A single Get1/2 heterodimer can function as minimal insertase; recent work supports a Get1/2 channel mechanism.</td>
+<td>Wang et al., 2011, doi:10.1016/j.molcel.2011.07.020, https://doi.org/10.1016/j.molcel.2011.07.020; Heo et al., 2023, doi:10.1016/j.celrep.2022.111921, https://doi.org/10.1016/j.celrep.2022.111921 (wang2011themechanismof pages 1-2, zalisko2017tailanchoredprotein pages 6-11)</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>Cytosol / cytoplasm</td>
+<td>Core GET-pathway function places Get3 in the cytosol as the soluble TA-targeting ATPase that shuttles between pretargeting factors and the ER.</td>
+<td>In stress/starvation, soluble Get3 relocalizes to cytosolic foci/GET bodies within ~1 h.</td>
+<td>Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334; Jennrich, 2024, doi:10.53846/goediss-10715, https://doi.org/10.53846/goediss-10715 (denic2013endoplasmicreticulumtargeting pages 5-7, jennrich2024characterizationofstressinduced pages 113-115)</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>Endoplasmic reticulum membrane</td>
+<td>A substantial fraction of Get3 is membrane-associated through interaction with the ER Get1/Get2 receptor complex during cargo delivery and recycling.</td>
+<td>Membrane association is ATP-sensitive and reversible.</td>
+<td>Wang et al., 2011, doi:10.1016/j.molcel.2011.07.020, https://doi.org/10.1016/j.molcel.2011.07.020; Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334 (wang2011themechanismof pages 1-2, denic2013endoplasmicreticulumtargeting pages 5-7)</td>
+</tr>
+<tr>
+<td>CC</td>
+<td>GET complex</td>
+<td>Get3 physically and functionally associates with the pretargeting complex (Sgt2/Get4/Get5) and the ER receptor/insertase (Get1/Get2), defining it as a core GET-pathway component.</td>
+<td>Loss of GET components causes strong aggregation/proteostasis phenotypes; in 2023 screening, GET1/2/3 were top hits.</td>
+<td>Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334; Josefson et al., 2023, doi:10.1038/s41598-023-35666-8, https://doi.org/10.1038/s41598-023-35666-8 (denic2013endoplasmicreticulumtargeting pages 3-4, josefson2023thegetpathway pages 1-2)</td>
+</tr>
+<tr>
+<td>MF/BP</td>
+<td>Unfolded protein binding / ATP-independent holdase chaperone</td>
+<td>Under oxidative or ATP-depleting stress, Get3 undergoes redox remodeling and switches from TA-targeting ATPase to ATP-independent holdase that binds unfolding proteins and suppresses aggregation.</td>
+<td>Chaperone activation T1/2 &lt;1 min with H2O2/Cu2+ and ~5 min with H2O2 alone; oxidized Get3 retains &lt;20% ATPase activity; near-complete citrate synthase aggregation suppression at 8:1 Get3:substrate.</td>
+<td>Voth et al., 2014, doi:10.1016/j.molcel.2014.08.017, https://doi.org/10.1016/j.molcel.2014.08.017; Powis et al., 2013, doi:10.1242/jcs.112151, https://doi.org/10.1242/jcs.112151 (voth2014theproteintargeting pages 2-3, powis2013get3isa pages 6-7)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>Response to oxidative stress / metal stress</td>
+<td>get3Δ cells show copper and oxidative-stress sensitivity, and oxidized Get3 accumulates in stress foci with Hsp70/Hsp104, supporting a condition-specific stress-protective role.</td>
+<td>Example condition: 1 mM CuSO4 at 37°C for 4 h induces relocalization; Get3 abundance ~17,300 molecules/cell vs Get1 ~2,250.</td>
+<td>Voth et al., 2014, doi:10.1016/j.molcel.2014.08.017, https://doi.org/10.1016/j.molcel.2014.08.017; Reichmann et al., 2018, doi:10.1016/j.molcel.2017.12.021, https://doi.org/10.1016/j.molcel.2017.12.021 (voth2014theproteintargeting pages 9-10, voth2014theproteintargeting pages 8-9, reichmann2018maintainingahealthy pages 3-4)</td>
+</tr>
+<tr>
+<td>MF/BP</td>
+<td>Guanine nucleotide exchange factor activity for Gpa1 / pheromone signaling</td>
+<td>Arr4 and Get3 are aliases, and a 2008 study reported direct Gpa1 binding, accelerated nucleotide exchange, and reduced pheromone signaling in arr4Δ cells, but this role is less integrated into the later core Get3 literature and should be treated as context-specific/cautious.</td>
+<td>GTPγS binding increased from 0.085 to 0.36 pmol/pmol/min; Pi release from 0.009 to 0.021 pmol/pmol/min; arr4Δ reduced pheromone-induced FUS1-lacZ by ~50% and mating by ~40%.</td>
+<td>Lee, 2008, doi:10.17615/tt4v-sn52, https://doi.org/10.17615/tt4v-sn52; Garcia-Marcos, 2024, doi:10.1016/j.jbc.2024.105756, https://doi.org/10.1016/j.jbc.2024.105756 (michael2008activationofg pages 128-134, michael2008activationofg pages 121-128, michael2008activationofg pages 167-173)</td>
+</tr>
+<tr>
+<td>BP/CC</td>
+<td>Golgi-to-ER retrograde transport with Erd2/HDEL receptor</td>
+<td>Retrieved sources do not provide direct mechanistic evidence for Get3 in Erd2/HDEL-mediated retrograde transport; available data suggest any trafficking effects are indirect consequences of TA-client mislocalization/proteostasis defects.</td>
+<td>Negative evidence: Get3 foci under starvation were explicitly not Golgi-localized.</td>
+<td>Powis et al., 2013, doi:10.1242/jcs.112151, https://doi.org/10.1242/jcs.112151 (powis2013get3isa pages 3-5, powis2013get3isa pages 7-8, powis2013get3isa pages 6-7)</td>
+</tr>
+<tr>
+<td>BP</td>
+<td>Proteostasis bottleneck / recent 2023 development</td>
+<td>A 2023 genome-wide screen found GET pathway loss to be a major non-stress proteostasis bottleneck, indicating broad cellular consequences beyond TA-client targeting.</td>
+<td>Nearly 100% of get1Δ/get2Δ/get3Δ cells displayed Hsp104-GFP foci; 24% of get2Δ foci-forming hits were intrinsically disordered vs ~7.7% expected genome-wide; get3Δ median replicative lifespan 14 vs WT 20 generations.</td>
+<td>Josefson et al., 2023, doi:10.1038/s41598-023-35666-8, https://doi.org/10.1038/s41598-023-35666-8 (josefson2023thegetpathway pages 1-2, josefson2023thegetpathway pages 3-5, josefson2023thegetpathway pages 6-8)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: This table summarizes GO-relevant evidence for Saccharomyces cerevisiae Get3/Arr4 (Q12154) across molecular function, biological process, and cellular component. It highlights strongly supported core GET-pathway annotations and distinguishes stress-induced or less-established context-specific roles.</em></p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<p><strong>Tail-anchored (TA) membrane proteins</strong> are defined by a single C-terminal transmembrane domain (TMD) that emerges only after translation termination; thus they require <strong>post-translational targeting and insertion</strong> into the ER membrane. The yeast GET pathway comprises a <strong>cytosolic pre-targeting complex</strong> (Sgt2/Get4/Get5), the central targeting ATPase <strong>Get3</strong>, and the ER membrane receptor/insertase <strong>Get1/Get2</strong>. Get3/Arr4 is therefore naturally annotated across GO aspects: <strong>Molecular Function (MF)</strong> (ATP binding/hydrolysis; TA-client binding), <strong>Biological Process (BP)</strong> (TA targeting/insertion), and <strong>Cellular Component (CC)</strong> (cytosol and ER membrane/GET complex) (denic2013endoplasmicreticulumtargeting pages 4-5, denic2013endoplasmicreticulumtargeting pages 5-7).</p>
+<p>Mechanistically, Get3 is a <strong>SIMIBI-class ATPase</strong> whose nucleotide state controls an <strong>open/closed homodimer</strong> cycle that binds, shields, and releases hydrophobic TMDs, enabling safe cytosolic transit and delivery to the ER receptor (denic2013endoplasmicreticulumtargeting pages 5-7, mariappan2011themechanismof pages 22-25).</p>
+<h3 id="2-core-go-evidence-for-canonical-get-pathway-functions">2) Core GO evidence for canonical GET-pathway functions</h3>
+<h4 id="21-atp-binding-and-atpaseatp-hydrolysis-mf">2.1 ATP binding and ATPase/ATP hydrolysis (MF)</h4>
+<p>Structural and biochemical evidence supports that Get3 is an ATPase with multiple nucleotide-linked conformations (open/closed/transition-state analog), consistent with GO:ATP binding and ATP hydrolysis-coupled function (denic2013endoplasmicreticulumtargeting pages 5-7, denic2013endoplasmicreticulumtargeting pages 4-5). Functionally, ATP hydrolysis is required for productive insertion because a hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays (mariappan2011themechanismof pages 22-25). </p>
+<p>Quantitative receptor-binding parameters link the nucleotide cycle to ER docking: Get2 binds ATP-bound Get3 with <strong>Kd ~190 nM</strong>, and the post-release Get1–Get3 nucleotide-free complex is very stable (<strong>Kd ~50 nM</strong>) (mariappan2011themechanismof pages 22-25).</p>
+<h4 id="22-homodimeric-cytosolic-targeting-factor-ta-tmd-bindingshielding-mfbp">2.2 Homodimeric cytosolic targeting factor; TA-TMD binding/shielding (MF/BP)</h4>
+<p>Get3 is described as a <strong>Zn2+-stabilized homodimer</strong> whose dimer interface forms a <strong>composite hydrophobic groove</strong> that binds an α-helical TA TMD; mutations that increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide dependent (denic2013endoplasmicreticulumtargeting pages 5-7). Get2 can bind the ATP-closed Get3 conformation without disrupting the hydrophobic groove, supporting a model where Get3 <strong>shields the TA TMD during delivery</strong> (mariappan2011themechanismof pages 22-25).</p>
+<h4 id="23-delivery-to-er-get1get2-receptorinsertase-and-ta-insertion-bp">2.3 Delivery to ER Get1/Get2 receptor/insertase and TA insertion (BP)</h4>
+<p>Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane machinery for insertion, with <strong>Get2 tethering</strong> membrane-proximal Get3–TA complexes and <strong>Get1 driving ATPase-dependent substrate release</strong> for insertion (wang2011themechanismof pages 1-2). Mechanistically, Get1 can “wedge open” Get3 after nucleotide hydrolysis to trigger TMD release, and ATP promotes disruption/dissociation of the Get1–Get3 complex to recycle Get3 (mariappan2011themechanismof pages 22-25). </p>
+<p><strong>Recent development (2023):</strong> a mechanistic update supports the concept that the <strong>Get1/2 insertase forms a channel</strong> mediating TA insertion, refining how GO “TA insertion into ER membrane” may be interpreted structurally/mechanistically in modern annotations (Heo et al., 2023-01; doi:10.1016/j.celrep.2022.111921; https://doi.org/10.1016/j.celrep.2022.111921) (zalisko2017tailanchoredprotein pages 6-11).</p>
+<h4 id="24-localization-cytosolcytoplasm-and-er-membrane-get-complex-cc">2.4 Localization: cytosol/cytoplasm and ER membrane; GET complex (CC)</h4>
+<p>Core pathway evidence places Get3 as a <strong>cytosolic shuttle</strong> that also becomes <strong>ER membrane-associated</strong> via Get1/Get2 during docking/release; membrane association is ATP-sensitive and reversible (wang2011themechanismof pages 1-2, denic2013endoplasmicreticulumtargeting pages 5-7). Accordingly, CC annotations should include cytosol/cytoplasm and association with the ER membrane GET receptor complex.</p>
+<h3 id="3-non-corecontext-specific-roles-evidence-strength-and-go-implications">3) Non-core/context-specific roles: evidence strength and GO implications</h3>
+<h4 id="31-atp-independent-holdasechaperone-unfolded-protein-binding-oxidative-stress-response-mfbp">3.1 ATP-independent holdase/chaperone; unfolded protein binding; oxidative stress response (MF/BP)</h4>
+<p><strong>Strong evidence supports a regulated “moonlighting” role</strong>: under oxidative stress or ATP depletion, Get3 is converted from ATPase targeting factor into an <strong>ATP-independent holdase chaperone</strong>.</p>
+<p>Mechanism: oxidation triggers disulfide bond formation and zinc release with partial unfolding/oligomerization; oxidized Get3 becomes ATPase-inactive yet binds unfolding proteins and prevents aggregation (voth2014theproteintargeting pages 1-2, ulrich2021thiolbasedswitchingmechanisms pages 5-6). Quantitatively, oxidative activation is rapid (<strong>T1/2 &lt; 1 min</strong> with H2O2/Cu2+; <strong>~5 min</strong> with H2O2 alone), and oxidized Get3 can almost completely suppress citrate synthase aggregation at an <strong>8:1 Get3:substrate</strong> ratio; oxidized Get3 retains <strong>&lt;20%</strong> ATPase activity (voth2014theproteintargeting pages 2-3). Stress phenotypes and in vivo relocalization are consistent with a protective role during copper/oxidative stress (example: <strong>1 mM CuSO4 at 37°C for 4 h</strong>) (voth2014theproteintargeting pages 9-10).</p>
+<p><strong>GO guidance implication:</strong> MF terms like “unfolded protein binding” and BP terms like “response to oxidative stress” are well supported but <strong>condition-specific</strong> and should not replace the core TA-targeting annotations.</p>
+<h4 id="32-heatmetalarsenite-response">3.2 Heat/metal/arsenite response</h4>
+<p>Metal/oxidative stress support is direct (copper sensitivity; copper-triggered relocalization) (voth2014theproteintargeting pages 9-10, voth2014theproteintargeting pages 8-9). Heat stress is referenced as a sensitivity phenotype associated with get3 deletion in the oxidative-stress chaperone study, but the mechanistic evidence in the retrieved excerpts is strongest for oxidative/metal stress rather than a dedicated heat-response pathway (voth2014theproteintargeting pages 1-2).</p>
+<h4 id="33-golgi-to-er-retrograde-transport-erd2hdel-receptor-and-golgi-localization">3.3 Golgi-to-ER retrograde transport (Erd2/HDEL receptor) and Golgi localization</h4>
+<p>No direct evidence for Erd2/HDEL-mediated retrograde transport involvement was found in the retrieved primary mechanistic GET literature. Moreover, during glucose starvation Get3 foci were explicitly <strong>not Golgi-localized</strong> (Golgi marker Anp1 used to exclude Golgi) (powis2013get3isa pages 3-5). Available data instead suggest that any trafficking phenotypes (e.g., involving Sed5 stability) likely reflect <strong>indirect consequences</strong> of TA mis-targeting or proteostasis disruption rather than a primary Erd2-dependent role (powis2013get3isa pages 6-7).</p>
+<h4 id="34-guanine-nucleotide-exchange-factor-gef-activity-for-gpa1-pheromone-signaling">3.4 Guanine nucleotide exchange factor (GEF) activity for Gpa1; pheromone signaling</h4>
+<p>A 2008 study reported that Arr4 is a <strong>non-receptor GEF for Gpa1</strong> and indicates that <strong>Arr4 is an alias of Get3</strong> (“Get3, an alias for Arr4”) (Lee, 2008; doi:10.17615/tt4v-sn52; https://doi.org/10.17615/tt4v-sn52) (michael2008activationofg pages 167-173). The same source describes direct biochemical activity: Arr4 increased GTPγS binding from <strong>0.085 → 0.36 pmol GTPγS·pmol Gpa1−1·min−1</strong> and Pi release from <strong>0.009 → 0.021 pmol Pi·pmol Gpa1−1·min−1</strong>, and arr4Δ reduced pheromone-induced transcription (~50% in FUS1-lacZ) and mating (~40%) (michael2008activationofg pages 121-128, michael2008activationofg pages 128-134). </p>
+<p><strong>Caution for GO annotation:</strong> while this evidence is quantitative and directly biochemical, it is (i) less represented in later, GET-pathway-centric mechanistic syntheses and (ii) potentially context-dependent (copper/dimerization dependence noted in that work). Thus, annotating “GEF activity” may be appropriate but should be <strong>qualified with evidence code and context</strong>, and not conflated with Get3’s core TA-targeting role.</p>
+<h4 id="35-generic-protein-binding-and-identical-protein-binding">3.5 Generic protein binding and identical protein binding</h4>
+<p>“Identical protein binding” is consistent with obligate Get3 homodimerization required for TA binding and function (denic2013endoplasmicreticulumtargeting pages 5-7, jennrich2024characterizationofstressinduced pages 20-23). “Protein binding” is trivially true (clients and partners), but is low-specificity relative to mechanistically informative terms such as “tail-anchored protein binding” or “unfolded protein binding.”</p>
+<h3 id="4-recent-developments-20232024">4) Recent developments (2023–2024)</h3>
+<p><strong>Insertase mechanism refinement (2023):</strong> Get1/2 is proposed to form a channel enabling insertion, strengthening mechanistic grounding for BP annotations related to TA insertion into ER membrane (Heo et al., 2023-01; doi:10.1016/j.celrep.2022.111921) (zalisko2017tailanchoredprotein pages 6-11).</p>
+<p><strong>GET pathway as a proteostasis bottleneck (2023):</strong> A genome-wide screen found GET1/2/3 among top aggregation hits; manual verification showed <strong>~100%</strong> of get1Δ/get2Δ/get3Δ cells had Hsp104-GFP foci at 30°C, and get3Δ median replicative lifespan was <strong>14 generations vs 20 in WT</strong>. Disorder was enriched among proteins forming foci in GET mutants (<strong>24% vs ~7.7%</strong> expected) (Josefson et al., 2023-06; doi:10.1038/s41598-023-35666-8; https://doi.org/10.1038/s41598-023-35666-8) (josefson2023thegetpathway pages 1-2, josefson2023thegetpathway pages 6-8, josefson2023thegetpathway pages 3-5).</p>
+<p><strong>Stress-induced cytosolic assemblies / “GET bodies” (2024):</strong> During glucose starvation, GET components assemble into cytosolic foci within <strong>~1 h</strong>; Hsp70 chaperones robustly co-localize later (<strong>~4 h</strong>), and after prolonged starvation Hsp70s appear in <strong>≥70%</strong> of foci (Jennrich, 2024; doi:10.53846/goediss-10715; https://doi.org/10.53846/goediss-10715) (jennrich2024characterizationofstressinduced pages 113-115).</p>
+<h3 id="5-applications-and-real-world-implementations">5) Applications and real-world implementations</h3>
+<ol>
+<li><strong>In vitro reconstitution</strong> of TA targeting/insertion (Get3 with Get1/2 and upstream factors) provides a rigorous platform for mapping GO evidence to direct biochemical activity and defining minimal machinery (wang2011themechanismof pages 1-2, mariappan2011themechanismof pages 22-25).</li>
+<li><strong>Fluorescent reporters</strong> (e.g., Hsp104-GFP aggregation, TA SNARE Sed5 reporters) and genome-wide genetics quantify system-level consequences of GET dysfunction, bridging molecular GO terms with cellular phenotypes (josefson2023thegetpathway pages 1-2, powis2013get3isa pages 6-7).</li>
+<li><strong>Stress/foci imaging paradigms</strong> support CC/BP annotations for cytosolic assemblies under starvation and for stress-associated relocalization consistent with holdase function (powis2013get3isa pages 3-5, jennrich2024characterizationofstressinduced pages 113-115).</li>
+</ol>
+<h3 id="visual-evidence">Visual evidence</h3>
+<p>A schematic summarizing the canonical GET pathway and Get3 relocalization to deposition sites under starvation/blocked ATP hydrolysis is available (Powis et al., 2013; doi:10.1242/jcs.112151; https://doi.org/10.1242/jcs.112151) (powis2013get3isa media e2d53b1f).</p>
+<h3 id="bottom-line-for-go-annotation-focus">Bottom line for GO annotation focus</h3>
+<p><strong>Core, high-confidence GO annotations</strong> for Get3/Arr4 should prioritize ATP binding/ATPase activity coupled to TA TMD binding/shielding, ER targeting, and Get1/Get2-dependent TA insertion, with CC terms spanning cytosol and ER membrane/GET complex (mariappan2011themechanismof pages 22-25, wang2011themechanismof pages 1-2, denic2013endoplasmicreticulumtargeting pages 5-7). <strong>Secondary but well-supported condition-specific annotations</strong> include ATP-independent unfolded-protein binding/holdase and oxidative/metal stress response. <strong>Trafficking claims involving Erd2/HDEL</strong> lack direct support in the retrieved evidence. <strong>GEF activity for Gpa1</strong> has direct quantitative biochemical evidence in one source and is cited in later reviews, but appears more context-limited and should be annotated cautiously with appropriate evidence coding and notes (michael2008activationofg pages 128-134, michael2008activationofg pages 167-173).</p>
+<p>References</p>
+<ol>
+<li>
+<p>(mariappan2011themechanismof pages 22-25): Malaiyalam Mariappan, Agnieszka Mateja, Malgorzata Dobosz, Elia Bove, Ramanujan S. Hegde, and Robert J. Keenan. The mechanism of membrane-associated steps in tail-anchored protein insertion. Nature, 477:61-66, Sep 2011. URL: https://doi.org/10.1038/nature10362, doi:10.1038/nature10362. This article has 201 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(denic2013endoplasmicreticulumtargeting pages 5-7): Vladimir Denic, V. Dötsch, and I. Sinning. Endoplasmic reticulum targeting and insertion of tail-anchored membrane proteins by the get pathway. Cold Spring Harbor perspectives in biology, 5 8:a013334, Aug 2013. URL: https://doi.org/10.1101/cshperspect.a013334, doi:10.1101/cshperspect.a013334. This article has 92 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(jennrich2024characterizationofstressinduced pages 20-23): Jonas Jennrich. Characterization of stress-induced cytosolic assemblies containing components of the guided-entry of tail-anchored proteins targeting pathway. ArXiv, 2024. URL: https://doi.org/10.53846/goediss-10715, doi:10.53846/goediss-10715. This article has 0 citations.</p>
+</li>
+<li>
+<p>(wang2011themechanismof pages 1-2): Fei Wang, Andrew Whynot, Matthew Tung, and Vladimir Denic. The mechanism of tail-anchored protein insertion into the er membrane. Molecular cell, 43 5:738-50, Sep 2011. URL: https://doi.org/10.1016/j.molcel.2011.07.020, doi:10.1016/j.molcel.2011.07.020. This article has 121 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(denic2013endoplasmicreticulumtargeting pages 4-5): Vladimir Denic, V. Dötsch, and I. Sinning. Endoplasmic reticulum targeting and insertion of tail-anchored membrane proteins by the get pathway. Cold Spring Harbor perspectives in biology, 5 8:a013334, Aug 2013. URL: https://doi.org/10.1101/cshperspect.a013334, doi:10.1101/cshperspect.a013334. This article has 92 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(zalisko2017tailanchoredprotein pages 6-11): Benjamin Edward Zalisko. Tail anchored protein insertion by a get1/2 heterodimer. Jan 2017. URL: https://doi.org/10.6082/m1pg1pvq, doi:10.6082/m1pg1pvq. This article has 0 citations.</p>
+</li>
+<li>
+<p>(jennrich2024characterizationofstressinduced pages 113-115): Jonas Jennrich. Characterization of stress-induced cytosolic assemblies containing components of the guided-entry of tail-anchored proteins targeting pathway. ArXiv, 2024. URL: https://doi.org/10.53846/goediss-10715, doi:10.53846/goediss-10715. This article has 0 citations.</p>
+</li>
+<li>
+<p>(denic2013endoplasmicreticulumtargeting pages 3-4): Vladimir Denic, V. Dötsch, and I. Sinning. Endoplasmic reticulum targeting and insertion of tail-anchored membrane proteins by the get pathway. Cold Spring Harbor perspectives in biology, 5 8:a013334, Aug 2013. URL: https://doi.org/10.1101/cshperspect.a013334, doi:10.1101/cshperspect.a013334. This article has 92 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(josefson2023thegetpathway pages 1-2): Rebecca Josefson, Navinder Kumar, Xinxin Hao, Beidong Liu, and Thomas Nyström. The get pathway is a major bottleneck for maintaining proteostasis in saccharomyces cerevisiae. Scientific Reports, Jun 2023. URL: https://doi.org/10.1038/s41598-023-35666-8, doi:10.1038/s41598-023-35666-8. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(voth2014theproteintargeting pages 2-3): Wilhelm Voth, Markus Schick, Stephanie Gates, Sheng Li, Fabio Vilardi, Irina Gostimskaya, Daniel R. Southworth, Blanche Schwappach, and Ursula Jakob. The protein targeting factor get3 functions as atp-independent chaperone under oxidative stress conditions. Molecular cell, 56 1:116-27, Oct 2014. URL: https://doi.org/10.1016/j.molcel.2014.08.017, doi:10.1016/j.molcel.2014.08.017. This article has 95 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(powis2013get3isa pages 6-7): Katie Powis, Bianca Schrul, Heather Tienson, Irina Gostimskaya, Michal Breker, Stephen High, Maya Schuldiner, Ursula Jakob, and Blanche Schwappach. Get3 is a holdase chaperone and moves to deposition sites for aggregated proteins when membrane targeting is blocked. Journal of Cell Science, 126:473-483, Jan 2013. URL: https://doi.org/10.1242/jcs.112151, doi:10.1242/jcs.112151. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(voth2014theproteintargeting pages 9-10): Wilhelm Voth, Markus Schick, Stephanie Gates, Sheng Li, Fabio Vilardi, Irina Gostimskaya, Daniel R. Southworth, Blanche Schwappach, and Ursula Jakob. The protein targeting factor get3 functions as atp-independent chaperone under oxidative stress conditions. Molecular cell, 56 1:116-27, Oct 2014. URL: https://doi.org/10.1016/j.molcel.2014.08.017, doi:10.1016/j.molcel.2014.08.017. This article has 95 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(voth2014theproteintargeting pages 8-9): Wilhelm Voth, Markus Schick, Stephanie Gates, Sheng Li, Fabio Vilardi, Irina Gostimskaya, Daniel R. Southworth, Blanche Schwappach, and Ursula Jakob. The protein targeting factor get3 functions as atp-independent chaperone under oxidative stress conditions. Molecular cell, 56 1:116-27, Oct 2014. URL: https://doi.org/10.1016/j.molcel.2014.08.017, doi:10.1016/j.molcel.2014.08.017. This article has 95 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(reichmann2018maintainingahealthy pages 3-4): Dana Reichmann, Wilhelm Voth, and Ursula Jakob. Maintaining a healthy proteome during oxidative stress. Molecular cell, 69 2:203-213, Jan 2018. URL: https://doi.org/10.1016/j.molcel.2017.12.021, doi:10.1016/j.molcel.2017.12.021. This article has 224 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(michael2008activationofg pages 128-134): Michael Lee. Activation of g protein signaling by a non-receptor exchange factor. Text, 2008. URL: https://doi.org/10.17615/tt4v-sn52, doi:10.17615/tt4v-sn52. This article has 1 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(michael2008activationofg pages 121-128): Michael Lee. Activation of g protein signaling by a non-receptor exchange factor. Text, 2008. URL: https://doi.org/10.17615/tt4v-sn52, doi:10.17615/tt4v-sn52. This article has 1 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(michael2008activationofg pages 167-173): Michael Lee. Activation of g protein signaling by a non-receptor exchange factor. Text, 2008. URL: https://doi.org/10.17615/tt4v-sn52, doi:10.17615/tt4v-sn52. This article has 1 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(powis2013get3isa pages 3-5): Katie Powis, Bianca Schrul, Heather Tienson, Irina Gostimskaya, Michal Breker, Stephen High, Maya Schuldiner, Ursula Jakob, and Blanche Schwappach. Get3 is a holdase chaperone and moves to deposition sites for aggregated proteins when membrane targeting is blocked. Journal of Cell Science, 126:473-483, Jan 2013. URL: https://doi.org/10.1242/jcs.112151, doi:10.1242/jcs.112151. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(powis2013get3isa pages 7-8): Katie Powis, Bianca Schrul, Heather Tienson, Irina Gostimskaya, Michal Breker, Stephen High, Maya Schuldiner, Ursula Jakob, and Blanche Schwappach. Get3 is a holdase chaperone and moves to deposition sites for aggregated proteins when membrane targeting is blocked. Journal of Cell Science, 126:473-483, Jan 2013. URL: https://doi.org/10.1242/jcs.112151, doi:10.1242/jcs.112151. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+<li>
+<p>(josefson2023thegetpathway pages 3-5): Rebecca Josefson, Navinder Kumar, Xinxin Hao, Beidong Liu, and Thomas Nyström. The get pathway is a major bottleneck for maintaining proteostasis in saccharomyces cerevisiae. Scientific Reports, Jun 2023. URL: https://doi.org/10.1038/s41598-023-35666-8, doi:10.1038/s41598-023-35666-8. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(josefson2023thegetpathway pages 6-8): Rebecca Josefson, Navinder Kumar, Xinxin Hao, Beidong Liu, and Thomas Nyström. The get pathway is a major bottleneck for maintaining proteostasis in saccharomyces cerevisiae. Scientific Reports, Jun 2023. URL: https://doi.org/10.1038/s41598-023-35666-8, doi:10.1038/s41598-023-35666-8. This article has 4 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(voth2014theproteintargeting pages 1-2): Wilhelm Voth, Markus Schick, Stephanie Gates, Sheng Li, Fabio Vilardi, Irina Gostimskaya, Daniel R. Southworth, Blanche Schwappach, and Ursula Jakob. The protein targeting factor get3 functions as atp-independent chaperone under oxidative stress conditions. Molecular cell, 56 1:116-27, Oct 2014. URL: https://doi.org/10.1016/j.molcel.2014.08.017, doi:10.1016/j.molcel.2014.08.017. This article has 95 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(ulrich2021thiolbasedswitchingmechanisms pages 5-6): Kathrin Ulrich, Blanche Schwappach, and Ursula Jakob. Thiol-based switching mechanisms of stress-sensing chaperones. Biological Chemistry, 402:239-252, Oct 2021. URL: https://doi.org/10.1515/hsz-2020-0262, doi:10.1515/hsz-2020-0262. This article has 24 citations and is from a peer-reviewed journal.</p>
+</li>
+<li>
+<p>(powis2013get3isa media e2d53b1f): Katie Powis, Bianca Schrul, Heather Tienson, Irina Gostimskaya, Michal Breker, Stephen High, Maya Schuldiner, Ursula Jakob, and Blanche Schwappach. Get3 is a holdase chaperone and moves to deposition sites for aggregated proteins when membrane targeting is blocked. Journal of Cell Science, 126:473-483, Jan 2013. URL: https://doi.org/10.1242/jcs.112151, doi:10.1242/jcs.112151. This article has 84 citations and is from a domain leading peer-reviewed journal.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>mariappan2011themechanismof pages 22-25</li>
+<li>denic2013endoplasmicreticulumtargeting pages 5-7</li>
+<li>wang2011themechanismof pages 1-2</li>
+<li>zalisko2017tailanchoredprotein pages 6-11</li>
+<li>voth2014theproteintargeting pages 2-3</li>
+<li>voth2014theproteintargeting pages 9-10</li>
+<li>voth2014theproteintargeting pages 1-2</li>
+<li>michael2008activationofg pages 167-173</li>
+<li>jennrich2024characterizationofstressinduced pages 113-115</li>
+<li>jennrich2024characterizationofstressinduced pages 20-23</li>
+<li>denic2013endoplasmicreticulumtargeting pages 4-5</li>
+<li>denic2013endoplasmicreticulumtargeting pages 3-4</li>
+<li>josefson2023thegetpathway pages 1-2</li>
+<li>voth2014theproteintargeting pages 8-9</li>
+<li>reichmann2018maintainingahealthy pages 3-4</li>
+<li>michael2008activationofg pages 128-134</li>
+<li>michael2008activationofg pages 121-128</li>
+<li>josefson2023thegetpathway pages 3-5</li>
+<li>josefson2023thegetpathway pages 6-8</li>
+<li>ulrich2021thiolbasedswitchingmechanisms pages 5-6</li>
+<li>https://doi.org/10.1038/nature10362;</li>
+<li>https://doi.org/10.1101/cshperspect.a013334</li>
+<li>https://doi.org/10.1101/cshperspect.a013334;</li>
+<li>https://doi.org/10.53846/goediss-10715</li>
+<li>https://doi.org/10.1038/nature10362</li>
+<li>https://doi.org/10.1016/j.molcel.2011.07.020;</li>
+<li>https://doi.org/10.1016/j.molcel.2011.07.020</li>
+<li>https://doi.org/10.1016/j.celrep.2022.111921</li>
+<li>https://doi.org/10.1038/s41598-023-35666-8</li>
+<li>https://doi.org/10.1016/j.molcel.2014.08.017;</li>
+<li>https://doi.org/10.1242/jcs.112151</li>
+<li>https://doi.org/10.1016/j.molcel.2017.12.021</li>
+<li>https://doi.org/10.17615/tt4v-sn52;</li>
+<li>https://doi.org/10.1016/j.jbc.2024.105756</li>
+<li>https://doi.org/10.17615/tt4v-sn52</li>
+<li>https://doi.org/10.1038/nature10362,</li>
+<li>https://doi.org/10.1101/cshperspect.a013334,</li>
+<li>https://doi.org/10.53846/goediss-10715,</li>
+<li>https://doi.org/10.1016/j.molcel.2011.07.020,</li>
+<li>https://doi.org/10.6082/m1pg1pvq,</li>
+<li>https://doi.org/10.1038/s41598-023-35666-8,</li>
+<li>https://doi.org/10.1016/j.molcel.2014.08.017,</li>
+<li>https://doi.org/10.1242/jcs.112151,</li>
+<li>https://doi.org/10.1016/j.molcel.2017.12.021,</li>
+<li>https://doi.org/10.17615/tt4v-sn52,</li>
+<li>https://doi.org/10.1515/hsz-2020-0262,</li>
+</ol>
+            </div>
+        </details>
+
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(GET3-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="Q12154" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="get3-notes">GET3 notes</h1>
+<p>Falcon deep research supports GET3 as the central ATPase of the yeast GET pathway: "Functionally, ATP hydrolysis is required for productive insertion because a hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays" [file:yeast/GET3/GET3-deep-research-falcon.md].</p>
+<p>The canonical mechanism is a cytosolic homodimeric targeting cycle: "Get3 is described as a <strong>Zn2+-stabilized homodimer</strong> whose dimer interface forms a <strong>composite hydrophobic groove</strong>" that binds the tail-anchor TMD [file:yeast/GET3/GET3-deep-research-falcon.md].</p>
+<p>Falcon distinguishes the core GET pathway from secondary roles. Stress-induced holdase/chaperone activity is real but non-core: "under oxidative stress or ATP depletion, Get3 is converted from ATPase targeting factor into an <strong>ATP-independent holdase chaperone</strong>" [file:yeast/GET3/GET3-deep-research-falcon.md].</p>
+<p>The Falcon report did not find direct support for Erd2/HDEL-mediated Golgi-to-ER retrograde transport as a primary GET3 function, so the corresponding GOA rows should stay non-core [file:yeast/GET3/GET3-deep-research-falcon.md].</p>
+            </div>
+        </details>
+
+    </div>
+
 
     <!-- YAML Preview Section -->
     <div class="section">
@@ -5171,6 +6202,11 @@ existing_annotations:
     summary: &#39;Manual review: GET complex is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -5180,15 +6216,25 @@ existing_annotations:
     summary: &#39;Manual review: ATP hydrolysis activity is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Functionally, ATP hydrolysis is required for productive insertion because a
+        hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays
 - term:
     id: GO:0071816
     label: tail-anchored membrane protein insertion into ER membrane
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: &#39;Manual review: tail-anchored membrane protein insertion into ER membrane is consistent with known biology of GET3.&#39;
+    summary: &#39;Manual review: tail-anchored membrane protein insertion into ER membrane is consistent with
+      known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane
+        machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and
+        **Get1 driving ATPase-dependent substrate release** for insertion
 - term:
     id: GO:0006457
     label: protein folding
@@ -5197,7 +6243,8 @@ existing_annotations:
   review:
     summary: &#39;Manual review: protein folding may be context-dependent or peripheral for GET3.&#39;
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0000166
     label: nucleotide binding
@@ -5225,6 +6272,11 @@ existing_annotations:
     summary: &#39;Manual review: cytoplasm is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
@@ -5234,6 +6286,11 @@ existing_annotations:
     summary: &#39;Manual review: endoplasmic reticulum is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0005794
     label: Golgi apparatus
@@ -5242,7 +6299,8 @@ existing_annotations:
   review:
     summary: &#39;Manual review: Golgi apparatus may be context-dependent or peripheral for GET3.&#39;
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0016192
     label: vesicle-mediated transport
@@ -5251,7 +6309,8 @@ existing_annotations:
   review:
     summary: &#39;Manual review: vesicle-mediated transport may be context-dependent or peripheral for GET3.&#39;
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0016787
     label: hydrolase activity
@@ -5260,7 +6319,8 @@ existing_annotations:
   review:
     summary: &#39;Manual review: hydrolase activity may be context-dependent or peripheral for GET3.&#39;
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -5270,6 +6330,10 @@ existing_annotations:
     summary: &#39;Manual review: ATP hydrolysis activity is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Functionally, ATP hydrolysis is required for productive insertion because a
+        hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays
 - term:
     id: GO:0043529
     label: GET complex
@@ -5279,6 +6343,11 @@ existing_annotations:
     summary: &#39;Manual review: GET complex is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0045048
     label: protein insertion into ER membrane
@@ -5288,15 +6357,22 @@ existing_annotations:
     summary: &#39;Manual review: protein insertion into ER membrane is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane
+        machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and
+        **Get1 driving ATPase-dependent substrate release** for insertion
 - term:
     id: GO:0046685
     label: response to arsenic-containing substance
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: &#39;Manual review: response to arsenic-containing substance may be context-dependent or peripheral for GET3.&#39;
+    summary: &#39;Manual review: response to arsenic-containing substance may be context-dependent or peripheral
+      for GET3.&#39;
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0046872
     label: metal ion binding
@@ -5305,7 +6381,8 @@ existing_annotations:
   review:
     summary: &#39;Manual review: metal ion binding may be context-dependent or peripheral for GET3.&#39;
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0005515
     label: protein binding
@@ -5474,54 +6551,102 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:16260785
   review:
-    summary: &#39;Manual review: identical protein binding is too generic or over-extended for GET3.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: &#39;Manual review: identical protein binding captures the obligate Get3 homodimer that forms
+      the tail-anchored protein binding groove.&#39;
+    action: ACCEPT
+    reason: Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic
+      groove that binds and shields tail-anchored protein transmembrane domains.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface
+        forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that
+        increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide
+        dependent
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:19675567
   review:
-    summary: &#39;Manual review: identical protein binding is too generic or over-extended for GET3.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: &#39;Manual review: identical protein binding captures the obligate Get3 homodimer that forms
+      the tail-anchored protein binding groove.&#39;
+    action: ACCEPT
+    reason: Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic
+      groove that binds and shields tail-anchored protein transmembrane domains.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface
+        forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that
+        increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide
+        dependent
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:19706470
   review:
-    summary: &#39;Manual review: identical protein binding is too generic or over-extended for GET3.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: &#39;Manual review: identical protein binding captures the obligate Get3 homodimer that forms
+      the tail-anchored protein binding groove.&#39;
+    action: ACCEPT
+    reason: Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic
+      groove that binds and shields tail-anchored protein transmembrane domains.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface
+        forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that
+        increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide
+        dependent
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:22124326
   review:
-    summary: &#39;Manual review: identical protein binding is too generic or over-extended for GET3.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: &#39;Manual review: identical protein binding captures the obligate Get3 homodimer that forms
+      the tail-anchored protein binding groove.&#39;
+    action: ACCEPT
+    reason: Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic
+      groove that binds and shields tail-anchored protein transmembrane domains.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface
+        forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that
+        increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide
+        dependent
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:24727835
   review:
-    summary: &#39;Manual review: identical protein binding is too generic or over-extended for GET3.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: &#39;Manual review: identical protein binding captures the obligate Get3 homodimer that forms
+      the tail-anchored protein binding groove.&#39;
+    action: ACCEPT
+    reason: Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic
+      groove that binds and shields tail-anchored protein transmembrane domains.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface
+        forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that
+        increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide
+        dependent
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:25745174
   review:
-    summary: &#39;Manual review: identical protein binding is too generic or over-extended for GET3.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: &#39;Manual review: identical protein binding captures the obligate Get3 homodimer that forms
+      the tail-anchored protein binding groove.&#39;
+    action: ACCEPT
+    reason: Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic
+      groove that binds and shields tail-anchored protein transmembrane domains.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface
+        forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that
+        increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide
+        dependent
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
@@ -5531,6 +6656,11 @@ existing_annotations:
     summary: &#39;Manual review: endoplasmic reticulum membrane is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0045048
     label: protein insertion into ER membrane
@@ -5540,6 +6670,11 @@ existing_annotations:
     summary: &#39;Manual review: protein insertion into ER membrane is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane
+        machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and
+        **Get1 driving ATPase-dependent substrate release** for insertion
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -5549,15 +6684,25 @@ existing_annotations:
     summary: &#39;Manual review: ATP hydrolysis activity is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Functionally, ATP hydrolysis is required for productive insertion because a
+        hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays
 - term:
     id: GO:0071816
     label: tail-anchored membrane protein insertion into ER membrane
   evidence_type: IMP
   original_reference_id: PMID:18724936
   review:
-    summary: &#39;Manual review: tail-anchored membrane protein insertion into ER membrane is consistent with known biology of GET3.&#39;
+    summary: &#39;Manual review: tail-anchored membrane protein insertion into ER membrane is consistent with
+      known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane
+        machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and
+        **Get1 driving ATPase-dependent substrate release** for insertion
 - term:
     id: GO:0008270
     label: zinc ion binding
@@ -5566,16 +6711,24 @@ existing_annotations:
   review:
     summary: &#39;Manual review: zinc ion binding may be context-dependent or peripheral for GET3.&#39;
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0044183
     label: protein folding chaperone
   evidence_type: IDA
   original_reference_id: PMID:25242142
   review:
-    summary: &#39;Manual review: protein folding chaperone is too generic or over-extended for GET3.&#39;
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: &#39;Manual review: protein folding chaperone activity is supported under oxidative or ATP-depleting
+      stress but is not the core GET-pathway function.&#39;
+    action: KEEP_AS_NON_CORE
+    reason: Keep as non-core because Get3 has a regulated ATP-independent holdase role during
+      oxidative stress, while the primary function remains ATP-dependent tail-anchored protein
+      targeting to the ER.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: under oxidative stress or ATP depletion, Get3 is converted from ATPase
+        targeting factor into an **ATP-independent holdase chaperone**.
 - term:
     id: GO:0043529
     label: GET complex
@@ -5585,6 +6738,11 @@ existing_annotations:
     summary: &#39;Manual review: GET complex is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0005829
     label: cytosol
@@ -5594,6 +6752,11 @@ existing_annotations:
     summary: &#39;Manual review: cytosol is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
@@ -5603,6 +6766,11 @@ existing_annotations:
     summary: &#39;Manual review: endoplasmic reticulum is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0005829
     label: cytosol
@@ -5612,6 +6780,11 @@ existing_annotations:
     summary: &#39;Manual review: cytosol is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0005829
     label: cytosol
@@ -5621,6 +6794,11 @@ existing_annotations:
     summary: &#39;Manual review: cytosol is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0005829
     label: cytosol
@@ -5630,81 +6808,128 @@ existing_annotations:
     summary: &#39;Manual review: cytosol is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0034599
     label: cellular response to oxidative stress
   evidence_type: IDA
   original_reference_id: PMID:25242142
   review:
-    summary: &#39;Manual review: cellular response to oxidative stress may be context-dependent or peripheral for GET3.&#39;
+    summary: &#39;Manual review: cellular response to oxidative stress may be context-dependent or peripheral
+      for GET3.&#39;
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:25242142
   review:
-    summary: &#39;Manual review: unfolded protein binding is better represented by a more specific replacement term for GET3.&#39;
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0140597
-      label: protein carrier chaperone
+    summary: &#39;Manual review: unfolded protein binding is supported for the oxidative-stress holdase state
+      of Get3 but is condition-specific.&#39;
+    action: KEEP_AS_NON_CORE
+    reason: Keep as non-core rather than replacing it; Falcon and the source literature support
+      unfolded-protein binding during stress-induced Get3 holdase activity, distinct from the core
+      GET targeting ATPase cycle.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: under oxidative stress or ATP depletion, Get3 is converted from ATPase
+        targeting factor into an **ATP-independent holdase chaperone**.
 - term:
     id: GO:0000750
     label: pheromone-dependent signal transduction involved in conjugation with cellular fusion
   evidence_type: IMP
   original_reference_id: PMID:18261907
   review:
-    summary: &#39;Manual review: pheromone-dependent signal transduction involved in conjugation with cellular fusion may be context-dependent or peripheral for GET3.&#39;
+    summary: &#39;Manual review: pheromone-dependent signal transduction involved in conjugation with cellular
+      fusion may be context-dependent or peripheral for GET3.&#39;
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0005085
     label: guanyl-nucleotide exchange factor activity
   evidence_type: IDA
   original_reference_id: PMID:18261907
   review:
-    summary: &#39;Manual review: guanyl-nucleotide exchange factor activity may be context-dependent or peripheral for GET3.&#39;
+    summary: &#39;Manual review: guanyl-nucleotide exchange factor activity for Gpa1 is directly reported
+      but remains context-specific relative to the canonical GET pathway.&#39;
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Keep as non-core because one quantitative source supports Arr4/Get3 GEF activity in
+      pheromone signaling, but this role is less integrated with later GET-pathway mechanistic
+      literature than TA-protein targeting.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: A 2008 study reported that Arr4 is a **non-receptor GEF for Gpa1** and
+        indicates that **Arr4 is an alias of Get3**
 - term:
     id: GO:0006620
     label: post-translational protein targeting to endoplasmic reticulum membrane
   evidence_type: IDA
   original_reference_id: PMID:20850366
   review:
-    summary: &#39;Manual review: post-translational protein targeting to endoplasmic reticulum membrane is consistent with known biology of GET3.&#39;
+    summary: &#39;Manual review: post-translational protein targeting to endoplasmic reticulum membrane is
+      consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane
+        machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and
+        **Get1 driving ATPase-dependent substrate release** for insertion
 - term:
     id: GO:0006890
     label: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum
   evidence_type: IDA
   original_reference_id: PMID:16269340
   review:
-    summary: &#39;Manual review: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum may be context-dependent or peripheral for GET3.&#39;
+    summary: &#39;Manual review: Golgi-to-ER retrograde transport evidence appears indirect for GET3 and should
+      not be treated as core function.&#39;
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Keep as non-core because the reviewed GET-pathway literature does not provide direct
+      Erd2/HDEL-mediated retrograde-transport evidence for Get3; trafficking effects may be
+      secondary to TA-client targeting or proteostasis defects.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: No direct evidence for Erd2/HDEL-mediated retrograde transport involvement
+        was found in the retrieved primary mechanistic GET literature.
 - term:
     id: GO:0006890
     label: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum
   evidence_type: IMP
   original_reference_id: PMID:16269340
   review:
-    summary: &#39;Manual review: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum may be context-dependent or peripheral for GET3.&#39;
+    summary: &#39;Manual review: Golgi-to-ER retrograde transport evidence appears indirect for GET3 and should
+      not be treated as core function.&#39;
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Keep as non-core because the reviewed GET-pathway literature does not provide direct
+      Erd2/HDEL-mediated retrograde-transport evidence for Get3; trafficking effects may be
+      secondary to TA-client targeting or proteostasis defects.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: No direct evidence for Erd2/HDEL-mediated retrograde transport involvement
+        was found in the retrieved primary mechanistic GET literature.
 - term:
     id: GO:0006890
     label: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum
   evidence_type: IGI
   original_reference_id: PMID:16269340
   review:
-    summary: &#39;Manual review: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum may be context-dependent or peripheral for GET3.&#39;
+    summary: &#39;Manual review: Golgi-to-ER retrograde transport evidence appears indirect for GET3 and should
+      not be treated as core function.&#39;
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Keep as non-core because the reviewed GET-pathway literature does not provide direct
+      Erd2/HDEL-mediated retrograde-transport evidence for Get3; trafficking effects may be
+      secondary to TA-client targeting or proteostasis defects.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: No direct evidence for Erd2/HDEL-mediated retrograde transport involvement
+        was found in the retrieved primary mechanistic GET literature.
 - term:
     id: GO:0009408
     label: response to heat
@@ -5713,7 +6938,8 @@ existing_annotations:
   review:
     summary: &#39;Manual review: response to heat may be context-dependent or peripheral for GET3.&#39;
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0010038
     label: response to metal ion
@@ -5722,7 +6948,8 @@ existing_annotations:
   review:
     summary: &#39;Manual review: response to metal ion may be context-dependent or peripheral for GET3.&#39;
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -5732,6 +6959,10 @@ existing_annotations:
     summary: &#39;Manual review: ATP hydrolysis activity is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Functionally, ATP hydrolysis is required for productive insertion because a
+        hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays
 - term:
     id: GO:0043529
     label: GET complex
@@ -5741,7 +6972,18 @@ existing_annotations:
     summary: &#39;Manual review: GET complex is consistent with known biology of GET3.&#39;
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 references:
+- id: file:yeast/GET3/GET3-deep-research-falcon.md
+  title: Falcon deep research report for GET3
+  findings: []
+- id: file:yeast/GET3/GET3-uniprot.txt
+  title: UniProt record for yeast GET3
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
@@ -5752,10 +6994,12 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000104
-  title: Electronic Gene Ontology annotations created by transferring manual GO annotations between related proteins based on shared sequence features
+  title: Electronic Gene Ontology annotations created by transferring manual GO annotations between
+    related proteins based on shared sequence features
   findings: []
 - id: GO_REF:0000108
   title: Automatic assignment of GO terms using logical inference, based on on inter-ontology links
@@ -5767,7 +7011,8 @@ references:
   title: A comprehensive two-hybrid analysis to explore the yeast protein interactome.
   findings: []
 - id: PMID:11805837
-  title: Systematic identification of protein complexes in Saccharomyces cerevisiae by mass spectrometry.
+  title: Systematic identification of protein complexes in Saccharomyces cerevisiae by mass
+    spectrometry.
   findings: []
 - id: PMID:12680698
   title: The Saccharomyces cerevisiae Arr4p is involved in metal and heat tolerance.
@@ -5776,10 +7021,12 @@ references:
   title: Global analysis of protein localization in budding yeast.
   findings: []
 - id: PMID:16260785
-  title: The yeast Arr4p ATPase binds the chloride transporter Gef1p when copper is available in the cytosol.
+  title: The yeast Arr4p ATPase binds the chloride transporter Gef1p when copper is available in the
+    cytosol.
   findings: []
 - id: PMID:16269340
-  title: Exploration of the function and organization of the yeast early secretory pathway through an epistatic miniarray profile.
+  title: Exploration of the function and organization of the yeast early secretory pathway through
+    an epistatic miniarray profile.
   findings: []
 - id: PMID:16429126
   title: Proteome survey reveals modularity of the yeast cell machinery.
@@ -5788,10 +7035,12 @@ references:
   title: Global landscape of protein complexes in the yeast Saccharomyces cerevisiae.
   findings: []
 - id: PMID:16816426
-  title: The conserved ATPase Get3/Arr4 modulates the activity of membrane-associated proteins in Saccharomyces cerevisiae.
+  title: The conserved ATPase Get3/Arr4 modulates the activity of membrane-associated proteins in
+    Saccharomyces cerevisiae.
   findings: []
 - id: PMID:18261907
-  title: Coactivation of G protein signaling by cell-surface receptors and an intracellular exchange factor.
+  title: Coactivation of G protein signaling by cell-surface receptors and an intracellular exchange
+    factor.
   findings: []
 - id: PMID:18467557
   title: An in vivo map of the yeast protein interactome.
@@ -5812,7 +7061,8 @@ references:
   title: Crystal structure of Get4-Get5 complex and its interactions with Sgt2, Get3, and Ydj1.
   findings: []
 - id: PMID:20850366
-  title: A chaperone cascade sorts proteins for posttranslational membrane insertion into the endoplasmic reticulum.
+  title: A chaperone cascade sorts proteins for posttranslational membrane insertion into the
+    endoplasmic reticulum.
   findings: []
 - id: PMID:21866104
   title: The mechanism of membrane-associated steps in tail-anchored protein insertion.
@@ -5824,10 +7074,12 @@ references:
   title: Crystal structure of ATP-bound Get3-Get4-Get5 complex reveals regulation of Get3 by Get4.
   findings: []
 - id: PMID:25242142
-  title: The protein targeting factor Get3 functions as ATP-independent chaperone under oxidative stress conditions.
+  title: The protein targeting factor Get3 functions as ATP-independent chaperone under oxidative
+    stress conditions.
   findings: []
 - id: PMID:25745174
-  title: Protein targeting. Structure of the Get3 targeting factor in complex with its membrane protein cargo.
+  title: Protein targeting. Structure of the Get3 targeting factor in complex with its membrane
+    protein cargo.
   findings: []
 - id: PMID:26928762
   title: &#39;One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.&#39;
@@ -5853,13 +7105,51 @@ references:
 - id: Reactome:R-SCE-9629050
   title: SBH1:GET3:ATP:GET4:MDY2:SGT2 dissociates and GET3 hydrolyzes ATP yielding SBH1:GET3:ADP
   findings: []
+core_functions:
+- molecular_function:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  directly_involved_in:
+  - id: GO:0071816
+    label: tail-anchored membrane protein insertion into ER membrane
+  - id: GO:0006620
+    label: post-translational protein targeting to endoplasmic reticulum membrane
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  description: Get3 is the central ATPase of the yeast GET pathway. As a cytosolic homodimer, it
+    binds and shields tail-anchored protein transmembrane domains, delivers the client to the ER
+    Get1/Get2 receptor/insertase, and uses ATP hydrolysis to drive productive release and insertion
+    into the ER membrane.
+  supported_by:
+  - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+    supporting_text: Functionally, ATP hydrolysis is required for productive insertion because a
+      hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays
+  - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+    supporting_text: Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface
+      forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that
+      increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide
+      dependent
+  - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+    supporting_text: Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane
+      machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and
+      **Get1 driving ATPase-dependent substrate release** for insertion
+  - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+    supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes
+      **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is
+      ATP-sensitive and reversible
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []
 </code></pre>
             </div>
         </details>
     </div>
 
     <!-- Pathway Visualization Link -->
-    
+
 
     <style>
         /* Markdown Section Styles */

--- a/genes/yeast/GET3/GET3-ai-review.yaml
+++ b/genes/yeast/GET3/GET3-ai-review.yaml
@@ -29,6 +29,11 @@ existing_annotations:
     summary: 'Manual review: GET complex is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -38,15 +43,25 @@ existing_annotations:
     summary: 'Manual review: ATP hydrolysis activity is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Functionally, ATP hydrolysis is required for productive insertion because a
+        hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays
 - term:
     id: GO:0071816
     label: tail-anchored membrane protein insertion into ER membrane
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'Manual review: tail-anchored membrane protein insertion into ER membrane is consistent with known biology of GET3.'
+    summary: 'Manual review: tail-anchored membrane protein insertion into ER membrane is consistent with
+      known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane
+        machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and
+        **Get1 driving ATPase-dependent substrate release** for insertion
 - term:
     id: GO:0006457
     label: protein folding
@@ -55,7 +70,8 @@ existing_annotations:
   review:
     summary: 'Manual review: protein folding may be context-dependent or peripheral for GET3.'
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0000166
     label: nucleotide binding
@@ -83,6 +99,11 @@ existing_annotations:
     summary: 'Manual review: cytoplasm is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
@@ -92,6 +113,11 @@ existing_annotations:
     summary: 'Manual review: endoplasmic reticulum is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0005794
     label: Golgi apparatus
@@ -100,7 +126,8 @@ existing_annotations:
   review:
     summary: 'Manual review: Golgi apparatus may be context-dependent or peripheral for GET3.'
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0016192
     label: vesicle-mediated transport
@@ -109,7 +136,8 @@ existing_annotations:
   review:
     summary: 'Manual review: vesicle-mediated transport may be context-dependent or peripheral for GET3.'
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0016787
     label: hydrolase activity
@@ -118,7 +146,8 @@ existing_annotations:
   review:
     summary: 'Manual review: hydrolase activity may be context-dependent or peripheral for GET3.'
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -128,6 +157,10 @@ existing_annotations:
     summary: 'Manual review: ATP hydrolysis activity is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Functionally, ATP hydrolysis is required for productive insertion because a
+        hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays
 - term:
     id: GO:0043529
     label: GET complex
@@ -137,6 +170,11 @@ existing_annotations:
     summary: 'Manual review: GET complex is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0045048
     label: protein insertion into ER membrane
@@ -146,15 +184,22 @@ existing_annotations:
     summary: 'Manual review: protein insertion into ER membrane is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane
+        machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and
+        **Get1 driving ATPase-dependent substrate release** for insertion
 - term:
     id: GO:0046685
     label: response to arsenic-containing substance
   evidence_type: IEA
   original_reference_id: GO_REF:0000043
   review:
-    summary: 'Manual review: response to arsenic-containing substance may be context-dependent or peripheral for GET3.'
+    summary: 'Manual review: response to arsenic-containing substance may be context-dependent or peripheral
+      for GET3.'
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0046872
     label: metal ion binding
@@ -163,7 +208,8 @@ existing_annotations:
   review:
     summary: 'Manual review: metal ion binding may be context-dependent or peripheral for GET3.'
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0005515
     label: protein binding
@@ -332,54 +378,102 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:16260785
   review:
-    summary: 'Manual review: identical protein binding is too generic or over-extended for GET3.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: 'Manual review: identical protein binding captures the obligate Get3 homodimer that forms
+      the tail-anchored protein binding groove.'
+    action: ACCEPT
+    reason: Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic
+      groove that binds and shields tail-anchored protein transmembrane domains.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface
+        forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that
+        increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide
+        dependent
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:19675567
   review:
-    summary: 'Manual review: identical protein binding is too generic or over-extended for GET3.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: 'Manual review: identical protein binding captures the obligate Get3 homodimer that forms
+      the tail-anchored protein binding groove.'
+    action: ACCEPT
+    reason: Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic
+      groove that binds and shields tail-anchored protein transmembrane domains.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface
+        forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that
+        increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide
+        dependent
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:19706470
   review:
-    summary: 'Manual review: identical protein binding is too generic or over-extended for GET3.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: 'Manual review: identical protein binding captures the obligate Get3 homodimer that forms
+      the tail-anchored protein binding groove.'
+    action: ACCEPT
+    reason: Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic
+      groove that binds and shields tail-anchored protein transmembrane domains.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface
+        forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that
+        increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide
+        dependent
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:22124326
   review:
-    summary: 'Manual review: identical protein binding is too generic or over-extended for GET3.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: 'Manual review: identical protein binding captures the obligate Get3 homodimer that forms
+      the tail-anchored protein binding groove.'
+    action: ACCEPT
+    reason: Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic
+      groove that binds and shields tail-anchored protein transmembrane domains.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface
+        forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that
+        increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide
+        dependent
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:24727835
   review:
-    summary: 'Manual review: identical protein binding is too generic or over-extended for GET3.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: 'Manual review: identical protein binding captures the obligate Get3 homodimer that forms
+      the tail-anchored protein binding groove.'
+    action: ACCEPT
+    reason: Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic
+      groove that binds and shields tail-anchored protein transmembrane domains.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface
+        forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that
+        increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide
+        dependent
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:25745174
   review:
-    summary: 'Manual review: identical protein binding is too generic or over-extended for GET3.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: 'Manual review: identical protein binding captures the obligate Get3 homodimer that forms
+      the tail-anchored protein binding groove.'
+    action: ACCEPT
+    reason: Retained because Get3 functions as a homodimer; dimer closure generates the hydrophobic
+      groove that binds and shields tail-anchored protein transmembrane domains.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface
+        forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that
+        increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide
+        dependent
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
@@ -389,6 +483,11 @@ existing_annotations:
     summary: 'Manual review: endoplasmic reticulum membrane is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0045048
     label: protein insertion into ER membrane
@@ -398,6 +497,11 @@ existing_annotations:
     summary: 'Manual review: protein insertion into ER membrane is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane
+        machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and
+        **Get1 driving ATPase-dependent substrate release** for insertion
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -407,15 +511,25 @@ existing_annotations:
     summary: 'Manual review: ATP hydrolysis activity is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Functionally, ATP hydrolysis is required for productive insertion because a
+        hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays
 - term:
     id: GO:0071816
     label: tail-anchored membrane protein insertion into ER membrane
   evidence_type: IMP
   original_reference_id: PMID:18724936
   review:
-    summary: 'Manual review: tail-anchored membrane protein insertion into ER membrane is consistent with known biology of GET3.'
+    summary: 'Manual review: tail-anchored membrane protein insertion into ER membrane is consistent with
+      known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane
+        machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and
+        **Get1 driving ATPase-dependent substrate release** for insertion
 - term:
     id: GO:0008270
     label: zinc ion binding
@@ -424,16 +538,24 @@ existing_annotations:
   review:
     summary: 'Manual review: zinc ion binding may be context-dependent or peripheral for GET3.'
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0044183
     label: protein folding chaperone
   evidence_type: IDA
   original_reference_id: PMID:25242142
   review:
-    summary: 'Manual review: protein folding chaperone is too generic or over-extended for GET3.'
-    action: MARK_AS_OVER_ANNOTATED
-    reason: Marked over-annotated because more specific terms capture the biology more accurately.
+    summary: 'Manual review: protein folding chaperone activity is supported under oxidative or ATP-depleting
+      stress but is not the core GET-pathway function.'
+    action: KEEP_AS_NON_CORE
+    reason: Keep as non-core because Get3 has a regulated ATP-independent holdase role during
+      oxidative stress, while the primary function remains ATP-dependent tail-anchored protein
+      targeting to the ER.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: under oxidative stress or ATP depletion, Get3 is converted from ATPase
+        targeting factor into an **ATP-independent holdase chaperone**.
 - term:
     id: GO:0043529
     label: GET complex
@@ -443,6 +565,11 @@ existing_annotations:
     summary: 'Manual review: GET complex is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0005829
     label: cytosol
@@ -452,6 +579,11 @@ existing_annotations:
     summary: 'Manual review: cytosol is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0005783
     label: endoplasmic reticulum
@@ -461,6 +593,11 @@ existing_annotations:
     summary: 'Manual review: endoplasmic reticulum is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0005829
     label: cytosol
@@ -470,6 +607,11 @@ existing_annotations:
     summary: 'Manual review: cytosol is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0005829
     label: cytosol
@@ -479,6 +621,11 @@ existing_annotations:
     summary: 'Manual review: cytosol is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0005829
     label: cytosol
@@ -488,81 +635,128 @@ existing_annotations:
     summary: 'Manual review: cytosol is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 - term:
     id: GO:0034599
     label: cellular response to oxidative stress
   evidence_type: IDA
   original_reference_id: PMID:25242142
   review:
-    summary: 'Manual review: cellular response to oxidative stress may be context-dependent or peripheral for GET3.'
+    summary: 'Manual review: cellular response to oxidative stress may be context-dependent or peripheral
+      for GET3.'
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0051082
     label: unfolded protein binding
   evidence_type: IDA
   original_reference_id: PMID:25242142
   review:
-    summary: 'Manual review: unfolded protein binding is better represented by a more specific replacement term for GET3.'
-    action: MODIFY
-    reason: Modified to align with current curation guidance and improve term specificity.
-    proposed_replacement_terms:
-    - id: GO:0140597
-      label: protein carrier chaperone
+    summary: 'Manual review: unfolded protein binding is supported for the oxidative-stress holdase state
+      of Get3 but is condition-specific.'
+    action: KEEP_AS_NON_CORE
+    reason: Keep as non-core rather than replacing it; Falcon and the source literature support
+      unfolded-protein binding during stress-induced Get3 holdase activity, distinct from the core
+      GET targeting ATPase cycle.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: under oxidative stress or ATP depletion, Get3 is converted from ATPase
+        targeting factor into an **ATP-independent holdase chaperone**.
 - term:
     id: GO:0000750
     label: pheromone-dependent signal transduction involved in conjugation with cellular fusion
   evidence_type: IMP
   original_reference_id: PMID:18261907
   review:
-    summary: 'Manual review: pheromone-dependent signal transduction involved in conjugation with cellular fusion may be context-dependent or peripheral for GET3.'
+    summary: 'Manual review: pheromone-dependent signal transduction involved in conjugation with cellular
+      fusion may be context-dependent or peripheral for GET3.'
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0005085
     label: guanyl-nucleotide exchange factor activity
   evidence_type: IDA
   original_reference_id: PMID:18261907
   review:
-    summary: 'Manual review: guanyl-nucleotide exchange factor activity may be context-dependent or peripheral for GET3.'
+    summary: 'Manual review: guanyl-nucleotide exchange factor activity for Gpa1 is directly reported
+      but remains context-specific relative to the canonical GET pathway.'
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Keep as non-core because one quantitative source supports Arr4/Get3 GEF activity in
+      pheromone signaling, but this role is less integrated with later GET-pathway mechanistic
+      literature than TA-protein targeting.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: A 2008 study reported that Arr4 is a **non-receptor GEF for Gpa1** and
+        indicates that **Arr4 is an alias of Get3**
 - term:
     id: GO:0006620
     label: post-translational protein targeting to endoplasmic reticulum membrane
   evidence_type: IDA
   original_reference_id: PMID:20850366
   review:
-    summary: 'Manual review: post-translational protein targeting to endoplasmic reticulum membrane is consistent with known biology of GET3.'
+    summary: 'Manual review: post-translational protein targeting to endoplasmic reticulum membrane is
+      consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane
+        machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and
+        **Get1 driving ATPase-dependent substrate release** for insertion
 - term:
     id: GO:0006890
     label: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum
   evidence_type: IDA
   original_reference_id: PMID:16269340
   review:
-    summary: 'Manual review: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum may be context-dependent or peripheral for GET3.'
+    summary: 'Manual review: Golgi-to-ER retrograde transport evidence appears indirect for GET3 and should
+      not be treated as core function.'
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Keep as non-core because the reviewed GET-pathway literature does not provide direct
+      Erd2/HDEL-mediated retrograde-transport evidence for Get3; trafficking effects may be
+      secondary to TA-client targeting or proteostasis defects.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: No direct evidence for Erd2/HDEL-mediated retrograde transport involvement
+        was found in the retrieved primary mechanistic GET literature.
 - term:
     id: GO:0006890
     label: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum
   evidence_type: IMP
   original_reference_id: PMID:16269340
   review:
-    summary: 'Manual review: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum may be context-dependent or peripheral for GET3.'
+    summary: 'Manual review: Golgi-to-ER retrograde transport evidence appears indirect for GET3 and should
+      not be treated as core function.'
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Keep as non-core because the reviewed GET-pathway literature does not provide direct
+      Erd2/HDEL-mediated retrograde-transport evidence for Get3; trafficking effects may be
+      secondary to TA-client targeting or proteostasis defects.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: No direct evidence for Erd2/HDEL-mediated retrograde transport involvement
+        was found in the retrieved primary mechanistic GET literature.
 - term:
     id: GO:0006890
     label: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum
   evidence_type: IGI
   original_reference_id: PMID:16269340
   review:
-    summary: 'Manual review: retrograde vesicle-mediated transport, Golgi to endoplasmic reticulum may be context-dependent or peripheral for GET3.'
+    summary: 'Manual review: Golgi-to-ER retrograde transport evidence appears indirect for GET3 and should
+      not be treated as core function.'
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Keep as non-core because the reviewed GET-pathway literature does not provide direct
+      Erd2/HDEL-mediated retrograde-transport evidence for Get3; trafficking effects may be
+      secondary to TA-client targeting or proteostasis defects.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: No direct evidence for Erd2/HDEL-mediated retrograde transport involvement
+        was found in the retrieved primary mechanistic GET literature.
 - term:
     id: GO:0009408
     label: response to heat
@@ -571,7 +765,8 @@ existing_annotations:
   review:
     summary: 'Manual review: response to heat may be context-dependent or peripheral for GET3.'
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0010038
     label: response to metal ion
@@ -580,7 +775,8 @@ existing_annotations:
   review:
     summary: 'Manual review: response to metal ion may be context-dependent or peripheral for GET3.'
     action: KEEP_AS_NON_CORE
-    reason: Kept as non-core to preserve potentially valid context-specific annotation without elevating it to core function.
+    reason: Kept as non-core to preserve potentially valid context-specific annotation without
+      elevating it to core function.
 - term:
     id: GO:0016887
     label: ATP hydrolysis activity
@@ -590,6 +786,10 @@ existing_annotations:
     summary: 'Manual review: ATP hydrolysis activity is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Functionally, ATP hydrolysis is required for productive insertion because a
+        hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays
 - term:
     id: GO:0043529
     label: GET complex
@@ -599,7 +799,18 @@ existing_annotations:
     summary: 'Manual review: GET complex is consistent with known biology of GET3.'
     action: ACCEPT
     reason: Retained as supported or plausible for this gene and evidence context.
+    supported_by:
+    - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+      supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also
+        becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane
+        association is ATP-sensitive and reversible
 references:
+- id: file:yeast/GET3/GET3-deep-research-falcon.md
+  title: Falcon deep research report for GET3
+  findings: []
+- id: file:yeast/GET3/GET3-uniprot.txt
+  title: UniProt record for yeast GET3
+  findings: []
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
@@ -610,10 +821,12 @@ references:
   title: Gene Ontology annotation based on UniProtKB/Swiss-Prot keyword mapping
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary
+    mapping, accompanied by conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000104
-  title: Electronic Gene Ontology annotations created by transferring manual GO annotations between related proteins based on shared sequence features
+  title: Electronic Gene Ontology annotations created by transferring manual GO annotations between
+    related proteins based on shared sequence features
   findings: []
 - id: GO_REF:0000108
   title: Automatic assignment of GO terms using logical inference, based on on inter-ontology links
@@ -625,7 +838,8 @@ references:
   title: A comprehensive two-hybrid analysis to explore the yeast protein interactome.
   findings: []
 - id: PMID:11805837
-  title: Systematic identification of protein complexes in Saccharomyces cerevisiae by mass spectrometry.
+  title: Systematic identification of protein complexes in Saccharomyces cerevisiae by mass
+    spectrometry.
   findings: []
 - id: PMID:12680698
   title: The Saccharomyces cerevisiae Arr4p is involved in metal and heat tolerance.
@@ -634,10 +848,12 @@ references:
   title: Global analysis of protein localization in budding yeast.
   findings: []
 - id: PMID:16260785
-  title: The yeast Arr4p ATPase binds the chloride transporter Gef1p when copper is available in the cytosol.
+  title: The yeast Arr4p ATPase binds the chloride transporter Gef1p when copper is available in the
+    cytosol.
   findings: []
 - id: PMID:16269340
-  title: Exploration of the function and organization of the yeast early secretory pathway through an epistatic miniarray profile.
+  title: Exploration of the function and organization of the yeast early secretory pathway through
+    an epistatic miniarray profile.
   findings: []
 - id: PMID:16429126
   title: Proteome survey reveals modularity of the yeast cell machinery.
@@ -646,10 +862,12 @@ references:
   title: Global landscape of protein complexes in the yeast Saccharomyces cerevisiae.
   findings: []
 - id: PMID:16816426
-  title: The conserved ATPase Get3/Arr4 modulates the activity of membrane-associated proteins in Saccharomyces cerevisiae.
+  title: The conserved ATPase Get3/Arr4 modulates the activity of membrane-associated proteins in
+    Saccharomyces cerevisiae.
   findings: []
 - id: PMID:18261907
-  title: Coactivation of G protein signaling by cell-surface receptors and an intracellular exchange factor.
+  title: Coactivation of G protein signaling by cell-surface receptors and an intracellular exchange
+    factor.
   findings: []
 - id: PMID:18467557
   title: An in vivo map of the yeast protein interactome.
@@ -670,7 +888,8 @@ references:
   title: Crystal structure of Get4-Get5 complex and its interactions with Sgt2, Get3, and Ydj1.
   findings: []
 - id: PMID:20850366
-  title: A chaperone cascade sorts proteins for posttranslational membrane insertion into the endoplasmic reticulum.
+  title: A chaperone cascade sorts proteins for posttranslational membrane insertion into the
+    endoplasmic reticulum.
   findings: []
 - id: PMID:21866104
   title: The mechanism of membrane-associated steps in tail-anchored protein insertion.
@@ -682,10 +901,12 @@ references:
   title: Crystal structure of ATP-bound Get3-Get4-Get5 complex reveals regulation of Get3 by Get4.
   findings: []
 - id: PMID:25242142
-  title: The protein targeting factor Get3 functions as ATP-independent chaperone under oxidative stress conditions.
+  title: The protein targeting factor Get3 functions as ATP-independent chaperone under oxidative
+    stress conditions.
   findings: []
 - id: PMID:25745174
-  title: Protein targeting. Structure of the Get3 targeting factor in complex with its membrane protein cargo.
+  title: Protein targeting. Structure of the Get3 targeting factor in complex with its membrane
+    protein cargo.
   findings: []
 - id: PMID:26928762
   title: 'One library to make them all: streamlining the creation of yeast libraries via a SWAp-Tag strategy.'
@@ -711,3 +932,41 @@ references:
 - id: Reactome:R-SCE-9629050
   title: SBH1:GET3:ATP:GET4:MDY2:SGT2 dissociates and GET3 hydrolyzes ATP yielding SBH1:GET3:ADP
   findings: []
+core_functions:
+- molecular_function:
+    id: GO:0016887
+    label: ATP hydrolysis activity
+  directly_involved_in:
+  - id: GO:0071816
+    label: tail-anchored membrane protein insertion into ER membrane
+  - id: GO:0006620
+    label: post-translational protein targeting to endoplasmic reticulum membrane
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  - id: GO:0005789
+    label: endoplasmic reticulum membrane
+  description: Get3 is the central ATPase of the yeast GET pathway. As a cytosolic homodimer, it
+    binds and shields tail-anchored protein transmembrane domains, delivers the client to the ER
+    Get1/Get2 receptor/insertase, and uses ATP hydrolysis to drive productive release and insertion
+    into the ER membrane.
+  supported_by:
+  - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+    supporting_text: Functionally, ATP hydrolysis is required for productive insertion because a
+      hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays
+  - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+    supporting_text: Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface
+      forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that
+      increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide
+      dependent
+  - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+    supporting_text: Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane
+      machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and
+      **Get1 driving ATPase-dependent substrate release** for insertion
+  - reference_id: file:yeast/GET3/GET3-deep-research-falcon.md
+    supporting_text: Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes
+      **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is
+      ATP-sensitive and reversible
+proposed_new_terms: []
+suggested_questions: []
+suggested_experiments: []

--- a/genes/yeast/GET3/GET3-deep-research-falcon.md
+++ b/genes/yeast/GET3/GET3-deep-research-falcon.md
@@ -1,0 +1,224 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-13T03:01:39.869307'
+end_time: '2026-05-13T03:18:20.507928'
+duration_seconds: 1000.64
+provider_config:
+  timeout: 600
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 46
+---
+
+## Question
+
+GO annotation research for Saccharomyces cerevisiae GET3/ARR4 (UniProt Q12154). Focus on GO evidence for core functions: ATPase/ATP hydrolysis and ATP binding, homodimeric GET3 as cytosolic targeting factor for tail-anchored membrane proteins, binding/shielding TA protein transmembrane domains, delivery to the ER membrane GET1/GET2 insertase/receptor, tail-anchored membrane protein insertion into ER membrane, GET complex, cytosol/cytoplasm and ER membrane localization. Evaluate non-core or context-specific roles: oxidative-stress ATP-independent holdase/chaperone, protein folding/unfolded protein binding, heat/metal/arsenite response, Golgi-to-ER retrograde transport with Erd2/HDEL receptor, guanyl-nucleotide exchange factor activity for Gpa1/pheromone signaling, generic protein binding and identical protein binding. Include PMID/DOI citations and keep under 1200 words.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+GO annotation research for Saccharomyces cerevisiae GET3/ARR4 (UniProt Q12154). Focus on GO evidence for core functions: ATPase/ATP hydrolysis and ATP binding, homodimeric GET3 as cytosolic targeting factor for tail-anchored membrane proteins, binding/shielding TA protein transmembrane domains, delivery to the ER membrane GET1/GET2 insertase/receptor, tail-anchored membrane protein insertion into ER membrane, GET complex, cytosol/cytoplasm and ER membrane localization. Evaluate non-core or context-specific roles: oxidative-stress ATP-independent holdase/chaperone, protein folding/unfolded protein binding, heat/metal/arsenite response, Golgi-to-ER retrograde transport with Erd2/HDEL receptor, guanyl-nucleotide exchange factor activity for Gpa1/pheromone signaling, generic protein binding and identical protein binding. Include PMID/DOI citations and keep under 1200 words.
+
+## Research report: GO-annotation evidence for *S. cerevisiae* Get3/Arr4 (UniProt Q12154)
+
+### Scope and sources
+This report summarizes Gene Ontology (GO)-relevant experimental evidence for Get3/Arr4, emphasizing core Guided Entry of Tail-anchored proteins (GET) pathway roles and evaluating proposed non-core/context-specific roles. Priority is given to recent 2023–2024 work when available, complemented by high-confidence mechanistic primary studies.
+
+A compact evidence map is provided in the table artifact below.
+
+| GO aspect | Proposed GO term/concept | Evidence summary | Key quantitative data | Strongest supporting citations with year/DOI/URL |
+|---|---|---|---|---|
+| MF | ATPase activity / ATP hydrolysis | Get3 is a SIMIBI-class ATPase whose nucleotide cycle drives conformational switching needed for TA-client release at the ER; hydrolysis-defective mutants remain substrate-bound and insertion-defective. | Get2 binds ATP-bound Get3 with Kd ~190 nM; Get1 binds post-release apo-Get3 with Kd ~50 nM. | Mariappan et al., 2011, doi:10.1038/nature10362, https://doi.org/10.1038/nature10362; Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334 (mariappan2011themechanismof pages 22-25, denic2013endoplasmicreticulumtargeting pages 5-7) |
+| MF | ATP binding | Structural states with AMPPNP, ADP, and ADP·AlF4− show ATP-dependent open/closed Get3 dimer conformations required for substrate capture and receptor engagement. | ATP-bound state preferentially engages Get4/Get5; Get4/Get5 has ~10-fold lower affinity for ADP-bound Get3. | Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334; Jennrich, 2024, doi:10.53846/goediss-10715, https://doi.org/10.53846/goediss-10715 (denic2013endoplasmicreticulumtargeting pages 5-7, jennrich2024characterizationofstressinduced pages 20-23) |
+| MF | Tail-anchored membrane protein binding / TMD shielding | Zn2+-stabilized homodimeric Get3 forms a composite hydrophobic groove that binds and shields α-helical TA transmembrane domains in the cytosol. | Hydrophilizing groove mutations reduce TA binding; hydrolysis-deficient D57N/D57E mutants trap substrate-bound states. | Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334; Mariappan et al., 2011, doi:10.1038/nature10362, https://doi.org/10.1038/nature10362 (denic2013endoplasmicreticulumtargeting pages 5-7, mariappan2011themechanismof pages 22-25) |
+| MF | Identical protein binding / homodimerization | Get3 functions as an obligate homodimer, and dimer closure generates the TA-binding site central to GET-pathway activity. | Obligatory Zn2+-coordinated homodimer; tetramers also observed under oxidizing/stress conditions. | Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334; Jennrich, 2024, doi:10.53846/goediss-10715, https://doi.org/10.53846/goediss-10715 (denic2013endoplasmicreticulumtargeting pages 5-7, jennrich2024characterizationofstressinduced pages 20-23) |
+| BP | Cytosolic targeting factor for TA proteins | Get3 receives TA clients from the Sgt2/Get4/Get5 pretargeting machinery and escorts them post-translationally from the cytosol to the ER receptor. | Reconstituted Get3–Sec22 complexes are insertion-competent. | Wang et al., 2011, doi:10.1016/j.molcel.2011.07.020, https://doi.org/10.1016/j.molcel.2011.07.020; Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334 (wang2011themechanismof pages 1-2, denic2013endoplasmicreticulumtargeting pages 4-5) |
+| BP | Delivery to ER membrane Get1/Get2 receptor/insertase | Get2 first tethers the Get3-TA complex to the ER, then Get1 binds and wedges open Get3 to trigger cargo release for membrane insertion. | Minimal functional membrane machinery is Get1/Get2; ATP disrupts Get1–Get3 complex for recycling. | Mariappan et al., 2011, doi:10.1038/nature10362, https://doi.org/10.1038/nature10362; Wang et al., 2011, doi:10.1016/j.molcel.2011.07.020, https://doi.org/10.1016/j.molcel.2011.07.020 (mariappan2011themechanismof pages 22-25, wang2011themechanismof pages 1-2) |
+| BP | Tail-anchored protein insertion into ER membrane | Get1/Get2 constitute the ER insertase/receptor complex, and Get3 ATPase cycling is essential for productive TA insertion rather than mere docking. | A single Get1/2 heterodimer can function as minimal insertase; recent work supports a Get1/2 channel mechanism. | Wang et al., 2011, doi:10.1016/j.molcel.2011.07.020, https://doi.org/10.1016/j.molcel.2011.07.020; Heo et al., 2023, doi:10.1016/j.celrep.2022.111921, https://doi.org/10.1016/j.celrep.2022.111921 (wang2011themechanismof pages 1-2, zalisko2017tailanchoredprotein pages 6-11) |
+| CC | Cytosol / cytoplasm | Core GET-pathway function places Get3 in the cytosol as the soluble TA-targeting ATPase that shuttles between pretargeting factors and the ER. | In stress/starvation, soluble Get3 relocalizes to cytosolic foci/GET bodies within ~1 h. | Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334; Jennrich, 2024, doi:10.53846/goediss-10715, https://doi.org/10.53846/goediss-10715 (denic2013endoplasmicreticulumtargeting pages 5-7, jennrich2024characterizationofstressinduced pages 113-115) |
+| CC | Endoplasmic reticulum membrane | A substantial fraction of Get3 is membrane-associated through interaction with the ER Get1/Get2 receptor complex during cargo delivery and recycling. | Membrane association is ATP-sensitive and reversible. | Wang et al., 2011, doi:10.1016/j.molcel.2011.07.020, https://doi.org/10.1016/j.molcel.2011.07.020; Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334 (wang2011themechanismof pages 1-2, denic2013endoplasmicreticulumtargeting pages 5-7) |
+| CC | GET complex | Get3 physically and functionally associates with the pretargeting complex (Sgt2/Get4/Get5) and the ER receptor/insertase (Get1/Get2), defining it as a core GET-pathway component. | Loss of GET components causes strong aggregation/proteostasis phenotypes; in 2023 screening, GET1/2/3 were top hits. | Denic et al., 2013, doi:10.1101/cshperspect.a013334, https://doi.org/10.1101/cshperspect.a013334; Josefson et al., 2023, doi:10.1038/s41598-023-35666-8, https://doi.org/10.1038/s41598-023-35666-8 (denic2013endoplasmicreticulumtargeting pages 3-4, josefson2023thegetpathway pages 1-2) |
+| MF/BP | Unfolded protein binding / ATP-independent holdase chaperone | Under oxidative or ATP-depleting stress, Get3 undergoes redox remodeling and switches from TA-targeting ATPase to ATP-independent holdase that binds unfolding proteins and suppresses aggregation. | Chaperone activation T1/2 <1 min with H2O2/Cu2+ and ~5 min with H2O2 alone; oxidized Get3 retains <20% ATPase activity; near-complete citrate synthase aggregation suppression at 8:1 Get3:substrate. | Voth et al., 2014, doi:10.1016/j.molcel.2014.08.017, https://doi.org/10.1016/j.molcel.2014.08.017; Powis et al., 2013, doi:10.1242/jcs.112151, https://doi.org/10.1242/jcs.112151 (voth2014theproteintargeting pages 2-3, powis2013get3isa pages 6-7) |
+| BP | Response to oxidative stress / metal stress | get3Δ cells show copper and oxidative-stress sensitivity, and oxidized Get3 accumulates in stress foci with Hsp70/Hsp104, supporting a condition-specific stress-protective role. | Example condition: 1 mM CuSO4 at 37°C for 4 h induces relocalization; Get3 abundance ~17,300 molecules/cell vs Get1 ~2,250. | Voth et al., 2014, doi:10.1016/j.molcel.2014.08.017, https://doi.org/10.1016/j.molcel.2014.08.017; Reichmann et al., 2018, doi:10.1016/j.molcel.2017.12.021, https://doi.org/10.1016/j.molcel.2017.12.021 (voth2014theproteintargeting pages 9-10, voth2014theproteintargeting pages 8-9, reichmann2018maintainingahealthy pages 3-4) |
+| MF/BP | Guanine nucleotide exchange factor activity for Gpa1 / pheromone signaling | Arr4 and Get3 are aliases, and a 2008 study reported direct Gpa1 binding, accelerated nucleotide exchange, and reduced pheromone signaling in arr4Δ cells, but this role is less integrated into the later core Get3 literature and should be treated as context-specific/cautious. | GTPγS binding increased from 0.085 to 0.36 pmol/pmol/min; Pi release from 0.009 to 0.021 pmol/pmol/min; arr4Δ reduced pheromone-induced FUS1-lacZ by ~50% and mating by ~40%. | Lee, 2008, doi:10.17615/tt4v-sn52, https://doi.org/10.17615/tt4v-sn52; Garcia-Marcos, 2024, doi:10.1016/j.jbc.2024.105756, https://doi.org/10.1016/j.jbc.2024.105756 (michael2008activationofg pages 128-134, michael2008activationofg pages 121-128, michael2008activationofg pages 167-173) |
+| BP/CC | Golgi-to-ER retrograde transport with Erd2/HDEL receptor | Retrieved sources do not provide direct mechanistic evidence for Get3 in Erd2/HDEL-mediated retrograde transport; available data suggest any trafficking effects are indirect consequences of TA-client mislocalization/proteostasis defects. | Negative evidence: Get3 foci under starvation were explicitly not Golgi-localized. | Powis et al., 2013, doi:10.1242/jcs.112151, https://doi.org/10.1242/jcs.112151 (powis2013get3isa pages 3-5, powis2013get3isa pages 7-8, powis2013get3isa pages 6-7) |
+| BP | Proteostasis bottleneck / recent 2023 development | A 2023 genome-wide screen found GET pathway loss to be a major non-stress proteostasis bottleneck, indicating broad cellular consequences beyond TA-client targeting. | Nearly 100% of get1Δ/get2Δ/get3Δ cells displayed Hsp104-GFP foci; 24% of get2Δ foci-forming hits were intrinsically disordered vs ~7.7% expected genome-wide; get3Δ median replicative lifespan 14 vs WT 20 generations. | Josefson et al., 2023, doi:10.1038/s41598-023-35666-8, https://doi.org/10.1038/s41598-023-35666-8 (josefson2023thegetpathway pages 1-2, josefson2023thegetpathway pages 3-5, josefson2023thegetpathway pages 6-8) |
+
+
+*Table: This table summarizes GO-relevant evidence for Saccharomyces cerevisiae Get3/Arr4 (Q12154) across molecular function, biological process, and cellular component. It highlights strongly supported core GET-pathway annotations and distinguishes stress-induced or less-established context-specific roles.*
+
+### 1) Key concepts and definitions (current understanding)
+**Tail-anchored (TA) membrane proteins** are defined by a single C-terminal transmembrane domain (TMD) that emerges only after translation termination; thus they require **post-translational targeting and insertion** into the ER membrane. The yeast GET pathway comprises a **cytosolic pre-targeting complex** (Sgt2/Get4/Get5), the central targeting ATPase **Get3**, and the ER membrane receptor/insertase **Get1/Get2**. Get3/Arr4 is therefore naturally annotated across GO aspects: **Molecular Function (MF)** (ATP binding/hydrolysis; TA-client binding), **Biological Process (BP)** (TA targeting/insertion), and **Cellular Component (CC)** (cytosol and ER membrane/GET complex) (denic2013endoplasmicreticulumtargeting pages 4-5, denic2013endoplasmicreticulumtargeting pages 5-7).
+
+Mechanistically, Get3 is a **SIMIBI-class ATPase** whose nucleotide state controls an **open/closed homodimer** cycle that binds, shields, and releases hydrophobic TMDs, enabling safe cytosolic transit and delivery to the ER receptor (denic2013endoplasmicreticulumtargeting pages 5-7, mariappan2011themechanismof pages 22-25).
+
+### 2) Core GO evidence for canonical GET-pathway functions
+#### 2.1 ATP binding and ATPase/ATP hydrolysis (MF)
+Structural and biochemical evidence supports that Get3 is an ATPase with multiple nucleotide-linked conformations (open/closed/transition-state analog), consistent with GO:ATP binding and ATP hydrolysis-coupled function (denic2013endoplasmicreticulumtargeting pages 5-7, denic2013endoplasmicreticulumtargeting pages 4-5). Functionally, ATP hydrolysis is required for productive insertion because a hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays (mariappan2011themechanismof pages 22-25). 
+
+Quantitative receptor-binding parameters link the nucleotide cycle to ER docking: Get2 binds ATP-bound Get3 with **Kd ~190 nM**, and the post-release Get1–Get3 nucleotide-free complex is very stable (**Kd ~50 nM**) (mariappan2011themechanismof pages 22-25).
+
+#### 2.2 Homodimeric cytosolic targeting factor; TA-TMD binding/shielding (MF/BP)
+Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface forms a **composite hydrophobic groove** that binds an α-helical TA TMD; mutations that increase groove hydrophilicity reduce TA binding, and conformational closure is nucleotide dependent (denic2013endoplasmicreticulumtargeting pages 5-7). Get2 can bind the ATP-closed Get3 conformation without disrupting the hydrophobic groove, supporting a model where Get3 **shields the TA TMD during delivery** (mariappan2011themechanismof pages 22-25).
+
+#### 2.3 Delivery to ER Get1/Get2 receptor/insertase and TA insertion (BP)
+Biochemical reconstitution demonstrates Get1/Get2 are the minimal ER membrane machinery for insertion, with **Get2 tethering** membrane-proximal Get3–TA complexes and **Get1 driving ATPase-dependent substrate release** for insertion (wang2011themechanismof pages 1-2). Mechanistically, Get1 can “wedge open” Get3 after nucleotide hydrolysis to trigger TMD release, and ATP promotes disruption/dissociation of the Get1–Get3 complex to recycle Get3 (mariappan2011themechanismof pages 22-25). 
+
+**Recent development (2023):** a mechanistic update supports the concept that the **Get1/2 insertase forms a channel** mediating TA insertion, refining how GO “TA insertion into ER membrane” may be interpreted structurally/mechanistically in modern annotations (Heo et al., 2023-01; doi:10.1016/j.celrep.2022.111921; https://doi.org/10.1016/j.celrep.2022.111921) (zalisko2017tailanchoredprotein pages 6-11).
+
+#### 2.4 Localization: cytosol/cytoplasm and ER membrane; GET complex (CC)
+Core pathway evidence places Get3 as a **cytosolic shuttle** that also becomes **ER membrane-associated** via Get1/Get2 during docking/release; membrane association is ATP-sensitive and reversible (wang2011themechanismof pages 1-2, denic2013endoplasmicreticulumtargeting pages 5-7). Accordingly, CC annotations should include cytosol/cytoplasm and association with the ER membrane GET receptor complex.
+
+### 3) Non-core/context-specific roles: evidence strength and GO implications
+#### 3.1 ATP-independent holdase/chaperone; unfolded protein binding; oxidative stress response (MF/BP)
+**Strong evidence supports a regulated “moonlighting” role**: under oxidative stress or ATP depletion, Get3 is converted from ATPase targeting factor into an **ATP-independent holdase chaperone**.
+
+Mechanism: oxidation triggers disulfide bond formation and zinc release with partial unfolding/oligomerization; oxidized Get3 becomes ATPase-inactive yet binds unfolding proteins and prevents aggregation (voth2014theproteintargeting pages 1-2, ulrich2021thiolbasedswitchingmechanisms pages 5-6). Quantitatively, oxidative activation is rapid (**T1/2 < 1 min** with H2O2/Cu2+; **~5 min** with H2O2 alone), and oxidized Get3 can almost completely suppress citrate synthase aggregation at an **8:1 Get3:substrate** ratio; oxidized Get3 retains **<20%** ATPase activity (voth2014theproteintargeting pages 2-3). Stress phenotypes and in vivo relocalization are consistent with a protective role during copper/oxidative stress (example: **1 mM CuSO4 at 37°C for 4 h**) (voth2014theproteintargeting pages 9-10).
+
+**GO guidance implication:** MF terms like “unfolded protein binding” and BP terms like “response to oxidative stress” are well supported but **condition-specific** and should not replace the core TA-targeting annotations.
+
+#### 3.2 Heat/metal/arsenite response
+Metal/oxidative stress support is direct (copper sensitivity; copper-triggered relocalization) (voth2014theproteintargeting pages 9-10, voth2014theproteintargeting pages 8-9). Heat stress is referenced as a sensitivity phenotype associated with get3 deletion in the oxidative-stress chaperone study, but the mechanistic evidence in the retrieved excerpts is strongest for oxidative/metal stress rather than a dedicated heat-response pathway (voth2014theproteintargeting pages 1-2).
+
+#### 3.3 Golgi-to-ER retrograde transport (Erd2/HDEL receptor) and Golgi localization
+No direct evidence for Erd2/HDEL-mediated retrograde transport involvement was found in the retrieved primary mechanistic GET literature. Moreover, during glucose starvation Get3 foci were explicitly **not Golgi-localized** (Golgi marker Anp1 used to exclude Golgi) (powis2013get3isa pages 3-5). Available data instead suggest that any trafficking phenotypes (e.g., involving Sed5 stability) likely reflect **indirect consequences** of TA mis-targeting or proteostasis disruption rather than a primary Erd2-dependent role (powis2013get3isa pages 6-7).
+
+#### 3.4 Guanine nucleotide exchange factor (GEF) activity for Gpa1; pheromone signaling
+A 2008 study reported that Arr4 is a **non-receptor GEF for Gpa1** and indicates that **Arr4 is an alias of Get3** (“Get3, an alias for Arr4”) (Lee, 2008; doi:10.17615/tt4v-sn52; https://doi.org/10.17615/tt4v-sn52) (michael2008activationofg pages 167-173). The same source describes direct biochemical activity: Arr4 increased GTPγS binding from **0.085 → 0.36 pmol GTPγS·pmol Gpa1−1·min−1** and Pi release from **0.009 → 0.021 pmol Pi·pmol Gpa1−1·min−1**, and arr4Δ reduced pheromone-induced transcription (~50% in FUS1-lacZ) and mating (~40%) (michael2008activationofg pages 121-128, michael2008activationofg pages 128-134). 
+
+**Caution for GO annotation:** while this evidence is quantitative and directly biochemical, it is (i) less represented in later, GET-pathway-centric mechanistic syntheses and (ii) potentially context-dependent (copper/dimerization dependence noted in that work). Thus, annotating “GEF activity” may be appropriate but should be **qualified with evidence code and context**, and not conflated with Get3’s core TA-targeting role.
+
+#### 3.5 Generic protein binding and identical protein binding
+“Identical protein binding” is consistent with obligate Get3 homodimerization required for TA binding and function (denic2013endoplasmicreticulumtargeting pages 5-7, jennrich2024characterizationofstressinduced pages 20-23). “Protein binding” is trivially true (clients and partners), but is low-specificity relative to mechanistically informative terms such as “tail-anchored protein binding” or “unfolded protein binding.”
+
+### 4) Recent developments (2023–2024)
+**Insertase mechanism refinement (2023):** Get1/2 is proposed to form a channel enabling insertion, strengthening mechanistic grounding for BP annotations related to TA insertion into ER membrane (Heo et al., 2023-01; doi:10.1016/j.celrep.2022.111921) (zalisko2017tailanchoredprotein pages 6-11).
+
+**GET pathway as a proteostasis bottleneck (2023):** A genome-wide screen found GET1/2/3 among top aggregation hits; manual verification showed **~100%** of get1Δ/get2Δ/get3Δ cells had Hsp104-GFP foci at 30°C, and get3Δ median replicative lifespan was **14 generations vs 20 in WT**. Disorder was enriched among proteins forming foci in GET mutants (**24% vs ~7.7%** expected) (Josefson et al., 2023-06; doi:10.1038/s41598-023-35666-8; https://doi.org/10.1038/s41598-023-35666-8) (josefson2023thegetpathway pages 1-2, josefson2023thegetpathway pages 6-8, josefson2023thegetpathway pages 3-5).
+
+**Stress-induced cytosolic assemblies / “GET bodies” (2024):** During glucose starvation, GET components assemble into cytosolic foci within **~1 h**; Hsp70 chaperones robustly co-localize later (**~4 h**), and after prolonged starvation Hsp70s appear in **≥70%** of foci (Jennrich, 2024; doi:10.53846/goediss-10715; https://doi.org/10.53846/goediss-10715) (jennrich2024characterizationofstressinduced pages 113-115).
+
+### 5) Applications and real-world implementations
+1. **In vitro reconstitution** of TA targeting/insertion (Get3 with Get1/2 and upstream factors) provides a rigorous platform for mapping GO evidence to direct biochemical activity and defining minimal machinery (wang2011themechanismof pages 1-2, mariappan2011themechanismof pages 22-25).
+2. **Fluorescent reporters** (e.g., Hsp104-GFP aggregation, TA SNARE Sed5 reporters) and genome-wide genetics quantify system-level consequences of GET dysfunction, bridging molecular GO terms with cellular phenotypes (josefson2023thegetpathway pages 1-2, powis2013get3isa pages 6-7).
+3. **Stress/foci imaging paradigms** support CC/BP annotations for cytosolic assemblies under starvation and for stress-associated relocalization consistent with holdase function (powis2013get3isa pages 3-5, jennrich2024characterizationofstressinduced pages 113-115).
+
+### Visual evidence
+A schematic summarizing the canonical GET pathway and Get3 relocalization to deposition sites under starvation/blocked ATP hydrolysis is available (Powis et al., 2013; doi:10.1242/jcs.112151; https://doi.org/10.1242/jcs.112151) (powis2013get3isa media e2d53b1f).
+
+### Bottom line for GO annotation focus
+**Core, high-confidence GO annotations** for Get3/Arr4 should prioritize ATP binding/ATPase activity coupled to TA TMD binding/shielding, ER targeting, and Get1/Get2-dependent TA insertion, with CC terms spanning cytosol and ER membrane/GET complex (mariappan2011themechanismof pages 22-25, wang2011themechanismof pages 1-2, denic2013endoplasmicreticulumtargeting pages 5-7). **Secondary but well-supported condition-specific annotations** include ATP-independent unfolded-protein binding/holdase and oxidative/metal stress response. **Trafficking claims involving Erd2/HDEL** lack direct support in the retrieved evidence. **GEF activity for Gpa1** has direct quantitative biochemical evidence in one source and is cited in later reviews, but appears more context-limited and should be annotated cautiously with appropriate evidence coding and notes (michael2008activationofg pages 128-134, michael2008activationofg pages 167-173).
+
+References
+
+1. (mariappan2011themechanismof pages 22-25): Malaiyalam Mariappan, Agnieszka Mateja, Malgorzata Dobosz, Elia Bove, Ramanujan S. Hegde, and Robert J. Keenan. The mechanism of membrane-associated steps in tail-anchored protein insertion. Nature, 477:61-66, Sep 2011. URL: https://doi.org/10.1038/nature10362, doi:10.1038/nature10362. This article has 201 citations and is from a highest quality peer-reviewed journal.
+
+2. (denic2013endoplasmicreticulumtargeting pages 5-7): Vladimir Denic, V. Dötsch, and I. Sinning. Endoplasmic reticulum targeting and insertion of tail-anchored membrane proteins by the get pathway. Cold Spring Harbor perspectives in biology, 5 8:a013334, Aug 2013. URL: https://doi.org/10.1101/cshperspect.a013334, doi:10.1101/cshperspect.a013334. This article has 92 citations and is from a peer-reviewed journal.
+
+3. (jennrich2024characterizationofstressinduced pages 20-23): Jonas Jennrich. Characterization of stress-induced cytosolic assemblies containing components of the guided-entry of tail-anchored proteins targeting pathway. ArXiv, 2024. URL: https://doi.org/10.53846/goediss-10715, doi:10.53846/goediss-10715. This article has 0 citations.
+
+4. (wang2011themechanismof pages 1-2): Fei Wang, Andrew Whynot, Matthew Tung, and Vladimir Denic. The mechanism of tail-anchored protein insertion into the er membrane. Molecular cell, 43 5:738-50, Sep 2011. URL: https://doi.org/10.1016/j.molcel.2011.07.020, doi:10.1016/j.molcel.2011.07.020. This article has 121 citations and is from a highest quality peer-reviewed journal.
+
+5. (denic2013endoplasmicreticulumtargeting pages 4-5): Vladimir Denic, V. Dötsch, and I. Sinning. Endoplasmic reticulum targeting and insertion of tail-anchored membrane proteins by the get pathway. Cold Spring Harbor perspectives in biology, 5 8:a013334, Aug 2013. URL: https://doi.org/10.1101/cshperspect.a013334, doi:10.1101/cshperspect.a013334. This article has 92 citations and is from a peer-reviewed journal.
+
+6. (zalisko2017tailanchoredprotein pages 6-11): Benjamin Edward Zalisko. Tail anchored protein insertion by a get1/2 heterodimer. Jan 2017. URL: https://doi.org/10.6082/m1pg1pvq, doi:10.6082/m1pg1pvq. This article has 0 citations.
+
+7. (jennrich2024characterizationofstressinduced pages 113-115): Jonas Jennrich. Characterization of stress-induced cytosolic assemblies containing components of the guided-entry of tail-anchored proteins targeting pathway. ArXiv, 2024. URL: https://doi.org/10.53846/goediss-10715, doi:10.53846/goediss-10715. This article has 0 citations.
+
+8. (denic2013endoplasmicreticulumtargeting pages 3-4): Vladimir Denic, V. Dötsch, and I. Sinning. Endoplasmic reticulum targeting and insertion of tail-anchored membrane proteins by the get pathway. Cold Spring Harbor perspectives in biology, 5 8:a013334, Aug 2013. URL: https://doi.org/10.1101/cshperspect.a013334, doi:10.1101/cshperspect.a013334. This article has 92 citations and is from a peer-reviewed journal.
+
+9. (josefson2023thegetpathway pages 1-2): Rebecca Josefson, Navinder Kumar, Xinxin Hao, Beidong Liu, and Thomas Nyström. The get pathway is a major bottleneck for maintaining proteostasis in saccharomyces cerevisiae. Scientific Reports, Jun 2023. URL: https://doi.org/10.1038/s41598-023-35666-8, doi:10.1038/s41598-023-35666-8. This article has 4 citations and is from a peer-reviewed journal.
+
+10. (voth2014theproteintargeting pages 2-3): Wilhelm Voth, Markus Schick, Stephanie Gates, Sheng Li, Fabio Vilardi, Irina Gostimskaya, Daniel R. Southworth, Blanche Schwappach, and Ursula Jakob. The protein targeting factor get3 functions as atp-independent chaperone under oxidative stress conditions. Molecular cell, 56 1:116-27, Oct 2014. URL: https://doi.org/10.1016/j.molcel.2014.08.017, doi:10.1016/j.molcel.2014.08.017. This article has 95 citations and is from a highest quality peer-reviewed journal.
+
+11. (powis2013get3isa pages 6-7): Katie Powis, Bianca Schrul, Heather Tienson, Irina Gostimskaya, Michal Breker, Stephen High, Maya Schuldiner, Ursula Jakob, and Blanche Schwappach. Get3 is a holdase chaperone and moves to deposition sites for aggregated proteins when membrane targeting is blocked. Journal of Cell Science, 126:473-483, Jan 2013. URL: https://doi.org/10.1242/jcs.112151, doi:10.1242/jcs.112151. This article has 84 citations and is from a domain leading peer-reviewed journal.
+
+12. (voth2014theproteintargeting pages 9-10): Wilhelm Voth, Markus Schick, Stephanie Gates, Sheng Li, Fabio Vilardi, Irina Gostimskaya, Daniel R. Southworth, Blanche Schwappach, and Ursula Jakob. The protein targeting factor get3 functions as atp-independent chaperone under oxidative stress conditions. Molecular cell, 56 1:116-27, Oct 2014. URL: https://doi.org/10.1016/j.molcel.2014.08.017, doi:10.1016/j.molcel.2014.08.017. This article has 95 citations and is from a highest quality peer-reviewed journal.
+
+13. (voth2014theproteintargeting pages 8-9): Wilhelm Voth, Markus Schick, Stephanie Gates, Sheng Li, Fabio Vilardi, Irina Gostimskaya, Daniel R. Southworth, Blanche Schwappach, and Ursula Jakob. The protein targeting factor get3 functions as atp-independent chaperone under oxidative stress conditions. Molecular cell, 56 1:116-27, Oct 2014. URL: https://doi.org/10.1016/j.molcel.2014.08.017, doi:10.1016/j.molcel.2014.08.017. This article has 95 citations and is from a highest quality peer-reviewed journal.
+
+14. (reichmann2018maintainingahealthy pages 3-4): Dana Reichmann, Wilhelm Voth, and Ursula Jakob. Maintaining a healthy proteome during oxidative stress. Molecular cell, 69 2:203-213, Jan 2018. URL: https://doi.org/10.1016/j.molcel.2017.12.021, doi:10.1016/j.molcel.2017.12.021. This article has 224 citations and is from a highest quality peer-reviewed journal.
+
+15. (michael2008activationofg pages 128-134): Michael Lee. Activation of g protein signaling by a non-receptor exchange factor. Text, 2008. URL: https://doi.org/10.17615/tt4v-sn52, doi:10.17615/tt4v-sn52. This article has 1 citations and is from a peer-reviewed journal.
+
+16. (michael2008activationofg pages 121-128): Michael Lee. Activation of g protein signaling by a non-receptor exchange factor. Text, 2008. URL: https://doi.org/10.17615/tt4v-sn52, doi:10.17615/tt4v-sn52. This article has 1 citations and is from a peer-reviewed journal.
+
+17. (michael2008activationofg pages 167-173): Michael Lee. Activation of g protein signaling by a non-receptor exchange factor. Text, 2008. URL: https://doi.org/10.17615/tt4v-sn52, doi:10.17615/tt4v-sn52. This article has 1 citations and is from a peer-reviewed journal.
+
+18. (powis2013get3isa pages 3-5): Katie Powis, Bianca Schrul, Heather Tienson, Irina Gostimskaya, Michal Breker, Stephen High, Maya Schuldiner, Ursula Jakob, and Blanche Schwappach. Get3 is a holdase chaperone and moves to deposition sites for aggregated proteins when membrane targeting is blocked. Journal of Cell Science, 126:473-483, Jan 2013. URL: https://doi.org/10.1242/jcs.112151, doi:10.1242/jcs.112151. This article has 84 citations and is from a domain leading peer-reviewed journal.
+
+19. (powis2013get3isa pages 7-8): Katie Powis, Bianca Schrul, Heather Tienson, Irina Gostimskaya, Michal Breker, Stephen High, Maya Schuldiner, Ursula Jakob, and Blanche Schwappach. Get3 is a holdase chaperone and moves to deposition sites for aggregated proteins when membrane targeting is blocked. Journal of Cell Science, 126:473-483, Jan 2013. URL: https://doi.org/10.1242/jcs.112151, doi:10.1242/jcs.112151. This article has 84 citations and is from a domain leading peer-reviewed journal.
+
+20. (josefson2023thegetpathway pages 3-5): Rebecca Josefson, Navinder Kumar, Xinxin Hao, Beidong Liu, and Thomas Nyström. The get pathway is a major bottleneck for maintaining proteostasis in saccharomyces cerevisiae. Scientific Reports, Jun 2023. URL: https://doi.org/10.1038/s41598-023-35666-8, doi:10.1038/s41598-023-35666-8. This article has 4 citations and is from a peer-reviewed journal.
+
+21. (josefson2023thegetpathway pages 6-8): Rebecca Josefson, Navinder Kumar, Xinxin Hao, Beidong Liu, and Thomas Nyström. The get pathway is a major bottleneck for maintaining proteostasis in saccharomyces cerevisiae. Scientific Reports, Jun 2023. URL: https://doi.org/10.1038/s41598-023-35666-8, doi:10.1038/s41598-023-35666-8. This article has 4 citations and is from a peer-reviewed journal.
+
+22. (voth2014theproteintargeting pages 1-2): Wilhelm Voth, Markus Schick, Stephanie Gates, Sheng Li, Fabio Vilardi, Irina Gostimskaya, Daniel R. Southworth, Blanche Schwappach, and Ursula Jakob. The protein targeting factor get3 functions as atp-independent chaperone under oxidative stress conditions. Molecular cell, 56 1:116-27, Oct 2014. URL: https://doi.org/10.1016/j.molcel.2014.08.017, doi:10.1016/j.molcel.2014.08.017. This article has 95 citations and is from a highest quality peer-reviewed journal.
+
+23. (ulrich2021thiolbasedswitchingmechanisms pages 5-6): Kathrin Ulrich, Blanche Schwappach, and Ursula Jakob. Thiol-based switching mechanisms of stress-sensing chaperones. Biological Chemistry, 402:239-252, Oct 2021. URL: https://doi.org/10.1515/hsz-2020-0262, doi:10.1515/hsz-2020-0262. This article has 24 citations and is from a peer-reviewed journal.
+
+24. (powis2013get3isa media e2d53b1f): Katie Powis, Bianca Schrul, Heather Tienson, Irina Gostimskaya, Michal Breker, Stephen High, Maya Schuldiner, Ursula Jakob, and Blanche Schwappach. Get3 is a holdase chaperone and moves to deposition sites for aggregated proteins when membrane targeting is blocked. Journal of Cell Science, 126:473-483, Jan 2013. URL: https://doi.org/10.1242/jcs.112151, doi:10.1242/jcs.112151. This article has 84 citations and is from a domain leading peer-reviewed journal.
+
+## Citations
+
+1. mariappan2011themechanismof pages 22-25
+2. denic2013endoplasmicreticulumtargeting pages 5-7
+3. wang2011themechanismof pages 1-2
+4. zalisko2017tailanchoredprotein pages 6-11
+5. voth2014theproteintargeting pages 2-3
+6. voth2014theproteintargeting pages 9-10
+7. voth2014theproteintargeting pages 1-2
+8. michael2008activationofg pages 167-173
+9. jennrich2024characterizationofstressinduced pages 113-115
+10. jennrich2024characterizationofstressinduced pages 20-23
+11. denic2013endoplasmicreticulumtargeting pages 4-5
+12. denic2013endoplasmicreticulumtargeting pages 3-4
+13. josefson2023thegetpathway pages 1-2
+14. voth2014theproteintargeting pages 8-9
+15. reichmann2018maintainingahealthy pages 3-4
+16. michael2008activationofg pages 128-134
+17. michael2008activationofg pages 121-128
+18. josefson2023thegetpathway pages 3-5
+19. josefson2023thegetpathway pages 6-8
+20. ulrich2021thiolbasedswitchingmechanisms pages 5-6
+21. https://doi.org/10.1038/nature10362;
+22. https://doi.org/10.1101/cshperspect.a013334
+23. https://doi.org/10.1101/cshperspect.a013334;
+24. https://doi.org/10.53846/goediss-10715
+25. https://doi.org/10.1038/nature10362
+26. https://doi.org/10.1016/j.molcel.2011.07.020;
+27. https://doi.org/10.1016/j.molcel.2011.07.020
+28. https://doi.org/10.1016/j.celrep.2022.111921
+29. https://doi.org/10.1038/s41598-023-35666-8
+30. https://doi.org/10.1016/j.molcel.2014.08.017;
+31. https://doi.org/10.1242/jcs.112151
+32. https://doi.org/10.1016/j.molcel.2017.12.021
+33. https://doi.org/10.17615/tt4v-sn52;
+34. https://doi.org/10.1016/j.jbc.2024.105756
+35. https://doi.org/10.17615/tt4v-sn52
+36. https://doi.org/10.1038/nature10362,
+37. https://doi.org/10.1101/cshperspect.a013334,
+38. https://doi.org/10.53846/goediss-10715,
+39. https://doi.org/10.1016/j.molcel.2011.07.020,
+40. https://doi.org/10.6082/m1pg1pvq,
+41. https://doi.org/10.1038/s41598-023-35666-8,
+42. https://doi.org/10.1016/j.molcel.2014.08.017,
+43. https://doi.org/10.1242/jcs.112151,
+44. https://doi.org/10.1016/j.molcel.2017.12.021,
+45. https://doi.org/10.17615/tt4v-sn52,
+46. https://doi.org/10.1515/hsz-2020-0262,

--- a/genes/yeast/GET3/GET3-notes.md
+++ b/genes/yeast/GET3/GET3-notes.md
@@ -1,0 +1,9 @@
+# GET3 notes
+
+Falcon deep research supports GET3 as the central ATPase of the yeast GET pathway: "Functionally, ATP hydrolysis is required for productive insertion because a hydrolysis-deficient Get3 mutant remains substrate-bound and is inactive in insertion assays" [file:yeast/GET3/GET3-deep-research-falcon.md].
+
+The canonical mechanism is a cytosolic homodimeric targeting cycle: "Get3 is described as a **Zn2+-stabilized homodimer** whose dimer interface forms a **composite hydrophobic groove**" that binds the tail-anchor TMD [file:yeast/GET3/GET3-deep-research-falcon.md].
+
+Falcon distinguishes the core GET pathway from secondary roles. Stress-induced holdase/chaperone activity is real but non-core: "under oxidative stress or ATP depletion, Get3 is converted from ATPase targeting factor into an **ATP-independent holdase chaperone**" [file:yeast/GET3/GET3-deep-research-falcon.md].
+
+The Falcon report did not find direct support for Erd2/HDEL-mediated Golgi-to-ER retrograde transport as a primary GET3 function, so the corresponding GOA rows should stay non-core [file:yeast/GET3/GET3-deep-research-falcon.md].


### PR DESCRIPTION
## Summary
- add Falcon deep research for yeast GET3
- incorporate Falcon evidence into the GET3 review YAML
- add a core function for the GET-pathway ATPase role
- update homodimer, stress-holdase, unfolded-protein binding, GEF, and retrograde-transport reviews based on Falcon evidence
- add GET3 notes and re-render the review HTML

## Validation
- `uv run python scripts/validate_deep_research.py genes/yeast/GET3/GET3-deep-research-falcon.md`
- `just validate yeast GET3`
- exact supporting_text audit: 37 snippets found in cached sources/Falcon report
- `git diff --check`
