### PR TITLE
CDH1: closeout — description, core_functions, status COMPLETE (#348)

### DIFF
--- a/genes/human/CDH1/CDH1-ai-review.yaml
+++ b/genes/human/CDH1/CDH1-ai-review.yaml
@@ -1,11 +1,22 @@
 id: P12830
 gene_symbol: CDH1
 product_type: PROTEIN
-status: INITIALIZED
+status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'TODO: Add description for CDH1'
+description: 'CDH1 encodes E-cadherin (epithelial cadherin), the prototypical type-I classical
+  cadherin and the principal calcium-dependent cell-cell adhesion molecule of epithelia. This
+  single-pass transmembrane glycoprotein has five extracellular cadherin (EC) repeats that bind
+  calcium and mediate homophilic trans-adhesion with E-cadherin on neighbouring cells, while its
+  cytoplasmic tail nucleates the cadherin-catenin complex by binding p120-catenin, beta-catenin
+  and gamma-catenin/plakoglobin; alpha-catenin in turn couples this complex to the cortical actin
+  cytoskeleton. Through these interactions E-cadherin builds and maintains adherens junctions,
+  establishes epithelial apicobasal polarity and tissue integrity, and facilitates early
+  desmosome assembly. E-cadherin is a potent invasion and tumour suppressor: loss of function
+  promotes epithelial-to-mesenchymal transition and is causative in hereditary diffuse gastric
+  cancer and lobular breast carcinoma. E-cadherin is additionally exploited as a host cell-surface
+  receptor by Listeria monocytogenes internalin A.'
 alternative_products:
 - name: '1'
   id: P12830-1
@@ -2280,3 +2291,68 @@ references:
 - id: Reactome:R-NUL-2534209
   title: E-cadherin strand dimer degradation by PS1
   findings: []
+- id: file:human/CDH1/CDH1-uniprot.txt
+  title: UniProt record for human CDH1 (P12830)
+  findings:
+  - statement: Cadherins, including E-cadherin/CDH1, are calcium-dependent cell adhesion proteins.
+    supporting_text: Cadherins are calcium-dependent cell adhesion proteins
+  - statement: E-cadherin mediates homophilic cell-cell adhesion by preferentially interacting
+      with itself.
+    supporting_text: They preferentially interact with themselves in a homophilic manner in
+      connecting cells
+  - statement: E-cadherin is a component of an E-cadherin/catenin adhesion complex containing
+      beta-catenin or gamma-catenin, located at adherens junctions.
+    supporting_text: beta-catenin/CTNNB1 or gamma-catenin/JUP
+core_functions:
+- description: E-cadherin engages in calcium-dependent homophilic trans-interaction with
+    E-cadherin molecules on adjacent epithelial cells through its five extracellular cadherin
+    (EC) repeats. This homophilic binding is the molecular basis of E-cadherin-mediated cell-cell
+    adhesion and the nucleation of adherens junctions.
+  molecular_function:
+    id: GO:0045296
+    label: cadherin binding
+  supported_by:
+  - reference_id: file:human/CDH1/CDH1-uniprot.txt
+    supporting_text: They preferentially interact with themselves in a homophilic manner in
+      connecting cells
+  locations:
+  - id: GO:0016328
+    label: lateral plasma membrane
+  - id: GO:0005912
+    label: adherens junction
+  directly_involved_in:
+  - id: GO:0007156
+    label: homophilic cell-cell adhesion
+- description: The C-terminal cytoplasmic domain of E-cadherin binds beta-catenin (and
+    gamma-catenin/plakoglobin), forming the cadherin-catenin complex. This complex couples
+    E-cadherin to the cortical actin cytoskeleton via alpha-catenin, mechanically linking
+    cell-cell adhesion to the cytoskeleton and stabilizing adherens junctions.
+  molecular_function:
+    id: GO:0008013
+    label: beta-catenin binding
+  supported_by:
+  - reference_id: file:human/CDH1/CDH1-uniprot.txt
+    supporting_text: beta-catenin/CTNNB1 or gamma-catenin/JUP
+  locations:
+  - id: GO:0016328
+    label: lateral plasma membrane
+  - id: GO:0005912
+    label: adherens junction
+  directly_involved_in:
+  - id: GO:0034332
+    label: adherens junction organization
+- description: Calcium ions bind at the linker regions between E-cadherin's extracellular
+    cadherin repeats, rigidifying the ectodomain into the conformation required for homophilic
+    trans-adhesion; cadherin-mediated cell-cell adhesion is strictly calcium-dependent.
+  molecular_function:
+    id: GO:0005509
+    label: calcium ion binding
+  supported_by:
+  - reference_id: file:human/CDH1/CDH1-uniprot.txt
+    supporting_text: Cadherins are calcium-dependent cell adhesion proteins
+  locations:
+  - id: GO:0016328
+    label: lateral plasma membrane
+  directly_involved_in:
+  - id: GO:0007156
+    label: homophilic cell-cell adhesion


### PR DESCRIPTION
## Summary

Completes the human **CDH1 / E-cadherin** (UniProt P12830) GO annotation review for issue #348. All 200 existing annotations were reviewed across batches 1–5 (PRs #591, #592/#593, #596, #599, #601 — all merged), but the review file still had the closeout blockers `just validate` flagged: a `TODO` placeholder `description`, **no `core_functions`**, and `status: INITIALIZED`. This PR retires those — the same closeout pattern used for the BRAF review in #573.

- **description**: replaced the TODO placeholder with an accurate synthesis — prototypical type-I classical cadherin; Ca²⁺-dependent homophilic trans-adhesion via 5 EC repeats; cytoplasmic cadherin–catenin complex (p120/β-catenin/γ-catenin → α-catenin → actin); adherens-junction assembly, epithelial polarity/integrity, early desmosome assembly; invasion/tumour suppressor (EMT, HDGC, lobular breast carcinoma); *Listeria* InlA receptor.
- **core_functions**: 3 GO-CAM-style entries, each using a `molecular_function` term **already ACCEPTed in-file**:
  1. `GO:0045296` cadherin binding — homophilic trans-adhesion
  2. `GO:0008013` beta-catenin binding — cadherin–catenin complex / cytoskeletal coupling
  3. `GO:0005509` calcium ion binding — Ca²⁺-dependence of adhesion
- **new reference**: `file:human/CDH1/CDH1-uniprot.txt` (with a `findings` block), grounding the core functions in verified exact-substring quotes from the UniProt record.
- **status**: `INITIALIZED` → `COMPLETE`.

## Validation

`just validate human CDH1` → ✅ **Valid**. The TODO-description and no-core-functions warnings are gone. The 5 remaining warnings are all pre-existing "Inconsistent review actions" coarse-check false-positives (intentional evidence-type-based action splits) — unchanged by this PR, and one of them (`GO:0030057` desmosome) is being corrected separately by the open PR #600.

## Scope / risk

- **Low.** 1 file, +78/−2. No annotation `action` flips, no removals — purely description/core_functions/status completion.
- **No conflict** with the two other open CDH1 PRs: #600 edits one annotation row (~line 247); #602 adds a new file. This PR touches only the file head (status/description) and appends to the end (reference + core_functions).

## Note on the 2 `UNDECIDED` rows

The review retains 2 `UNDECIDED` annotations — `GO:0030027` lamellipodium (PMID:24046456) and `GO:0048471` perinuclear region of cytoplasm (PMID:16338932). Both source papers are cached **abstract-only** (`full_text_available: false`); the abstracts do not address either localization. Per `CLAUDE.md`, `UNDECIDED` is the correct action when the relevant publication cannot be accessed. These should be resolved if/when full text becomes available; they do not block `status: COMPLETE`.

## Test plan
- [x] `just validate human CDH1` passes
- [ ] Maintainer review of the description and core_functions synthesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)