### PR TITLE
CDH1: batch 2 — review 14 IBA core-function annotations (#348)

### DIFF
--- a/genes/human/CDH1/CDH1-ai-review.yaml
+++ b/genes/human/CDH1/CDH1-ai-review.yaml
@@ -19,112 +19,126 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: IBA projection from the PANTHER classical cadherin family tree (PTHR24027, subfamily SF319 Cadherin-1) via GO_REF:0000033. E-cadherin contributes to epithelial cell morphogenesis because cadherin-mediated adhesion shapes epithelial cells and is required to establish and maintain epithelial architecture. However, cell morphogenesis is a broad downstream outcome of the core adhesion and junction-organizing activity rather than a distinct core function. The precise core CDH1 processes (calcium-dependent homophilic cell-cell adhesion, cadherin-mediated adhesion, adherens junction organization) are captured by other rows in this file.
+    action: KEEP_AS_NON_CORE
+    reason: Real but general developmental/cellular outcome downstream of the core adhesion function; the precise core processes (GO:0044331 cell-cell adhesion mediated by cadherin, GO:0034332 adherens junction organization) are ACCEPTed elsewhere in this batch. Mechanical IBA-PANTHER batch (batch 2 of #348).
 - term:
     id: GO:0016477
     label: cell migration
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: IBA projection from the PANTHER cadherin family tree (PTHR24027) via GO_REF:0000033. E-cadherin participates in cell migration processes — it is retained at junctions during collective epithelial migration such as wound healing, and conversely its loss drives the epithelial-mesenchymal transition that licenses single-cell motility and invasion. The bare cell migration term carries no directionality, whereas the best-established directional CDH1 role is suppression of single-cell migration/invasion, separately captured by the IMP GO:0030336 (negative regulation of cell migration) row in this file (PMID:16882694). The generic involved_in cell-migration inference is therefore a real but non-core, context-dependent association.
+    action: KEEP_AS_NON_CORE
+    reason: Generic non-directional migration term; the core CDH1 activity is cell-cell adhesion rather than migration per se, and the directional regulatory role (suppression of migration/invasion) is captured by GO:0030336 elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
 - term:
     id: GO:0007043
     label: cell-cell junction assembly
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: IBA projection from the PANTHER classical cadherin family tree (PTHR24027) via GO_REF:0000033. E-cadherin nucleates assembly of epithelial cell-cell junctions — homophilic trans-engagement of E-cadherin ectodomains initiates cell-cell contact, and the cytoplasmic tail recruits the catenins that build the adherens junction and template subsequent tight-junction and desmosome formation. This is a core, well-established CDH1 function, consistent with the more specific GO:0034332 (adherens junction organization) row.
+    action: ACCEPT
+    reason: Core CDH1 biological process — E-cadherin is the founding adhesion receptor that initiates epithelial cell-cell junction assembly. Mechanical IBA-PANTHER batch (batch 2 of #348).
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: IBA projection (is_active_in) from the PANTHER cadherin tree (PTHR24027) via GO_REF:0000033. E-cadherin is a type-I single-pass transmembrane glycoprotein; its steady-state location is the plasma membrane and adherens junction, with only its ~150-residue C-terminal tail exposed to the cytosol. Annotating the protein as is_active_in the cytoplasm (GO:0005737) is over-broad — it asserts a generic compartment that does not reflect where the protein resides or acts. The accurate localizations (plasma membrane, adherens junction, lateral plasma membrane) are captured by other rows in this file.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: Over-broad CC for a single-pass transmembrane plasma-membrane protein; cytoplasm is not entirely wrong (the cytoplasmic tail faces the cytosol) but does not reflect the protein actual residence or site of action. More precise CC terms (GO:0005886 plasma membrane, GO:0005912 adherens junction, GO:0016328 lateral plasma membrane) are present in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
 - term:
     id: GO:0008013
     label: beta-catenin binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: IBA projection from the PANTHER cadherin tree (PTHR24027) via GO_REF:0000033. The E-cadherin cytoplasmic catenin-binding domain directly binds beta-catenin (CTNNB1); this interaction links the cadherin to the actin cytoskeleton via alpha-catenin and is the molecular basis of the cadherin-catenin complex. Independently supported within this file by IPI/IDA evidence on this same term (PMID:18593713, Smad7 stabilizes beta-catenin binding to the E-cadherin complex; PMID:17620337) and by Reactome TAS rows describing CDH1-CTNNB1 complex formation.
+    action: ACCEPT
+    reason: Canonical core CDH1 molecular function — direct beta-catenin binding by the cadherin cytoplasmic tail is the defining interaction of the cadherin-catenin complex. Corroborated by IPI (PMID:18593713) and IDA (PMID:17620337) evidence on this exact term elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
 - term:
     id: GO:0044331
     label: cell-cell adhesion mediated by cadherin
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: IBA projection from the PANTHER classical cadherin tree (PTHR24027) via GO_REF:0000033. Cadherin-mediated cell-cell adhesion is the defining function of E-cadherin — calcium-dependent homophilic trans-interaction of ectodomains between adjacent epithelial cells. This is the central core CDH1 process. Independently supported in this file by IDA evidence on the same term (PMID:18593713) and by the crystallographic adhesion-architecture reference PMID:21300292.
+    action: ACCEPT
+    reason: Defining core biological process of E-cadherin — homophilic cadherin-mediated cell-cell adhesion. Corroborated by IDA evidence on this exact term (PMID:18593713) elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
 - term:
     id: GO:0016342
     label: catenin complex
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: IBA projection (part_of) from the PANTHER cadherin tree (PTHR24027) via GO_REF:0000033. E-cadherin is the transmembrane core of the cadherin-catenin (catenin) complex; its cytoplasmic tail scaffolds beta-catenin and gamma-catenin and, via alpha-catenin, the actin cytoskeleton. Independently supported in this file by IDA evidence on the same GO:0016342 term (PMID:18593713).
+    action: ACCEPT
+    reason: Core CDH1 cellular component — E-cadherin is the obligate transmembrane component of the catenin complex. Corroborated by IDA evidence on this exact term (PMID:18593713) elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
 - term:
     id: GO:0045296
     label: cadherin binding
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: IBA projection from the PANTHER cadherin tree (PTHR24027) via GO_REF:0000033. E-cadherin engages in cadherin binding through calcium-dependent homophilic trans- and cis-interactions of its ectodomain (the EC1 strand-swap dimer interface), the mechanistic basis of homophilic cell-cell adhesion. Independently supported in this file by HDA evidence on the same term (PMID:25468996, the E-cadherin interactome) and the crystallographic reference PMID:21300292.
+    action: ACCEPT
+    reason: Core CDH1 molecular function — homophilic cadherin-cadherin binding via the ectodomain is the adhesive activity of E-cadherin. Corroborated by HDA evidence on this exact term (PMID:25468996) elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
 - term:
     id: GO:0034332
     label: adherens junction organization
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: IBA projection from the PANTHER classical cadherin tree (PTHR24027) via GO_REF:0000033. E-cadherin is the founding component that organizes the epithelial adherens junction — clustering of trans-engaged cadherins together with recruitment of the catenin-actin module assembles and maintains the zonula adherens. Independently supported in this file by IMP evidence on the same term (PMID:21724833).
+    action: ACCEPT
+    reason: Core CDH1 biological process — E-cadherin organizes the adherens junction. Corroborated by IMP evidence on this exact term (PMID:21724833) elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
 - term:
     id: GO:0005912
     label: adherens junction
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: IBA projection (is_active_in) from the PANTHER classical cadherin tree (PTHR24027) via GO_REF:0000033. The adherens junction (zonula adherens) is the principal site of E-cadherin residence and function in epithelial cells. This is a core CDH1 cellular component, independently supported in this file by multiple IDA rows on the same term (PMID:22294297, PMID:18343367, PMID:27760340, PMID:24046456, PMID:20086044, PMID:16338932).
+    action: ACCEPT
+    reason: Core CDH1 cellular component — the adherens junction is the defining site of E-cadherin localization and activity, corroborated by numerous IDA rows on this exact term in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
 - term:
     id: GO:0007416
     label: synapse assembly
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: IBA projection from the PANTHER cadherin tree (PTHR24027) via GO_REF:0000033, originating from the broad ancestral node PTN000616414. Classical cadherins contribute to synapse assembly and stabilization in the nervous system, and E-cadherin has documented roles at neuronal synapses; however, for the canonical epithelial CDH1 this is a tissue-specific, non-core context rather than a defining function. The core CDH1 role is epithelial cell-cell adhesion at adherens junctions.
+    action: KEEP_AS_NON_CORE
+    reason: Tissue/cell-type-specific neuronal context (synapse assembly) rather than a core epithelial CDH1 function; projected from a broad ancestral PANTHER node. Mechanical IBA-PANTHER batch (batch 2 of #348).
 - term:
     id: GO:0016339
     label: calcium-dependent cell-cell adhesion
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: IBA projection from the PANTHER classical cadherin tree (PTHR24027) via GO_REF:0000033. E-cadherin adhesion is strictly calcium-dependent — Ca2+ ions bridge the linker regions between extracellular cadherin (EC) domains, rigidifying the ectodomain into the conformation competent for homophilic trans-binding. GO:0016339 (attachment of one cell to another via adhesion molecules that require calcium) precisely describes the core CDH1 adhesive process. Consistent with the IEA GO:0005509 (calcium ion binding) row in this file.
+    action: ACCEPT
+    reason: Core CDH1 biological process — calcium-dependent homophilic cell-cell adhesion is the defining activity of E-cadherin. Mechanical IBA-PANTHER batch (batch 2 of #348).
 - term:
     id: GO:0016600
     label: flotillin complex
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: IBA projection (part_of) from the PANTHER cadherin tree (PTHR24027) via GO_REF:0000033, from the broad ancestral node PTN000616414. GO:0016600 (flotillin complex) is defined as a protein complex containing flotillin-1 and flotillin-2 (and possibly associated proteins). E-cadherin is recruited to flotillin-rich membrane microdomains that stabilize cadherins at cell-cell junctions (shown experimentally in PMID:24046456, the separate IDA GO:0016600 row in this file), but it is not a constitutive flotillin subunit. Annotating E-cadherin as part_of the flotillin complex by phylogenetic inference overstates this microdomain association into structural complex membership. (The IDA flotillin row, PMID:24046456, is left PENDING for a later batch.)
+    action: MARK_AS_OVER_ANNOTATED
+    reason: The part_of qualifier overstates a membrane-microdomain association as structural membership of the flotillin-1/-2 complex; E-cadherin is recruited to flotillin microdomains but is not a flotillin-complex subunit. Not entirely wrong (flotillin-microdomain localization is experimentally supported by PMID:24046456) but an over-annotation as an IBA part_of inference. Mechanical IBA-PANTHER batch (batch 2 of #348).
 - term:
     id: GO:0043296
     label: apical junction complex
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: IBA projection (is_active_in) from the PANTHER cadherin tree (PTHR24027) via GO_REF:0000033, from the broad ancestral node PTN000616414. The apical junction complex (GO:0043296) is the composite apical unit comprising the tight junction, the zonula adherens and desmosomes. E-cadherin is the core of the zonula adherens, one of the three constituents of the apical junction complex, so the annotation is not wrong; however, the precise and core CDH1 cellular component is the adherens junction itself (GO:0005912, ACCEPTed in this batch), and the broader composite grouping is best treated as non-core.
+    action: KEEP_AS_NON_CORE
+    reason: Accurate but broader-than-precise CC grouping; the precise core localization is GO:0005912 adherens junction. E-cadherin resides specifically in the zonula adherens sub-compartment of the apical junction complex. Mechanical IBA-PANTHER batch (batch 2 of #348).
 - term:
     id: GO:0005509
     label: calcium ion binding


### PR DESCRIPTION
## Summary

Second review batch for the freshly-seeded CDH1 (E-cadherin, UniProt P12830) review tracked in #348, continuing the per-batch cadence established by batch 1 (#591, merged). This batch resolves the **14 IBA annotations** projected from the PANTHER classical cadherin family tree (**PTHR24027**, subfamily SF319 Cadherin-1) via `GO_REF:0000033` — the phylogenetic-inference block that defines the gene's core function set.

One file changed: `genes/human/CDH1/CDH1-ai-review.yaml` (+42/−28).

## Outcome — 14 rows resolved

### 8 × ACCEPT (core)
The canonical E-cadherin adhesion/junction machinery, each independently corroborated by experimental rows (IDA/IPI/IMP/HDA) on the **same GO term** elsewhere in the file:

| Term | Qualifier | Corroborating in-file evidence |
|---|---|---|
| `GO:0007043` cell-cell junction assembly | involved_in | — (consistent with GO:0034332) |
| `GO:0008013` beta-catenin binding | enables | IPI PMID:18593713, IDA PMID:17620337 |
| `GO:0044331` cell-cell adhesion mediated by cadherin | involved_in | IDA PMID:18593713 |
| `GO:0016342` catenin complex | part_of | IDA PMID:18593713 |
| `GO:0045296` cadherin binding | enables | HDA PMID:25468996 |
| `GO:0034332` adherens junction organization | involved_in | IMP PMID:21724833 |
| `GO:0005912` adherens junction | is_active_in | 6 IDA rows (PMID:22294297, 18343367, 27760340, 24046456, 20086044, 16338932) |
| `GO:0016339` calcium-dependent cell-cell adhesion | involved_in | consistent with IEA GO:0005509 calcium ion binding |

### 4 × KEEP_AS_NON_CORE
- `GO:0000902` **cell morphogenesis** and `GO:0016477` **cell migration** — real but broad downstream outcomes of the core adhesion function; CDH1's directional migration role (suppression of invasion) is separately captured by the IMP `GO:0030336` row.
- `GO:0007416` **synapse assembly** — genuine cadherin-family neuronal role, but tissue-specific and non-core for epithelial CDH1; projected from the broad ancestral PANTHER node PTN000616414.
- `GO:0043296` **apical junction complex** — accurate (the zonula adherens is a constituent of the AJC) but broader than the precise core CC `GO:0005912` adherens junction.

### 2 × MARK_AS_OVER_ANNOTATED
- `GO:0005737` **cytoplasm** (`is_active_in`) — over-broad CC for a type-I single-pass transmembrane plasma-membrane protein; only the ~150-residue cytoplasmic tail faces the cytosol. Precise CC terms (plasma membrane, adherens junction, lateral plasma membrane) are already in the file.
- `GO:0016600` **flotillin complex** (`part_of`) — `GO:0016600` is the flotillin-1/-2 complex. E-cadherin is *recruited to* flotillin-rich microdomains (experimentally shown, PMID:24046456) but is **not** a flotillin subunit; the IBA `part_of` inference overstates microdomain association as structural membership. The separate IDA flotillin row (PMID:24046456) is left PENDING for a later batch.

## Annotation review state after this PR

- `action: PENDING` 161 → **147** (14 resolved)
- `action: ACCEPT` 0 → **8**
- `action: KEEP_AS_NON_CORE` 0 → **4**
- `action: MARK_AS_OVER_ANNOTATED` 39 → **41**

## Validation

`just validate human CDH1` → ✓ Valid. Three pre-existing seed-state warnings unchanged (TODO `description`, PENDING rows remaining, no `core_functions`) — these resolve in the final closeout batch. No new files, no derived-file edits.

## Scope / risk

- **Scope:** one coherent evidence block (IBA / GO_REF:0000033), one file.
- **Risk:** Low. Judgment-based core-function review rather than a uniform mechanical flip, but each ACCEPT is cross-checked against same-term experimental evidence already in the file, and the term definitions for the two MARK_AS_OVER_ANNOTATED and the borderline KEEP rows were verified against OLS. No rows removed; no `core_functions`/`description` changes.

## Not in scope (deferred to future batches)

- Remaining 147 PENDING rows (IEA CC/BP blocks, IEA `GO_REF:0000107` ortholog block, ~80 TAS Reactome trafficking rows, IDA/IMP/EXP experimental rows, the 6 IPI `GO:0042802` identical-protein-binding rows)
- Seeding proposed `NEW` rows for `GO:0045294` alpha-catenin binding and `GO:0070097` delta-catenin binding (flagged in #591 review)
- `description` + `core_functions` synthesis and `CDH1-pathway.md` (final closeout)

Refs #348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)