### PR TITLE
BRAF: add description + core_functions, set status COMPLETE (#344)

### DIFF
--- a/genes/human/BRAF/BRAF-ai-review.yaml
+++ b/genes/human/BRAF/BRAF-ai-review.yaml
@@ -1,11 +1,26 @@
 id: P15056
 gene_symbol: BRAF
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for BRAF'
+description: 'BRAF encodes a RAF-family serine/threonine protein kinase (EC 2.7.11.1)
+  that is the canonical mitogen-activated protein kinase kinase kinase (MAP3K) of the
+  RAS-RAF-MEK-ERK signaling cascade. In quiescent cells BRAF is autoinhibited by an
+  intramolecular interaction between its N-terminal regulatory region and the C-terminal
+  kinase domain. Mitogenic stimulation generates GTP-loaded RAS, which binds the BRAF
+  RAS-binding domain (RBD), relieves autoinhibition, and recruits BRAF to the plasma
+  membrane. Activation requires side-to-side dimerization — BRAF homodimers and, most
+  potently, BRAF-RAF1 (CRAF) heterodimers — stabilized by 14-3-3 proteins and the
+  HSP90/CDC37 chaperone system. Activated BRAF phosphorylates and activates MAP2K1/MAP2K2
+  (MEK1/MEK2), the committed step that propagates mitogenic signaling through ERK1/ERK2
+  to control proliferation, differentiation and survival. BRAF localizes to the
+  cytoplasm/cytosol and to the plasma membrane in its active RAS-bound state. It is a
+  major oncogenic driver: the V600E activating mutation, which renders the kinase
+  constitutively active as a RAS-independent monomer, is recurrent in melanoma,
+  papillary thyroid carcinoma, colorectal cancer, hairy-cell leukemia and other tumors,
+  and germline BRAF mutations cause cardiofaciocutaneous syndrome.'
 existing_annotations:
 - term:
     id: GO:0005737
@@ -2045,3 +2060,59 @@ references:
 - id: Reactome:R-HSA-9660538
   title: Mutant MRAS:SHOC2:PPP1CC complexes dephosphorylate inactive RAFs
   findings: []
+- id: file:human/BRAF/BRAF-uniprot.txt
+  title: UniProt record for human BRAF (P15056)
+  findings:
+  - statement: BRAF phosphorylates MAP2K1 (MEK1) and thereby activates the MAP kinase
+      signal transduction pathway.
+    supporting_text: Phosphorylates MAP2K1, and thereby activates the MAP kinase signal
+      transduction pathway
+  - statement: BRAF is an ATP-dependent protein serine/threonine kinase (EC 2.7.11.1).
+    supporting_text: L-seryl-[protein] + ATP = O-phospho-L-seryl-[protein] + ADP
+core_functions:
+- description: BRAF is the canonical RAF-family MAP kinase kinase kinase (MAP3K) of the
+    RAS-RAF-MEK-ERK cascade. After RAS-GTP-driven membrane recruitment and side-to-side
+    dimerization (BRAF homodimers and the more potent BRAF-RAF1 heterodimers), BRAF
+    phosphorylates and activates MAP2K1/MAP2K2 (MEK1/MEK2) — the committed step that
+    propagates mitogenic signaling to ERK1/ERK2.
+  supported_by:
+  - reference_id: file:human/BRAF/BRAF-uniprot.txt
+    supporting_text: Phosphorylates MAP2K1, and thereby activates the MAP kinase signal
+      transduction pathway
+  - reference_id: PMID:29433126
+    supporting_text: BRAF phosphorylation of MEK1
+  molecular_function:
+    id: GO:0004709
+    label: MAP kinase kinase kinase activity
+  directly_involved_in:
+  - id: GO:0000165
+    label: MAPK cascade
+  - id: GO:0070374
+    label: positive regulation of ERK1 and ERK2 cascade
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  - id: GO:0005886
+    label: plasma membrane
+- description: BRAF is an ATP-dependent protein serine/threonine kinase. Its intrinsic
+    catalytic activity, demonstrated by direct in vitro kinase assays, phosphorylates
+    substrate serine/threonine residues (most importantly the activation-loop serines
+    of MEK1/MEK2); this enzymatic activity is the molecular basis for its MAP3K function
+    and for its oncogenic activation by the V600E mutation.
+  supported_by:
+  - reference_id: file:human/BRAF/BRAF-uniprot.txt
+    supporting_text: L-seryl-[protein] + ATP = O-phospho-L-seryl-[protein] + ADP
+  - reference_id: PMID:21441910
+    supporting_text: kinase activity
+  molecular_function:
+    id: GO:0004674
+    label: protein serine/threonine kinase activity
+  directly_involved_in:
+  - id: GO:0000165
+    label: MAPK cascade
+  locations:
+  - id: GO:0005829
+    label: cytosol
+  - id: GO:0005886
+    label: plasma membrane
+proposed_new_terms: []


### PR DESCRIPTION
## Summary

Closes the two remaining closure blockers for the **BRAF** GO annotation review (#344). After the per-batch annotation PRs (final batch #571) the review reached **0 PENDING / 0 UNDECIDED** with 172 rows reviewed, but the file was still `status: INITIALIZED` with a TODO-placeholder `description` and no `core_functions`. This brings BRAF to the same closure-ready state as the other completed gene reviews (cf. AATF #270 → COMPLETE).

- **description**: replaced the `TODO` placeholder with an accurate synthesis — RAF-family Ser/Thr kinase (EC 2.7.11.1), the canonical MAP3K of the RAS-RAF-MEK-ERK cascade; autoinhibition relief by RAS-GTP, side-to-side homo/heterodimerization, 14-3-3 and HSP90/CDC37 regulation; V600E oncogenic driver; germline CFC syndrome.
- **core_functions**: two GO-CAM-style entries grounded in the file's own evidence —
  - `GO:0004709` MAP kinase kinase kinase activity → `GO:0000165` MAPK cascade, `GO:0070374` positive regulation of ERK1/2 cascade
  - `GO:0004674` protein serine/threonine kinase activity → `GO:0000165` MAPK cascade
  - supported_by the UniProt record (new `file:human/BRAF/BRAF-uniprot.txt` reference with `findings`, matching the validated KRAS pattern) plus in-file PMIDs (29433126, 21441910)
- **status**: `INITIALIZED` → `COMPLETE`

## Validation

`just validate human BRAF` → **✓ Valid**. Schema, term, and reference validation all pass.

The single remaining best-practices warning is **intentional and biologically correct**, not a defect introduced here:

> Inconsistent review actions for term GO:0042802 (identical protein binding): ACCEPT ×6; MARK_AS_OVER_ANNOTATED ×1

This is the known coarse-check false-positive analyzed in PR #571: the 5–6 ACCEPT rows are genuine BRAF dimerization (homodimer / RAF1 heterodimer) structural/biochemical evidence — a real core function — whereas the single `MARK_AS_OVER_ANNOTATED` row is the misattributed PMID:35512704 **V600E/KEAP1 heterotypic neoPPI** (not self-dimerization). The divergence is correct curation and is deliberately left as-is; "fixing" it to silence the warning would degrade annotation quality.

Scope: 1 file, +73/−2. No annotation `action` flips, no removals — purely the description/core_functions/status completion.

## Test plan

- [x] `just validate human BRAF` passes (only the intentional GO:0042802 warning)
- [ ] Maintainer review of `description` and `core_functions` synthesis
- [ ] After merge: BRAF review is functionally complete; optional remaining follow-up is the `BRAF-pathway.md` precedent (#391/#393/#404/#407/#409) — deliberately not bundled here

🤖 Generated with [Claude Code](https://claude.com/claude-code)