### PR TITLE
CDH1: batch 3 — review 14 IEA annotations (#348)

### DIFF
--- a/genes/human/CDH1/CDH1-ai-review.yaml
+++ b/genes/human/CDH1/CDH1-ai-review.yaml
@@ -145,112 +145,126 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: "InterPro2GO electronic annotation (GO_REF:0000002) projected from the cadherin extracellular (EC) domain signatures in the E-cadherin ectodomain. E-cadherin's five tandem cadherin repeats (EC1-EC5) coordinate Ca2+ ions at the inter-domain linker regions; this calcium binding rigidifies the ectodomain into the elongated conformation competent for homophilic trans-adhesion and is the molecular basis of the calcium dependence of cadherin adhesion. UniProt P12830 carries the Calcium and Metal-binding keywords with explicit Ca2+-binding site features in the EC linkers. The annotation is accurate and mechanistically central."
+    action: ACCEPT
+    reason: "Core CDH1 molecular function - Ca2+ coordination by the inter-EC-domain linkers is mechanistically required for cadherin adhesion and underlies the calcium-dependent adhesion captured by GO:0016339 (ACCEPTed in the IBA batch). Mechanical IEA batch (batch 3 of #348)."
 - term:
     id: GO:0005576
     label: extracellular region
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: "Electronic annotation (GO_REF:0000044) mapped from UniProt subcellular-location/topology data. E-cadherin is a single-pass type I membrane protein - its large N-terminal ectodomain faces the extracellular space, but the intact protein resides in the plasma membrane, not free in the extracellular region. Extracellular-region localization is only literally true for the proteolytically shed soluble ectodomain (soluble E-cadherin, sE-cad), which is separately supported by an IDA row (PMID:34742300) and Reactome TAS rows elsewhere in this file. As a cellular-component assertion for the intact protein, GO:0005576 is over-broad; the accurate CC is GO:0005886 plasma membrane."
+    action: MARK_AS_OVER_ANNOTATED
+    reason: "Over-broad CC - E-cadherin is a plasma-membrane protein, not a resident of the extracellular region; the term is only literally correct for the shed soluble ectodomain. The accurate CC GO:0005886 plasma membrane is ACCEPTed in this batch. Mechanical IEA batch (batch 3 of #348)."
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: "Electronic annotation (GO_REF:0000044) mapped from the UniProt 'Cytoplasm' subcellular-location term. For a single-pass type I transmembrane protein, only the ~150-residue C-terminal catenin-binding tail faces the cytosol; the intact protein resides at the plasma membrane and adherens junction. UniProt curates the cytoplasmic location as a product of regulated proteolysis (sequential proteolysis induced by apoptosis or calcium influx translocates E-cadherin from sites of cell-cell contact to the cytoplasm), i.e. it reflects a cleaved fragment rather than the intact membrane protein. Annotating the protein as located in the cytoplasm is over-broad, consistent with the parallel IBA GO:0005737 row already MARK_AS_OVER_ANNOTATED in this file."
+    action: MARK_AS_OVER_ANNOTATED
+    reason: "Over-broad CC for a single-pass transmembrane plasma-membrane protein; cytoplasmic localization reflects regulated proteolytic cleavage and translocation, not the intact protein's residence. Consistent with the MARK_AS_OVER_ANNOTATED disposition of the IBA GO:0005737 row in this file. Mechanical IEA batch (batch 3 of #348)."
 - term:
     id: GO:0005768
     label: endosome
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: "Electronic annotation (GO_REF:0000044) mapped from the UniProt 'Endosome' subcellular-location term, which is experimentally supported (UniProt cites PubMed:15689490; the same study underlies the EXP GO:0005768 row in this file). E-cadherin transits the endosomal system during endocytic internalisation and Rab11-dependent recycling back to the plasma membrane - a major route for regulating surface cadherin levels and junction remodelling. The endosomal pool is real but represents E-cadherin's trafficking itinerary rather than the site of its adhesive function."
+    action: KEEP_AS_NON_CORE
+    reason: "Genuine, experimentally supported localization (endocytic recycling pathway) but non-core - it reflects E-cadherin trafficking and turnover rather than its core adhesive activity, which occurs at the plasma membrane and adherens junction. Mechanical IEA batch (batch 3 of #348)."
 - term:
     id: GO:0005794
     label: Golgi apparatus
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: "Electronic annotation (GO_REF:0000044) mapped from the UniProt 'Golgi apparatus, trans-Golgi network' subcellular-location term, which is experimentally supported (UniProt cites PubMed:15689490). Newly synthesised E-cadherin transits the Golgi and trans-Golgi network during biosynthetic delivery to the basolateral plasma membrane, colocalising with RAB11A endosomes en route. The Golgi pool reflects secretory-pathway transit, not the site of E-cadherin's adhesive function."
+    action: KEEP_AS_NON_CORE
+    reason: "Genuine but non-core localization - the Golgi/TGN pool reflects biosynthetic transit of newly synthesised E-cadherin to the cell surface, not its core adhesive activity. Mechanical IEA batch (batch 3 of #348)."
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: "Electronic annotation (GO_REF:0000120) asserting plasma-membrane localization. E-cadherin is a single-pass type I plasma-membrane glycoprotein; the cell membrane is its principal site of residence and function. UniProt P12830 curates 'Cell membrane; Single-pass type I membrane protein', and the localization is corroborated extensively in this file by EXP/IDA evidence (PMID:19403558, PMID:20859650, PMID:28301459, PMID:36309486) and numerous Reactome TAS rows."
+    action: ACCEPT
+    reason: "Core CDH1 cellular component - the plasma membrane is the principal site of E-cadherin residence and adhesive activity; heavily corroborated by experimental rows in this file. Mechanical IEA batch (batch 3 of #348)."
 - term:
     id: GO:0005912
     label: adherens junction
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: "Electronic annotation (GO_REF:0000044) mapped from the UniProt 'Cell junction, adherens junction' subcellular-location term, which is experimentally supported (UniProt cites PubMed:18343367, PubMed:22294297, PubMed:27760340, PubMed:28169360). The adherens junction (zonula adherens) is the defining functional site of E-cadherin in epithelial cells. This row duplicates the IBA GO:0005912 row already ACCEPTed in this file and is independently supported by multiple IDA rows on the same term."
+    action: ACCEPT
+    reason: "Core CDH1 cellular component - the adherens junction is the defining site of E-cadherin localization and activity; consistent with the ACCEPTed IBA GO:0005912 row and multiple IDA rows in this file. Mechanical IEA batch (batch 3 of #348)."
 - term:
     id: GO:0007155
     label: cell adhesion
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: "InterPro2GO electronic annotation (GO_REF:0000002) projected from the cadherin domain signatures. 'Cell adhesion' is correct for E-cadherin but is a broad grandparent term that also subsumes cell-substrate adhesion and non-cadherin adhesion systems, so it carries little information about CDH1 function. The precise descendant terms are present in this file - GO:0098609 cell-cell adhesion (ACCEPTed in this batch), and GO:0044331 cell-cell adhesion mediated by cadherin and GO:0016339 calcium-dependent cell-cell adhesion (both ACCEPTed in the IBA batch)."
+    action: MARK_AS_OVER_ANNOTATED
+    reason: "Over-broad parent BP - correct but uninformative; the specific cell-cell and cadherin-mediated adhesion children are already annotated and ACCEPTed in this file. Mechanical IEA batch (batch 3 of #348)."
 - term:
     id: GO:0007156
     label: homophilic cell-cell adhesion
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: "InterPro2GO electronic annotation (GO_REF:0000002) projected from the cadherin domain signatures. GO:0007156 is defined as the attachment of an adhesion molecule in one cell to an identical molecule in an adjacent cell - precisely the homophilic trans-interaction of E-cadherin EC1 ectodomains that mediates epithelial cell-cell adhesion. Independently supported in this file by NAS evidence on the same term (PMID:16338932, PMID:8033105)."
+    action: ACCEPT
+    reason: "Core CDH1 biological process - homophilic cell-cell adhesion via the cadherin ectodomain is the defining activity of E-cadherin. Mechanical IEA batch (batch 3 of #348)."
 - term:
     id: GO:0016020
     label: membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: "InterPro2GO electronic annotation (GO_REF:0000002) projected from the transmembrane cadherin signatures. 'Membrane' is correct for this single-pass transmembrane protein but is the broad parent of the accurate, specific term GO:0005886 plasma membrane, which is present and ACCEPTed in this batch. As a bare cellular component it conveys nothing beyond 'membrane protein'."
+    action: MARK_AS_OVER_ANNOTATED
+    reason: "Over-broad parent CC - subsumed by the specific GO:0005886 plasma membrane row ACCEPTed in this batch. Mechanical IEA batch (batch 3 of #348)."
 - term:
     id: GO:0030054
     label: cell junction
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: "ARBA machine-learning electronic annotation (GO_REF:0000117). 'Cell junction' is correct for E-cadherin but is a broad parent term covering tight junctions, gap junctions, synapses and cell-substrate junctions. The precise CC terms are present in this file - GO:0005912 adherens junction (ACCEPTed) and GO:0030057 desmosome (KEEP_AS_NON_CORE in this batch)."
+    action: MARK_AS_OVER_ANNOTATED
+    reason: "Over-broad parent CC - correct but uninformative; the specific junction localizations (adherens junction, desmosome) are already annotated in this file. Mechanical IEA batch (batch 3 of #348)."
 - term:
     id: GO:0030057
     label: desmosome
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: "Electronic annotation (GO_REF:0000044) mapped from the UniProt 'Cell junction, desmosome' subcellular-location term, which is experimentally supported (UniProt cites PubMed:25208567, PubMed:29999492, PubMed:33596089; corroborated by IDA rows PMID:29999492 and PMID:33596089 in this file). E-cadherin is recruited to nascent desmosomes during their assembly and binds desmoglein to facilitate desmosome formation, accumulating progressively at mature desmosomal junctions. This is a genuine localization, but the desmosome is not the core functional site of E-cadherin - the classical cadherin function is centred on the adherens junction."
+    action: KEEP_AS_NON_CORE
+    reason: "Real, experimentally curated localization - E-cadherin is recruited to desmosomes and binds desmoglein during desmosome assembly - but non-core; E-cadherin's defining residence is the adherens junction (GO:0005912). Mechanical IEA batch (batch 3 of #348)."
 - term:
     id: GO:0034329
     label: cell junction assembly
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: "ARBA machine-learning electronic annotation (GO_REF:0000117). E-cadherin nucleates assembly of epithelial cell-cell junctions, but GO:0034329 is a broad parent term that also covers cell-substrate junction assembly. The precise process term GO:0007043 cell-cell junction assembly is present in this file and was ACCEPTed as a core process in the IBA batch."
+    action: MARK_AS_OVER_ANNOTATED
+    reason: "Over-broad parent BP - subsumed by the specific GO:0007043 cell-cell junction assembly row ACCEPTed in the IBA batch. Mechanical IEA batch (batch 3 of #348)."
 - term:
     id: GO:0098609
     label: cell-cell adhesion
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    summary: "InterPro2GO electronic annotation (GO_REF:0000002) projected from the cadherin domain signatures. Cell-cell adhesion is the defining biological process of E-cadherin - calcium-dependent homophilic trans-interaction of ectodomains between adjacent epithelial cells. It is more specific and informative than the broad GO:0007155 cell adhesion parent (MARK_AS_OVER_ANNOTATED in this batch), and is independently supported in this file by IDA evidence on the same term (PMID:16338932)."
+    action: ACCEPT
+    reason: "Core CDH1 biological process - cell-cell adhesion is the central function of E-cadherin; corroborated by IDA evidence on this exact term (PMID:16338932) in this file. Mechanical IEA batch (batch 3 of #348)."
 - term:
     id: GO:0005515
     label: protein binding


### PR DESCRIPTION
## Summary

Continues the CDH1 GO annotation review (issue #348). This PR reviews **all 14 `IEA` (electronic) annotations** in `CDH1-ai-review.yaml`, cross-checked against the curated UniProt P12830 subcellular-location block and the GOA evidence. Net effect: **PENDING 147 → 133**.

Edits are confined to the contiguous IEA block (orig. lines ~142–253), non-overlapping with the open PR #592 (`GO:0042802` rows ~534–561), so the two PRs merge cleanly.

### ACCEPT (5) — precise + core
| GO term | Source | Note |
|---|---|---|
| GO:0005509 calcium ion binding | InterPro2GO | Ca²⁺ coordination by the inter-EC-domain linkers; mechanistically central |
| GO:0005886 plasma membrane | GO_REF:0000120 | Principal site of residence; corroborated by EXP/IDA/TAS rows |
| GO:0005912 adherens junction | UniProt SubCell | Defining functional site; duplicates ACCEPTed IBA row |
| GO:0007156 homophilic cell-cell adhesion | InterPro2GO | The defining BP of E-cadherin |
| GO:0098609 cell-cell adhesion | InterPro2GO | Core BP; corroborated by IDA PMID:16338932 |

### KEEP_AS_NON_CORE (3) — real but peripheral
| GO term | Note |
|---|---|
| GO:0005768 endosome | Endocytic recycling itinerary (EXP PMID:15689490) — trafficking, not core |
| GO:0005794 Golgi apparatus | Biosynthetic transit to the cell surface — not core |
| GO:0030057 desmosome | Experimentally curated (E-cadherin binds desmoglein during desmosome assembly) but non-core; defining residence is the adherens junction |

### MARK_AS_OVER_ANNOTATED (6) — over-broad parent terms
GO:0005576 extracellular region (plasma-membrane protein, only the shed soluble ectodomain is extracellular); GO:0005737 cytoplasm (reflects regulated proteolytic cleavage — consistent with the IBA cytoplasm row); GO:0007155 cell adhesion; GO:0016020 membrane; GO:0030054 cell junction; GO:0034329 cell junction assembly — each is a broad parent whose precise, informative child term is already present and ACCEPTed in the file.

## Note for maintainers — latent YAML truncation bug

The seed/batch-1/batch-2 rows write `summary`/`reason` as **unquoted** YAML scalars ending in `(batch N of #348).`. PyYAML treats ` #` in a plain scalar as a comment, so those `reason` fields are **silently truncated** at `(batch N of` (verified: `existing_annotations[0].review.reason` ends `"...(batch 2 of"`). This batch's new strings are **double-quoted** to avoid the issue. The pre-existing truncated rows are out of scope here (and overlap PR #592's territory) but warrant a separate cleanup pass.

## Validation

`just validate human CDH1` → ✓ Valid, with 3 expected in-progress warnings (TODO description, 133 PENDING, no `core_functions`).

## Remaining work (~133 PENDING, future batches)
~56 TAS (Reactome), ~38 IDA/EXP/HDA, ~8 IMP, residual NAS/IPI rows, plus `description`, `core_functions`, and `references`.

Posted as **draft** — automated curation scanner output, for maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)