### PR TITLE
Validator: skip inconsistent-actions warning for IPI rows with distinct PMIDs (#347)

### DIFF
--- a/src/ai_gene_review/validation/validator.py
+++ b/src/ai_gene_review/validation/validator.py
@@ -372,6 +372,28 @@ def check_best_practices_rules(
                             if len(non_new_actions) <= 1:
                                 continue
 
+                    # Special case: IPI rows with distinct PMIDs are evaluated
+                    # per-reference (each IntAct row is anchored to a specific
+                    # interaction paper). Divergent actions across rows then
+                    # reflect "different papers support different conclusions"
+                    # rather than curator inconsistency. The canonical example
+                    # is GO:0042802 identical protein binding on BRAF/RB1 where
+                    # some IPI rows demonstrate self-association and others
+                    # cite papers about heterotypic interactions.
+                    all_ipi = all(ec == "IPI" for _, _, ec in actions_list)
+                    if all_ipi:
+                        references = []
+                        for idx, _, _ in actions_list:
+                            annotation = data["existing_annotations"][idx]
+                            ref_id = annotation.get("original_reference_id")
+                            if ref_id:
+                                references.append(ref_id)
+                        if (
+                            len(references) == len(actions_list)
+                            and len(set(references)) == len(references)
+                        ):
+                            continue
+
                     # Get the term label for better error messages
                     term_label = None
                     for annotation in data["existing_annotations"]:

--- a/tests/test_inconsistent_review_actions_validation.py
+++ b/tests/test_inconsistent_review_actions_validation.py
@@ -1,0 +1,159 @@
+"""Test the BestPractices ``inconsistent_review_actions`` validator check.
+
+The check fires when a single GO term carries divergent ``review.action`` values
+across multiple rows in ``existing_annotations``. That's a useful signal for
+catching curator inconsistency, but it has a well-documented false positive
+class: when each row is anchored to a distinct primary reference (different
+``original_reference_id``) and the evidence is IPI ("Inferred from Physical
+Interaction"), the divergent actions reflect *per-reference* evidence
+assessment, not a curation error.
+
+The canonical example is GO:0042802 (identical protein binding): each IPI
+row in GOA comes from a distinct IntAct interaction paper, and reviewers
+correctly diverge — ACCEPT on rows where the cited paper genuinely
+demonstrates self-association, MARK_AS_OVER_ANNOTATED on rows where the
+cited paper supports a different (e.g. heterotypic) interaction. Both
+RB1 and BRAF reviews carry this pattern intentionally. Silencing the
+divergence at the YAML level would degrade curation quality.
+
+This module locks in the targeted exemption: IPI evidence + all distinct
+PMIDs → no warning. Every other configuration still warns.
+"""
+
+from pathlib import Path
+import tempfile
+
+import yaml
+
+from ai_gene_review.validation import validate_gene_review
+
+
+def _build_yaml(term_id: str, rows: list[dict]) -> dict:
+    """Construct a minimal review YAML covering the inconsistent-action case."""
+
+    annotations = []
+    for row in rows:
+        annotations.append(
+            {
+                "term": {"id": term_id, "label": "identical protein binding"},
+                "evidence_type": row["evidence_type"],
+                "original_reference_id": row["pmid"],
+                "review": {
+                    "action": row["action"],
+                    "reason": row.get("reason", "test"),
+                },
+            }
+        )
+
+    return {
+        "id": "Q12345",
+        "gene_symbol": "TEST",
+        "taxon": {"id": "NCBITaxon:9606", "label": "Homo sapiens"},
+        "description": "Test gene",
+        "references": [{"id": row["pmid"], "title": "Paper"} for row in rows],
+        "existing_annotations": annotations,
+    }
+
+
+def _has_inconsistent_action_warning(report) -> bool:
+    return any(
+        issue.check_type == "inconsistent_review_actions" for issue in report.issues
+    )
+
+
+def _validate(yaml_data: dict) -> object:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "TEST-ai-review.yaml"
+        path.write_text(yaml.dump(yaml_data))
+        return validate_gene_review(path, check_best_practices=True)
+
+
+def test_ipi_distinct_pmid_divergence_suppressed():
+    """The RB1/BRAF GO:0042802 pattern: IPI rows, distinct PMIDs, divergent actions.
+
+    Each row is independently evaluated against a distinct primary reference,
+    so the divergence is a valid curation outcome rather than a defect. The
+    validator must not raise an ``inconsistent_review_actions`` warning here.
+    """
+    yaml_data = _build_yaml(
+        "GO:0042802",
+        [
+            {"evidence_type": "IPI", "pmid": "PMID:19727074", "action": "ACCEPT"},
+            {
+                "evidence_type": "IPI",
+                "pmid": "PMID:35512704",
+                "action": "MARK_AS_OVER_ANNOTATED",
+            },
+        ],
+    )
+    report = _validate(yaml_data)
+    assert not _has_inconsistent_action_warning(report), (
+        "IPI rows with distinct PMIDs should not trigger the inconsistent-actions warning"
+    )
+
+
+def test_ipi_same_pmid_divergence_still_warns():
+    """Same PMID across IPI rows with divergent actions remains a real defect.
+
+    If two rows cite the *same* paper but disagree on the curation action,
+    that's curator inconsistency, not evidence-differentiated reasoning.
+    The validator must still warn.
+    """
+    yaml_data = _build_yaml(
+        "GO:0042802",
+        [
+            {"evidence_type": "IPI", "pmid": "PMID:19727074", "action": "ACCEPT"},
+            {
+                "evidence_type": "IPI",
+                "pmid": "PMID:19727074",
+                "action": "MARK_AS_OVER_ANNOTATED",
+            },
+        ],
+    )
+    report = _validate(yaml_data)
+    assert _has_inconsistent_action_warning(report), (
+        "Same PMID with divergent IPI actions should still trigger the warning"
+    )
+
+
+def test_mixed_evidence_divergence_still_warns():
+    """Mixed evidence types (e.g. IPI + IDA) on the same term remain flagged.
+
+    The exemption is narrowly scoped to IPI evidence because that's where
+    the per-reference IntAct semantics make divergence valid. Mixed evidence
+    types on the same term should still consolidate; divergence there is
+    likely a real curation issue.
+    """
+    yaml_data = _build_yaml(
+        "GO:0042802",
+        [
+            {"evidence_type": "IPI", "pmid": "PMID:19727074", "action": "ACCEPT"},
+            {
+                "evidence_type": "IDA",
+                "pmid": "PMID:25155755",
+                "action": "MARK_AS_OVER_ANNOTATED",
+            },
+        ],
+    )
+    report = _validate(yaml_data)
+    assert _has_inconsistent_action_warning(report), (
+        "Mixed evidence types with divergent actions should still trigger the warning"
+    )
+
+
+def test_ipi_distinct_pmid_consistent_actions_no_warning():
+    """Sanity check: consistent IPI actions across distinct PMIDs never warn.
+
+    This is the common case (multiple IntAct rows, all ACCEPTed) and should
+    not trigger the inconsistent-actions warning under any version of the
+    check — the exemption is irrelevant here.
+    """
+    yaml_data = _build_yaml(
+        "GO:0042802",
+        [
+            {"evidence_type": "IPI", "pmid": "PMID:19727074", "action": "ACCEPT"},
+            {"evidence_type": "IPI", "pmid": "PMID:25155755", "action": "ACCEPT"},
+        ],
+    )
+    report = _validate(yaml_data)
+    assert not _has_inconsistent_action_warning(report)


### PR DESCRIPTION
## Summary

- Adds a narrowly-scoped exemption to the `inconsistent_review_actions` best-practices check: when **all annotations to a GO term use IPI evidence** and **each has a distinct `original_reference_id`**, the divergent actions no longer trigger a warning.
- Clears the last remaining `just validate` warning on both RB1 (#347) and BRAF (#344) without per-gene whitelists or status-field workarounds.
- TDD: 4 new parametrized cases lock in the targeted exemption (positive case, same-PMID still warns, mixed-evidence still warns, consistent-actions sanity check).

## Why this is the right shape

The check is genuinely useful — same-PMID divergence and mixed-evidence divergence on one term usually signal curator inconsistency. But IPI evidence is special: each IntAct row in GOA is anchored to a distinct primary interaction paper, and reviewers correctly diverge per paper (some demonstrate self-association → ACCEPT; others cite heterotypic interactions → MARK_AS_OVER_ANNOTATED).

Canonical case is GO:0042802 (identical protein binding) on RB1 and BRAF:

| Gene | Row | PMID | Action | What the paper actually shows |
|------|-----|------|--------|------------------------------|
| RB1 | IPI | PMID:8288605 | KEEP_AS_NON_CORE | Hensey 1994 — recombinant p110RB self-oligomerization (yeast two-hybrid + native PAGE + EM) |
| RB1 | IPI | PMID:16360038 | MARK_AS_OVER_ANNOTATED | Rubin 2005 — RbC–E2F1–DP1 *heterotypic* crystal structure, no RB1 self-association |
| BRAF | IPI ×6 | PMID:19727074, 25155755, 25437913, 22510884, 16858395, 22169110 | ACCEPT | Canonical BRAF homodimer literature |
| BRAF | IPI | PMID:35512704 | MARK_AS_OVER_ANNOTATED | Mo 2022 — BRAF V600E/KEAP1 *heterotypic* neoPPI, not self-association |

Forcing consistency would either resurrect unsupported homo-dimerization claims (from the wrong papers) or discard real biochemical evidence — both regressions in curation quality.

## What's excluded from the exemption

- Same PMID with divergent IPI actions → still warns (real curator inconsistency)
- Mixed evidence types (e.g. IPI + IDA) → still warns (the ATF3 #307 pattern where REMOVE rows cite wrong-gene papers — that warning is doing useful work)
- Single-evidence-type non-IPI divergence → still warns

## Verification

```
$ just validate human RB1
✓ Valid                    # was: ✓ Valid (with 1 warnings)

$ just validate human BRAF
✓ Valid                    # was: ✓ Valid (with 1 warnings)

$ just validate human ATF3
✓ Valid (with 3 warnings)  # unchanged — mixed-evidence divergence still flagged

$ uv run pytest tests/ -q
281 passed, 40 deselected
```

## Closure status of #347

After this merges, RB1 will validate with zero warnings — same closure-ready state as the other 7 curation issues. Promotion `DRAFT → COMPLETE` is then a clean maintainer call (matching the BRAF #573 / AATF #572 precedent without any lingering warnings to justify).

## Precedent

Follows PR #584 (deep-research-in-core-functions exemption, merged ~3h before this run) — validator-level fixes for documented false-positive classes over per-gene workarounds. The previous scanner pass on this issue [explicitly offered](https://github.com/ai4curation/ai-gene-review/issues/347#issuecomment-4416180123) to scope this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)