### PR TITLE
RB1: batch 18 — MARK_AS_OVER_ANNOTATED 2 PMID:16360038 generic-binding rows (#347)

### DIFF
--- a/genes/human/RB1/RB1-ai-review.yaml
+++ b/genes/human/RB1/RB1-ai-review.yaml
@@ -844,8 +844,23 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:16360038
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'Rubin et al. 2005 (PMID:16360038, Cell) is the crystal structure of
+      the Rb C-terminal domain (RbC) bound to the E2F1-DP1 heterodimer. It characterizes
+      a high-affinity heterotypic interaction in which RbC contacts the marked-box
+      domains of E2F1 and DP1, plus a phosphorylation-induced intramolecular RbC-pocket
+      contact within a single RB1 molecule. It does not demonstrate RB1 homodimerization
+      or RB1-RB1 self-association, and RB1 is not characterized as a homodimer in its
+      core E2F-repression / chromatin-scaffolding biology. GO:0042802 identical protein
+      binding implies an RB1-RB1 interaction that this paper does not support. The
+      informative interactions from this structure are already captured by the batch-17
+      ACCEPT rows GO:0035189 (Rb-E2F complex) and GO:0060090 (molecular adaptor activity).'
+    action: MARK_AS_OVER_ANNOTATED
+    reason: 'The cited Rubin 2005 structure characterizes heterotypic RbC-E2F1-DP1
+      binding, not RB1 self-association; identical protein binding is an unsupported,
+      uninformative generic binding term for this evidence. Conservative demotion consistent
+      with the GO:0005515 precedent in this same review and the batch-17 handling of
+      PMID:16360038. A second independent GO:0042802 row (PMID:8288605) remains PENDING
+      and is deferred to a later batch.'
 - term:
     id: GO:0042802
     label: identical protein binding
@@ -1696,8 +1711,20 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:16360038
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'Rubin et al. 2005 (PMID:16360038, Cell) demonstrates that CDK phosphorylation
+      of RB1 itself drives E2F release: phosphorylation at S788/S795 directly destabilizes
+      one set of RbC-E2F-DP contacts, while phosphorylation at T821/T826 induces an
+      intramolecular RbC-pocket interaction that destabilizes the remaining contacts.
+      RB1 is the phosphoprotein in this mechanism and phosphorylation promotes dissociation;
+      the paper does not show RB1 binding to a phosphorylated partner protein. GO:0051219
+      phosphoprotein binding (binding a phosphorylated protein) is therefore not supported
+      by this evidence and mischaracterizes the phospho-regulation-of-RB1 / E2F-release
+      mechanism the paper actually establishes.'
+    action: MARK_AS_OVER_ANNOTATED
+    reason: 'The cited paper characterizes phosphorylation OF RB1 driving E2F release,
+      the opposite of RB1 binding a phosphoprotein partner; the term is unsupported
+      by this source. Conservative demotion consistent with the GO:0005515 precedent
+      in this review and the batch-17 handling of PMID:16360038.'
 - term:
     id: GO:0045445
     label: myoblast differentiation


### PR DESCRIPTION
## Summary

Batch 18 of the RB1 GO-annotation review (#347). Resolves the **2 remaining `PMID:16360038` PENDING rows** — the [Rubin et al. 2005 *Cell*](https://doi.org/10.1016/j.cell.2005.09.044) RbC–E2F1–DP1 crystal-structure paper that **batch 17 (#562, merged)** already mined for its canonical structural rows (`GO:0035189` Rb-E2F complex, `GO:0060090` molecular adaptor activity → ACCEPT). The two leftover rows are generic binding terms not supported by that paper's evidence:

| Term | Ev | Decision | Rationale (grounded in cached `publications/PMID_16360038.md`) |
|------|----|----------|----------------------------------------------------------------|
| `GO:0042802` identical protein binding | IPI | `MARK_AS_OVER_ANNOTATED` | Paper characterizes **heterotypic** RbC–E2F1–DP1 binding; it does **not** show RB1 homodimerization / RB1–RB1 self-association. RB1 is not a characterized homodimer in its core biology. |
| `GO:0051219` phosphoprotein binding | IPI | `MARK_AS_OVER_ANNOTATED` | Paper shows phosphorylation **of RB1 itself** (S788/S795, T821/T826) driving E2F **release** — RB1 is the phosphoprotein and phospho promotes *dissociation*, not RB1 binding *to* a phosphoprotein partner. |

Both demoted **conservatively** to `MARK_AS_OVER_ANNOTATED` (not REMOVE), consistent with the `GO:0005515` precedent already in this review and batch 17's handling of the same paper. The second independent `GO:0042802` row (`PMID:8288605`) is left PENDING and explicitly deferred to a later batch to keep this batch single-paper and small.

`PENDING 20 → 18`. `just validate human RB1` → ✓ Valid (the 2 warnings are pre-existing: remaining-PENDING on an in-progress batched review, and the general deep-research-reference suggestion).

## Cadence

One-draft-at-a-time cadence respected: batch 17 (#562) **merged** to `main` (commit `1987441b6`) before this batch was opened; no other open RB1 PR. Opened ready-for-review per the documented root-cause that leaving completed batches in draft self-inflicts merge starvation (see #344 root-cause thread).

## Test plan

- [x] `just validate human RB1` passes (✓ Valid)
- [x] YAML parses; `PENDING` 20 → 18; `MARK_AS_OVER_ANNOTATED` 96 → 98
- [x] Diff scoped to `genes/human/RB1/RB1-ai-review.yaml` only (derived `cache/go/terms.csv` excluded)
- [ ] Maintainer review of the two MARK_AS_OVER_ANNOTATED justifications against `publications/PMID_16360038.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)