### PR TITLE
RB1: batch 19 — resolve 2 remaining PMID:8245034 (E7/Rb-E2F) PENDING rows (#347)

### DIFF
--- a/genes/human/RB1/RB1-ai-review.yaml
+++ b/genes/human/RB1/RB1-ai-review.yaml
@@ -1420,16 +1420,42 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:8245034
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'Pahel et al. 1993 (PMID:8245034) characterizes purified HPV16 E7 and
+      shows it "binds the retinoblastoma protein avidly and specifically, and it can
+      dissociate the E2F transcription factor when assayed in vitro." Demonstrating
+      that E7 dissociates E2F from RB1 directly evidences the pre-existing RB1-E2F
+      complex. The Rb-E2F complex is the namesake, canonical RB1 mechanism: the RB_A/RB_B
+      pocket engages activator E2F1/2/3 to occupy E2F target promoters (PMID:7923370;
+      deep research synthesis). This exact GO:0035189 term is already independently
+      ACCEPTed on IBA (GO_REF:0000033, batch 6), IPI (PMID:16360038, batch 17), and
+      IEA (PR #461) evidence elsewhere in this file.'
+    action: ACCEPT
+    reason: 'Canonical core RB1 function — the Rb-E2F complex is the defining RB1 mechanism,
+      independently and robustly supported across IBA/IPI/IEA evidence already ACCEPTed
+      on this exact term in this file. Same canonical-Rb-E2F ACCEPT precedent as the
+      batch-17 PMID:16360038 structural rows. Mechanical canonical-Rb-E2F batch (batch
+      19 of #347).'
 - term:
     id: GO:0097718
     label: disordered domain specific binding
   evidence_type: IPI
   original_reference_id: PMID:8245034
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'Pahel et al. 1993 (PMID:8245034) is an HPV16 E7 biochemistry paper showing
+      E7 (an intrinsically disordered viral oncoprotein) binds RB1 and dissociates
+      E2F. GO:0097718 disordered domain specific binding is a generic, uninformative
+      binding term that does not capture RB1''s specific LxCxE-cleft / RB_A-RB_B pocket
+      adapter biology, and the paper does not set out to characterize RB1''s binding
+      specificity for disordered domains as such. The informative interaction from
+      this paper is already captured by the ACCEPTed GO:0035189 (Rb-E2F complex) row
+      from the same reference.'
+    action: MARK_AS_OVER_ANNOTATED
+    reason: 'Generic, uninformative binding term for RB1''s well-characterized adapter/scaffolding
+      biology, derived from an HPV E7 biochemistry paper rather than a study of RB1
+      disordered-domain binding specificity. Conservative demotion consistent with
+      the uniform GO:0005515 protein-binding precedent in this same review and the
+      batch-18 PMID:16360038 generic-binding handling (GO:0042802 / GO:0051219). Mechanical
+      generic-binding batch (batch 19 of #347).'
 - term:
     id: GO:0010629
     label: negative regulation of gene expression


### PR DESCRIPTION
## Summary

RB1 batch 19 of #347. Clears the **2 remaining PENDING rows from PMID:8245034** (Pahel et al. 1993, HPV16 E7 biochemistry). The third row from this paper — `GO:0005654` nucleoplasm IDA — was already ACCEPTed in batch 10, so this fully resolves PMID:8245034.

| Term | Evidence | Action | Rationale |
|------|----------|--------|-----------|
| `GO:0035189` Rb-E2F complex | IDA | **ACCEPT** | The paper shows purified HPV16 E7 binds RB1 and *dissociates E2F in vitro* — directly evidencing the pre-existing Rb-E2F complex, RB1's canonical/namesake mechanism. This exact term is already independently ACCEPTed on IBA (`GO_REF:0000033`, batch 6), IPI (`PMID:16360038`, batch 17) and IEA (PR #461). Same canonical-Rb-E2F ACCEPT precedent as batch 17. |
| `GO:0097718` disordered domain specific binding | IPI | **MARK_AS_OVER_ANNOTATED** | Generic, uninformative binding term derived from an E7 biochemistry paper; does not capture RB1's specific LxCxE-cleft / RB_A-RB_B pocket adapter biology. Same precedent as the uniform `GO:0005515` protein-binding demotions in this file and the batch-18 `PMID:16360038` generic-binding handling. |

PENDING: **18 → 16**.

## Test plan

- [x] `just validate human RB1` → ✓ Valid (2 pre-existing, file-wide warnings: residual PENDING count; no deep-research refs — neither introduced by this batch)
- [x] Diff scoped to `genes/human/RB1/RB1-ai-review.yaml` only (+30/−4); validation-regenerated cache files deliberately excluded
- [x] Both rows anchored on the cached `PMID:8245034` abstract and existing same-term ACCEPT precedent in-file

🤖 Generated with [Claude Code](https://claude.com/claude-code)