### PR TITLE
RB1: fix 25 unquoted reason fields causing silent YAML parser truncation

### DIFF
--- a/genes/human/RB1/RB1-ai-review.yaml
+++ b/genes/human/RB1/RB1-ai-review.yaml
@@ -1185,7 +1185,7 @@ existing_annotations:
   review:
     summary: 'TAS annotation citing Becker et al. 2009 (PMID:19149898), which reviews hypophosphorylated pRb as a Pol II transcriptional corepressor that silences E2F-target S-phase genes via the RB-E2F repressor complex (and recruits chromatin-modifying partners HDAC1, BRM, BRG1/SMARCA4). Negative regulation of Pol II transcription is a canonical core RB1 activity; already ACCEPTed elsewhere in this file via IEA (GO_REF:0000107) and supported by IDA evidence on PMID:7923370 and PMID:1531329.'
     action: ACCEPT
-    reason: Negative regulation of Pol II transcription is one of the best-characterized RB1 activities and is consistent with the existing core_functions[0] block (E2F repression at S-phase promoters). PMID:19149898 explicitly describes pRb as forming "active pRb-E2F transcriptional repressor complexes that silence genes required for S-phase entry." Mechanical TAS batch (batch 9 of #347) — all 8 PMID:19149898 TAS rows describe canonical RB1 repressor/cell-cycle functions and are uniformly ACCEPTed in this batch.
+    reason: 'Negative regulation of Pol II transcription is one of the best-characterized RB1 activities and is consistent with the existing core_functions[0] block (E2F repression at S-phase promoters). PMID:19149898 explicitly describes pRb as forming "active pRb-E2F transcriptional repressor complexes that silence genes required for S-phase entry." Mechanical TAS batch (batch 9 of #347) — all 8 PMID:19149898 TAS rows describe canonical RB1 repressor/cell-cycle functions and are uniformly ACCEPTed in this batch.'
 - term:
     id: GO:2000134
     label: negative regulation of G1/S transition of mitotic cell cycle
@@ -1194,7 +1194,7 @@ existing_annotations:
   review:
     summary: 'TAS annotation citing Becker et al. 2009 (PMID:19149898), which reviews the prototypical RB1 function at the G1/S restriction point — hypophosphorylated pRb sequesters E2F1/2/3 and prevents S-phase entry until inactivated by Cyclin D-CDK4/6 and Cyclin E-CDK2 phosphorylation. Negative regulation of G1/S is a canonical core RB1 activity, already captured elsewhere in this file via IBA (PR #490, GO_REF:0000033) and IEA propagation.'
     action: ACCEPT
-    reason: Negative regulation of the G1/S transition is the defining RB1 tumor-suppressor activity, central to the existing core_functions[0] block. PMID:19149898 directly describes the CDK4/6/Cyclin D - pRb - E2F switch at the G1/S restriction point. Mechanical TAS batch (batch 9 of #347).
+    reason: 'Negative regulation of the G1/S transition is the defining RB1 tumor-suppressor activity, central to the existing core_functions[0] block. PMID:19149898 directly describes the CDK4/6/Cyclin D - pRb - E2F switch at the G1/S restriction point. Mechanical TAS batch (batch 9 of #347).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1203,7 +1203,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1212,7 +1212,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1221,7 +1221,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0051276
     label: chromosome organization
@@ -1257,7 +1257,7 @@ existing_annotations:
   review:
     summary: 'TAS annotation citing Becker et al. 2009 (PMID:19149898), which describes hypophosphorylated pRb as a transcriptional corepressor that represses E2F-target promoters via chromatin remodeling — including direct interactions with HDAC1, BRM, and the SWI/SNF catalytic subunit BRG1/SMARCA4. Transcription corepressor activity is a canonical RB1 MF activity already supported by IDA evidence elsewhere in this file.'
     action: ACCEPT
-    reason: Transcription corepressor activity is one of the defining biochemical activities of RB1 at E2F-target promoters and is consistent with the existing core_functions[0] block. PMID:19149898 explicitly frames pRb as forming "transcriptional repressor complexes that silence genes required for S-phase entry." Mechanical TAS batch (batch 9 of #347).
+    reason: 'Transcription corepressor activity is one of the defining biochemical activities of RB1 at E2F-target promoters and is consistent with the existing core_functions[0] block. PMID:19149898 explicitly frames pRb as forming "transcriptional repressor complexes that silence genes required for S-phase entry." Mechanical TAS batch (batch 9 of #347).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1266,7 +1266,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1275,7 +1275,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1284,7 +1284,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1293,7 +1293,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1302,7 +1302,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005634
     label: nucleus
@@ -1614,7 +1614,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1623,7 +1623,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1632,7 +1632,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1641,7 +1641,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1650,7 +1650,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1659,7 +1659,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1668,7 +1668,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1677,7 +1677,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005654
     label: nucleoplasm
@@ -1686,7 +1686,7 @@ existing_annotations:
   review:
     summary: TAS annotation for nucleoplasmic localization sourced from a Reactome pathway event. RB1 is a chromatin-bound nuclear corepressor that occupies E2F-target gene promoters in the nucleoplasm; nucleoplasmic localization of hypophosphorylated active RB1 is well established and is the compartment in which RB1 binds E2F1/2/3 and recruits chromatin corepressors (HDAC1, SUV39H1, BRG1/SMARCA4) (PMID:7923370; deep research synthesis).
     action: ACCEPT
-    reason: Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
+    reason: 'Nucleoplasmic localization is the canonical compartment for active hypophosphorylated RB1 and is well supported across the literature. Each of the 17 Reactome TAS events is a separate nucleoplasm annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).'
 - term:
     id: GO:0005515
     label: protein binding
@@ -1928,7 +1928,7 @@ existing_annotations:
   review:
     summary: 'TAS annotation citing Becker et al. 2009 (PMID:19149898), which describes pRb-mediated chromatin remodeling at E2F-target promoters via recruitment of BRM, BRG1/SMARCA4 (SWI/SNF catalytic subunit), and HDAC1. Chromatin remodeling is a canonical RB1 BP activity supported by extensive primary literature (PMID:7923370; deep research synthesis).'
     action: ACCEPT
-    reason: Chromatin remodeling via SWI/SNF and histone-deacetylase recruitment is a canonical mechanism for RB1-mediated E2F repression. PMID:19149898 directly states pRb "can repress gene transcription at least partly by remodelling chromatin structure through its interactions with proteins such as HDAC1, BRM and BRG1." Mechanical TAS batch (batch 9 of #347).
+    reason: 'Chromatin remodeling via SWI/SNF and histone-deacetylase recruitment is a canonical mechanism for RB1-mediated E2F repression. PMID:19149898 directly states pRb "can repress gene transcription at least partly by remodelling chromatin structure through its interactions with proteins such as HDAC1, BRM and BRG1." Mechanical TAS batch (batch 9 of #347).'
 - term:
     id: GO:0016514
     label: SWI/SNF complex
@@ -1937,7 +1937,7 @@ existing_annotations:
   review:
     summary: 'TAS annotation citing Becker et al. 2009 (PMID:19149898), which describes RB1 association with the SWI/SNF chromatin-remodeling complex via the catalytic subunits BRM and BRG1/SMARCA4. The RB1-BRG1 interaction recruits SWI/SNF to E2F-responsive promoters to enhance pRb transcriptional repressor activity (cited refs 4 and 5 in Becker et al.).'
     action: ACCEPT
-    reason: RB1's recruitment of SWI/SNF to E2F-target chromatin is one of the canonical chromatin-coregulator interactions for RB1, with direct biochemical support across multiple primary papers. PMID:19149898 explicitly describes "BRG1, as the catalytic core of the SWI/SNF chromatin remodelling complex, the interaction between BRG1 and pRb was proposed to recruit the complex to E2F responsive promoters." Mechanical TAS batch (batch 9 of #347).
+    reason: 'RB1''s recruitment of SWI/SNF to E2F-target chromatin is one of the canonical chromatin-coregulator interactions for RB1, with direct biochemical support across multiple primary papers. PMID:19149898 explicitly describes "BRG1, as the catalytic core of the SWI/SNF chromatin remodelling complex, the interaction between BRG1 and pRb was proposed to recruit the complex to E2F responsive promoters." Mechanical TAS batch (batch 9 of #347).'
 - term:
     id: GO:0035189
     label: Rb-E2F complex
@@ -1946,7 +1946,7 @@ existing_annotations:
   review:
     summary: 'TAS annotation citing Becker et al. 2009 (PMID:19149898), which describes "active pRb-E2F transcriptional repressor complexes that silence genes required for S-phase entry." Rb-E2F complex membership is the defining biochemical complex for RB1''s tumor-suppressor function and is already independently captured in this file by IBA (PR #490) and IPI (PMID:8245034) evidence.'
     action: ACCEPT
-    reason: Rb-E2F complex membership is the defining biochemical complex for RB1's tumor-suppressor activity at the G1/S restriction point. PMID:19149898 directly anchors this annotation to the active pRb-E2F repressor complex framework. Mechanical TAS batch (batch 9 of #347).
+    reason: 'Rb-E2F complex membership is the defining biochemical complex for RB1''s tumor-suppressor activity at the G1/S restriction point. PMID:19149898 directly anchors this annotation to the active pRb-E2F repressor complex framework. Mechanical TAS batch (batch 9 of #347).'
 - term:
     id: GO:0045892
     label: negative regulation of DNA-templated transcription
@@ -1955,7 +1955,7 @@ existing_annotations:
   review:
     summary: 'TAS annotation citing Becker et al. 2009 (PMID:19149898), which reviews pRb as a transcriptional corepressor that silences E2F-target genes via chromatin remodeling. Negative regulation of DNA-templated transcription is the general BP parent of the canonical pRb-E2F repression activity (GO:0000122 is the Pol II-specific child) and is already supported by IDA evidence on PMID:12065415 and PMID:10783144 elsewhere in this file.'
     action: ACCEPT
-    reason: Negative regulation of DNA-templated transcription is a canonical RB1 activity, well anchored to the pRb-E2F repressor model that PMID:19149898 reviews. Mechanical TAS batch (batch 9 of #347).
+    reason: 'Negative regulation of DNA-templated transcription is a canonical RB1 activity, well anchored to the pRb-E2F repressor model that PMID:19149898 reviews. Mechanical TAS batch (batch 9 of #347).'
 - term:
     id: GO:0051726
     label: regulation of cell cycle
@@ -1964,7 +1964,7 @@ existing_annotations:
   review:
     summary: 'TAS annotation citing Becker et al. 2009 (PMID:19149898), which reviews the canonical p16INK4a–Cyclin D-CDK4/6–pRb–E2F G1/S switch. Regulation of cell cycle is a canonical RB1 BP, already captured in this file via IEA propagation (GO_REF:0000120) and by multiple direct experimental rows on G1/S regulators.'
     action: ACCEPT
-    reason: Regulation of the cell cycle is one of the defining RB1 tumor-suppressor functions, central to the existing core_functions[0] block (G1/S restriction). PMID:19149898 directly anchors RB1 to the canonical CDK4/6-cyclin D-pRb-E2F G1/S switch. Mechanical TAS batch (batch 9 of #347).
+    reason: 'Regulation of the cell cycle is one of the defining RB1 tumor-suppressor functions, central to the existing core_functions[0] block (G1/S restriction). PMID:19149898 directly anchors RB1 to the canonical CDK4/6-cyclin D-pRb-E2F G1/S switch. Mechanical TAS batch (batch 9 of #347).'
 - term:
     id: GO:0005515
     label: protein binding


### PR DESCRIPTION
## Summary

Fixes a YAML-parser content-loss bug in `genes/human/RB1/RB1-ai-review.yaml`. Twenty-five `reason:` fields were unquoted scalars containing ` #NNN` sequences (space before hash). Per YAML spec, a space-hash sequence in a plain scalar introduces a comment, silently truncating the parsed value.

This was first identified in the companion PR #649 (CDH1, same pattern, 14 fields).

## Truncation detail

**8 fields** in batch-9 (TAS, PMID:19149898) rows ended with:
```
...Mechanical TAS batch (batch 9 of   ← parsed value stops here
```
instead of:
```
...Mechanical TAS batch (batch 9 of #347) — all 8 PMID:19149898 TAS rows...
```

**17 fields** in nucleoplasm Reactome-TAS rows ended with:
```
...consolidated to ACCEPT with a uniform template (BRAF PR   ← truncated
```
instead of:
```
...consolidated to ACCEPT with a uniform template (BRAF PR #440 / KRAS PR #349 precedent for analogous Reactome TAS localization sweeps).
```

## Impact

- HTML rendering (`ai-gene-review render human RB1`) showed truncated reasons
- Any downstream tooling consuming the parsed YAML received truncated values
- The raw YAML source preserved the full text (visible in `cat`/`grep`) — the issue was only visible at parse time

## Fix

Single-quote the 25 affected `reason:` lines (+25/-25, one file). Matches the format already used by correctly-quoted fields in the same file. No GO term, action, evidence, or annotation logic changes.

## Verification

- Before: `yaml.safe_load()` produced 25 truncated reason values
- After: `yaml.safe_load()` → 0 truncated values
- `just validate human RB1` → ✓ Valid (0 warnings, 0 PENDING, 0 UNDECIDED)

## Selection context

Issue #347 (RB1) is already closed. This PR addresses the residual content bug surfaced by a fresh re-verification this run. Companion PR #649 (CDH1, same defect class, already approved and ready-for-review) was identified first; this PR addresses the only other affected file repo-wide (verified: all other `*-ai-review.yaml` files were checked and have no analogous unquoted `#NNN` truncation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)