### PR TITLE
BCAP31: downgrade ER-to-Golgi transport over-annotations (go-annotation#6385)

### DIFF
--- a/genes/human/BCAP31/BCAP31-ai-review.html
+++ b/genes/human/BCAP31/BCAP31-ai-review.html
@@ -633,6 +633,63 @@
             margin-left: auto;
         }
 
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
         @media print {
             body {
                 padding: 1rem;
@@ -737,7 +794,7 @@
                 <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
             </span>
         </div>
-        <p>BCAP31 (also known as BAP31) is an abundant ER-resident integral membrane protein that functions as a chaperone and cargo receptor for ER quality control. It has three transmembrane domains with a cytosolic C-terminal coiled-coil domain containing a KKXX ER-retrieval motif. BCAP31 plays essential roles in (1) ER-to-Golgi transport of select membrane proteins, (2) ER-associated degradation (ERAD) by promoting retrotranslocation of misfolded proteins via interaction with Sec61 and Derlin-1, and (3) mitochondrial homeostasis via ER-mitochondria contact sites through interaction with Tom40 to facilitate import of Complex I components. Importantly, while BCAP31 is cleaved by caspase-8 during apoptosis to generate a p20 fragment, this reflects its role as a SUBSTRATE of apoptosis machinery, not a direct participant in apoptosis initiation. The p20 cleavage product induces ER calcium release and mitochondrial fission as a consequence of apoptotic signaling. Loss-of-function mutations cause DDCH syndrome (deafness, dystonia, central hypomyelination).</p>
+        <p>BCAP31 (also known as BAP31) is an abundant ER-resident integral membrane protein that functions as a translocon-associated protein translocation chaperone for ER quality control. It has three transmembrane domains with a cytosolic C-terminal coiled-coil domain containing a KKXX ER-retrieval motif. BCAP31 plays essential roles in (1) quality control of newly synthesized membrane proteins (controlling their egress, retention, and degradation), (2) ER-associated degradation (ERAD) by promoting retrotranslocation of misfolded proteins via interaction with Sec61 and Derlin-1, and (3) mitochondrial homeostasis via ER-mitochondria contact sites through interaction with Tom40 to facilitate import of Complex I components. Importantly, while BCAP31 is cleaved by caspase-8 during apoptosis to generate a p20 fragment, this reflects its role as a SUBSTRATE of apoptosis machinery, not a direct participant in apoptosis initiation. The p20 cleavage product induces ER calcium release and mitochondrial fission as a consequence of apoptotic signaling. Loss-of-function mutations cause DDCH syndrome (deafness, dystonia, central hypomyelination).</p>
     </div>
     
 
@@ -879,10 +936,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P51572" data-a="GO:0006888" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P51572" data-a="GO:0006888" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -890,12 +947,12 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> BCAP31 functions as a cargo receptor that promotes ER export of select membrane proteins. This is a core function supported by multiple studies showing BCAP31 controls the fate of newly synthesized membrane proteins including their egress from the ER (PMID:18555783). The protein shuttles between ER and intermediate compartment/cis-Golgi (UniProt).
+                            <strong>Summary:</strong> Per geneontology/go-annotation#6385, GO curators flag this IBA as an over-propagation from PANTHER node PTN000294723. BCAP31 acts upstream of the ER exit site as a translocon-associated quality-control chaperone, not as a dedicated cargo receptor that mediates ER-to-Golgi vesicular transport. Its effect on ER export of select membrane proteins (e.g. MHC class I) is an indirect downstream consequence of its chaperone/QC role: it engages clients at the earliest folding steps, knockdown only delays rather than abolishes export, and its C-terminal KKXX motif is a COPI retrieval signal rather than an anterograde export signal.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> Core function. BCAP31 is described as an ER protein-sorting factor controlling egress of membrane proteins (PMID:18555783). The deep research confirms this as a primary function.
+                            <strong>Reason:</strong> Over-annotation flagged by GO curators in geneontology/go-annotation#6385. BCAP31&#39;s well-supported molecular role is protein translocation chaperone activity (GO:0140388) associated with the Sec61 translocon; ER-to-Golgi vesicle-mediated transport is at most an indirect downstream effect, so the IBA involved_in over-states a direct mechanistic role. Curator M. Feuermann is re-annotating the PANTHER family with corrected terms.
                         </div>
                         
                         
@@ -948,10 +1005,10 @@
                         
                     </td>
                     <td>
-                        <span class="action-badge action-accept">
-                            ACCEPT
+                        <span class="action-badge action-markasoverannotated">
+                            MARK AS OVER ANNOTATED
                         </span>
-                        <span class="vote-buttons" data-g="P51572" data-a="GO:0070973" data-r="GO_REF:0000033" data-act="ACCEPT">
+                        <span class="vote-buttons" data-g="P51572" data-a="GO:0070973" data-r="GO_REF:0000033" data-act="MARK_AS_OVER_ANNOTATED">
                             <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
                             <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
                         </span>
@@ -959,12 +1016,12 @@
                     <td>
                         
                         <div style="margin-bottom: 0.5rem;">
-                            <strong>Summary:</strong> BCAP31 cycles between peripheral ER and a juxtanuclear ER quality control compartment related to ERAD, and functions in cargo selection for ER export. The IBA annotation is consistent with the broader role in ER-to-Golgi transport.
+                            <strong>Summary:</strong> Per geneontology/go-annotation#6385, this IBA is an over-propagation from PANTHER node PTN000294723 (it is asserted on the S. pombe ortholog SPAC9E9.04 and propagated across the family). BCAP31 acts as a translocon-associated chaperone upstream of the ER exit site; actively localizing proteins to ER exit sites is not a directly supported function.
                         </div>
                         
                         
                         <div>
-                            <strong>Reason:</strong> Consistent with core cargo receptor/ER export function. The deep research describes BCAP31 as cycling between peripheral ER and juxtanuclear ERQC compartment.
+                            <strong>Reason:</strong> Over-propagated IBA flagged in geneontology/go-annotation#6385. BCAP31&#39;s core role is ER quality control / protein translocation chaperone activity at the Sec61 translocon, not delivery of cargo to ER exit sites.
                         </div>
                         
                         
@@ -1135,7 +1192,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Correct general process. BCAP31 is a cargo receptor for membrane protein transport.
+                            <strong>Reason:</strong> Correct general process. BCAP31 is a protein translocation chaperone for membrane proteins.
                         </div>
                         
                         
@@ -1268,7 +1325,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Correct general process annotation consistent with core cargo receptor function.
+                            <strong>Reason:</strong> Correct general process annotation consistent with core protein translocation chaperone function.
                         </div>
                         
                         
@@ -1370,7 +1427,7 @@
                         
                         
                         <div>
-                            <strong>Reason:</strong> Correct general process consistent with cargo receptor function.
+                            <strong>Reason:</strong> Correct general process consistent with protein translocation chaperone function.
                         </div>
                         
                         
@@ -4551,6 +4608,86 @@
                     </td>
                 </tr>
                 
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140388" target="_blank" class="term-link">
+                                    GO:0140388
+                                </a>
+                            </span>
+                            <span class="term-label">protein translocation chaperone activity</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/18555783" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:18555783
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    BAP31 interacts with Sec61 translocons and promotes retrotra...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="P51572" data-a="GO:0140388" data-r="PMID:18555783" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> NEW annotation capturing BCAP31&#39;s core molecular function. Per geneontology/go-annotation#6385, GO curator M. Feuermann identifies protein translocation chaperone activity as the correct molecular function for this PANTHER family (PTN000294723). BCAP31 associates with the Sec61 translocon and with newly synthesized integral membrane proteins, chaperoning them through folding/retention and, for misfolded clients, retrotranslocation for degradation.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Replaces the over-stated cargo-receptor / ER-to-Golgi-transport framing (see GO:0006888, marked over-annotated). GO:0140388 is the molecular function recommended by GO curators in geneontology/go-annotation#6385 and is supported by the Sec61/Derlin-1 translocon-association data in PMID:18555783.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/18555783" target="_blank" class="term-link">
+                                        PMID:18555783
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">BAP31 is an endoplasmic reticulum protein-sorting factor that associates with newly synthesized integral membrane proteins and controls their fate (i.e., egress, retention, survival, or degradation)</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
             </tbody>
         </table>
     </div>
@@ -4563,8 +4700,8 @@
         <div class="core-function-card">
             
             <div style="display: flex; justify-content: space-between; align-items: center;">
-                <h3>BCAP31 functions as a cargo receptor for selective ER-to-Golgi transport of membrane proteins including MHC class I molecules and tetraspanins.</h3>
-                <span class="vote-buttons" data-g="P51572" data-a="FUNCTION: BCAP31 functions as a cargo receptor for selective..." data-r="" data-act="CORE_FUNCTION">
+                <h3>BCAP31 acts as a translocon-associated chaperone for newly synthesized integral membrane proteins, associating with the Sec61 translocon and controlling client protein fate (egress, retention, survival, or degradation). Per geneontology/go-annotation#6385, GO curators identify protein translocation chaperone activity, not a dedicated ER-to-Golgi cargo-receptor function, as the well-supported core molecular role.</h3>
+                <span class="vote-buttons" data-g="P51572" data-a="FUNCTION: BCAP31 acts as a translocon-associated chaperone f..." data-r="" data-act="CORE_FUNCTION">
                     <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
                     <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
                 </span>
@@ -4576,8 +4713,8 @@
                 <div class="function-term-group">
                     <div class="function-term-label">Molecular Function:</div>
                     <span class="badge">
-                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140597" target="_blank" class="term-link">
-                            protein carrier chaperone
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0140388" target="_blank" class="term-link">
+                            protein translocation chaperone activity
                         </a>
                     </span>
                 </div>
@@ -4589,8 +4726,8 @@
                     <div class="function-annotations">
                         
                         <span class="badge">
-                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0006888" target="_blank" class="term-link">
-                                endoplasmic reticulum to Golgi vesicle-mediated transport
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0036503" target="_blank" class="term-link">
+                                ERAD pathway
                             </a>
                         </span>
                         
@@ -5472,126 +5609,47 @@
     <!-- Computational Predictions Section -->
     
 
-    <!-- Additional Documentation Sections -->
+    <!-- Deep Research Sections -->
     
     <div class="section">
-        <h2 class="section-title">📚 Additional Documentation</h2>
+        <h2 class="section-title">Deep Research</h2>
         
-        <details class="markdown-section">
-            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
                 <div style="flex: 1;">
-                    <h3 style="display: inline;">Deep Research Falcon</h3>
+                    <h3 style="display: inline;">Falcon</h3>
                     <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(BCAP31-deep-research-falcon.md)</span>
                 </div>
-                <div class="vote-buttons" data-g="P51572" data-a="DOC: Deep Research Falcon" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
-                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
-                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                <div class="vote-buttons" data-g="P51572" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
                 </div>
             </summary>
             <div class="markdown-content">
-                <hr />
-<p>provider: falcon<br />
-model: Edison Scientific Literature<br />
-cached: false<br />
-start_time: '2026-01-18T20:25:39.666706'<br />
-end_time: '2026-01-18T20:33:54.331414'<br />
-duration_seconds: 494.66<br />
-template_file: templates/gene_research_go_focused.md<br />
-template_variables:<br />
-  organism: human<br />
-  gene_id: BCAP31<br />
-  gene_symbol: BCAP31<br />
-  uniprot_accession: P51572<br />
-  protein_description: 'RecName: Full=B-cell receptor-associated protein 31; Short=BCR-associated<br />
-    protein 31; Short=Bap31; AltName: Full=6C6-AG tumor-associated antigen; AltName:<br />
-    Full=Protein CDM; AltName: Full=p28;'<br />
-  gene_info: Name=BCAP31 {ECO:0000312|HGNC:HGNC:16695}; Synonyms=BAP31 {ECO:0000303|PubMed:25854864},<br />
-    DXS1357E;<br />
-  organism_full: Homo sapiens (Human).<br />
-  protein_family: Belongs to the BCAP29/BCAP31 family. .<br />
-  protein_domains: BAP29/BAP31. (IPR008417); BAP29/BAP31_N. (IPR040463); Bap31/Bap29_C.<br />
-    (IPR041672); Bap31 (PF05529); Bap31_Bap29_C (PF18035)<br />
-provider_config:<br />
-  timeout: 600<br />
-  max_retries: 3<br />
-  parameters:<br />
-    allowed_domains: []<br />
-    temperature: 0.1<br />
-citation_count: 10</p>
-<hr />
-<h2 id="question">Question</h2>
-<h1 id="gene-research-for-functional-annotation">Gene Research for Functional Annotation</h1>
-<h2 id="critical-geneprotein-identification-context">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
-<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
-<h3 id="target-geneprotein-identity-from-uniprot">Target Gene/Protein Identity (from UniProt):</h3>
-<ul>
-<li><strong>UniProt Accession:</strong> P51572</li>
-<li><strong>Protein Description:</strong> RecName: Full=B-cell receptor-associated protein 31; Short=BCR-associated protein 31; Short=Bap31; AltName: Full=6C6-AG tumor-associated antigen; AltName: Full=Protein CDM; AltName: Full=p28;</li>
-<li><strong>Gene Information:</strong> Name=BCAP31 {ECO:0000312|HGNC:HGNC:16695}; Synonyms=BAP31 {ECO:0000303|PubMed:25854864}, DXS1357E;</li>
-<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
-<li><strong>Protein Family:</strong> Belongs to the BCAP29/BCAP31 family. .</li>
-<li><strong>Key Domains:</strong> BAP29/BAP31. (IPR008417); BAP29/BAP31_N. (IPR040463); Bap31/Bap29_C. (IPR041672); Bap31 (PF05529); Bap31_Bap29_C (PF18035)</li>
-</ul>
-<h3 id="mandatory-verification-steps">MANDATORY VERIFICATION STEPS:</h3>
-<ol>
-<li><strong>Check if the gene symbol "BCAP31" matches the protein description above</strong></li>
-<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
-<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
-<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
-</ol>
-<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
-<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
-- State clearly: "The gene symbol 'BCAP31' is ambiguous or literature is limited for this specific protein"<br />
-- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
-- Describe the protein based ONLY on the UniProt information provided above<br />
-- Suggest that the protein function can be inferred from domain/family information</p>
-<h3 id="research-target">Research Target:</h3>
-<p>Please provide a comprehensive research report on the gene <strong>BCAP31</strong> (gene ID: BCAP31, UniProt: P51572) in human.</p>
-<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
-<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
-this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
-<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
-<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
-<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
-<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
-<h2 id="output">Output</h2>
-<p>Question: You are an expert researcher providing comprehensive, well-cited information.</p>
-<p>Provide detailed information focusing on:<br />
-1. Key concepts and definitions with current understanding<br />
-2. Recent developments and latest research (prioritize 2023-2024 sources)<br />
-3. Current applications and real-world implementations<br />
-4. Expert opinions and analysis from authoritative sources<br />
-5. Relevant statistics and data from recent studies</p>
-<p>Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.<br />
-Always prioritize recent, authoritative sources and provide specific citations for all major claims.</p>
-<h1 id="gene-research-for-functional-annotation_1">Gene Research for Functional Annotation</h1>
-<h2 id="critical-geneprotein-identification-context_1">⚠️ CRITICAL: Gene/Protein Identification Context</h2>
-<p><strong>BEFORE YOU BEGIN RESEARCH:</strong> You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.</p>
-<h3 id="target-geneprotein-identity-from-uniprot_1">Target Gene/Protein Identity (from UniProt):</h3>
-<ul>
-<li><strong>UniProt Accession:</strong> P51572</li>
-<li><strong>Protein Description:</strong> RecName: Full=B-cell receptor-associated protein 31; Short=BCR-associated protein 31; Short=Bap31; AltName: Full=6C6-AG tumor-associated antigen; AltName: Full=Protein CDM; AltName: Full=p28;</li>
-<li><strong>Gene Information:</strong> Name=BCAP31 {ECO:0000312|HGNC:HGNC:16695}; Synonyms=BAP31 {ECO:0000303|PubMed:25854864}, DXS1357E;</li>
-<li><strong>Organism (full):</strong> Homo sapiens (Human).</li>
-<li><strong>Protein Family:</strong> Belongs to the BCAP29/BCAP31 family. .</li>
-<li><strong>Key Domains:</strong> BAP29/BAP31. (IPR008417); BAP29/BAP31_N. (IPR040463); Bap31/Bap29_C. (IPR041672); Bap31 (PF05529); Bap31_Bap29_C (PF18035)</li>
-</ul>
-<h3 id="mandatory-verification-steps_1">MANDATORY VERIFICATION STEPS:</h3>
-<ol>
-<li><strong>Check if the gene symbol "BCAP31" matches the protein description above</strong></li>
-<li><strong>Verify the organism is correct:</strong> Homo sapiens (Human).</li>
-<li><strong>Check if protein family/domains align with what you find in literature</strong></li>
-<li><strong>If you find literature for a DIFFERENT gene with the same or similar symbol, STOP</strong></li>
-</ol>
-<h3 id="if-gene-symbol-is-ambiguous-or-you-cannot-find-relevant-literature_1">If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:</h3>
-<p><strong>DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.</strong> Instead:<br />
-- State clearly: "The gene symbol 'BCAP31' is ambiguous or literature is limited for this specific protein"<br />
-- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")<br />
-- Describe the protein based ONLY on the UniProt information provided above<br />
-- Suggest that the protein function can be inferred from domain/family information</p>
-<h3 id="research-target_1">Research Target:</h3>
-<p>Please provide a comprehensive research report on the gene <strong>BCAP31</strong> (gene ID: BCAP31, UniProt: P51572) in human.</p>
-<p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+                
+                <div class="report-meta">
+                    
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+                    
+                    
+                    <span class="report-badge">Falcon</span>
+                    
+                    
+                    <span class="report-badge">Edison Scientific Literature</span>
+                    
+                    
+                    <span class="report-badge">10 citations</span>
+                    
+                    
+                    
+                    <span class="report-meta-text">2026-01-18T20:33:54.331414</span>
+                    
+                    
+                    
+                </div>
+                
+                
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
 <p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
 this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
 <p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
@@ -5694,6 +5752,14 @@ BCAP31 encodes an ER-resident, three-pass membrane chaperone/cargo receptor that
             </div>
         </details>
         
+    </div>
+    
+
+    <!-- Additional Documentation Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+        
         <details class="markdown-section">
             <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <div style="flex: 1;">
@@ -5746,6 +5812,33 @@ BCAP31 encodes an ER-resident, three-pass membrane chaperone/cargo receptor that
 <li>The plasma membrane (<code>GO:0005886</code>) call referenced under "Localization Calls" was resolved as <code>MARK_AS_OVER_ANNOTATED</code> in PR #317. The PMID:8706661 surface-antigen detection is real but represents a trafficking intermediate / overexpression artifact in transfected cells; later work establishes ER/ERGIC residency as the primary biology, consistent with the cytoplasmic KKXX retrieval motif.</li>
 <li>The clathrin-coated vesicle (<code>GO:0030136</code>) IEA was resolved as <code>MARK_AS_OVER_ANNOTATED</code> in the same PR — Ensembl rat transfer with no human-specific support, and BCAP31 traffics via COPI/COPII machinery rather than the clathrin pathway.</li>
 </ul>
+<h2 id="re-review-prompted-by-geneontologygo-annotation6385-2026-05-22">Re-review prompted by geneontology/go-annotation#6385 (2026-05-22)</h2>
+<p>GO curators raised a PAINT issue (PANTHER:PTN000294723) questioning the<br />
+<code>involved_in GO:0006888 endoplasmic reticulum to Golgi vesicle-mediated transport</code><br />
+IBA on human BCAP31 and its orthologs, plus <code>GO:0070973 protein localization to ER
+exit site</code> on the <em>S. pombe</em> ortholog SPAC9E9.04. The curator argument is that<br />
+BCAP31 acts <em>upstream</em> of the ER exit site as a quality-control / translocation<br />
+chaperone, so the anterograde-transport IBA is an erroneous over-propagation:</p>
+<ul>
+<li>Engagement begins at the earliest folding steps (heavy chain + β2-microglobulin<br />
+  association for MHC class I), far upstream of any exit-site decision.</li>
+<li>BCAP31 knockout only <em>delays</em>, does not abolish, surface class I export.</li>
+<li>The C-terminal KKXX dilysine motif is a COPI retrieval signal (retention), not<br />
+  an anterograde export signal.</li>
+</ul>
+<p>Curator M. Feuermann (GO_Central PAINT) commented (2026-05-21) that the family<br />
+lacked the right terms and recommends MF <code>GO:0140388 protein translocation
+chaperone activity</code>; he is re-annotating the family. Curator V. Wood notes the<br />
+core biology is BAP31 interacting with Sec61 translocons and promoting<br />
+retrotranslocation of CFTRΔF508 via the Derlin-1 complex (PMID:18555783).</p>
+<p>Actions taken in this review update:<br />
+- <code>GO:0006888</code> and <code>GO:0070973</code>: <code>ACCEPT</code> → <code>MARK_AS_OVER_ANNOTATED</code>.<br />
+- <code>core_functions</code> entry 1: MF changed <code>GO:0140597 protein carrier activity</code> →<br />
+<code>GO:0140388 protein translocation chaperone activity</code>; <code>directly_involved_in</code><br />
+  changed <code>GO:0006888</code> → <code>GO:0036503 ERAD pathway</code>; "cargo receptor" framing<br />
+  removed in favour of translocon-associated chaperone framing.<br />
+- <code>description</code> and several annotation <code>reason</code> fields reworded to drop the<br />
+  "cargo receptor" characterization.</p>
             </div>
         </details>
         
@@ -5768,12 +5861,14 @@ taxon:
   label: Homo sapiens
 description: &gt;-
   BCAP31 (also known as BAP31) is an abundant ER-resident integral membrane protein
-  that functions as a chaperone and cargo receptor for ER quality control. It has
+  that functions as a translocon-associated protein translocation chaperone for ER
+  quality control. It has
   three
   transmembrane domains with a cytosolic C-terminal coiled-coil domain containing
   a
-  KKXX ER-retrieval motif. BCAP31 plays essential roles in (1) ER-to-Golgi transport
-  of select membrane proteins, (2) ER-associated degradation (ERAD) by promoting
+  KKXX ER-retrieval motif. BCAP31 plays essential roles in (1) quality control of
+  newly synthesized membrane proteins (controlling their egress, retention, and
+  degradation), (2) ER-associated degradation (ERAD) by promoting
   retrotranslocation of misfolded proteins via interaction with Sec61 and Derlin-1,
   and (3) mitochondrial homeostasis via ER-mitochondria contact sites through interaction
   with Tom40 to facilitate import of Complex I components. Importantly, while BCAP31
@@ -5817,16 +5912,23 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: &gt;-
-      BCAP31 functions as a cargo receptor that promotes ER export of select membrane
-      proteins. This is a core function supported by multiple studies showing BCAP31
-      controls the fate of newly synthesized membrane proteins including their egress
-      from the ER (PMID:18555783). The protein shuttles between ER and intermediate
-      compartment/cis-Golgi (UniProt).
-    action: ACCEPT
+      Per geneontology/go-annotation#6385, GO curators flag this IBA as an
+      over-propagation from PANTHER node PTN000294723. BCAP31 acts upstream of the
+      ER exit site as a translocon-associated quality-control chaperone, not as a
+      dedicated cargo receptor that mediates ER-to-Golgi vesicular transport. Its
+      effect on ER export of select membrane proteins (e.g. MHC class I) is an
+      indirect downstream consequence of its chaperone/QC role: it engages clients
+      at the earliest folding steps, knockdown only delays rather than abolishes
+      export, and its C-terminal KKXX motif is a COPI retrieval signal rather than
+      an anterograde export signal.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Core function. BCAP31 is described as an ER protein-sorting factor controlling
-      egress of membrane proteins (PMID:18555783). The deep research confirms this
-      as a primary function.
+      Over-annotation flagged by GO curators in geneontology/go-annotation#6385.
+      BCAP31&#39;s well-supported molecular role is protein translocation chaperone
+      activity (GO:0140388) associated with the Sec61 translocon; ER-to-Golgi
+      vesicle-mediated transport is at most an indirect downstream effect, so the
+      IBA involved_in over-states a direct mechanistic role. Curator M. Feuermann
+      is re-annotating the PANTHER family with corrected terms.
     supported_by:
     - reference_id: PMID:18555783
       supporting_text: &#34;BAP31 is an endoplasmic reticulum protein-sorting factor that
@@ -5839,15 +5941,16 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: &gt;-
-      BCAP31 cycles between peripheral ER and a juxtanuclear ER quality control
-      compartment
-      related to ERAD, and functions in cargo selection for ER export. The IBA annotation
-      is consistent with the broader role in ER-to-Golgi transport.
-    action: ACCEPT
+      Per geneontology/go-annotation#6385, this IBA is an over-propagation from
+      PANTHER node PTN000294723 (it is asserted on the S. pombe ortholog
+      SPAC9E9.04 and propagated across the family). BCAP31 acts as a
+      translocon-associated chaperone upstream of the ER exit site; actively
+      localizing proteins to ER exit sites is not a directly supported function.
+    action: MARK_AS_OVER_ANNOTATED
     reason: &gt;-
-      Consistent with core cargo receptor/ER export function. The deep research
-      describes
-      BCAP31 as cycling between peripheral ER and juxtanuclear ERQC compartment.
+      Over-propagated IBA flagged in geneontology/go-annotation#6385. BCAP31&#39;s core
+      role is ER quality control / protein translocation chaperone activity at the
+      Sec61 translocon, not delivery of cargo to ER exit sites.
     supported_by:
     - reference_id: PMID:18555783
       supporting_text: &#34;BAP31 is an endoplasmic reticulum protein-sorting factor that
@@ -5891,7 +5994,8 @@ existing_annotations:
       process annotation.
     action: ACCEPT
     reason: &gt;-
-      Correct general process. BCAP31 is a cargo receptor for membrane protein transport.
+      Correct general process. BCAP31 is a protein translocation chaperone for membrane
+      proteins.
 - term:
     id: GO:0006915
     label: apoptotic process
@@ -5939,7 +6043,8 @@ existing_annotations:
       specifically functions in ER-to-Golgi transport and ERAD.
     action: ACCEPT
     reason: &gt;-
-      Correct general process annotation consistent with core cargo receptor function.
+      Correct general process annotation consistent with core protein translocation
+      chaperone function.
 - term:
     id: GO:0016020
     label: membrane
@@ -5965,7 +6070,7 @@ existing_annotations:
       trafficking, though the more specific term is also annotated.
     action: ACCEPT
     reason: &gt;-
-      Correct general process consistent with cargo receptor function.
+      Correct general process consistent with protein translocation chaperone function.
 - term:
     id: GO:0033116
     label: endoplasmic reticulum-Golgi intermediate compartment membrane
@@ -6695,6 +6800,31 @@ existing_annotations:
       supporting_text: &#34;BAP31 associates with the N terminus of one of its newly synthesized
         client proteins, the DeltaF508 mutant of CFTR, and promotes its retrotranslocation
         from the ER and degradation by the cytoplasmic 26S proteasome system&#34;
+- term:
+    id: GO:0140388
+    label: protein translocation chaperone activity
+  evidence_type: IDA
+  original_reference_id: PMID:18555783
+  review:
+    summary: &gt;-
+      NEW annotation capturing BCAP31&#39;s core molecular function. Per
+      geneontology/go-annotation#6385, GO curator M. Feuermann identifies protein
+      translocation chaperone activity as the correct molecular function for this
+      PANTHER family (PTN000294723). BCAP31 associates with the Sec61 translocon
+      and with newly synthesized integral membrane proteins, chaperoning them
+      through folding/retention and, for misfolded clients, retrotranslocation for
+      degradation.
+    action: NEW
+    reason: &gt;-
+      Replaces the over-stated cargo-receptor / ER-to-Golgi-transport framing (see
+      GO:0006888, marked over-annotated). GO:0140388 is the molecular function
+      recommended by GO curators in geneontology/go-annotation#6385 and is
+      supported by the Sec61/Derlin-1 translocon-association data in PMID:18555783.
+    supported_by:
+    - reference_id: PMID:18555783
+      supporting_text: &#34;BAP31 is an endoplasmic reticulum protein-sorting factor that
+        associates with newly synthesized integral membrane proteins and controls
+        their fate (i.e., egress, retention, survival, or degradation)&#34;
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with 
@@ -6830,17 +6960,21 @@ references:
   findings: []
 core_functions:
 - molecular_function:
-    id: GO:0140597
-    label: protein carrier chaperone
+    id: GO:0140388
+    label: protein translocation chaperone activity
   description: &gt;-
-    BCAP31 functions as a cargo receptor for selective ER-to-Golgi transport of
-    membrane proteins including MHC class I molecules and tetraspanins.
+    BCAP31 acts as a translocon-associated chaperone for newly synthesized integral
+    membrane proteins, associating with the Sec61 translocon and controlling client
+    protein fate (egress, retention, survival, or degradation). Per
+    geneontology/go-annotation#6385, GO curators identify protein translocation
+    chaperone activity, not a dedicated ER-to-Golgi cargo-receptor function, as the
+    well-supported core molecular role.
   locations:
   - id: GO:0005789
     label: endoplasmic reticulum membrane
   directly_involved_in:
-  - id: GO:0006888
-    label: endoplasmic reticulum to Golgi vesicle-mediated transport
+  - id: GO:0036503
+    label: ERAD pathway
   supported_by:
   - reference_id: PMID:18555783
     supporting_text: &#34;BAP31 is an endoplasmic reticulum protein-sorting factor that

--- a/genes/human/BCAP31/BCAP31-ai-review.yaml
+++ b/genes/human/BCAP31/BCAP31-ai-review.yaml
@@ -7,12 +7,14 @@ taxon:
   label: Homo sapiens
 description: >-
   BCAP31 (also known as BAP31) is an abundant ER-resident integral membrane protein
-  that functions as a chaperone and cargo receptor for ER quality control. It has
+  that functions as a translocon-associated protein translocation chaperone for ER
+  quality control. It has
   three
   transmembrane domains with a cytosolic C-terminal coiled-coil domain containing
   a
-  KKXX ER-retrieval motif. BCAP31 plays essential roles in (1) ER-to-Golgi transport
-  of select membrane proteins, (2) ER-associated degradation (ERAD) by promoting
+  KKXX ER-retrieval motif. BCAP31 plays essential roles in (1) quality control of
+  newly synthesized membrane proteins (controlling their egress, retention, and
+  degradation), (2) ER-associated degradation (ERAD) by promoting
   retrotranslocation of misfolded proteins via interaction with Sec61 and Derlin-1,
   and (3) mitochondrial homeostasis via ER-mitochondria contact sites through interaction
   with Tom40 to facilitate import of Complex I components. Importantly, while BCAP31
@@ -56,16 +58,23 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: >-
-      BCAP31 functions as a cargo receptor that promotes ER export of select membrane
-      proteins. This is a core function supported by multiple studies showing BCAP31
-      controls the fate of newly synthesized membrane proteins including their egress
-      from the ER (PMID:18555783). The protein shuttles between ER and intermediate
-      compartment/cis-Golgi (UniProt).
-    action: ACCEPT
+      Per geneontology/go-annotation#6385, GO curators flag this IBA as an
+      over-propagation from PANTHER node PTN000294723. BCAP31 acts upstream of the
+      ER exit site as a translocon-associated quality-control chaperone, not as a
+      dedicated cargo receptor that mediates ER-to-Golgi vesicular transport. Its
+      effect on ER export of select membrane proteins (e.g. MHC class I) is an
+      indirect downstream consequence of its chaperone/QC role: it engages clients
+      at the earliest folding steps, knockdown only delays rather than abolishes
+      export, and its C-terminal KKXX motif is a COPI retrieval signal rather than
+      an anterograde export signal.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Core function. BCAP31 is described as an ER protein-sorting factor controlling
-      egress of membrane proteins (PMID:18555783). The deep research confirms this
-      as a primary function.
+      Over-annotation flagged by GO curators in geneontology/go-annotation#6385.
+      BCAP31's well-supported molecular role is protein translocation chaperone
+      activity (GO:0140388) associated with the Sec61 translocon; ER-to-Golgi
+      vesicle-mediated transport is at most an indirect downstream effect, so the
+      IBA involved_in over-states a direct mechanistic role. Curator M. Feuermann
+      is re-annotating the PANTHER family with corrected terms.
     supported_by:
     - reference_id: PMID:18555783
       supporting_text: "BAP31 is an endoplasmic reticulum protein-sorting factor that
@@ -78,15 +87,16 @@ existing_annotations:
   original_reference_id: GO_REF:0000033
   review:
     summary: >-
-      BCAP31 cycles between peripheral ER and a juxtanuclear ER quality control
-      compartment
-      related to ERAD, and functions in cargo selection for ER export. The IBA annotation
-      is consistent with the broader role in ER-to-Golgi transport.
-    action: ACCEPT
+      Per geneontology/go-annotation#6385, this IBA is an over-propagation from
+      PANTHER node PTN000294723 (it is asserted on the S. pombe ortholog
+      SPAC9E9.04 and propagated across the family). BCAP31 acts as a
+      translocon-associated chaperone upstream of the ER exit site; actively
+      localizing proteins to ER exit sites is not a directly supported function.
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Consistent with core cargo receptor/ER export function. The deep research
-      describes
-      BCAP31 as cycling between peripheral ER and juxtanuclear ERQC compartment.
+      Over-propagated IBA flagged in geneontology/go-annotation#6385. BCAP31's core
+      role is ER quality control / protein translocation chaperone activity at the
+      Sec61 translocon, not delivery of cargo to ER exit sites.
     supported_by:
     - reference_id: PMID:18555783
       supporting_text: "BAP31 is an endoplasmic reticulum protein-sorting factor that
@@ -130,7 +140,8 @@ existing_annotations:
       process annotation.
     action: ACCEPT
     reason: >-
-      Correct general process. BCAP31 is a cargo receptor for membrane protein transport.
+      Correct general process. BCAP31 is a protein translocation chaperone for membrane
+      proteins.
 - term:
     id: GO:0006915
     label: apoptotic process
@@ -178,7 +189,8 @@ existing_annotations:
       specifically functions in ER-to-Golgi transport and ERAD.
     action: ACCEPT
     reason: >-
-      Correct general process annotation consistent with core cargo receptor function.
+      Correct general process annotation consistent with core protein translocation
+      chaperone function.
 - term:
     id: GO:0016020
     label: membrane
@@ -204,7 +216,7 @@ existing_annotations:
       trafficking, though the more specific term is also annotated.
     action: ACCEPT
     reason: >-
-      Correct general process consistent with cargo receptor function.
+      Correct general process consistent with protein translocation chaperone function.
 - term:
     id: GO:0033116
     label: endoplasmic reticulum-Golgi intermediate compartment membrane
@@ -934,6 +946,31 @@ existing_annotations:
       supporting_text: "BAP31 associates with the N terminus of one of its newly synthesized
         client proteins, the DeltaF508 mutant of CFTR, and promotes its retrotranslocation
         from the ER and degradation by the cytoplasmic 26S proteasome system"
+- term:
+    id: GO:0140388
+    label: protein translocation chaperone activity
+  evidence_type: IDA
+  original_reference_id: PMID:18555783
+  review:
+    summary: >-
+      NEW annotation capturing BCAP31's core molecular function. Per
+      geneontology/go-annotation#6385, GO curator M. Feuermann identifies protein
+      translocation chaperone activity as the correct molecular function for this
+      PANTHER family (PTN000294723). BCAP31 associates with the Sec61 translocon
+      and with newly synthesized integral membrane proteins, chaperoning them
+      through folding/retention and, for misfolded clients, retrotranslocation for
+      degradation.
+    action: NEW
+    reason: >-
+      Replaces the over-stated cargo-receptor / ER-to-Golgi-transport framing (see
+      GO:0006888, marked over-annotated). GO:0140388 is the molecular function
+      recommended by GO curators in geneontology/go-annotation#6385 and is
+      supported by the Sec61/Derlin-1 translocon-association data in PMID:18555783.
+    supported_by:
+    - reference_id: PMID:18555783
+      supporting_text: "BAP31 is an endoplasmic reticulum protein-sorting factor that
+        associates with newly synthesized integral membrane proteins and controls
+        their fate (i.e., egress, retention, survival, or degradation)"
 references:
 - id: GO_REF:0000002
   title: Gene Ontology annotation through association of InterPro records with 
@@ -1069,17 +1106,21 @@ references:
   findings: []
 core_functions:
 - molecular_function:
-    id: GO:0140597
-    label: protein carrier chaperone
+    id: GO:0140388
+    label: protein translocation chaperone activity
   description: >-
-    BCAP31 functions as a cargo receptor for selective ER-to-Golgi transport of
-    membrane proteins including MHC class I molecules and tetraspanins.
+    BCAP31 acts as a translocon-associated chaperone for newly synthesized integral
+    membrane proteins, associating with the Sec61 translocon and controlling client
+    protein fate (egress, retention, survival, or degradation). Per
+    geneontology/go-annotation#6385, GO curators identify protein translocation
+    chaperone activity, not a dedicated ER-to-Golgi cargo-receptor function, as the
+    well-supported core molecular role.
   locations:
   - id: GO:0005789
     label: endoplasmic reticulum membrane
   directly_involved_in:
-  - id: GO:0006888
-    label: endoplasmic reticulum to Golgi vesicle-mediated transport
+  - id: GO:0036503
+    label: ERAD pathway
   supported_by:
   - reference_id: PMID:18555783
     supporting_text: "BAP31 is an endoplasmic reticulum protein-sorting factor that

--- a/genes/human/BCAP31/BCAP31-ai-review.yaml
+++ b/genes/human/BCAP31/BCAP31-ai-review.yaml
@@ -212,11 +212,17 @@ existing_annotations:
   original_reference_id: GO_REF:0000043
   review:
     summary: >-
-      General term for vesicle transport. Consistent with BCAP31's role in ER-to-Golgi
-      trafficking, though the more specific term is also annotated.
-    action: ACCEPT
+      Broad vesicle-mediated transport term. BCAP31's core function is translocon-associated
+      retrotranslocation via Sec61/Derlin-1, which is a channel-mediated protein translocation
+      process, not vesicle-mediated transport. This annotation shares the same over-annotation
+      basis as its child GO:0006888 (ER-to-Golgi vesicle-mediated transport).
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Correct general process consistent with protein translocation chaperone function.
+      Accepting the parent while marking child GO:0006888 MARK_AS_OVER_ANNOTATED for
+      the same reason would be logically inconsistent. Retrotranslocation via Sec61/Derlin-1
+      is a channel-mediated process distinct from vesicle-mediated transport. The IEA
+      provenance (GO_REF:0000043, UniProtKB keyword mapping) does not override the
+      biological reasoning established in the GO:0006888 review.
 - term:
     id: GO:0033116
     label: endoplasmic reticulum-Golgi intermediate compartment membrane
@@ -915,14 +921,24 @@ existing_annotations:
     label: protein carrier chaperone
   evidence_type: NAS
   review:
-    summary: Added to align core_functions with existing annotations.
+    summary: >-
+      Broader carrier chaperone term. GO:0140388 (protein translocation chaperone activity)
+      is the curator-recommended primary MF for BCAP31 per geneontology/go-annotation#6385;
+      GO:0140597 is retained as a secondary annotation capturing the general
+      client-escorting and fate-decision role (egress, retention, or degradation) that
+      encompasses but is not limited to the translocation-specific GO:0140388 activity.
     action: NEW
-    reason: Core function term not present in existing_annotations.
+    reason: >-
+      GO:0140597 (protein carrier chaperone) is the parent term of GO:0140388 and
+      captures the broader aspect of BCAP31 function: associating with newly synthesized
+      integral membrane proteins and directing their fate across all outcomes (folding,
+      retention, ERAD, or export). Retained as secondary alongside the more specific
+      curator-recommended GO:0140388.
     supported_by:
     - reference_id: PMID:18555783
-      supporting_text: "BAP31 associates with the N terminus of one of its newly synthesized
-        client proteins, the DeltaF508 mutant of CFTR, and promotes its retrotranslocation
-        from the ER and degradation by the cytoplasmic 26S proteasome system"
+      supporting_text: "BAP31 is an endoplasmic reticulum protein-sorting factor that
+        associates with newly synthesized integral membrane proteins and controls their
+        fate (i.e., egress, retention, survival, or degradation)"
 - term:
     id: GO:0036503
     label: ERAD pathway
@@ -1130,9 +1146,11 @@ core_functions:
     id: GO:0140597
     label: protein carrier chaperone
   description: >-
-    BCAP31 promotes ERAD by interacting with the Sec61 translocon, TRAM, and Derlin-1
-    complex to facilitate retrotranslocation and proteasomal degradation of misfolded
-    ER membrane proteins like CFTR-deltaF508.
+    BCAP31 acts as a general carrier chaperone at the ER membrane, associating with
+    newly synthesized integral membrane proteins and directing their fate — whether
+    egress to the Golgi, retention in the ER for further folding, or delivery to ERAD
+    for degradation. This broader client-sorting role encompasses the translocation-
+    specific function captured by GO:0140388.
   locations:
   - id: GO:0005789
     label: endoplasmic reticulum membrane
@@ -1141,9 +1159,9 @@ core_functions:
     label: positive regulation of ERAD pathway
   supported_by:
   - reference_id: PMID:18555783
-    supporting_text: "BAP31 associates with the N terminus of one of its newly synthesized
-      client proteins, the DeltaF508 mutant of CFTR, and promotes its retrotranslocation
-      from the ER and degradation by the cytoplasmic 26S proteasome system"
+    supporting_text: "BAP31 is an endoplasmic reticulum protein-sorting factor that
+      associates with newly synthesized integral membrane proteins and controls their
+      fate (i.e., egress, retention, survival, or degradation)"
 - molecular_function:
     id: GO:0044877
     label: protein-containing complex binding

--- a/genes/human/BCAP31/BCAP31-notes.md
+++ b/genes/human/BCAP31/BCAP31-notes.md
@@ -50,3 +50,33 @@ GO:0036503 ERAD pathway is justified because the strongest mechanistic evidence 
 
 - The plasma membrane (`GO:0005886`) call referenced under "Localization Calls" was resolved as `MARK_AS_OVER_ANNOTATED` in PR #317. The PMID:8706661 surface-antigen detection is real but represents a trafficking intermediate / overexpression artifact in transfected cells; later work establishes ER/ERGIC residency as the primary biology, consistent with the cytoplasmic KKXX retrieval motif.
 - The clathrin-coated vesicle (`GO:0030136`) IEA was resolved as `MARK_AS_OVER_ANNOTATED` in the same PR — Ensembl rat transfer with no human-specific support, and BCAP31 traffics via COPI/COPII machinery rather than the clathrin pathway.
+
+## Re-review prompted by geneontology/go-annotation#6385 (2026-05-22)
+
+GO curators raised a PAINT issue (PANTHER:PTN000294723) questioning the
+`involved_in GO:0006888 endoplasmic reticulum to Golgi vesicle-mediated transport`
+IBA on human BCAP31 and its orthologs, plus `GO:0070973 protein localization to ER
+exit site` on the *S. pombe* ortholog SPAC9E9.04. The curator argument is that
+BCAP31 acts *upstream* of the ER exit site as a quality-control / translocation
+chaperone, so the anterograde-transport IBA is an erroneous over-propagation:
+
+- Engagement begins at the earliest folding steps (heavy chain + β2-microglobulin
+  association for MHC class I), far upstream of any exit-site decision.
+- BCAP31 knockout only *delays*, does not abolish, surface class I export.
+- The C-terminal KKXX dilysine motif is a COPI retrieval signal (retention), not
+  an anterograde export signal.
+
+Curator M. Feuermann (GO_Central PAINT) commented (2026-05-21) that the family
+lacked the right terms and recommends MF `GO:0140388 protein translocation
+chaperone activity`; he is re-annotating the family. Curator V. Wood notes the
+core biology is BAP31 interacting with Sec61 translocons and promoting
+retrotranslocation of CFTRΔF508 via the Derlin-1 complex (PMID:18555783).
+
+Actions taken in this review update:
+- `GO:0006888` and `GO:0070973`: `ACCEPT` → `MARK_AS_OVER_ANNOTATED`.
+- `core_functions` entry 1: MF changed `GO:0140597 protein carrier activity` →
+  `GO:0140388 protein translocation chaperone activity`; `directly_involved_in`
+  changed `GO:0006888` → `GO:0036503 ERAD pathway`; "cargo receptor" framing
+  removed in favour of translocon-associated chaperone framing.
+- `description` and several annotation `reason` fields reworded to drop the
+  "cargo receptor" characterization.


### PR DESCRIPTION
## Summary

Addresses geneontology/go-annotation#6385 — a PAINT issue (PANTHER:PTN000294723) where GO curators flagged the IBA `involved_in GO:0006888 endoplasmic reticulum to Golgi vesicle-mediated transport` on human BCAP31 (and `GO:0070973 protein localization to ER exit site` on the *S. pombe* ortholog SPAC9E9.04) as **erroneous over-propagation**.

The current `genes/human/BCAP31/BCAP31-ai-review.yaml` (status `COMPLETE`) `ACCEPT`ed GO:0006888 as the #1 core function, framing BCAP31 as a "cargo receptor." The upstream curators dispute this:

- **V. Wood** (issue author): BCAP31 acts *upstream* of the ER exit site — it interacts with Sec61 translocons and promotes retrotranslocation of CFTRΔF508 via the Derlin-1 complex (PMID:18555783); the anterograde-transport annotation is erroneous.
- **M. Feuermann** (GO_Central PAINT, 2026-05-21): the family lacked the right terms; the correct MF is **`GO:0140388 protein translocation chaperone activity`**. He is re-annotating the PANTHER family.
- Supporting points from the issue: BCAP31 engages clients at the earliest folding steps; knockout only *delays* (not abolishes) export; its C-terminal KKXX motif is a COPI retrieval signal, not an export signal.

## Changes to `BCAP31-ai-review.yaml`

- `GO:0006888` and `GO:0070973`: `ACCEPT` → `MARK_AS_OVER_ANNOTATED`, with reasoning citing #6385.
- Added `GO:0140388 protein translocation chaperone activity` as a `NEW` annotation (the curator-recommended MF).
- `core_functions` entry 1: MF `GO:0140597 protein carrier activity` → `GO:0140388`; `directly_involved_in` `GO:0006888` → `GO:0036503 ERAD pathway`; "cargo receptor" framing replaced with translocon-associated chaperone framing.
- `description` and three annotation `reason` fields reworded to drop the "cargo receptor" characterization.
- `BCAP31-notes.md`: appended a journal entry documenting the re-review.

All GO term IDs verified via OLS. `just validate human BCAP31` passes cleanly (no warnings). HTML re-rendered.

## Test plan

- [x] `just validate human BCAP31` — all validations pass
- [x] All GO term IDs (GO:0140388, GO:0036503, GO:0006888, GO:0070973) verified via OLS
- [x] HTML re-rendered with `just render human BCAP31`
- [ ] Curator review of `MARK_AS_OVER_ANNOTATED` vs `REMOVE` for the two IBAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)