### PR TITLE
CDH1: batch 4 — review 56 TAS Reactome localization rows (#348)

### DIFF
--- a/genes/human/CDH1/CDH1-ai-review.yaml
+++ b/genes/human/CDH1/CDH1-ai-review.yaml
@@ -854,296 +854,333 @@ existing_annotations:
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9935547
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9935547): Endocytosed, ubiquitinated CDH1/E-cadherin is sorted to lysosomes for degradation as part of junction turnover and downregulation. Lysosomal localization is real but reflects CDH1 degradative turnover rather than the site of its core adhesion function.'
+    reason: 'Real but non-core CC -- lysosomal localization reflects CDH1 degradative turnover; core localization and function are at the plasma membrane and adherens junction. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005765
     label: lysosomal membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9935552
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9935552): Endocytosed, ubiquitinated CDH1/E-cadherin is sorted to lysosomes for degradation as part of junction turnover and downregulation. Lysosomal localization is real but reflects CDH1 degradative turnover rather than the site of its core adhesion function.'
+    reason: 'Real but non-core CC -- lysosomal localization reflects CDH1 degradative turnover; core localization and function are at the plasma membrane and adherens junction. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9934752
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9934752): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9934753
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9934753): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0031901
     label: early endosome membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9934752
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9934752): CDH1/E-cadherin undergoes clathrin-mediated endocytosis and is trafficked through early endosomes during junction remodelling, recycling, and degradative sorting (e.g. following CBLL1/Hakai-mediated ubiquitination). Early endosome localization is real but reflects CDH1 trafficking/turnover rather than the site of its core adhesion function. Consistent with KEEP_AS_NON_CORE on the IEA endosome annotation in this file.'
+    reason: 'Real but non-core CC -- early endosome localization reflects CDH1 endocytic trafficking/turnover; consistent with KEEP_AS_NON_CORE on the IEA endosome row. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0031901
     label: early endosome membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9935552
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9935552): CDH1/E-cadherin undergoes clathrin-mediated endocytosis and is trafficked through early endosomes during junction remodelling, recycling, and degradative sorting (e.g. following CBLL1/Hakai-mediated ubiquitination). Early endosome localization is real but reflects CDH1 trafficking/turnover rather than the site of its core adhesion function. Consistent with KEEP_AS_NON_CORE on the IEA endosome annotation in this file.'
+    reason: 'Real but non-core CC -- early endosome localization reflects CDH1 endocytic trafficking/turnover; consistent with KEEP_AS_NON_CORE on the IEA endosome row. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9934751
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9934751): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9934755
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9934755): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9766227
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9766227): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9934584
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9934584): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0031901
     label: early endosome membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9766223
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9766223): CDH1/E-cadherin undergoes clathrin-mediated endocytosis and is trafficked through early endosomes during junction remodelling, recycling, and degradative sorting (e.g. following CBLL1/Hakai-mediated ubiquitination). Early endosome localization is real but reflects CDH1 trafficking/turnover rather than the site of its core adhesion function. Consistent with KEEP_AS_NON_CORE on the IEA endosome annotation in this file.'
+    reason: 'Real but non-core CC -- early endosome localization reflects CDH1 endocytic trafficking/turnover; consistent with KEEP_AS_NON_CORE on the IEA endosome row. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0031901
     label: early endosome membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9934584
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9934584): CDH1/E-cadherin undergoes clathrin-mediated endocytosis and is trafficked through early endosomes during junction remodelling, recycling, and degradative sorting (e.g. following CBLL1/Hakai-mediated ubiquitination). Early endosome localization is real but reflects CDH1 trafficking/turnover rather than the site of its core adhesion function. Consistent with KEEP_AS_NON_CORE on the IEA endosome annotation in this file.'
+    reason: 'Real but non-core CC -- early endosome localization reflects CDH1 endocytic trafficking/turnover; consistent with KEEP_AS_NON_CORE on the IEA endosome row. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9766219
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9766219): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9816278
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9816278): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9817325
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9817325): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9817330
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9817330): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9934294
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9934294): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9934410
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9934410): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9934411
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9934411): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9934486
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9934486): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0000139
     label: Golgi membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9816275
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9816275): CDH1/E-cadherin transits and is further processed/glycosylated in the Golgi apparatus en route from the ER to the plasma membrane. Golgi localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function. Consistent with KEEP_AS_NON_CORE on the IEA Golgi apparatus annotation in this file.'
+    reason: 'Real but non-core CC -- the Golgi is a transient biosynthetic/processing compartment for CDH1 maturation; consistent with KEEP_AS_NON_CORE on the IEA Golgi apparatus row. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0000139
     label: Golgi membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9816278
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9816278): CDH1/E-cadherin transits and is further processed/glycosylated in the Golgi apparatus en route from the ER to the plasma membrane. Golgi localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function. Consistent with KEEP_AS_NON_CORE on the IEA Golgi apparatus annotation in this file.'
+    reason: 'Real but non-core CC -- the Golgi is a transient biosynthetic/processing compartment for CDH1 maturation; consistent with KEEP_AS_NON_CORE on the IEA Golgi apparatus row. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0000139
     label: Golgi membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9934330
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9934330): CDH1/E-cadherin transits and is further processed/glycosylated in the Golgi apparatus en route from the ER to the plasma membrane. Golgi localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function. Consistent with KEEP_AS_NON_CORE on the IEA Golgi apparatus annotation in this file.'
+    reason: 'Real but non-core CC -- the Golgi is a transient biosynthetic/processing compartment for CDH1 maturation; consistent with KEEP_AS_NON_CORE on the IEA Golgi apparatus row. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0000139
     label: Golgi membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9935209
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9935209): CDH1/E-cadherin transits and is further processed/glycosylated in the Golgi apparatus en route from the ER to the plasma membrane. Golgi localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function. Consistent with KEEP_AS_NON_CORE on the IEA Golgi apparatus annotation in this file.'
+    reason: 'Real but non-core CC -- the Golgi is a transient biosynthetic/processing compartment for CDH1 maturation; consistent with KEEP_AS_NON_CORE on the IEA Golgi apparatus row. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005796
     label: Golgi lumen
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9816275
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9816275): CDH1/E-cadherin transits and is further processed/glycosylated in the Golgi apparatus en route from the ER to the plasma membrane. Golgi localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function. Consistent with KEEP_AS_NON_CORE on the IEA Golgi apparatus annotation in this file.'
+    reason: 'Real but non-core CC -- the Golgi is a transient biosynthetic/processing compartment for CDH1 maturation; consistent with KEEP_AS_NON_CORE on the IEA Golgi apparatus row. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0000139
     label: Golgi membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9816273
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9816273): CDH1/E-cadherin transits and is further processed/glycosylated in the Golgi apparatus en route from the ER to the plasma membrane. Golgi localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function. Consistent with KEEP_AS_NON_CORE on the IEA Golgi apparatus annotation in this file.'
+    reason: 'Real but non-core CC -- the Golgi is a transient biosynthetic/processing compartment for CDH1 maturation; consistent with KEEP_AS_NON_CORE on the IEA Golgi apparatus row. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9816273
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9816273): As a secretory-pathway transmembrane glycoprotein, pro-CDH1/E-cadherin is co-translationally inserted into, N-glycosylated, and folded within the endoplasmic reticulum before transport to the Golgi and plasma membrane. ER localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function.'
+    reason: 'Real but non-core CC -- the endoplasmic reticulum is a transient biosynthetic/folding compartment for CDH1 maturation; core localization and function are at the plasma membrane and adherens junction. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9933194
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9933194): As a secretory-pathway transmembrane glycoprotein, pro-CDH1/E-cadherin is co-translationally inserted into, N-glycosylated, and folded within the endoplasmic reticulum before transport to the Golgi and plasma membrane. ER localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function.'
+    reason: 'Real but non-core CC -- the endoplasmic reticulum is a transient biosynthetic/folding compartment for CDH1 maturation; core localization and function are at the plasma membrane and adherens junction. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9933380
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9933380): As a secretory-pathway transmembrane glycoprotein, pro-CDH1/E-cadherin is co-translationally inserted into, N-glycosylated, and folded within the endoplasmic reticulum before transport to the Golgi and plasma membrane. ER localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function.'
+    reason: 'Real but non-core CC -- the endoplasmic reticulum is a transient biosynthetic/folding compartment for CDH1 maturation; core localization and function are at the plasma membrane and adherens junction. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9816277
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9816277): As a secretory-pathway transmembrane glycoprotein, pro-CDH1/E-cadherin is co-translationally inserted into, N-glycosylated, and folded within the endoplasmic reticulum before transport to the Golgi and plasma membrane. ER localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function.'
+    reason: 'Real but non-core CC -- the endoplasmic reticulum is a transient biosynthetic/folding compartment for CDH1 maturation; core localization and function are at the plasma membrane and adherens junction. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9932352
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9932352): As a secretory-pathway transmembrane glycoprotein, pro-CDH1/E-cadherin is co-translationally inserted into, N-glycosylated, and folded within the endoplasmic reticulum before transport to the Golgi and plasma membrane. ER localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function.'
+    reason: 'Real but non-core CC -- the endoplasmic reticulum is a transient biosynthetic/folding compartment for CDH1 maturation; core localization and function are at the plasma membrane and adherens junction. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9932913
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9932913): As a secretory-pathway transmembrane glycoprotein, pro-CDH1/E-cadherin is co-translationally inserted into, N-glycosylated, and folded within the endoplasmic reticulum before transport to the Golgi and plasma membrane. ER localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function.'
+    reason: 'Real but non-core CC -- the endoplasmic reticulum is a transient biosynthetic/folding compartment for CDH1 maturation; core localization and function are at the plasma membrane and adherens junction. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9932988
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9932988): As a secretory-pathway transmembrane glycoprotein, pro-CDH1/E-cadherin is co-translationally inserted into, N-glycosylated, and folded within the endoplasmic reticulum before transport to the Golgi and plasma membrane. ER localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function.'
+    reason: 'Real but non-core CC -- the endoplasmic reticulum is a transient biosynthetic/folding compartment for CDH1 maturation; core localization and function are at the plasma membrane and adherens junction. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9816276
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9816276): As a secretory-pathway transmembrane glycoprotein, pro-CDH1/E-cadherin is co-translationally inserted into, N-glycosylated, and folded within the endoplasmic reticulum before transport to the Golgi and plasma membrane. ER localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function.'
+    reason: 'Real but non-core CC -- the endoplasmic reticulum is a transient biosynthetic/folding compartment for CDH1 maturation; core localization and function are at the plasma membrane and adherens junction. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9932344
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9932344): As a secretory-pathway transmembrane glycoprotein, pro-CDH1/E-cadherin is co-translationally inserted into, N-glycosylated, and folded within the endoplasmic reticulum before transport to the Golgi and plasma membrane. ER localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function.'
+    reason: 'Real but non-core CC -- the endoplasmic reticulum is a transient biosynthetic/folding compartment for CDH1 maturation; core localization and function are at the plasma membrane and adherens junction. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005788
     label: endoplasmic reticulum lumen
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9932162
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9932162): As a secretory-pathway transmembrane glycoprotein, pro-CDH1/E-cadherin is co-translationally inserted into, N-glycosylated, and folded within the endoplasmic reticulum before transport to the Golgi and plasma membrane. ER localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function.'
+    reason: 'Real but non-core CC -- the endoplasmic reticulum is a transient biosynthetic/folding compartment for CDH1 maturation; core localization and function are at the plasma membrane and adherens junction. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9932162
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9932162): As a secretory-pathway transmembrane glycoprotein, pro-CDH1/E-cadherin is co-translationally inserted into, N-glycosylated, and folded within the endoplasmic reticulum before transport to the Golgi and plasma membrane. ER localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function.'
+    reason: 'Real but non-core CC -- the endoplasmic reticulum is a transient biosynthetic/folding compartment for CDH1 maturation; core localization and function are at the plasma membrane and adherens junction. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0002159
     label: desmosome assembly
@@ -1239,16 +1276,18 @@ existing_annotations:
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9768614
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9768614): As a secretory-pathway transmembrane glycoprotein, pro-CDH1/E-cadherin is co-translationally inserted into, N-glycosylated, and folded within the endoplasmic reticulum before transport to the Golgi and plasma membrane. ER localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function.'
+    reason: 'Real but non-core CC -- the endoplasmic reticulum is a transient biosynthetic/folding compartment for CDH1 maturation; core localization and function are at the plasma membrane and adherens junction. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9768618
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from Reactome (R-HSA-9768618): As a secretory-pathway transmembrane glycoprotein, pro-CDH1/E-cadherin is co-translationally inserted into, N-glycosylated, and folded within the endoplasmic reticulum before transport to the Golgi and plasma membrane. ER localization is real but represents a transient biosynthetic/processing compartment rather than the site of CDH1 core adhesion function.'
+    reason: 'Real but non-core CC -- the endoplasmic reticulum is a transient biosynthetic/folding compartment for CDH1 maturation; core localization and function are at the plasma membrane and adherens junction. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005515
     label: protein binding
@@ -1338,24 +1377,27 @@ existing_annotations:
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-8876948
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-8876948): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-8876993
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-8876993): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-8877003
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-8877003): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005912
     label: adherens junction
@@ -1427,104 +1469,117 @@ existing_annotations:
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-3827958
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-3827958): CDH1/E-cadherin has a large N-terminal ectodomain (EC1-EC5) that occupies the extracellular space, and proteolytic shedding (e.g. by MMP9/KLK7) releases a soluble extracellular ectodomain fragment. Consistent with the extracellular region annotation ACCEPTed on IEA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the EC1-EC5 ectodomain occupies the extracellular region and the shed soluble ectodomain is an extracellular fragment; consistent with extracellular region ACCEPT on IEA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005576
     label: extracellular region
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-4224014
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-4224014): CDH1/E-cadherin has a large N-terminal ectodomain (EC1-EC5) that occupies the extracellular space, and proteolytic shedding (e.g. by MMP9/KLK7) releases a soluble extracellular ectodomain fragment. Consistent with the extracellular region annotation ACCEPTed on IEA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the EC1-EC5 ectodomain occupies the extracellular region and the shed soluble ectodomain is an extracellular fragment; consistent with extracellular region ACCEPT on IEA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-3827958
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-3827958): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-4224014
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-4224014): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-NUL-2534209
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-NUL-2534209): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-202939
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-202939): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-265422
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-265422): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-419001
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-419001): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-419002
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-419002): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5672304
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-5672304): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-8876497
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-8876497): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9825774
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9825774): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9926527
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: ACCEPT
+    summary: 'TAS from Reactome (R-HSA-9926527): The plasma membrane is the primary steady-state localization of CDH1/E-cadherin. As a type-I single-pass transmembrane glycoprotein, mature E-cadherin resides at the lateral/basolateral plasma membrane of epithelial cells, where it mediates calcium-dependent homophilic trans-dimerisation and cell-cell adhesion. Consistent with the plasma membrane annotations ACCEPTed on IEA and IDA evidence elsewhere in this file.'
+    reason: 'Core CDH1 cellular component -- the lateral/basolateral plasma membrane is the primary site of CDH1 localization and adhesive activity; consistent with plasma membrane ACCEPT on IEA/IDA evidence elsewhere in this file. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0005515
     label: protein binding
@@ -1596,8 +1651,9 @@ existing_annotations:
   evidence_type: TAS
   original_reference_id: PMID:17047063
   review:
-    summary: 'TODO: Review this GOA annotation'
-    action: PENDING
+    action: KEEP_AS_NON_CORE
+    summary: 'TAS from PMID:17047063: CDH1/E-cadherin localizes to cell junctions. GO:0030054 cell junction is a broad parent term; the precise and informative CC annotation is GO:0005912 adherens junction (ACCEPTed in this file), the specific junction type where E-cadherin resides and functions. Consistent with KEEP_AS_NON_CORE on the IEA cell junction annotation in this file.'
+    reason: 'Real but non-core CC -- CDH1 localizes to cell junctions but the precise junction type is the adherens junction (GO:0005912, accepted elsewhere); consistent with KEEP_AS_NON_CORE on the IEA cell junction row. Reactome TAS localization batch (batch 4 of #348).'
 - term:
     id: GO:0022408
     label: negative regulation of cell-cell adhesion


### PR DESCRIPTION
## Summary

Batch 4 of the CDH1 / E-cadherin (UniProt P12830) GO annotation review for #348. Reviews all **56 PENDING TAS-evidence cellular-component localization annotations** (55 Reactome events + 1 PMID), reducing PENDING **114 → 58**.

| Action | Count | Terms |
|--------|-------|-------|
| **ACCEPT** | 30 | `GO:0005886` plasma membrane (28), `GO:0005576` extracellular region (2) |
| **KEEP_AS_NON_CORE** | 26 | `GO:0005789` ER membrane (12), `GO:0005788` ER lumen (1), `GO:0000139` Golgi membrane (5), `GO:0005796` Golgi lumen (1), `GO:0031901` early endosome membrane (4), `GO:0005765` lysosomal membrane (2), `GO:0030054` cell junction (1) |

## Rationale

The 56 TAS rows come from Reactome pathways modelling E-cadherin biosynthesis, trafficking, endocytosis, and degradation (e.g. *CDH1 translocates from ER to Golgi*, *Ubiquitinated CDH1 is endocytosed*, *Lysosomal degradation of ubiquitinated CDH1*, *E-cadherin degradation by MMP9, KLK7*).

- **Plasma membrane / extracellular region → ACCEPT** — the lateral/basolateral plasma membrane is the core steady-state localization where E-cadherin mediates calcium-dependent homophilic adhesion; the EC1-EC5 ectodomain (and shed soluble fragment) genuinely occupies the extracellular region.
- **ER / Golgi / early endosome / lysosome → KEEP_AS_NON_CORE** — real biology, but transient biosynthetic, trafficking, and degradative compartments rather than the site of core adhesion function.
- **Cell junction → KEEP_AS_NON_CORE** — broad parent of the core `GO:0005912` adherens junction term.

All actions match the **in-file IEA precedent** for the same terms (plasma membrane / extracellular region ACCEPTed; endosome / Golgi / cell junction KEEP_AS_NON_CORE in batch 3), so no new same-term-action validator warnings are introduced.

## Validation

`just validate human CDH1` → ✓ Valid. The 3 remaining warnings (TODO description, 58 PENDING, no `core_functions`) are pre-existing seed-state items to be closed in later batches.

## Scope / risk

Low. Single YAML file, mechanical diff (+168/−112 = 56 review blocks, two uniform templates), no annotation removals, no derived-file edits. Follows the established CDH1 batch-1/2/3 and BRAF/KRAS Reactome-TAS-localization precedent.

## Test plan

- [x] `just validate human CDH1` passes
- [ ] Maintainer review of the ACCEPT vs KEEP_AS_NON_CORE split

🤖 Generated with [Claude Code](https://claude.com/claude-code)