### PR TITLE
RB1: ACCEPT 4 canonical antiproliferative BP rows (batch 14 of #347)

### DIFF
--- a/genes/human/RB1/RB1-ai-review.yaml
+++ b/genes/human/RB1/RB1-ai-review.yaml
@@ -920,8 +920,9 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'IEA annotation projected from mouse Rb1 via Ensembl Compara (GO_REF:0000107) for negative regulation of cell growth. RB1 is the prototypical pocket-protein antiproliferative tumor suppressor: hypophosphorylated RB1 binds activator E2Fs (E2F1/2/3) via the RB_A/RB_B pocket, masks their transactivation domains, recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) and durably represses S-phase gene transcription, thereby restricting net cellular growth and proliferation (PMID:7923370; deep research synthesis). Already captured at higher specificity in this file via the GO:2000134 negative regulation of G1/S transition TAS row (PMID:19149898) ACCEPTed in batch 9 and the GO:0051726 regulation of cell cycle IEA row ACCEPTed in batch 5.'
+    action: ACCEPT
+    reason: 'Canonical RB1 antiproliferative function, well supported by experimental evidence already present in this file (PMID:7923370 RB-BRG1 cooperation; IDA/EXP rows in this annotation set) and by independent Reactome TAS rows previously ACCEPTed in PRs #440/#444. Mechanical IEA-canonical batch (batch 14 of #347).'
 - term:
     id: GO:0032869
     label: cellular response to insulin stimulus
@@ -946,8 +947,9 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'IEA annotation projected from mouse Rb1 via Ensembl Compara (GO_REF:0000107) for negative regulation of cell cycle. Negative regulation of cell-cycle progression is the defining RB1 tumor-suppressor activity: hypophosphorylated RB1 sequesters activator E2Fs and represses S-phase genes at the G1 restriction point until it is sequentially inactivated by Cyclin D-CDK4/6 and Cyclin E-CDK2 phosphorylation (PMID:7923370; deep research synthesis). Already captured at higher specificity in this file via the GO:2000134 negative regulation of G1/S transition TAS row (PMID:19149898) ACCEPTed in batch 9 and the GO:0051726 regulation of cell cycle IEA row ACCEPTed in batch 5.'
+    action: ACCEPT
+    reason: 'Canonical RB1 cell-cycle-restriction function, well supported by experimental evidence already present in this file (PMID:7923370 RB-BRG1 cooperation; IDA/EXP rows in this annotation set) and by independent Reactome TAS rows previously ACCEPTed in PRs #440/#444. Mechanical IEA-canonical batch (batch 14 of #347).'
 - term:
     id: GO:0050728
     label: negative regulation of inflammatory response
@@ -1255,8 +1257,9 @@ existing_annotations:
   evidence_type: ISS
   original_reference_id: GO_REF:0000024
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'ISS annotation projected via UniProt/InterPro template (GO_REF:0000024) for negative regulation of cell growth, based on conservation of the RB pocket domain. RB1 is the prototypical pocket-protein antiproliferative tumor suppressor: hypophosphorylated RB1 binds activator E2Fs (E2F1/2/3) via the RB_A/RB_B pocket and represses S-phase gene transcription, restricting net cellular growth and proliferation (PMID:7923370; deep research synthesis). Already captured at higher specificity in this file via the GO:2000134 negative regulation of G1/S transition TAS row (PMID:19149898) ACCEPTed in batch 9.'
+    action: ACCEPT
+    reason: 'Canonical RB1 antiproliferative function, well supported by experimental evidence already present in this file (PMID:7923370 RB-BRG1 cooperation; IDA/EXP rows in this annotation set) and by independent Reactome TAS rows previously ACCEPTed in PRs #440/#444. Mechanical ISS-canonical batch (batch 14 of #347).'
 - term:
     id: GO:0005829
     label: cytosol
@@ -1290,8 +1293,9 @@ existing_annotations:
   evidence_type: ISS
   original_reference_id: PMID:24027266
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'ISS annotation citing PMID:24027266 (MiR-26b in Alzheimer''s disease — miR-26b directly represses RB1 to drive cell-cycle re-entry in postmitotic neurons). The source paper''s mechanism establishes RB1 as the canonical brake on cell-cycle progression: loss of RB1 via miR-26b targeting is sufficient to license aberrant cell-cycle re-entry. Negative regulation of cell cycle is the defining RB1 tumor-suppressor activity (PMID:7923370; deep research synthesis), already captured at higher specificity in this file via the GO:2000134 negative regulation of G1/S transition TAS row (PMID:19149898) ACCEPTed in batch 9 and the GO:0051726 regulation of cell cycle IEA row ACCEPTed in batch 5.'
+    action: ACCEPT
+    reason: 'Canonical RB1 cell-cycle-restriction function, well supported by experimental evidence already present in this file (PMID:7923370 RB-BRG1 cooperation; IDA/EXP rows in this annotation set) and by independent Reactome TAS rows previously ACCEPTed in PRs #440/#444. Mechanical ISS-canonical batch (batch 14 of #347).'
 - term:
     id: GO:2001234
     label: negative regulation of apoptotic signaling pathway


### PR DESCRIPTION
## Summary

Batch 14 of the RB1 GO annotation review (#347). Mechanical consolidation of **4 PENDING rows** on canonical RB1 antiproliferative BPs to `ACCEPT`:

| Term | Evidence | Reference |
|------|----------|-----------|
| `GO:0030308` negative regulation of cell growth | IEA | GO_REF:0000107 |
| `GO:0030308` negative regulation of cell growth | ISS | GO_REF:0000024 |
| `GO:0045786` negative regulation of cell cycle | IEA | GO_REF:0000107 |
| `GO:0045786` negative regulation of cell cycle | ISS | PMID:24027266 |

## Why uniform `ACCEPT`

Both terms describe RB1's defining tumor-suppressor activity: hypophosphorylated RB1 sequesters activator E2Fs (E2F1/2/3) at the G1 restriction point and represses S-phase gene transcription via recruited chromatin corepressors. These rows are parent / sibling terms of the more specific `GO:2000134` (negative regulation of G1/S transition of mitotic cell cycle) already ACCEPTed in batch 9 (TAS PMID:19149898) and the `GO:0051726` (regulation of cell cycle) IEA row ACCEPTed in batch 5.

The PMID:24027266 ISS source (MiR-26b in Alzheimer's disease) is a tissue-specific neuronal paper, but its mechanism establishes RB1 as the canonical cell-cycle brake — miR-26b directly represses RB1 to license aberrant cell-cycle re-entry in postmitotic neurons. The function it describes (RB1 negatively regulates cell cycle) is canonical regardless of the projection source.

## Diff stats

- `+12 / -8` lines on `RB1-ai-review.yaml` only
- **PENDING count: 30 → 26 (−4)**
- `just validate human RB1` → ✓ Valid (2 pre-existing warnings unchanged: PENDING-count, deep-research-file)

## What remains after #347 batch 14 (26 PENDING)

Carryover groups (same shape as the [batch 13 carryover](https://github.com/ai4curation/ai-gene-review/issues/347#issuecomment-4448107000), minus this batch's 4 rows):

- **2 remaining IEA `GO_REF:0000107` rows** — `GO:0005819` spindle (mitotic, KEEP_AS_NON_CORE candidate paralleling batch 11 PMID:20551165 mitotic-fidelity cluster) and `GO:0019899` enzyme binding (uninformative MF parent, MARK_AS_OVER_ANNOTATED candidate paralleling generic GO:0005515 IPI treatment)
- **7 RB-E2F complex / self-interaction IPI rows** on `GO:0042802` / `GO:0035189` / `GO:0140297` / `GO:0061676` / `GO:0097718` / `GO:0051219` — clean cluster batch candidate
- **6 IDA/EXP/IMP canonical rows** on PMID:1531329 / PMID:8245034 / PMID:19223331 / PMID:25100735 / PMID:12037672 — drive core_functions block expansion
- **5 ISS/IEA singletons** + remaining odds

## Selection rationale (single-target scanner run)

Of the 8 open `curation`-labeled gene-review issues, 6 (#270 AATF, #305 ABCE1, #307 ATF3, #308 BAG3, #309 BCAP31, #343 KRAS) remain in fully-cleared closure-ready state with prior "stop posting" hand-offs and merged pathway PRs — re-posting on any of those would be queue churn that prior scanner passes have already flagged. That left BRAF (#344) and RB1 (#347) as the two actively-batched candidates. BRAF still has the [unresolved PR #535 conflict situation](https://github.com/ai4curation/ai-gene-review/issues/344#issuecomment-4448032199) (Falcon-DR PR APPROVED but `CONFLICTING / DIRTY` against `main`, last branch update 2026-05-13 — needs maintainer judgment on prose reconciliation, not scanner-actionable), so stacking another BRAF batch risks compounding the conflict. RB1's PR #548 merged 2026-05-14 15:44 UTC (~5.4h before this run), leaving the file in clean state with 30 PENDING and a clearly identifiable next mechanical batch. The 5.4h gap matches the [batch 11 → 12 cadence](https://github.com/ai4curation/ai-gene-review/issues/347#issuecomment-4445145017) (5.6h).

## Test plan

- [x] `just validate human RB1` → ✓ Valid (only pre-existing PENDING-count and deep-research-file warnings)
- [x] All 4 rows uniformly resolved to `ACCEPT` with row-specific summaries
- [x] All references already present in `references:` block; no new PMIDs
- [x] Diff scope limited to `genes/human/RB1/RB1-ai-review.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)