### PR TITLE
BRAF: batch 16 — resolve final 3 PENDING rows (#344)

### DIFF
--- a/genes/human/BRAF/BRAF-ai-review.yaml
+++ b/genes/human/BRAF/BRAF-ai-review.yaml
@@ -580,8 +580,9 @@ existing_annotations:
   evidence_type: IPI
   original_reference_id: PMID:35512704
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'IPI annotation for GO:0042802 identical protein binding, derived from Mo et al. 2022 Cell (PMID:35512704 — systematic discovery of mutation-directed neo-protein-protein interactions in cancer). The BRAF-specific finding in this high-throughput BRET screen is the BRAF V600E/KEAP1 neoPPI: a mutant-allele-specific heterotypic interaction between BRAF V600E and KEAP1 (a different protein) that rewires a BRAF V600E/KEAP1/NRF2 redox-signaling axis. The paper does not demonstrate BRAF self-association / homodimerization.'
+    action: MARK_AS_OVER_ANNOTATED
+    reason: 'BRAF homodimerization is a genuine, canonical core function and GO:0042802 identical protein binding is already ACCEPTed on the five dimerization-focused structural/biochemical rows in this file (PMID:19727074, PMID:25155755, PMID:25437913, PMID:22510884, plus PMID:16858395/PMID:22169110). However, PMID:35512704 does not support identical protein binding for BRAF: its BRAF finding is a V600E-specific heterotypic neoPPI with KEAP1, not BRAF self-dimerization. This reference-derived GO:0042802 row is therefore an over-annotation — the term is correct for BRAF but this particular evidence does not support it, and the homodimer biology is already fully captured by the ACCEPTed structural rows. Held back from the dimerization batch for this per-row consideration.'
 - term:
     id: GO:0005739
     label: mitochondrion
@@ -1155,8 +1156,12 @@ existing_annotations:
   evidence_type: IMP
   original_reference_id: PMID:29433126
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'IMP annotation for GO:0004708 MAP kinase kinase activity from Lavoie et al. 2018 Nature (PMID:29433126 — MEK drives BRAF activation through allosteric control of KSR proteins). The paper establishes that RAF-family kinase activation depends on kinase-domain dimerization and that BRAF acts on MEK within the RAS-RAF-MEK-ERK cascade. BRAF is a MAP kinase kinase kinase (MAP3K): it phosphorylates MEK1/MEK2 (the MAP2Ks); it does not phosphorylate ERK and does not itself have MAP2K (MAP kinase kinase) activity. GO:0004708 describes the catalytic activity of MEK, not of BRAF.'
+    action: MODIFY
+    reason: 'The essence of the annotation is sound (BRAF is the kinase that drives the MAPK cascade by phosphorylating the next kinase down), but GO:0004708 (MAP kinase kinase activity) is the wrong tier of the MAPK kinase cascade for BRAF. BRAF phosphorylates MEK1/MEK2 — the MAP2Ks — so BRAF''s molecular function is GO:0004709 MAP kinase kinase kinase activity (MAP3K activity), not MAP2K activity. MODIFY to GO:0004709, which is already independently ACCEPTed in this file via IBA propagation from PANTHER PTHR44329 (PR #448, line 38) and consistent with the canonical kinase MF evidence in-file (PMID:21441910 EXP, PMID:18567582 IDA). This resolves the long-standing MAP2K-vs-MAP3K carryover note flagged across earlier batches.'
+    proposed_replacement_terms:
+    - id: GO:0004709
+      label: MAP kinase kinase kinase activity
 - term:
     id: GO:0000165
     label: MAPK cascade
@@ -1425,8 +1430,9 @@ existing_annotations:
   original_reference_id: PMID:12194967
   negated: true
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: 'NOT (negated) IPI annotation for GO:0031267 small GTPase binding from Kontani et al. 2002 J Biol Chem (PMID:12194967 — Di-Ras, a distinct subgroup of Ras family GTPases with unique biochemical properties). Owing to effector-domain substitutions (Ile at the position corresponding to Ha-Ras Asp-33), the paper shows Di-Ras1/Di-Ras2 "fails to interact with the Ras-binding domain of Raf, resulting in no stimulation of mitogen-activated protein kinase." This is a deliberate, experimentally-grounded negative finding: the BRAF RAS-binding domain does not engage the Di-Ras subgroup of small GTPases.'
+    action: ACCEPT
+    reason: 'The negated annotation is correct and is a curatorially valuable negative assertion. PMID:12194967 directly and explicitly demonstrates that Di-Ras does not bind the Ras-binding domain of Raf and does not stimulate the MAPK pathway, supporting NOT|small GTPase binding for this specific GTPase subgroup. This does not contradict BRAF''s canonical RAS (HRAS/KRAS/NRAS) engagement via its RBD — it specifically records that the Di-Ras subfamily is not a BRAF RBD ligand. Consistent with the repository convention of retaining experimentally established non-interaction NOT annotations as-is; ACCEPT.'
 - term:
     id: GO:0005829
     label: cytosol


### PR DESCRIPTION
## Summary

Clears the **last 3 `PENDING`** annotation rows in `genes/human/BRAF/BRAF-ai-review.yaml`. After this PR the BRAF review has **0 PENDING / 0 UNDECIDED** and `just validate human BRAF` → ✓ Valid.

| Term | Evidence | Ref | Action | Rationale |
|------|----------|-----|--------|-----------|
| `GO:0042802` identical protein binding | IPI | PMID:35512704 | **MARK_AS_OVER_ANNOTATED** | Mo 2022 *Cell* demonstrates a BRAF **V600E/KEAP1 heterotypic neoPPI**, not BRAF homodimerization. The term is a genuine core function but is already fully captured by the 5 ACCEPTed dimerization structural/biochemical rows (PMID:19727074/25155755/25437913/22510884/16858395+22169110); this reference-derived row is an over-annotation. |
| `GO:0004708` MAP kinase kinase activity | IMP | PMID:29433126 | **MODIFY → `GO:0004709`** | BRAF is a MAP**3**K — it phosphorylates MEK1/MEK2 (the MAP2Ks), it does not have MAP2K activity. `GO:0004709` (MAP kinase kinase kinase activity) is already ACCEPTed in-file via IBA (PR #448, line 38). Resolves the long-standing MAP2K-vs-MAP3K carryover note. |
| `GO:0031267` small GTPase binding | NOT\|IPI | PMID:12194967 | **ACCEPT** | Kontani 2002 *JBC* shows Di-Ras "fails to interact with the Ras-binding domain of Raf, resulting in no stimulation of MAPK." A deliberate, experimentally-supported negative annotation; retained as-is per repo convention for established non-interactions. |

Each decision corresponds to a held-back per-row note explicitly recorded across earlier BRAF batches.

## Validation

- `just validate human BRAF` → **✓ Valid**
- `grep -c "action: PENDING"` → **0**; `grep -c "action: UNDECIDED"` → **0**
- Diff is tightly scoped: 3 action flips, +12/−6, single file

### Note on validator warning
This PR introduces one expected best-practices warning: *"Inconsistent review actions for term GO:0042802: ACCEPT (×6); MARK_AS_OVER_ANNOTATED (×1)"*. This is the same coarse-check false-positive class analyzed and dismissed in #307 (ATF3) — the validator cannot distinguish a *wrong-action* divergence from a *wrong-reference* one. Here the divergence is intentional and biologically correct: the 6 ACCEPT rows are genuine dimerization evidence; the 1 MARK_AS_OVER_ANNOTATED row is the misattributed PMID:35512704 neoPPI reference. Forcing it to ACCEPT would falsely assert that paper supports BRAF homodimerization. The two pre-existing warnings (description TODO, no core_functions) are unrelated to this change.

## Test plan

- [x] `just validate human BRAF` passes
- [x] 0 PENDING / 0 UNDECIDED remaining
- [ ] Maintainer review of the 3 per-row decisions

Closes the per-row review work tracked in #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)