### PR TITLE
CDH1: quote 14 reason fields to prevent YAML comment truncation (#348)

### DIFF
--- a/genes/human/CDH1/CDH1-ai-review.yaml
+++ b/genes/human/CDH1/CDH1-ai-review.yaml
@@ -32,7 +32,7 @@ existing_annotations:
   review:
     summary: IBA projection from the PANTHER classical cadherin family tree (PTHR24027, subfamily SF319 Cadherin-1) via GO_REF:0000033. E-cadherin contributes to epithelial cell morphogenesis because cadherin-mediated adhesion shapes epithelial cells and is required to establish and maintain epithelial architecture. However, cell morphogenesis is a broad downstream outcome of the core adhesion and junction-organizing activity rather than a distinct core function. The precise core CDH1 processes (calcium-dependent homophilic cell-cell adhesion, cadherin-mediated adhesion, adherens junction organization) are captured by other rows in this file.
     action: KEEP_AS_NON_CORE
-    reason: Real but general developmental/cellular outcome downstream of the core adhesion function; the precise core processes (GO:0044331 cell-cell adhesion mediated by cadherin, GO:0034332 adherens junction organization) are ACCEPTed elsewhere in this batch. Mechanical IBA-PANTHER batch (batch 2 of #348).
+    reason: 'Real but general developmental/cellular outcome downstream of the core adhesion function; the precise core processes (GO:0044331 cell-cell adhesion mediated by cadherin, GO:0034332 adherens junction organization) are ACCEPTed elsewhere in this batch. Mechanical IBA-PANTHER batch (batch 2 of #348).'
 - term:
     id: GO:0016477
     label: cell migration
@@ -41,7 +41,7 @@ existing_annotations:
   review:
     summary: IBA projection from the PANTHER cadherin family tree (PTHR24027) via GO_REF:0000033. E-cadherin participates in cell migration processes — it is retained at junctions during collective epithelial migration such as wound healing, and conversely its loss drives the epithelial-mesenchymal transition that licenses single-cell motility and invasion. The bare cell migration term carries no directionality, whereas the best-established directional CDH1 role is suppression of single-cell migration/invasion, separately captured by the IMP GO:0030336 (negative regulation of cell migration) row in this file (PMID:16882694). The generic involved_in cell-migration inference is therefore a real but non-core, context-dependent association.
     action: KEEP_AS_NON_CORE
-    reason: Generic non-directional migration term; the core CDH1 activity is cell-cell adhesion rather than migration per se, and the directional regulatory role (suppression of migration/invasion) is captured by GO:0030336 elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
+    reason: 'Generic non-directional migration term; the core CDH1 activity is cell-cell adhesion rather than migration per se, and the directional regulatory role (suppression of migration/invasion) is captured by GO:0030336 elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).'
 - term:
     id: GO:0007043
     label: cell-cell junction assembly
@@ -50,7 +50,7 @@ existing_annotations:
   review:
     summary: IBA projection from the PANTHER classical cadherin family tree (PTHR24027) via GO_REF:0000033. E-cadherin nucleates assembly of epithelial cell-cell junctions — homophilic trans-engagement of E-cadherin ectodomains initiates cell-cell contact, and the cytoplasmic tail recruits the catenins that build the adherens junction and template subsequent tight-junction and desmosome formation. This is a core, well-established CDH1 function, consistent with the more specific GO:0034332 (adherens junction organization) row.
     action: ACCEPT
-    reason: Core CDH1 biological process — E-cadherin is the founding adhesion receptor that initiates epithelial cell-cell junction assembly. Mechanical IBA-PANTHER batch (batch 2 of #348).
+    reason: 'Core CDH1 biological process — E-cadherin is the founding adhesion receptor that initiates epithelial cell-cell junction assembly. Mechanical IBA-PANTHER batch (batch 2 of #348).'
 - term:
     id: GO:0005737
     label: cytoplasm
@@ -59,7 +59,7 @@ existing_annotations:
   review:
     summary: IBA projection (is_active_in) from the PANTHER cadherin tree (PTHR24027) via GO_REF:0000033. E-cadherin is a type-I single-pass transmembrane glycoprotein; its steady-state location is the plasma membrane and adherens junction, with only its ~150-residue C-terminal tail exposed to the cytosol. Annotating the protein as is_active_in the cytoplasm (GO:0005737) is over-broad — it asserts a generic compartment that does not reflect where the protein resides or acts. The accurate localizations (plasma membrane, adherens junction, lateral plasma membrane) are captured by other rows in this file.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Over-broad CC for a single-pass transmembrane plasma-membrane protein; cytoplasm is not entirely wrong (the cytoplasmic tail faces the cytosol) but does not reflect the protein actual residence or site of action. More precise CC terms (GO:0005886 plasma membrane, GO:0005912 adherens junction, GO:0016328 lateral plasma membrane) are present in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
+    reason: 'Over-broad CC for a single-pass transmembrane plasma-membrane protein; cytoplasm is not entirely wrong (the cytoplasmic tail faces the cytosol) but does not reflect the protein actual residence or site of action. More precise CC terms (GO:0005886 plasma membrane, GO:0005912 adherens junction, GO:0016328 lateral plasma membrane) are present in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).'
 - term:
     id: GO:0008013
     label: beta-catenin binding
@@ -68,7 +68,7 @@ existing_annotations:
   review:
     summary: IBA projection from the PANTHER cadherin tree (PTHR24027) via GO_REF:0000033. The E-cadherin cytoplasmic catenin-binding domain directly binds beta-catenin (CTNNB1); this interaction links the cadherin to the actin cytoskeleton via alpha-catenin and is the molecular basis of the cadherin-catenin complex. Independently supported within this file by IPI/IDA evidence on this same term (PMID:18593713, Smad7 stabilizes beta-catenin binding to the E-cadherin complex; PMID:17620337) and by Reactome TAS rows describing CDH1-CTNNB1 complex formation.
     action: ACCEPT
-    reason: Canonical core CDH1 molecular function — direct beta-catenin binding by the cadherin cytoplasmic tail is the defining interaction of the cadherin-catenin complex. Corroborated by IPI (PMID:18593713) and IDA (PMID:17620337) evidence on this exact term elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
+    reason: 'Canonical core CDH1 molecular function — direct beta-catenin binding by the cadherin cytoplasmic tail is the defining interaction of the cadherin-catenin complex. Corroborated by IPI (PMID:18593713) and IDA (PMID:17620337) evidence on this exact term elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).'
 - term:
     id: GO:0044331
     label: cell-cell adhesion mediated by cadherin
@@ -77,7 +77,7 @@ existing_annotations:
   review:
     summary: IBA projection from the PANTHER classical cadherin tree (PTHR24027) via GO_REF:0000033. Cadherin-mediated cell-cell adhesion is the defining function of E-cadherin — calcium-dependent homophilic trans-interaction of ectodomains between adjacent epithelial cells. This is the central core CDH1 process. Independently supported in this file by IDA evidence on the same term (PMID:18593713) and by the crystallographic adhesion-architecture reference PMID:21300292.
     action: ACCEPT
-    reason: Defining core biological process of E-cadherin — homophilic cadherin-mediated cell-cell adhesion. Corroborated by IDA evidence on this exact term (PMID:18593713) elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
+    reason: 'Defining core biological process of E-cadherin — homophilic cadherin-mediated cell-cell adhesion. Corroborated by IDA evidence on this exact term (PMID:18593713) elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).'
 - term:
     id: GO:0016342
     label: catenin complex
@@ -86,7 +86,7 @@ existing_annotations:
   review:
     summary: IBA projection (part_of) from the PANTHER cadherin tree (PTHR24027) via GO_REF:0000033. E-cadherin is the transmembrane core of the cadherin-catenin (catenin) complex; its cytoplasmic tail scaffolds beta-catenin and gamma-catenin and, via alpha-catenin, the actin cytoskeleton. Independently supported in this file by IDA evidence on the same GO:0016342 term (PMID:18593713).
     action: ACCEPT
-    reason: Core CDH1 cellular component — E-cadherin is the obligate transmembrane component of the catenin complex. Corroborated by IDA evidence on this exact term (PMID:18593713) elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
+    reason: 'Core CDH1 cellular component — E-cadherin is the obligate transmembrane component of the catenin complex. Corroborated by IDA evidence on this exact term (PMID:18593713) elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).'
 - term:
     id: GO:0045296
     label: cadherin binding
@@ -95,7 +95,7 @@ existing_annotations:
   review:
     summary: IBA projection from the PANTHER cadherin tree (PTHR24027) via GO_REF:0000033. E-cadherin engages in cadherin binding through calcium-dependent homophilic trans- and cis-interactions of its ectodomain (the EC1 strand-swap dimer interface), the mechanistic basis of homophilic cell-cell adhesion. Independently supported in this file by HDA evidence on the same term (PMID:25468996, the E-cadherin interactome) and the crystallographic reference PMID:21300292.
     action: ACCEPT
-    reason: Core CDH1 molecular function — homophilic cadherin-cadherin binding via the ectodomain is the adhesive activity of E-cadherin. Corroborated by HDA evidence on this exact term (PMID:25468996) elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
+    reason: 'Core CDH1 molecular function — homophilic cadherin-cadherin binding via the ectodomain is the adhesive activity of E-cadherin. Corroborated by HDA evidence on this exact term (PMID:25468996) elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).'
 - term:
     id: GO:0034332
     label: adherens junction organization
@@ -104,7 +104,7 @@ existing_annotations:
   review:
     summary: IBA projection from the PANTHER classical cadherin tree (PTHR24027) via GO_REF:0000033. E-cadherin is the founding component that organizes the epithelial adherens junction — clustering of trans-engaged cadherins together with recruitment of the catenin-actin module assembles and maintains the zonula adherens. Independently supported in this file by IMP evidence on the same term (PMID:21724833).
     action: ACCEPT
-    reason: Core CDH1 biological process — E-cadherin organizes the adherens junction. Corroborated by IMP evidence on this exact term (PMID:21724833) elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
+    reason: 'Core CDH1 biological process — E-cadherin organizes the adherens junction. Corroborated by IMP evidence on this exact term (PMID:21724833) elsewhere in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).'
 - term:
     id: GO:0005912
     label: adherens junction
@@ -113,7 +113,7 @@ existing_annotations:
   review:
     summary: IBA projection (is_active_in) from the PANTHER classical cadherin tree (PTHR24027) via GO_REF:0000033. The adherens junction (zonula adherens) is the principal site of E-cadherin residence and function in epithelial cells. This is a core CDH1 cellular component, independently supported in this file by multiple IDA rows on the same term (PMID:22294297, PMID:18343367, PMID:27760340, PMID:24046456, PMID:20086044, PMID:16338932).
     action: ACCEPT
-    reason: Core CDH1 cellular component — the adherens junction is the defining site of E-cadherin localization and activity, corroborated by numerous IDA rows on this exact term in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).
+    reason: 'Core CDH1 cellular component — the adherens junction is the defining site of E-cadherin localization and activity, corroborated by numerous IDA rows on this exact term in the file. Mechanical IBA-PANTHER batch (batch 2 of #348).'
 - term:
     id: GO:0007416
     label: synapse assembly
@@ -122,7 +122,7 @@ existing_annotations:
   review:
     summary: IBA projection from the PANTHER cadherin tree (PTHR24027) via GO_REF:0000033, originating from the broad ancestral node PTN000616414. Classical cadherins contribute to synapse assembly and stabilization in the nervous system, and E-cadherin has documented roles at neuronal synapses; however, for the canonical epithelial CDH1 this is a tissue-specific, non-core context rather than a defining function. The core CDH1 role is epithelial cell-cell adhesion at adherens junctions.
     action: KEEP_AS_NON_CORE
-    reason: Tissue/cell-type-specific neuronal context (synapse assembly) rather than a core epithelial CDH1 function; projected from a broad ancestral PANTHER node. Mechanical IBA-PANTHER batch (batch 2 of #348).
+    reason: 'Tissue/cell-type-specific neuronal context (synapse assembly) rather than a core epithelial CDH1 function; projected from a broad ancestral PANTHER node. Mechanical IBA-PANTHER batch (batch 2 of #348).'
 - term:
     id: GO:0016339
     label: calcium-dependent cell-cell adhesion
@@ -131,7 +131,7 @@ existing_annotations:
   review:
     summary: IBA projection from the PANTHER classical cadherin tree (PTHR24027) via GO_REF:0000033. E-cadherin adhesion is strictly calcium-dependent — Ca2+ ions bridge the linker regions between extracellular cadherin (EC) domains, rigidifying the ectodomain into the conformation competent for homophilic trans-binding. GO:0016339 (attachment of one cell to another via adhesion molecules that require calcium) precisely describes the core CDH1 adhesive process. Consistent with the IEA GO:0005509 (calcium ion binding) row in this file.
     action: ACCEPT
-    reason: Core CDH1 biological process — calcium-dependent homophilic cell-cell adhesion is the defining activity of E-cadherin. Mechanical IBA-PANTHER batch (batch 2 of #348).
+    reason: 'Core CDH1 biological process — calcium-dependent homophilic cell-cell adhesion is the defining activity of E-cadherin. Mechanical IBA-PANTHER batch (batch 2 of #348).'
 - term:
     id: GO:0016600
     label: flotillin complex
@@ -140,7 +140,7 @@ existing_annotations:
   review:
     summary: IBA projection (part_of) from the PANTHER cadherin tree (PTHR24027) via GO_REF:0000033, from the broad ancestral node PTN000616414. GO:0016600 (flotillin complex) is defined as a protein complex containing flotillin-1 and flotillin-2 (and possibly associated proteins). E-cadherin is recruited to flotillin-rich membrane microdomains that stabilize cadherins at cell-cell junctions (shown experimentally in PMID:24046456, the separate IDA GO:0016600 row in this file), but it is not a constitutive flotillin subunit. Annotating E-cadherin as part_of the flotillin complex by phylogenetic inference overstates this microdomain association into structural complex membership. (The IDA flotillin row, PMID:24046456, is left PENDING for a later batch.)
     action: MARK_AS_OVER_ANNOTATED
-    reason: The part_of qualifier overstates a membrane-microdomain association as structural membership of the flotillin-1/-2 complex; E-cadherin is recruited to flotillin microdomains but is not a flotillin-complex subunit. Not entirely wrong (flotillin-microdomain localization is experimentally supported by PMID:24046456) but an over-annotation as an IBA part_of inference. Mechanical IBA-PANTHER batch (batch 2 of #348).
+    reason: 'The part_of qualifier overstates a membrane-microdomain association as structural membership of the flotillin-1/-2 complex; E-cadherin is recruited to flotillin microdomains but is not a flotillin-complex subunit. Not entirely wrong (flotillin-microdomain localization is experimentally supported by PMID:24046456) but an over-annotation as an IBA part_of inference. Mechanical IBA-PANTHER batch (batch 2 of #348).'
 - term:
     id: GO:0043296
     label: apical junction complex
@@ -149,7 +149,7 @@ existing_annotations:
   review:
     summary: IBA projection (is_active_in) from the PANTHER cadherin tree (PTHR24027) via GO_REF:0000033, from the broad ancestral node PTN000616414. The apical junction complex (GO:0043296) is the composite apical unit comprising the tight junction, the zonula adherens and desmosomes. E-cadherin is the core of the zonula adherens, one of the three constituents of the apical junction complex, so the annotation is not wrong; however, the precise and core CDH1 cellular component is the adherens junction itself (GO:0005912, ACCEPTed in this batch), and the broader composite grouping is best treated as non-core.
     action: KEEP_AS_NON_CORE
-    reason: Accurate but broader-than-precise CC grouping; the precise core localization is GO:0005912 adherens junction. E-cadherin resides specifically in the zonula adherens sub-compartment of the apical junction complex. Mechanical IBA-PANTHER batch (batch 2 of #348).
+    reason: 'Accurate but broader-than-precise CC grouping; the precise core localization is GO:0005912 adherens junction. E-cadherin resides specifically in the zonula adherens sub-compartment of the apical junction complex. Mechanical IBA-PANTHER batch (batch 2 of #348).'
 - term:
     id: GO:0005509
     label: calcium ion binding


### PR DESCRIPTION
## Summary

Fixes a YAML-parser content-loss bug in `genes/human/CDH1/CDH1-ai-review.yaml`. Fourteen `reason:` fields end with `... (batch 2 of #348).` as unquoted scalars. Per YAML rules, the leading space before `#348)` starts a comment, so when parsed the value silently truncates to `... (batch 2 of` — losing the `#348).` reference.

This affects:
- HTML rendering (`ai-gene-review render human CDH1`) — shows truncated reasons
- Any downstream tooling consuming the parsed YAML

The raw YAML source still shows full text (the `#348)` portion is preserved as a comment), so the issue is invisible until parse time.

## Fix

Single-quote the 14 affected `reason:` lines, matching the format already used elsewhere in the same file (the IEA batch-3 reasons at lines 161+ are correctly single-quoted and preserve `(batch 3 of #348)`).

```diff
-    reason: ... Mechanical IBA-PANTHER batch (batch 2 of #348).
+    reason: '... Mechanical IBA-PANTHER batch (batch 2 of #348).'
```

No GO term, action, evidence, or annotation logic changes. Diff is +14 / -14.

## Verification

Before fix: 14 review `reason` fields parse as truncated strings ending in `... (batch 2 of`.

After fix: 0 truncated reasons; all 14 parse with the full `... (batch 2 of #348).` text.

`just validate human CDH1` → ✓ All validations passed (0 warnings).

## Selection context

CDH1 (#348) is in identical `status: COMPLETE` closure-ready state as the other six open `curation`-labeled gene-review issues. Prior scanner passes have explicitly stop-posted on all 7 for status-comment churn. This PR is the only scanner-actionable defect surfaced by a fresh re-verification of `main` for #348 this run: it restores content originally written by the batch-2 author that the YAML parser silently dropped. Other closure-ready issues were left untouched (no candidate defect found by parallel checks).

A similar truncation pattern exists in `genes/human/RB1/RB1-ai-review.yaml` (8 fields, `(batch 9 of #347).` → truncated to `(batch 9 of`). Out of scope here — #347 is already closed. Worth a follow-up.

## Test plan

- [x] `just validate human CDH1` — passes (0 warnings)
- [x] Diff is minimal and surgical (+14 / -14, only single-quote wrapping)
- [x] Parsed YAML verified for 0 truncated reasons after fix

🤖 Automated curation scanner (high_effort tier) — single-target run on #348