### PR TITLE
ATF3 (#307): exempt per-citation REMOVE divergence from inconsistent-action check

### DIFF
--- a/src/ai_gene_review/validation/validator.py
+++ b/src/ai_gene_review/validation/validator.py
@@ -394,6 +394,43 @@ def check_best_practices_rules(
                         ):
                             continue
 
+                    # Special case: REMOVE rows anchored to a citation that
+                    # none of the kept rows cite. A REMOVE action means "this
+                    # specific GOA row should not exist"; when it is anchored
+                    # to a reference distinct from every kept row, the
+                    # divergence reflects a citation-specific rejection (e.g. a
+                    # wrong-gene paper wrongly attributed to this gene, or a
+                    # review that does not substantiate the term) rather than a
+                    # term-level judgment. As long as every non-REMOVE row
+                    # shares a single action, the term-level decision is itself
+                    # consistent, so the REMOVE divergence is not curator error.
+                    if "REMOVE" in unique_actions:
+                        non_remove_actions = set(
+                            action
+                            for _, action, _ in actions_list
+                            if action != "REMOVE"
+                        )
+                        if len(non_remove_actions) == 1:
+                            remove_refs = set()
+                            kept_refs = set()
+                            refs_complete = True
+                            for idx, action, _ in actions_list:
+                                annotation = data["existing_annotations"][idx]
+                                ref_id = annotation.get("original_reference_id")
+                                if not ref_id:
+                                    refs_complete = False
+                                    break
+                                if action == "REMOVE":
+                                    remove_refs.add(ref_id)
+                                else:
+                                    kept_refs.add(ref_id)
+                            if (
+                                refs_complete
+                                and remove_refs
+                                and not (remove_refs & kept_refs)
+                            ):
+                                continue
+
                     # Get the term label for better error messages
                     term_label = None
                     for annotation in data["existing_annotations"]:

--- a/tests/test_inconsistent_review_actions_validation.py
+++ b/tests/test_inconsistent_review_actions_validation.py
@@ -157,3 +157,74 @@ def test_ipi_distinct_pmid_consistent_actions_no_warning():
     )
     report = _validate(yaml_data)
     assert not _has_inconsistent_action_warning(report)
+
+
+def test_remove_distinct_citation_divergence_suppressed():
+    """REMOVE rows anchored to a wrong citation are not curator inconsistency.
+
+    The ATF3 GO:0000122 / GO:0001228 / GO:0045944 pattern: the term itself is
+    a valid annotation supported by several genuine ATF3 papers (all ACCEPT),
+    but one GOA row is anchored to a citation that does not substantiate it
+    (a wrong-gene paper, or a review that does not cover the gene). REMOVE on
+    that row is correct per-citation curation, not a term-level disagreement,
+    so the divergence must not be flagged.
+    """
+    yaml_data = _build_yaml(
+        "GO:0000122",
+        [
+            {"evidence_type": "IEA", "pmid": "PMID:7515060", "action": "ACCEPT"},
+            {"evidence_type": "IDA", "pmid": "PMID:8622660", "action": "ACCEPT"},
+            {"evidence_type": "TAS", "pmid": "PMID:14685163", "action": "REMOVE"},
+        ],
+    )
+    report = _validate(yaml_data)
+    assert not _has_inconsistent_action_warning(report), (
+        "A REMOVE row citing a reference distinct from the kept rows should "
+        "not trigger the inconsistent-actions warning"
+    )
+
+
+def test_remove_shared_citation_still_warns():
+    """A REMOVE row sharing a citation with a kept row remains a real defect.
+
+    If a REMOVE row and an ACCEPT row cite the *same* paper, the divergence
+    cannot be a per-citation judgment — it is curator inconsistency over the
+    same evidence and must still warn.
+    """
+    yaml_data = _build_yaml(
+        "GO:0000122",
+        [
+            {"evidence_type": "IDA", "pmid": "PMID:7515060", "action": "ACCEPT"},
+            {"evidence_type": "TAS", "pmid": "PMID:7515060", "action": "REMOVE"},
+        ],
+    )
+    report = _validate(yaml_data)
+    assert _has_inconsistent_action_warning(report), (
+        "A REMOVE row sharing a citation with a kept row should still warn"
+    )
+
+
+def test_remove_with_inconsistent_kept_actions_still_warns():
+    """REMOVE divergence is only exempt when the kept rows agree among themselves.
+
+    If, after setting aside the REMOVE rows, the remaining rows still carry
+    divergent actions (e.g. ACCEPT vs KEEP_AS_NON_CORE), the term-level
+    judgment is itself inconsistent and the warning must still fire.
+    """
+    yaml_data = _build_yaml(
+        "GO:0000122",
+        [
+            {"evidence_type": "IEA", "pmid": "PMID:7515060", "action": "ACCEPT"},
+            {
+                "evidence_type": "IDA",
+                "pmid": "PMID:8622660",
+                "action": "KEEP_AS_NON_CORE",
+            },
+            {"evidence_type": "TAS", "pmid": "PMID:14685163", "action": "REMOVE"},
+        ],
+    )
+    report = _validate(yaml_data)
+    assert _has_inconsistent_action_warning(report), (
+        "Divergent actions among the kept rows should still warn even when a "
+        "distinct-citation REMOVE row is present"
+    )


### PR DESCRIPTION
## Summary

Automated curation scanner run on issue **#307 (Review GO annotations: ATF3)**.

ATF3's review (`status: COMPLETE`, 0 PENDING, 0 UNDECIDED) validated `✓ Valid` but emitted **3 best-practices warnings** — `inconsistent_review_actions` for `GO:0000122`, `GO:0001228`, and `GO:0045944`. A prior scanner pass reported ATF3 as "validating clean"; that was inaccurate.

### Why the warnings were false positives

Each flagged term carries `ACCEPT` on several genuine ATF3 papers plus `REMOVE` on **one** row anchored to a wrong citation:

| Term | Kept rows | REMOVE row | Verified |
|------|-----------|-----------|----------|
| `GO:0000122` neg. reg. transcription | ACCEPT (IEA, IDA, IDA) | TAS `PMID:14685163` | `PMID:14685163` = *"Roles of CHOP/GADD153 in endoplasmic reticulum stress"* — a CHOP review, does not substantiate ATF3 |
| `GO:0001228` activator activity | ACCEPT (IEA, ISS) | IDA `PMID:16300731` | `PMID:16300731` = *"ATF5 increases cisplatin-induced apoptosis…"* — an **ATF5** paper |
| `GO:0045944` pos. reg. transcription | ACCEPT (IEA, NAS, IDA, ISS) | IDA `PMID:16300731` | same ATF5 paper |

The `REMOVE` actions are correct curation — removing GOA rows supported by wrong-gene / non-substantiating citations. A `REMOVE` anchored to a reference that none of the kept rows cite is a **citation-specific rejection**, not a term-level disagreement. Reconciling the review file would weaken correct curation.

### Change

Adds a validator exception in `check_best_practices_rules` (`validator.py`), parallel to the existing IPI per-reference exception:

> If a term's only divergent action is `REMOVE`, every non-`REMOVE` row shares a single action, and the `REMOVE` references are disjoint from the kept references → the divergence is per-citation, not curator inconsistency → no warning.

Genuine inconsistencies still warn: same-citation `REMOVE`/`ACCEPT`, or divergence among the kept rows. Regression-checked against CDH1 — its 4 inconsistent-action warnings (no `REMOVE` involved) correctly still fire.

- `genes/human/ATF3/ATF3-ai-review.yaml` → `✓ Valid` (0 warnings, was 3); no edit to the review file itself.
- 3 new tests in `test_inconsistent_review_actions_validation.py`; full validation suite (115 tests) passes; `ruff` clean.

Draft pending human review of the validator-policy change.

## Test plan

- [x] `pytest tests/test_inconsistent_review_actions_validation.py` — 7 passed
- [x] `pytest tests/ -k valid` — 115 passed
- [x] `just validate human ATF3` — ✓ Valid, 0 warnings
- [x] `just validate human CDH1` — 4 inconsistent-action warnings still fire (no regression)
- [x] `ruff check` — clean
- [ ] Maintainer review of the validator-policy change

🤖 Generated with [Claude Code](https://claude.com/claude-code)