### PR TITLE
CDH1: wire CDH1-deep-research-manual.md into references and core_functions (#348)

### DIFF
--- a/genes/human/CDH1/CDH1-ai-review.yaml
+++ b/genes/human/CDH1/CDH1-ai-review.yaml
@@ -2305,6 +2305,22 @@ references:
   - statement: E-cadherin is a component of an E-cadherin/catenin adhesion complex containing
       beta-catenin or gamma-catenin, located at adherens junctions.
     supporting_text: beta-catenin/CTNNB1 or gamma-catenin/JUP
+- id: file:human/CDH1/CDH1-deep-research-manual.md
+  title: Manual deep research summary for human CDH1 (E-cadherin)
+  findings:
+  - statement: E-cadherin mediates calcium-dependent homophilic trans-adhesion via strand-swap
+      dimerization between EC1 domains on apposing cells; trans interactions are sufficient
+      for aggregation while cis interactions are additionally required for junction assembly.
+    supporting_text: EC1 domains of each protomer closely interact and symmetrically exchange
+      their N-terminal β-strands, which contain a conserved tryptophan residue, Trp2; trans
+      interactions are sufficient to mediate aggregation, while cis interactions are further
+      required for assembly of junctions
+  - statement: The cytoplasmic tail of E-cadherin nucleates the cadherin-catenin complex
+      by binding beta-catenin/plakoglobin and p120-catenin, coupling homophilic adhesion
+      to the cortical actin cytoskeleton via alpha-catenin and adaptor proteins.
+    supporting_text: Component of an E-cadherin/catenin adhesion complex; the juxtamembrane
+      domain binds CTNND1 (p120-catenin); alpha-catenin links the complex to F-actin via
+      adaptor proteins including EPLIN and AF6/afadin
 core_functions:
 - description: E-cadherin engages in calcium-dependent homophilic trans-interaction with
     E-cadherin molecules on adjacent epithelial cells through its five extracellular cadherin
@@ -2317,6 +2333,11 @@ core_functions:
   - reference_id: file:human/CDH1/CDH1-uniprot.txt
     supporting_text: They preferentially interact with themselves in a homophilic manner in
       connecting cells
+  - reference_id: file:human/CDH1/CDH1-deep-research-manual.md
+    supporting_text: EC1 domains of each protomer closely interact and symmetrically exchange
+      their N-terminal β-strands, which contain a conserved tryptophan residue, Trp2; trans
+      interactions are sufficient to mediate aggregation, while cis interactions are further
+      required for assembly of junctions
   locations:
   - id: GO:0016328
     label: lateral plasma membrane


### PR DESCRIPTION
## Summary

Addresses the last outstanding best-practices warning in the CDH1 review
(`genes/human/CDH1/CDH1-ai-review.yaml`).

**Before:** 5 warnings — 4 inconsistent-action + 1 "no deep-research references"
**After:** 4 warnings — 4 inconsistent-action only (those are handled by open PR #607)

### Change

- Added `file:human/CDH1/CDH1-deep-research-manual.md` to the `references` section
  with two findings covering (1) EC1 strand-swap trans-dimerization and (2) the
  cadherin–catenin complex / actin linkage.
- Added a second `supported_by` entry to the first `core_functions` entry
  (homophilic cell-cell adhesion / cadherin binding) referencing the deep research
  file with the supporting quote from PMID:21300292.

### Validation

```
just validate human CDH1
→ ✓ Valid (with 4 warnings)
  ⚠ inconsistent actions: GO:0016600, GO:0043296, GO:0016020, GO:0030054
```
(The 4 remaining warnings are addressed by approved PR #607; this PR and #607
are non-conflicting — they touch different YAML keys.)

### Relationship to #607

This PR can be merged before or after #607; no conflicts expected.

Closes the "No annotations reference available deep research files" warning
for CDH1 (#348). Full closure of #348 is expected after both this PR and
PR #607 are merged.

*(Automated curation scanner — medium_effort tier, single-target run.)*