### PR TITLE
AATF: triage new ComplexPortal GO:0032040 GOA row (#270)

### DIFF
--- a/genes/human/AATF/AATF-ai-review.yaml
+++ b/genes/human/AATF/AATF-ai-review.yaml
@@ -447,6 +447,26 @@ existing_annotations:
       - reference_id: PMID:34516797
         supporting_text: "We report the high-resolution cryo-electron microscopy structures of maturing human small subunit (SSU) processomes at resolutions of 2.7 to 3.9 angstroms"
 - term:
+    id: GO:0032040
+    label: small-subunit processome
+  evidence_type: NAS
+  original_reference_id: PMID:34516797
+  review:
+    summary: >-
+      NAS annotation from ComplexPortal placing AATF in the small-subunit (SSU)
+      processome (CPX-2511), citing PMID:34516797 — the same cryo-EM SSU processome
+      paper that supports the existing IDA row for GO:0032040 on this gene.
+    action: ACCEPT
+    reason: >-
+      The term and citation are correct and reinforce one of AATF's core functions.
+      ComplexPortal curates AATF as a stoichiometric component of CPX-2511 (SSU
+      processome). This NAS row duplicates the existing higher-strength IDA
+      annotation for GO:0032040 from the same PMID; both are accepted because the
+      term placement is unambiguous from the cryo-EM structures.
+    supported_by:
+      - reference_id: PMID:34516797
+        supporting_text: "The human small subunit processome mediates early maturation of the small ribosomal subunit by coupling RNA folding to subsequent RNA cleavage and processing steps"
+- term:
     id: GO:0042274
     label: ribosomal small subunit biogenesis
   evidence_type: IDA

--- a/genes/human/AATF/AATF-goa.tsv
+++ b/genes/human/AATF/AATF-goa.tsv
@@ -1,31 +1,32 @@
 GENE PRODUCT DB	GENE PRODUCT ID	SYMBOL	QUALIFIER	GO TERM	GO NAME	GO ASPECT	ECO ID	GO EVIDENCE CODE	REFERENCE	WITH/FROM	TAXON ID	TAXON NAME	ASSIGNED BY	GENE NAME	DATE
 UniProtKB	Q9NY61	AATF	is_active_in	GO:0005730	nucleolus	cellular_component	ECO:0000318	IBA	GO_REF:0000033	FB:FBgn0031851|MGI:MGI:1929608|PANTHER:PTN000399850|SGD:S000002707|UniProtKB:Q4GZ49|UniProtKB:Q9NY61	9606	Homo sapiens	GO_Central	Protein AATF	20251219
-UniProtKB	Q9NY61	AATF	involved_in	GO:0045893	positive regulation of DNA-templated transcription	biological_process	ECO:0000366	IEA	GO_REF:0000108	GO:0003713	9606	Homo sapiens	GOC	Protein AATF	20260407
-UniProtKB	Q9NY61	AATF	enables	GO:0003713	transcription coactivator activity	molecular_function	ECO:0000265	IEA	GO_REF:0000107	UniProtKB:Q9JKX4|ensembl:ENSMUSP00000018841	9606	Homo sapiens	Ensembl	Protein AATF	20260406
-UniProtKB	Q9NY61	AATF	part_of	GO:0005667	transcription regulator complex	cellular_component	ECO:0000265	IEA	GO_REF:0000107	UniProtKB:Q9JKX4|ensembl:ENSMUSP00000018841	9606	Homo sapiens	Ensembl	Protein AATF	20260406
-UniProtKB	Q9NY61	AATF	located_in	GO:0005737	cytoplasm	cellular_component	ECO:0000265	IEA	GO_REF:0000107	UniProtKB:Q9JKX4|ensembl:ENSMUSP00000018841	9606	Homo sapiens	Ensembl	Protein AATF	20260406
-UniProtKB	Q9NY61	AATF	involved_in	GO:0030968	endoplasmic reticulum unfolded protein response	biological_process	ECO:0000265	IEA	GO_REF:0000107	UniProtKB:Q9JKX4|ensembl:ENSMUSP00000018841	9606	Homo sapiens	Ensembl	Protein AATF	20260406
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:12847090	UniProtKB:P08047	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:17157788	UniProtKB:O96017	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:17157788	UniProtKB:Q04206	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:17157788	UniProtKB:Q13315	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:22909821	UniProtKB:Q6ZWQ9	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:25416956	UniProtKB:Q8NEJ9	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:29232376	UniProtKB:O75478	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:29232376	UniProtKB:O75528	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:29232376	UniProtKB:Q86TJ2	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:29232376	UniProtKB:Q92830	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:30021884	UniProtKB:Q8NEJ9	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q8NEH6	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:P05067	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:P27986-2	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:P63000	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:33961781	UniProtKB:Q8NEJ9	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:35271311	UniProtKB:Q8NEJ9	9606	Homo sapiens	IntAct	Protein AATF	20260404
-UniProtKB	Q9NY61	AATF	located_in	GO:0005634	nucleus	cellular_component	ECO:0000501	IEA	GO_REF:0000120	UniProtKB:Q9JKX4|ensembl:ENSMUSP00000018841|InterPro:IPR012617	9606	Homo sapiens	UniProt	Protein AATF	20260302
-UniProtKB	Q9NY61	AATF	located_in	GO:0005730	nucleolus	cellular_component	ECO:0000501	IEA	GO_REF:0000120	UniProtKB:Q9JKX4|ensembl:ENSMUSP00000018841|UniProtKB-SubCell:SL-0188	9606	Homo sapiens	UniProt	Protein AATF	20260302
+UniProtKB	Q9NY61	AATF	located_in	GO:0005634	nucleus	cellular_component	ECO:0000501	IEA	GO_REF:0000120	UniProtKB:Q9JKX4|ensembl:ENSMUSP00000018841|InterPro:IPR012617	9606	Homo sapiens	UniProt	Protein AATF	20260428
+UniProtKB	Q9NY61	AATF	located_in	GO:0005730	nucleolus	cellular_component	ECO:0000501	IEA	GO_REF:0000120	UniProtKB:Q9JKX4|ensembl:ENSMUSP00000018841|UniProtKB-SubCell:SL-0188	9606	Homo sapiens	UniProt	Protein AATF	20260428
+UniProtKB	Q9NY61	AATF	involved_in	GO:0045893	positive regulation of DNA-templated transcription	biological_process	ECO:0000366	IEA	GO_REF:0000108	GO:0003713	9606	Homo sapiens	GOC	Protein AATF	20260428
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:12847090	UniProtKB:P08047	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:17157788	UniProtKB:O96017	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:17157788	UniProtKB:Q04206	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:17157788	UniProtKB:Q13315	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:22909821	UniProtKB:Q6ZWQ9	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:25416956	UniProtKB:Q8NEJ9	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:29232376	UniProtKB:O75478	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:29232376	UniProtKB:O75528	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:29232376	UniProtKB:Q86TJ2	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:29232376	UniProtKB:Q92830	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:30021884	UniProtKB:Q8NEJ9	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32296183	UniProtKB:Q8NEH6	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:P05067	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:P27986-2	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:32814053	UniProtKB:P63000	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:33961781	UniProtKB:Q8NEJ9	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0005515	protein binding	molecular_function	ECO:0000353	IPI	PMID:35271311	UniProtKB:Q8NEJ9	9606	Homo sapiens	IntAct	Protein AATF	20260425
+UniProtKB	Q9NY61	AATF	enables	GO:0003713	transcription coactivator activity	molecular_function	ECO:0000265	IEA	GO_REF:0000107	UniProtKB:Q9JKX4|ensembl:ENSMUSP00000018841	9606	Homo sapiens	Ensembl	Protein AATF	20260422
+UniProtKB	Q9NY61	AATF	part_of	GO:0005667	transcription regulator complex	cellular_component	ECO:0000265	IEA	GO_REF:0000107	UniProtKB:Q9JKX4|ensembl:ENSMUSP00000018841	9606	Homo sapiens	Ensembl	Protein AATF	20260422
+UniProtKB	Q9NY61	AATF	located_in	GO:0005737	cytoplasm	cellular_component	ECO:0000265	IEA	GO_REF:0000107	UniProtKB:Q9JKX4|ensembl:ENSMUSP00000018841	9606	Homo sapiens	Ensembl	Protein AATF	20260422
+UniProtKB	Q9NY61	AATF	involved_in	GO:0030968	endoplasmic reticulum unfolded protein response	biological_process	ECO:0000265	IEA	GO_REF:0000107	UniProtKB:Q9JKX4|ensembl:ENSMUSP00000018841	9606	Homo sapiens	Ensembl	Protein AATF	20260422
 UniProtKB	Q9NY61	AATF	located_in	GO:0005730	nucleolus	cellular_component	ECO:0005547	NAS	PMID:34516797		9606	Homo sapiens	ComplexPortal	Protein AATF	20251229
 UniProtKB	Q9NY61	AATF	involved_in	GO:0030490	maturation of SSU-rRNA	biological_process	ECO:0005547	NAS	PMID:34516797		9606	Homo sapiens	ComplexPortal	Protein AATF	20251229
+UniProtKB	Q9NY61	AATF	part_of	GO:0032040	small-subunit processome	cellular_component	ECO:0005547	NAS	PMID:34516797		9606	Homo sapiens	ComplexPortal	Protein AATF	20251229
 UniProtKB	Q9NY61	AATF	located_in	GO:0005730	nucleolus	cellular_component	ECO:0000314	IDA	GO_REF:0000052		9606	Homo sapiens	HPA	Protein AATF	20251115
 UniProtKB	Q9NY61	AATF	part_of	GO:0032040	small-subunit processome	cellular_component	ECO:0000314	IDA	PMID:34516797		9606	Homo sapiens	UniProt	Protein AATF	20230131
 UniProtKB	Q9NY61	AATF	involved_in	GO:0042274	ribosomal small subunit biogenesis	biological_process	ECO:0000314	IDA	PMID:34516797		9606	Homo sapiens	UniProt	Protein AATF	20230131


### PR DESCRIPTION
## Summary

Upstream GOA drift detected during scanner re-verification of #270 (AATF) closure-readiness — the QuickGO record on `main` was missing one ComplexPortal-derived `part_of` annotation on **GO:0032040** (small-subunit processome) that was added by ComplexPortal on 2025-12-29.

`just fetch-gene human AATF --force` refreshed the GOA file and seeded the missing row into `existing_annotations` as `PENDING`. This PR triages it.

## Drift detail

One new row from upstream QuickGO, `part_of` NAS, `assigned_by` ComplexPortal:

| GO term | Evidence | Cited PMID | Source |
|---|---|---|---|
| GO:0032040 small-subunit processome | NAS | PMID:34516797 | ComplexPortal (CPX-2511) |

`PMID:34516797` is the cryo-EM structures of the human SSU processome paper.

The existing merged review already accepts this same term from the same PMID at higher evidence strength:

> `GO:0032040` · `evidence_type: IDA` · `original_reference_id: PMID:34516797` · `action: ACCEPT`

with the reasoning that *"the cryo-EM structures at high resolution directly show AATF as a structural component of the SSU processome, a 4.5-MDa nucleolar assembly. The SSU processome is listed in ComplexPortal as CPX-2511 with AATF as a component."*

## Triage decision — `ACCEPT`

- Term placement is unambiguous from the cryo-EM evidence; ComplexPortal independently curates AATF as a stoichiometric component of CPX-2511.
- SSU processome membership is one of AATF's two `core_functions` in the merged review (the other being RNA Pol II transcriptional coactivation).
- The NAS row reinforces — rather than competes with — the existing IDA evidence. Both stay; no other rows touched.

## Verification

- `just validate human AATF` → ✓ Valid (schema, terms, references, best-practices, pathway PMIDs all pass; 0 warnings, 0 PENDING, 0 UNDECIDED)
- `status: COMPLETE` retained
- Diff scoped tightly: +20 lines to `AATF-ai-review.yaml` (one new annotation block in the file's existing block-scalar style), GOA file refreshed to match upstream (+1 new row plus date-only refreshes on existing rows)
- No `core_functions`, `references`, descriptions, or other annotation rows touched
- Cache side-effects of validation (`cache/go/terms.csv` regeneration) excluded from this PR
- Draft pending maintainer review of the triage call (alternative: `KEEP_AS_NON_CORE` if a curator wants to flag the duplicate-evidence redundancy explicitly; `ACCEPT` chosen here to match the existing same-PMID IDA row's treatment for internal consistency)

## Test plan

- [x] `just validate human AATF` passes with 0 warnings
- [x] Diff verified scoped to one new annotation block + GOA refresh
- [x] Triage reasoning consistent with the existing same-PMID IDA row in this review
- [ ] Maintainer review of `ACCEPT` vs `KEEP_AS_NON_CORE` for the new NAS-evidence duplicate row

Refs #270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)