### PR TITLE
AATF: set status COMPLETE (resolves stale IN_PROGRESS) (#270)

### DIFF
--- a/genes/human/AATF/AATF-ai-review.yaml
+++ b/genes/human/AATF/AATF-ai-review.yaml
@@ -1,7 +1,7 @@
 id: Q9NY61
 gene_symbol: AATF
 product_type: PROTEIN
-status: IN_PROGRESS
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens


### PR DESCRIPTION
## Summary

`genes/human/AATF/AATF-ai-review.yaml` carried `status: IN_PROGRESS`, but the review is substantively complete and the status field was stale. This PR flips it to `COMPLETE` — the single concrete, schema-grounded next step on issue #270 that no prior scanner pass had taken.

### Why this is correct (per schema)

`GeneReviewStatusEnum` in `src/ai_gene_review/schema/gene_review.yaml`:

- **IN_PROGRESS** — *"At least one annotation is PENDING and at least one annotation is not PENDING"*
- **COMPLETE** — *"No PENDING annotations and no validation warnings"*

AATF state:
- 35 annotations, **zero PENDING**: 22 ACCEPT, 10 KEEP_AS_NON_CORE, 2 MODIFY, 1 NEW (also zero UNDECIDED)
- `core_functions`, `references`, `existing_annotations` all fully populated
- `just validate human AATF` → `✓ All validations passed for human/AATF` (no warnings)

So `IN_PROGRESS` is invalid by the enum's own definition (it requires a PENDING annotation, of which there are none). `COMPLETE` is the correct value, consistent with the other closure-ready human reviews (ABCE1, ATF3, BAG3, BCAP31, KRAS — all `COMPLETE`).

### Scope / risk

- **Scope:** one line, one file. No annotation content, evidence, or core-function changes.
- **Risk:** Low. Validation passes before and after; this only corrects a metadata field that lagged the actual review state.
- Derived cache artifacts (`cache/go/terms.csv`) deliberately not committed.

Draft PR for maintainer review. After merge, issue #270 has no remaining loose ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)