### PR TITLE
CDH1: correct GO:0030057 desmosome IEA action — MARK_AS_OVER_ANNOTATED → KEEP_AS_NON_CORE (#348)

### DIFF
--- a/genes/human/CDH1/CDH1-ai-review.yaml
+++ b/genes/human/CDH1/CDH1-ai-review.yaml
@@ -244,9 +244,9 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    action: MARK_AS_OVER_ANNOTATED
-    summary: 'IEA from UniProt-GOA (GO_REF:0000044): Desmosomes are intercellular junctions built around desmosomal cadherins — desmogleins (DSG1-4) and desmocollins (DSC1-3). CDH1/E-cadherin is a classical cadherin at adherens junctions, not a structural component of desmosomes. This IEA annotation arises from generic cadherin-family domain mapping. Note: A separate IDA annotation on this term (PMID:33596089) is PENDING for review in a later batch.'
-    reason: 'CDH1 is a classical cadherin at adherens junctions, not a desmosomal cadherin; desmosomes are built from desmogleins/desmocollins; this IEA over-extends cadherin-family domain mapping to CDH1. IEA batch (batch 3 of #348).'
+    action: KEEP_AS_NON_CORE
+    summary: 'IEA from UniProt-GOA (GO_REF:0000044, the UniProtKB Subcellular Location keyword-to-GO mapping — not generic cadherin-family domain mapping): CDH1/E-cadherin localizes to desmosomes. UniProt P12830 curates "Cell junction, desmosome" as an experimentally-supported subcellular location (ECO:0000269|PubMed:25208567, PubMed:29999492, PubMed:33596089), and E-cadherin plays a role in the early stages of desmosome cell-cell junction formation by facilitating recruitment of DSG2 and DSP to desmosome plaques (PubMed:29999492). CDH1 is not itself a desmosomal cadherin (those are the desmogleins/desmocollins), but its desmosome localization and early-assembly role are genuine biology, not an over-annotation. This is peripheral to the core E-cadherin function at the adherens junction (GO:0005912, ACCEPTed in this file). Two IDA annotations on this term (PMID:33596089, PMID:29999492) and an IMP on GO:0002159 desmosome assembly (PMID:29999492) are PENDING for review in a later batch and should be reviewed consistently as KEEP_AS_NON_CORE.'
+    reason: 'GO_REF:0000044 propagates UniProt''s curated, experimentally-supported "Cell junction, desmosome" subcellular location (ECO:0000269|PubMed:25208567/29999492/33596089) — it is not generic domain mapping, and the desmosome localization plus early-desmosome-assembly role are genuine but peripheral to the core adherens-junction function of E-cadherin. Corrects the prior MARK_AS_OVER_ANNOTATED decision after a UniProt fact-check (see issue #348). IEA batch (batch 3 of #348) follow-up.'
 - term:
     id: GO:0034329
     label: cell junction assembly


### PR DESCRIPTION
## Summary

Targeted correction to the merged **batch 3** (#596) review of `CDH1-ai-review.yaml`. The `GO:0030057` desmosome IEA annotation (`GO_REF:0000044`) was set to `MARK_AS_OVER_ANNOTATED` with the reasoning that it *"arises from generic cadherin-family domain mapping"* and that CDH1 is *"not a structural component of desmosomes"*.

A UniProt fact-check shows that reasoning is **factually wrong**:

- UniProt **P12830** curates `SUBCELLULAR LOCATION: ... Cell junction, desmosome` with **experimental evidence** — `ECO:0000269|PubMed:25208567, PubMed:29999492, PubMed:33596089`.
- The FUNCTION block states E-cadherin *"plays a role in the early stages of desmosome cell-cell junction formation via facilitating the recruitment of DSG2 and DSP to desmosome plaques (PubMed:29999492)"*.
- `GO_REF:0000044` is the UniProtKB **Subcellular Location keyword-to-GO mapping**, i.e. a propagation of UniProt's curated localization — **not** generic cadherin-family domain mapping.

So the annotation reflects genuine, experimentally-supported biology, not an over-annotation. CDH1 is correctly *not* a desmosomal cadherin (those are the desmogleins/desmocollins), but it does localize to desmosomes and participate in their early assembly.

## Change

- `GO:0030057` (desmosome) IEA row: `action: MARK_AS_OVER_ANNOTATED` -> `KEEP_AS_NON_CORE`, with corrected `summary`/`reason` (3 lines changed). Desmosome localization is genuine but peripheral to the core adherens-junction function (`GO:0005912`, ACCEPTed elsewhere in this file).

## Why a standalone PR

- This resolves the **open fact-check question** explicitly raised in issue #348 ([the #595/#596 collision comment](https://github.com/ai4curation/ai-gene-review/issues/348#issuecomment-4507745379): *"These cannot both be true - please verify UniProt P12830's desmosome evidence before deciding."*). #596 merged before that verification happened.
- It does **not** collide with the open batch-4 PR #599 - #599's hunks are all at line >=854; this edit is at line ~247.
- It corrects a row already on `main`, so it is a follow-up correction rather than a new PENDING-row batch (no batch-slot conflict).

## Follow-up for batch 5

`GO:0030057` still has two PENDING IDA rows (PMID:33596089, PMID:29999492) and `GO:0002159` desmosome assembly has a PENDING IMP row (PMID:29999492). For consistency these should be reviewed as `KEEP_AS_NON_CORE` in the next batch.

## Test plan

- [x] `just validate human CDH1` -> Valid (only the 3 expected seed-state warnings: TODO description, PENDING annotations, no core_functions - unchanged)
- [x] No new "inconsistent review actions" validator warning introduced for `GO:0030057`

Generated with [Claude Code](https://claude.com/claude-code)