### PR TITLE
Validator: accept deep research cited in core_functions (#347)

### DIFF
--- a/src/ai_gene_review/validation/validator.py
+++ b/src/ai_gene_review/validation/validator.py
@@ -399,25 +399,37 @@ def check_best_practices_rules(
 
     # Check for usage of deep research results (including falcon, gemini, etc.)
     if "existing_annotations" in data and data["existing_annotations"]:
+        def _is_research_ref(sb: object) -> bool:
+            if not isinstance(sb, dict) or "reference_id" not in sb:
+                return False
+            ref_id = sb["reference_id"]
+            return (
+                isinstance(ref_id, str)
+                and ref_id.startswith("file:")
+                and "research" in ref_id
+                and ref_id.endswith(".md")
+            )
+
         has_research_support = False
 
         for annotation in data["existing_annotations"]:
             if isinstance(annotation, dict):
                 review = annotation.get("review", {})
                 if isinstance(review, dict):
-                    supported_by_list = review.get("supported_by", [])
-                    for sb in supported_by_list:
-                        if isinstance(sb, dict) and "reference_id" in sb:
-                            ref_id = sb["reference_id"]
-                            if (
-                                ref_id.startswith("file:")
-                                and "research" in ref_id
-                                and ref_id.endswith(".md")
-                            ):
-                                has_research_support = True
-                                break
-                    if has_research_support:
+                    if any(_is_research_ref(sb) for sb in review.get("supported_by", [])):
+                        has_research_support = True
                         break
+
+        # Also accept deep research cited at the core_functions level — reviewers
+        # often ground existing_annotations in primary literature PMIDs while
+        # using deep research synthesis to support the distilled core functions.
+        if not has_research_support and isinstance(data.get("core_functions"), list):
+            for cf in data["core_functions"]:
+                if isinstance(cf, dict) and any(
+                    _is_research_ref(sb) for sb in cf.get("supported_by", [])
+                ):
+                    has_research_support = True
+                    break
 
         if not has_research_support:
             if yaml_file is not None:

--- a/tests/test_no_deep_research_validation.py
+++ b/tests/test_no_deep_research_validation.py
@@ -168,6 +168,69 @@ def test_no_research_files_no_warning():
         assert not warning_found, "Should NOT warn when no research files exist"
 
 
+def test_deep_research_referenced_in_core_functions_no_warning():
+    """Deep research referenced in core_functions[].supported_by should suppress warning.
+
+    Reviewers commonly ground existing_annotations in primary literature PMIDs
+    (the canonically preferred evidence source) while citing deep research synthesis
+    documents at the core_functions level. The validator should recognise that
+    usage and not flag it as "deep research unused".
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+
+        research_file = tmpdir_path / "TEST-deep-research-falcon.md"
+        research_file.write_text("# Falcon deep research for TEST")
+
+        yaml_data = {
+            "id": "Q12345",
+            "gene_symbol": "TEST",
+            "taxon": {"id": "NCBITaxon:9606", "label": "Homo sapiens"},
+            "description": "Test gene",
+            "references": [
+                {"id": "PMID:12345", "title": "Test paper"},
+                {"id": "file:TEST-deep-research-falcon.md", "title": "Falcon deep research"},
+            ],
+            "existing_annotations": [
+                {
+                    "term": {"id": "GO:0005515", "label": "protein binding"},
+                    "evidence_type": "IDA",
+                    "original_reference_id": "PMID:12345",
+                    "review": {
+                        "action": "ACCEPT",
+                        "supported_by": [
+                            {"reference_id": "PMID:12345", "supporting_text": "..."}
+                        ],
+                    },
+                }
+            ],
+            "core_functions": [
+                {
+                    "description": "Test core function",
+                    "supported_by": [
+                        {
+                            "reference_id": "file:TEST-deep-research-falcon.md",
+                            "supporting_text": "Synthesized from deep research",
+                        }
+                    ],
+                }
+            ],
+        }
+
+        yaml_file = tmpdir_path / "TEST-ai-review.yaml"
+        with open(yaml_file, "w") as f:
+            yaml.dump(yaml_data, f)
+
+        report = validate_gene_review(yaml_file, check_best_practices=True)
+
+        warning_found = any(
+            issue.check_type == "no_deep_research_results" for issue in report.issues
+        )
+        assert not warning_found, (
+            "Should NOT warn when deep research is referenced in core_functions"
+        )
+
+
 @pytest.mark.parametrize("research_filename", [
     "TEST-openai-research.md",
     "TEST-falcon-research.md",


### PR DESCRIPTION
## Summary

Fixes the `no_deep_research_results` validator false positive that has kept #347 (RB1) in `DRAFT` rather than `COMPLETE`.

The best-practices check only scanned `existing_annotations[].review.supported_by`. Reviews that follow the common pattern of grounding annotations in primary-literature PMIDs (the canonically preferred evidence source) while citing the deep-research synthesis at the `core_functions[].supported_by` level were wrongly flagged as "deep research unused". This is exactly the case the prior scanner pass [documented on #347](https://github.com/ai4curation/ai-gene-review/issues/347#issuecomment-4416180123) but did not fix.

Change is scoped to the one branch in `src/ai_gene_review/validation/validator.py`:

- Refactor the inline "is research ref" predicate into a small helper for reuse.
- After the existing `existing_annotations` scan, also scan `core_functions[].supported_by`.
- New TDD test `test_deep_research_referenced_in_core_functions_no_warning` covers the case.

## Effect on existing reviews

| Gene | Before | After |
|------|--------|-------|
| RB1  | `✓ Valid (with 2 warnings)` | `✓ Valid (with 1 warnings)` (only the inconsistent-actions one — also a [documented false positive](https://github.com/ai4curation/ai-gene-review/issues/347#issuecomment-4416180123)) |
| BRAF, KRAS, BCAP31, ATF3, BAG3, AATF, ABCE1 | (warnings counts unchanged — none of these references the falcon file at the core_functions level either) | (unchanged) |

No content of any review YAML is modified.

## Test plan

- [x] `uv run pytest tests/test_no_deep_research_validation.py tests/test_validate_deep_research.py tests/test_validator.py tests/test_validator_core_functions.py` — 26 passed
- [x] Full test suite: `uv run pytest tests/ --ignore=tests/test_simple.py` — 254 passed
- [x] `just validate human RB1` — passes, only the remaining inconsistent-actions warning (the GO:0042802 KEEP_AS_NON_CORE vs MARK_AS_OVER_ANNOTATED case the prior comment documented as evidence-differentiated, not a real inconsistency)
- [x] Re-validated the 7 closure-ready siblings — no regressions

Drafted because it's a tooling change touching the shared validator; merging unblocks promoting #347 from `DRAFT` to `COMPLETE` once the remaining inconsistent-actions warning is similarly resolved (separate scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)