### PR TITLE
Add KAURENE_OXIDATION_OBSOLETION project (go-annotation#6433)

### DIFF
--- a/pages/projects/index.html
+++ b/pages/projects/index.html
@@ -253,6 +253,9 @@
         <div class="project-card">
             <a href="SDH_GP2TERM_CONTRIBUTES_TO.html">Succinate Dehydrogenase gp2term (GO:0008177 enables→contributes_to)</a>
         </div>
+        <div class="project-card">
+            <a href="KAURENE_OXIDATION_OBSOLETION.html">Ent-Kaurene Oxidation (GO:0010241 obsoletion)</a>
+        </div>
     </div>
 
     <h2>Bacterial Projects</h2>

--- a/pages/projects/index.html
+++ b/pages/projects/index.html
@@ -253,9 +253,6 @@
         <div class="project-card">
             <a href="SDH_GP2TERM_CONTRIBUTES_TO.html">Succinate Dehydrogenase gp2term (GO:0008177 enables→contributes_to)</a>
         </div>
-        <div class="project-card">
-            <a href="KAURENE_OXIDATION_OBSOLETION.html">Ent-Kaurene Oxidation (GO:0010241 obsoletion)</a>
-        </div>
     </div>
 
     <h2>Bacterial Projects</h2>
@@ -275,6 +272,9 @@
         </div>
         <div class="project-card">
             <a href="NICOTINE_BIOSYNTHESIS.html">Nicotine Biosynthesis</a>
+        </div>
+        <div class="project-card">
+            <a href="KAURENE_OXIDATION_OBSOLETION.html">Ent-Kaurene Oxidation (GO:0010241 obsoletion)</a>
         </div>
     </div>
 

--- a/projects/KAURENE_OXIDATION_OBSOLETION.md
+++ b/projects/KAURENE_OXIDATION_OBSOLETION.md
@@ -1,0 +1,140 @@
+# Ent-Kaurene Oxidation to Kaurenoic Acid — Obsoletion & Replacement
+
+## Overview
+
+A GO obsoletion proposal will obsolete `GO:0010241 ent-kaurene oxidation to
+kaurenoic acid` (a BP describing three successive oxidations of the 4-methyl
+group of ent-kaurene). The upstream rationale is that the experimental data
+behind the term is adequately captured by the broader BP
+`GO:0009686 gibberellin biosynthetic process`, and that any catalytic-activity
+content already has a dedicated MF — `GO:0052615 ent-kaurene oxidase activity`
+— which is unaffected by this obsoletion.
+
+This project tracks the two experimental annotations called out on the upstream
+list. Both impacted curation groups (UniProt and TAIR) are already marked
+`DONE` on the go-annotation issue, so this is primarily a queueing /
+documentation exercise — useful for keeping the AI Gene Review obsoletion log
+complete and for handling the InterPro2GO mapping that is still open.
+
+## Upstream tickets
+
+- Annotation tracker: [geneontology/go-annotation#6433](https://github.com/geneontology/go-annotation/issues/6433)
+- Ontology ticket: [geneontology/go-ontology#32078](https://github.com/geneontology/go-ontology/issues/32078)
+
+## Obsoletion plan (per upstream)
+
+| Obsoleted term | ID | Replacement |
+|---|---|---|
+| ent-kaurene oxidation to kaurenoic acid | GO:0010241 | GO:0009686 gibberellin biosynthetic process (BP); MF content moves to GO:0052615 ent-kaurene oxidase activity |
+
+Term labels verified in OLS on 2026-05-27:
+- `GO:0010241` (`ent-kaurene oxidation to kaurenoic acid`) — live, slated for obsoletion. Definition: "The three successive oxidations of the 4-methyl group of ent-kaurene to form ent-kaur-16-en-19-oate, kaurenoic acid. This process may be carried out entirely by the enzyme ent-kaurene oxidase."
+- `GO:0009686` (`gibberellin biosynthetic process`) — live, proposed BP replacement.
+- `GO:0052615` (`ent-kaurene oxidase activity`) — live MF (EC 1.14.14.86); not part of the obsoletion. SJM's comment on the upstream issue effectively treats `GO:0010241` as a redundant restatement of MF + BP.
+
+SJM comments on the two experimental annotations (paraphrased from
+go-annotation#6433):
+
+- PMID:22487175 (CYP701A6, Q5Z5R4) — only shows enzyme activity assays. No BP
+  evidence in the paper. SJM suggests "just removed" rather than remapped.
+- PMID:9671797 (KO, Q93ZB2) — ga3-1 mutant deficient in ent-kaurene oxidase
+  activity, framed in the abstract as "the first cytochrome P450-mediated
+  step in the gibberellin biosynthetic pathway". SJM suggests remapping to
+  GO:0009686.
+
+## Affected experimental annotations (upstream list)
+
+| # | Source | Accession | Symbol | Taxon | PMID | Evidence | Notes |
+|---|---|---|---|---|---|---|---|
+| 1 | UniProt | UniProtKB:Q5Z5R4 | CYP701A6 | NCBITaxon:39947 (Oryza sativa Japonica Group) | PMID:22487175 | IDA | Rice ent-kaurene oxidase 2 (EC 1.14.14.86). Paper is an enzyme assay; IDA was on a BP that is really an MF claim. Already has GO:0009686 IMP on the UniProt entry, so removal of the GO:0010241 IDA does not lose biological coverage. Upstream UniProt marked DONE. |
+| 2 | TAIR | UniProtKB:Q93ZB2 / AT5G25900 | KO (GA3, CYP701A3, KO1) | NCBITaxon:3702 (Arabidopsis thaliana) | PMID:9671797 | IMP | Arabidopsis ent-kaurene oxidase, chloroplastic (EC 1.14.14.86). The ga3-1 mutant phenotype underpins the gibberellin BP claim; remap to GO:0009686 is the upstream proposal. UniProt entry already lists GO:0009686 IDA. Upstream TAIR marked DONE. |
+
+Group impact tally (from upstream): UniProt 1 (DONE), TAIR 1 (DONE).
+
+## Mappings flagged for redirection
+
+- `interpro2go`: `InterPro:IPR044225` (Ent-kaurene oxidase, chloroplastic — plant
+  KO family, including AtKO1) → `GO:0010241`. Verified via InterPro REST on
+  2026-05-27 that the family entry exists and is named "Ent-kaurene oxidase,
+  chloroplastic". Once `GO:0010241` is obsoleted, the InterPro2GO mapping
+  should be reviewed. The MF replacement `GO:0052615 ent-kaurene oxidase
+  activity` is the cleaner target for this family because IPR044225 captures
+  the catalytic family, not a BP claim; an additional `GO:0009686 gibberellin
+  biosynthetic process` mapping would also be defensible since every member
+  of the family is a committed step in gibberellin biosynthesis.
+
+No UniRule, HAMAP, or UniProt-Keywords mappings to `GO:0010241` were listed by
+upstream.
+
+## Impact on this repo
+
+Neither affected gene currently has an `*-ai-review.yaml` in this repo
+(verified via `find genes -type d -iname 'CYP701*' -o -iname 'KO'` on
+2026-05-27). This project is therefore a queueing exercise rather than a
+re-review of existing files. Both annotations are already actioned upstream by
+UniProt and TAIR, so the value of pulling these into AI Gene Review is low
+relative to the open obsoletion projects (vesicle docking, hypochlorous acid,
+etc.), but the genes themselves are scientifically clean examples of plant
+gibberellin biosynthesis enzymes and would be useful as positive controls for
+GO:0009686 / GO:0052615 annotation.
+
+## Scope
+
+- Organism: Arabidopsis thaliana (KO, Q93ZB2) and Oryza sativa Japonica Group
+  (CYP701A6, Q5Z5R4). Plant gibberellin biosynthesis — both proteins are
+  CYP701-family cytochromes P450 catalysing the three sequential oxidations of
+  ent-kaurene to kaurenoic acid.
+- GO branch: BP (gibberellin biosynthetic process). The MF side
+  (`GO:0052615 ent-kaurene oxidase activity`) is the natural home for the
+  catalytic content currently described by `GO:0010241`.
+- Type of fix: structural / curation hygiene. The biology is uncontroversial;
+  the obsoletion is about removing a hybrid term whose BP framing actually
+  conflated three successive catalytic steps. No annotations need to be
+  rebutted on biological grounds; the question is just which of MF
+  (`GO:0052615`) and BP (`GO:0009686`) is the right home for each evidence
+  record.
+
+## Candidate genes for initial review
+
+Listed in priority order. Both are optional given the upstream DONE markers.
+
+1. **KO / GA3 (Arabidopsis, Q93ZB2)** — Higher-value review candidate of the
+   two. The PMID:9671797 paper is foundational for the gibberellin biosynthesis
+   pathway in plants and the gene already carries `GO:0009686 IDA` from
+   UniProt. A review would mostly serve as a positive-control example for the
+   `GO:0009686` + `GO:0052615` pairing.
+2. **CYP701A6 (Oryza sativa, Q5Z5R4)** — Rice ent-kaurene oxidase 2. Less
+   pressing because the upstream consensus (SJM) is that the IDA on
+   `GO:0010241` is best simply removed: the underlying paper (PMID:22487175)
+   is an enzyme assay, so the MF `GO:0052615` is the right destination, but
+   that MF is not currently in the existing annotation set on the gene.
+
+## Proposed approach
+
+1. **Wait for obsoletion to land before pulling into AI Gene Review.** The
+   ontology ticket (go-ontology#32078) is open. Both
+   group-level curation tasks are already DONE upstream, so there is nothing
+   urgent to do here.
+2. **Flag the IPR044225 InterPro2GO mapping** as the remaining open item, and
+   note that the cleanest redirect is to the MF `GO:0052615 ent-kaurene
+   oxidase activity` rather than the BP `GO:0009686 gibberellin biosynthetic
+   process` — the family is defined by catalytic activity, not pathway role.
+3. **If gene reviews are queued**, start with Arabidopsis KO (Q93ZB2). The
+   biology is canonical and well-supported; the review can serve as a positive
+   control for how to handle ent-kaurene-oxidase-family annotations once the
+   obsoletion lands.
+
+## Priority
+
+Low — both impacted curation groups marked DONE upstream. The InterPro2GO
+mapping redirect is the only piece that may still benefit from a comment on
+the upstream issue.
+
+## Status
+
+- 2026-05-27 — Project file created. Tracking go-annotation#6433 (opened
+  2026-05-26) and go-ontology#32078. Obsoletion not yet applied. UniProt and
+  TAIR marked DONE for the two affected experimental annotations. No
+  AI Gene Review files exist for either gene. OLS confirms GO:0010241,
+  GO:0009686, and GO:0052615 are all currently live; InterPro IPR044225
+  confirmed via REST.

--- a/publications/PMID_22487175.md
+++ b/publications/PMID_22487175.md
@@ -1,0 +1,56 @@
+---
+pmid: '22487175'
+title: A conformationally restricted uniconazole analogue as a specific inhibitor
+  of rice ent-kaurene oxidase, CYP701A6.
+authors:
+- Todoroki Y
+- Naiki K
+- Muramatsu T
+- Ohnishi T
+- Ueno K
+- Mizutani M
+- Hirai N
+journal: Bioorg Med Chem Lett
+year: '2012'
+full_text_available: false
+doi: 10.1016/j.bmcl.2012.03.028
+---
+
+# A conformationally restricted uniconazole analogue as a specific inhibitor of rice ent-kaurene oxidase, CYP701A6.
+**Authors:** Todoroki Y, Naiki K, Muramatsu T, Ohnishi T, Ueno K, Mizutani M, Hirai N
+**Journal:** Bioorg Med Chem Lett (2012)
+**DOI:** [10.1016/j.bmcl.2012.03.028](https://doi.org/10.1016/j.bmcl.2012.03.028)
+
+## Abstract
+
+1. Bioorg Med Chem Lett. 2012 May 1;22(9):3240-3. doi:
+10.1016/j.bmcl.2012.03.028.  Epub 2012 Mar 24.
+
+A conformationally restricted uniconazole analogue as a specific inhibitor of 
+rice ent-kaurene oxidase, CYP701A6.
+
+Todoroki Y(1), Naiki K, Muramatsu T, Ohnishi T, Ueno K, Mizutani M, Hirai N.
+
+Author information:
+(1)Department of Applied Biological Chemistry, Faculty of Agriculture, Shizuoka 
+University, Shizuoka 422-8529, Japan. aytodor@ipc.shizuoka.ac.jp
+
+The plant growth retardant uniconazole (UNI), which has been used as an 
+effective inhibitor of ent-kaurene oxidase (CYP701A) involved in gibberellin 
+biosynthesis, also strongly inhibits ABA 8'-hydroxylase (CYP707A), a key enzyme 
+in abscisic acid catabolism. Azole P450 inhibitors bind to the P450 active site 
+by both coordinating to the heme-iron atom via an sp(2) nitrogen and interacting 
+with surrounding protein residues through a lipophilic region. We hypothesized 
+that poor selectivity of UNI may result from its small molecular size and 
+flexible conformation that allows it to fit into active sites differing in size 
+and shape. To find a selective inhibitor of CYP701A based on this hypothesis, we 
+examined inhibitory activities of three types of UNI analogues, which were 
+conformationally constrained, enlarged in width, and enlarged in length, against 
+recombinant rice CYP701A6 and Arabidopsis CYP707A3. Conformationally restricted 
+analogues, UFAP2 and UFAP2N, inhibited CYP701A6 as strongly as UNI, whereas it 
+inhibited CYP707A3 less than UNI.
+
+Copyright © 2012 Elsevier Ltd. All rights reserved.
+
+DOI: 10.1016/j.bmcl.2012.03.028
+PMID: 22487175 [Indexed for MEDLINE]

--- a/publications/PMID_9671797.md
+++ b/publications/PMID_9671797.md
@@ -1,0 +1,90 @@
+---
+pmid: '9671797'
+title: Cloning of the Arabidopsis ent-kaurene oxidase gene GA3.
+authors:
+- Helliwell CA
+- Sheldon CC
+- Olive MR
+- Walker AR
+- Zeevaart JA
+- Peacock WJ
+- Dennis ES
+journal: Proc Natl Acad Sci U S A
+year: '1998'
+full_text_available: true
+full_text_extraction_method: html
+pmcid: PMC21195
+doi: 10.1073/pnas.95.15.9019
+---
+
+# Cloning of the Arabidopsis ent-kaurene oxidase gene GA3.
+**Authors:** Helliwell CA, Sheldon CC, Olive MR, Walker AR, Zeevaart JA, Peacock WJ, Dennis ES
+**Journal:** Proc Natl Acad Sci U S A (1998)
+**DOI:** [10.1073/pnas.95.15.9019](https://doi.org/10.1073/pnas.95.15.9019)
+**PMC:** [PMC21195](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC21195/)
+
+## Abstract
+
+1. Proc Natl Acad Sci U S A. 1998 Jul 21;95(15):9019-24. doi: 
+10.1073/pnas.95.15.9019.
+
+Cloning of the Arabidopsis ent-kaurene oxidase gene GA3.
+
+Helliwell CA(1), Sheldon CC, Olive MR, Walker AR, Zeevaart JA, Peacock WJ, 
+Dennis ES.
+
+Author information:
+(1)Commonwealth Scientific and Industrial Research Organization, Plant Industry, 
+GPO Box 1600, Canberra, ACT 2601, Australia.
+
+The ga3 mutant of Arabidopsis is a gibberellin-responsive dwarf. We present data 
+showing that the ga3-1 mutant is deficient in ent-kaurene oxidase activity, the 
+first cytochrome P450-mediated step in the gibberellin biosynthetic pathway. By 
+using a combination of conventional map-based cloning and random sequencing we 
+identified a putative cytochrome P450 gene mapping to the same location as GA3. 
+Relative to the progenitor line, two ga3 mutant alleles contained single base 
+changes generating in-frame stop codons in the predicted amino acid sequence of 
+the P450. A genomic clone spanning the P450 locus complemented the ga3-2 mutant. 
+The deduced GA3 protein defines an additional class of cytochrome P450 enzymes. 
+The GA3 gene was expressed in all tissues examined, RNA abundance being highest 
+in inflorescence tissue.
+
+DOI: 10.1073/pnas.95.15.9019
+PMCID: PMC21195
+PMID: 9671797 [Indexed for MEDLINE]
+
+## Full Text
+
+Abstract
+
+The ga3 mutant of Arabidopsis is a gibberellin-responsive dwarf. We present data showing that the ga3-1 mutant is deficient in ent- kaurene oxidase activity, the first cytochrome P450-mediated step in the gibberellin biosynthetic pathway. By using a combination of conventional map-based cloning and random sequencing we identified a putative cytochrome P450 gene mapping to the same location as GA3 . Relative to the progenitor line, two ga3 mutant alleles contained single base changes generating in-frame stop codons in the predicted amino acid sequence of the P450. A genomic clone spanning the P450 locus complemented the ga3-2 mutant. The deduced GA3 protein defines an additional class of cytochrome P450 enzymes. The GA3 gene was expressed in all tissues examined, RNA abundance being highest in inflorescence tissue.
+
+DNA Methods.
+
+Bacterial artificial chromosomes (BACs) were subcloned by partially digesting with Sau 3A1 and size-selecting fractions of 2–4 kbp using agarose gel electrophoresis followed by agarase digestion of the gel. Fragments were cloned in to pBluescript KS + (Stratagene). Larger fractions of 6–10 and 10–15 kbp were also isolated and cloned into pBin19 ( 24 ).
+
+Large-scale plant genomic DNA extraction was by the method of Dellaporta ( 25 ). Small-scale extraction of PCR-grade plant genomic DNA was by the method of Edwards ( 26 ). PCR was carried out by using 1 unit/50 μl reaction of Amplitaq DNA polymerase (Perkin–Elmer) using the manufacturer’s buffer, 1.5 mM MgCl 2 , 250 μM dNTPs, 1 μM oligonucleotide primers (shown in Fig. 3 , also Columbia ecotype (Col)-specific primer 5′-CTTGAGAGTAATAGGTAGG-3′ and L. er -specific primer 5′-AATGTGAATTGACTCGGTG-3′) and ≈0.1 μg genomic DNA. Cycling program; 95°C, 5 min, 95°C, 20 s; 50°C, 15 s; 72°C, 30 s; 35 cycles, 72°C, 5 min. Products were assessed by electrophoresis of a 5 μl sample on 1% agarose gels. PCR products were prepared for sequencing by using Wizard PCR preps (Promega). Sequencing reactions were carried out by using the Applied Biosystems dRhodamine Dye Terminator sequencing mix according to the manufacturer’s instructions and analyzed using an Applied Biosystems 377 sequencing machine. DNA sequences were analyzed by using the GCG suite of programs and blast searches were carried out via the Australian National Genome Information Service.
+
+RNA Methods.
+
+Total RNA was extracted from ≈1 g of plant material ( 27 ). RNA probes were synthesized by using the Promega Riboprobe system according to the manufacturer’s protocol. RNase protection assays were carried out using the Hybspeed RPA kit (Ambion, Austin, TX) with 10 5 cpm of the GA3 sense-specific probe and 10 μg of total plant RNA (determined spectrophotometrically and by ethidium bromide-stained agarose gels) in each reaction, following the manufacturer’s protocol. Protected fragments were precipitated and separated on 5% acrylamide/8 M urea gels. Position and intensity of radioactive bands was determined by PhosphorImager.
+
+DISCUSSION
+
+We have demonstrated that the ga3-1 mutant of Arabidopsis is deficient in ent -kaurene oxidase activity. The mutant accumulates ent -kaurene to the same level as tetcyclacis-treated wild-type plants and shows a growth response to ent -kaurenoic acid but not to ent -kaurene. It is therefore likely that GA3 encodes ent -kaurene oxidase, the first cytochrome P450-mediated step of the GA biosynthetic pathway ( 18 ). We isolated the GA3 gene by mapping the gene to a single BAC and used DNA sequence data to identify a single putative cytochrome P450 gene located on that BAC. We sequenced the P450 gene from wild-type L .er and from the two mutant alleles of ga3 . Each of the mutant alleles contained a single base change in the P450 gene. In both cases the mutation introduced a stop codon into the predicted ORF of the P450 gene. To confirm that this P450 was the GA3 gene, we complemented the ga3-2 mutant with a wild-type genomic clone. The transformed plants containing the transgene were restored to the wild-type phenotype.
+
+Our data suggest that there is a single ent -kaurene oxidase activity in Arabidopsis . DNA gel blots show that GA3 is a single copy gene and application of tetcyclacis to the ga3-1 mutant does not result in increased ent -kaurene accumulation. This contrasts with the GA 20-oxidase, catalyzing later reactions in the pathway, for which there are three genes in Arabidopsis ( 8 ). If there is an alternative ent -kaurene oxidase gene it is not closely related to GA3 and the gene product may not be a cytochrome P450 as its activity is not inhibited by tetcyclacis.
+
+Swain et al . ( 17 ) showed that the pea lh-2 mutant is blocked in the three steps from ent -kaurene to ent -kaurenoic acid. Extracts from embryos of the lh-2 mutant were unable to oxidize ent- kaurene, ent- kaurenol, and ent- kaurenal but were able to synthesize ent- kaurene and also to oxidize ent- kaurenoic acid to ent- 7α-hydroxy kaurenoic acid, suggesting that ent -kaurene oxidase catalyzes all three reactions. Our feeding data show that ga3-1 responds to ent -kaurenoic acid but not to ent -kaurene. A slight growth response to ent -kaurenol was observed, but notably did not lead to flowering as was the case when ga1-2 and ga2-1 were treated in the same way. This slight response to ent -kaurenol may be due to spontaneous oxidation or another oxidase activity that can act on ent -kaurenol but not ent -kaurene.
+
+We have observed that the ga3-1 mutant has a more severe phenotype than ga3-2 . The putative polypeptides encoded by both alleles are truncated before the heme-binding domain and would therefore not be expected to have ent -kaurene oxidase activity. However the less severe ga3-2 phenotype suggests that the ga3-2 gene product is capable of conferring some ent -kaurene oxidase activity. This could be by alternate splicing out of exon 5, which would restore the heme-binding domain or be due to an interaction of the truncated polypeptide with other proteins.
+
+The expression pattern of GA3 mRNA is consistent with its role in GA biosynthesis. The transcript is high in young seedlings where there is a high proportion of dividing and expanding cells and declines with increased age to a low level in mature leaves. The GA3 transcript level is also high in the elongating stems and further increased in the inflorescence. Our cDNA library screening also indicates that GA3 mRNA is expressed in developing seeds. GAs are particularly important in germination, stem growth, and flowering.
+
+A detailed study of expression of the GA1 gene ( 36 ) has shown that the GA1 promoter directs highest GUS expression in the rapidly growing tissues of transgenic Arabidopsis plants including embryos, meristems, anthers, and vascular tissue. GA1 encodes copalyl diphosphate synthase, a chloroplast-located enzyme catalyzing the first step of ent- kaurene synthesis. Our expression data suggest that the expression patterns of GA1 and GA3 may be closely related, as might be expected of genes encoding enzymes catalyzing successive steps in the GA biosynthetic pathway.
+
+The three GA 20-oxidases of Arabidopsis show differential tissue-specific expression; mRNA levels of at least one of the genes are high in stems, inflorescences, and siliques ( 8 ). Expression levels of the mRNAs of two of the 20-oxidase genes are increased in the ga1-2 mutant, and decreased in these plants by the application of endogenous GA, suggesting that there is feedback regulation in the pathway. We found no evidence of this type of regulation of the GA3 gene.
+
+Comparison of the derived amino acid sequence of the GA3 gene to other P450 enzymes shows that it encodes the first member of a new class of cytochrome P450 enzymes. The GA3 protein is not closely related to the maize Dwarf3 protein, also thought to be a GA biosynthetic P450. The number and positions of the introns in the GA3 gene differ from those in other known plant P450 genes. We plan to use the GA3 gene as a probe at reduced stringency to isolate related P450s. ent- Kaurenoic acid hydroxylase, the enzyme catalyzing the conversion of ent- kaurenoic acid to ent- 7α-hydroxy kaurenoic acid is also a cytochrome P450 mediated reaction. There are biosynthetic pathways in which adjacent steps are catalyzed by related P450s ( 37 , 38 ), so it is possible that the ent- kaurenoic acid hydroxylase amino acid sequence may be related to that of ent- kaurene oxidase.
+
+Data from Thlaspi arvense , a species closely related to Arabidopsis , demonstrate that the activities of ent- kaurene oxidase and ent- kaurenoic acid hydroxylase increase specifically in the shoot tip after vernalization ( 39 ). These changes in enzyme activities are coupled with a reduction in the pools of ent- kaurene and ent- kaurenoic acid in the shoot tip ( 40 ). This suggests that ent- kaurenoic acid hydroxylase and possibly ent- kaurene oxidase have a controlling role in the GA biosynthetic pathway and that the enzyme activities are under control of low temperature.


### PR DESCRIPTION
## Summary

- Adds `projects/KAURENE_OXIDATION_OBSOLETION.md` tracking the proposed obsoletion of `GO:0010241 ent-kaurene oxidation to kaurenoic acid`, with `GO:0009686 gibberellin biosynthetic process` as the BP replacement and `GO:0052615 ent-kaurene oxidase activity` (live MF, not obsoleted) as the proper home for the catalytic content.
- Documents the two affected experimental annotations from the upstream list: CYP701A6 (Q5Z5R4, rice, PMID:22487175, IDA) and KO (Q93ZB2, Arabidopsis, PMID:9671797, IMP). Both impacted curation groups (UniProt and TAIR) are already marked DONE on the upstream issue.
- Flags the remaining open `InterPro2GO` mapping for `IPR044225` (Ent-kaurene oxidase, chloroplastic) and recommends redirecting it to the MF `GO:0052615` rather than the BP `GO:0009686`, since the InterPro family is defined by catalytic activity rather than pathway role.
- Adds a project card to the manually-maintained `pages/projects/index.html` per CLAUDE.md.

Addresses geneontology/go-annotation#6433

## Test plan

- [ ] Verify `projects/KAURENE_OXIDATION_OBSOLETION.md` renders cleanly via `just render-projects projects/KAURENE_OXIDATION_OBSOLETION.md`
- [ ] Confirm the new card appears under the "Human / Mammalian Projects" obsoletion cluster on the rendered projects index
- [ ] Confirm no AI Gene Review files exist for CYP701A6 or KO (`find genes -type d -iname 'CYP701*' -o -iname 'KO'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)