### PR TITLE
RB1: set status DRAFT (0 PENDING after batch 23) (#347)

### DIFF
--- a/genes/human/RB1/RB1-ai-review.yaml
+++ b/genes/human/RB1/RB1-ai-review.yaml
@@ -1,7 +1,7 @@
 id: P06400
 gene_symbol: RB1
 product_type: PROTEIN
-status: INITIALIZED
+status: DRAFT
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens


### PR DESCRIPTION
## Summary

Closes the loop that the RB1 batch PRs (#576–#579, issue #347) left undone: the `status:` field was never advanced from `INITIALIZED`.

- After batch 23 (commit `673b3c647`, PR #579) RB1 has **0 PENDING / 0 UNDECIDED**.
- Per the schema `GeneReviewStatusEnum`, `INITIALIZED` means *"all annotations have action PENDING"* — factually incorrect for the current file.
- The enum-accurate value for **0 PENDING + remaining validation warnings** is `DRAFT` (*"review is complete but needs refinement"*). This is the conservative choice; it does **not** overclaim `COMPLETE`.

One-line change: `status: INITIALIZED` → `status: DRAFT`.

## Validation

`just validate human RB1` → schema / term / reference validation all pass. 2 best-practices warnings remain, both **benign and intentional**:

1. **GO:0042802** `KEEP_AS_NON_CORE` (PMID:8288605) vs `MARK_AS_OVER_ANNOTATED` (PMID:16360038). This divergence is deliberate and biologically correct: Hensey 1994 (PMID:8288605) genuinely demonstrates RB1 self-oligomerization (native PAGE + EM + Y2H), whereas Rubin 2005 (PMID:16360038) characterizes only the heterotypic RbC–E2F1–DP1 contact and does **not** support RB1–RB1 self-association. Forcing the two rows to a uniform action would be *incorrect* curation. This is the same intentional-divergence pattern explicitly accepted for BRAF in commit `6b82f4993`.
2. *"No annotations reference available deep research files"* — soft suggestion only.

## Maintainer decision

Promotion `DRAFT` → `COMPLETE` (formally accepting the two benign warnings, following the BRAF/AATF closure precedent in #573/#572) is left as a **maintainer judgment** and intentionally not done in this automated pass.

🤖 Automated curation-scanner pass for #347.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>