### PR TITLE
Regenerate pages and browser app

### DIFF
--- a/genes/CHLRE/CP12/CP12-ai-review.html
+++ b/genes/CHLRE/CP12/CP12-ai-review.html
@@ -1,0 +1,3758 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CP12 - AI Gene Review</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-keep-non-core: #3b82f6;
+            --color-undecided: #6b7280;
+            --color-new: #8b5cf6;
+            --color-mark-over: #eab308;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        .gene-info {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .info-item {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .info-label {
+            font-weight: 600;
+            color: var(--text-muted);
+        }
+
+        .aliases {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+        }
+
+        .status-badge {
+            padding: 0.375rem 0.875rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .status-initialized {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fde68a;
+        }
+
+        .status-in-progress {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+        }
+
+        .status-draft {
+            background-color: #fce7f3;
+            color: #831843;
+            border: 1px solid #fbcfe8;
+        }
+
+        .status-complete {
+            background-color: #d1fae5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+        }
+
+        .description-card {
+            background-color: var(--bg-light);
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .description-card h2 {
+            font-size: 1.25rem;
+            margin-bottom: 1rem;
+            color: #374151;
+        }
+
+        .section {
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .annotations-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            overflow: hidden;
+        }
+
+        .annotations-table thead {
+            background-color: var(--bg-light);
+        }
+
+        .annotations-table th {
+            text-align: left;
+            padding: 1rem;
+            font-weight: 600;
+            border-bottom: 2px solid var(--border-color);
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-muted);
+        }
+
+        .annotations-table td {
+            padding: 1rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .annotations-table tbody tr:hover {
+            background-color: #f9fafb;
+        }
+
+        .action-badge {
+            display: inline-block;
+            padding: 0.375rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+        }
+
+        .action-accept {
+            background-color: var(--color-accept);
+            color: white;
+        }
+
+        .action-remove {
+            background-color: var(--color-remove);
+            color: white;
+        }
+
+        .action-modify {
+            background-color: var(--color-modify);
+            color: white;
+        }
+
+        .action-keep_as_non_core {
+            background-color: var(--color-keep-non-core);
+            color: white;
+        }
+
+        .action-undecided {
+            background-color: var(--color-undecided);
+            color: white;
+        }
+
+        .action-new {
+            background-color: var(--color-new);
+            color: white;
+        }
+
+        .action-mark_as_over_annotated {
+            background-color: var(--color-mark-over);
+            color: white;
+        }
+
+        .term-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .term-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .term-label {
+            font-weight: 500;
+        }
+
+        .evidence-code {
+            font-family: monospace;
+            background-color: var(--bg-light);
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .not-badge {
+            display: inline-block;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            margin-left: 0.25rem;
+        }
+
+        .isoform-badge {
+            display: inline-block;
+            background-color: #eff6ff;
+            color: #1e40af;
+            border: 1px solid #bfdbfe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            margin-top: 0.25rem;
+        }
+
+        .core-function-card {
+            background-color: white;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .core-function-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+
+        .core-function-statement {
+            margin-bottom: 1rem;
+            padding: 0.75rem;
+            background-color: var(--bg-light);
+            border-left: 4px solid var(--color-accept);
+            border-radius: 0.25rem;
+        }
+
+        .function-annotations {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .reference-item {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .reference-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: start;
+            margin-bottom: 0.75rem;
+        }
+
+        .reference-id {
+            font-family: monospace;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .supported-by {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: #f3f4f6;
+            border-left: 3px solid #3b82f6;
+            border-radius: 0.25rem;
+            font-size: 0.875rem;
+        }
+
+        .supported-by-title {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .support-item {
+            margin-bottom: 0.5rem;
+        }
+
+        .support-ref {
+            font-weight: 500;
+            color: #2563eb;
+        }
+
+        .support-text {
+            color: #6b7280;
+            font-style: italic;
+            margin-left: 1rem;
+        }
+
+        a.term-link {
+            color: #2563eb;
+            text-decoration: none;
+        }
+
+        a.term-link:hover {
+            text-decoration: underline;
+        }
+
+        .core-function-terms {
+            margin-top: 1rem;
+        }
+
+        .function-term-group {
+            margin-bottom: 1rem;
+        }
+
+        .function-term-label {
+            font-weight: 600;
+            color: #4b5563;
+            margin-bottom: 0.25rem;
+        }
+
+        .reference-title {
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .findings-list {
+            margin-top: 1rem;
+            padding-left: 1.5rem;
+        }
+
+        .finding-item {
+            margin-bottom: 0.75rem;
+        }
+
+        .finding-statement {
+            font-weight: 500;
+            margin-bottom: 0.25rem;
+        }
+
+        .finding-text {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            font-style: italic;
+        }
+
+        .proposed-term {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fef3c7;
+        }
+
+        .question-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #dbeafe;
+        }
+
+        .experiment-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #f3e8ff;
+        }
+
+        .prediction-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: white;
+        }
+
+        .prediction-card .prediction-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+
+        .prediction-source {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .assessment-badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .assessment-cor { background-color: #dcfce7; color: #166534; }
+        .assessment-cnn { background-color: #dbeafe; color: #1e40af; }
+        .assessment-lsp { background-color: #fef9c3; color: #854d0e; }
+        .assessment-unc { background-color: #f3f4f6; color: #374151; }
+        .assessment-pli { background-color: #fee2e2; color: #991b1b; }
+        .assessment-npi { background-color: #fecaca; color: #7f1d1d; }
+        .assessment-rep { background-color: #fde68a; color: #92400e; }
+
+        .confidence-score {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            margin-left: 0.5rem;
+        }
+
+        .error-type-badge {
+            font-size: 0.75rem;
+            padding: 0.125rem 0.5rem;
+            border-radius: 0.25rem;
+            background-color: #fef2f2;
+            color: #991b1b;
+            border: 1px solid #fecaca;
+        }
+
+        .isoforms-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+            gap: 1rem;
+        }
+
+        .isoform-card {
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            padding: 1rem;
+            background-color: white;
+            transition: box-shadow 0.2s;
+        }
+
+        .isoform-card:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .functional-isoform-type {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .type-SPLICE_VARIANT, .type-SPLICE_CLASS {
+            background-color: #dbeafe;
+            color: #1e40af;
+            border: 1px solid #93c5fd;
+        }
+
+        .type-CLEAVAGE_PRODUCT {
+            background-color: #fef3c7;
+            color: #92400e;
+            border: 1px solid #fcd34d;
+        }
+
+        .type-MODIFICATION_STATE {
+            background-color: #f3e8ff;
+            color: #6b21a8;
+            border: 1px solid #c4b5fd;
+        }
+
+        .type-CONFORMATIONAL_STATE {
+            background-color: #dcfce7;
+            color: #166534;
+            border: 1px solid #86efac;
+        }
+
+        .functional-isoform-mappings {
+            margin-top: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .functional-isoform-mappings .mapping-type {
+            font-weight: 600;
+            color: var(--text-muted);
+            font-size: 0.75rem;
+        }
+
+        .functional-isoform-go {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .go-chip {
+            display: inline-block;
+            padding: 0.15rem 0.4rem;
+            background-color: #ecfdf5;
+            color: #047857;
+            border: 1px solid #a7f3d0;
+            border-radius: 0.25rem;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+
+        .isoform-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .isoform-name {
+            font-weight: 600;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .isoform-id {
+            font-family: monospace;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .isoform-sequence-note {
+            font-size: 0.875rem;
+            color: var(--text-muted);
+            margin-bottom: 0.5rem;
+            padding: 0.5rem;
+            background-color: var(--bg-light);
+            border-radius: 0.25rem;
+        }
+
+        .isoform-description {
+            font-size: 0.95rem;
+            line-height: 1.5;
+        }
+
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .collapsible:after {
+            content: ' ▼';
+            font-size: 0.75rem;
+        }
+
+        .collapsible.collapsed:after {
+            content: ' ►';
+        }
+
+        .collapse-content {
+            transition: max-height 0.3s ease;
+            overflow: hidden;
+        }
+
+        .collapsed + .collapse-content {
+            max-height: 0;
+        }
+
+        .no-data {
+            color: var(--text-muted);
+            font-style: italic;
+            padding: 1rem;
+            text-align: center;
+            background-color: var(--bg-light);
+            border-radius: 0.5rem;
+        }
+
+        /* Styling for markdown section summaries with voting */
+        .markdown-section summary {
+            padding: 0.75rem;
+            background: var(--bg-light);
+            border-radius: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .markdown-section summary:hover {
+            background: #e5e7eb;
+        }
+
+        .markdown-section summary .vote-buttons {
+            margin-left: auto;
+        }
+
+        .deep-research-section {
+            margin-bottom: 1rem;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8faff;
+        }
+
+        .deep-research-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .deep-research-section summary h3 {
+            margin: 0;
+            color: #3730a3;
+            font-size: 1.1rem;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin: 0.75rem 0 1rem;
+            align-items: center;
+        }
+
+        .report-badge {
+            display: inline-flex;
+            align-items: center;
+            border: 1px solid #c7d2fe;
+            border-radius: 999px;
+            background: #eef2ff;
+            color: #4338ca;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 0.2rem 0.6rem;
+        }
+
+        .report-meta-text {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+
+        .artifact-list {
+            display: grid;
+            gap: 0.75rem;
+            margin: 0.75rem 0 1rem;
+        }
+
+        .artifact-link {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin-top: 0.5rem;
+            word-break: break-word;
+        }
+
+        @media print {
+            body {
+                padding: 1rem;
+            }
+
+            .collapsible:after {
+                display: none;
+            }
+
+            .collapsed + .collapse-content {
+                max-height: none !important;
+            }
+        }
+
+        @media (max-width: 768px) {
+            body {
+                padding: 1rem;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .annotations-table {
+                font-size: 0.875rem;
+            }
+
+            .annotations-table th,
+            .annotations-table td {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>CP12</h1>
+        <div class="gene-info">
+            
+            <div class="info-item">
+                
+                <span class="info-label">UniProt ID:</span>
+                <span>
+                    <a href="https://www.uniprot.org/uniprotkb/A6Q0K5" target="_blank" class="term-link">
+                        A6Q0K5
+                    </a>
+                </span>
+                
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Organism:</span>
+                <span>Chlamydomonas reinhardtii</span>
+            </div>
+            
+            
+            <div class="info-item">
+                <span class="info-label">Review Status:</span>
+                <span class="status-badge status-draft">
+                    DRAFT
+                </span>
+            </div>
+            
+            
+        </div>
+        <div style="margin-top: 1rem; text-align: center;">
+            <a id="feedback-form-link"
+               href="#"
+               target="_blank"
+               style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 5px; font-weight: 600;">
+                📝 Provide Detailed Feedback
+            </a>
+            <script>
+                // Construct the form URL with proper encoding
+                // Extract organism code from the current page path (e.g., /genes/ARATH/APO1/ -> ARATH)
+                const pathParts = window.location.pathname.split('/');
+                const genesIndex = pathParts.indexOf('genes');
+                let organism = '';
+                if (genesIndex !== -1 && pathParts[genesIndex + 1]) {
+                    organism = pathParts[genesIndex + 1].toUpperCase();
+                }
+                const geneSymbol = "CP12";
+                const speciesGene = organism + ' ' + geneSymbol;
+                const formBaseUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSdTot9L6GVkkZYgLQT0E8ZdAJv8RiN5ZgOVkgWNcKSbYvxxzQ/viewform';
+                const entryId = '1226477767'; // Correct entry ID for Species/Gene field
+                const formUrl = formBaseUrl + '?entry.' + entryId + '=' + encodeURIComponent(speciesGene);
+                const feedbackLink = document.getElementById('feedback-form-link');
+                feedbackLink.href = formUrl;
+                // Add tooltip showing the pre-filled value
+                feedbackLink.title = 'Opens form with pre-filled: ' + speciesGene;
+            </script>
+        </div>
+    </div>
+
+    
+    <div class="description-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2>Gene Description</h2>
+            <span class="vote-buttons" data-g="A6Q0K5" data-a="DESCRIPTION: CP12 is a small (~8.5 kDa), nuclear-encoded, condi..." data-r="" data-act="DESCRIPTION">
+                <button class="vote-btn" data-v="up" title="Agree with this description">👍</button>
+                <button class="vote-btn" data-v="down" title="Disagree with this description">👎</button>
+            </span>
+        </div>
+        <p>CP12 is a small (~8.5 kDa), nuclear-encoded, conditionally disordered chloroplast protein that functions as a redox-sensitive linker/scaffold mediating the assembly of a supramolecular PRK/GAPDH/CP12 complex. In the dark, oxidized CP12 (with two intramolecular disulfide bonds) sequentially binds GAPDH then PRK, forming a ternary complex that inactivates both Calvin cycle enzymes. In the light, thioredoxin-mediated reduction of CP12 disulfide bonds causes the complex to dissociate, releasing active enzymes. CP12 also binds Cu2+ and Ni2+ ions in vitro; Cu2+ catalyzes re-oxidation of CP12 thiols, potentially linking metal homeostasis to Calvin cycle regulation.</p>
+    </div>
+    
+
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Proposed New Ontology Terms</h2>
+        
+        <div class="proposed-term">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>PRK-GAPDH-CP12 complex</h3>
+                <span class="vote-buttons" data-g="A6Q0K5" data-a="PRK-GAPDH-CP12 complex" data-r="" data-act="NEW">
+                    <button class="vote-btn" data-v="up" title="Agree this term should be created">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with creating this term">👎</button>
+                </span>
+            </div>
+
+            
+            <p><strong>Definition:</strong> A protein complex consisting of phosphoribulokinase (PRK), glyceraldehyde-3-phosphate dehydrogenase (GAPDH), and the linker protein CP12. The complex forms in the dark under oxidizing conditions and sequesters PRK and GAPDH in an inactive state, thereby negatively regulating the Calvin-Benson-Bassham cycle. Stoichiometry: 2 PRK dimers + 2 GAPDH tetramers + CP12.</p>
+            
+
+            
+            <p><strong>Justification:</strong> No GO complex term currently exists for this well-characterized supramolecular complex, which is conserved across photosynthetic organisms from cyanobacteria to higher plants. The current annotation uses the generic GO:0032991 (protein-containing complex).</p>
+            
+
+            
+            <p><strong>Parent term:</strong>
+                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
+                    protein-containing complex
+                </a>
+            </p>
+            
+
+            
+
+            
+            <p><strong>Supporting Evidence:</strong></p>
+            <ul style="margin-left: 1rem;">
+                
+                <li>
+                    
+                    <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" target="_blank" class="term-link">
+                        PMID:12846565
+                    </a>
+                    
+                    
+                    : It forms part of a core complex of two dimers of phosphoribulokinase (PRK), two tetramers of glyceraldehyde 3-phosphate dehydrogenase (GAPDH), and CP12
+                    
+                </li>
+                
+            </ul>
+            
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Existing Annotations Review</h2>
+        <table class="annotations-table">
+            <thead>
+                <tr>
+                    <th>GO Term</th>
+                    <th>Evidence</th>
+                    <th>Action</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009507" target="_blank" class="term-link">
+                                    GO:0009507
+                                </a>
+                            </span>
+                            <span class="term-label">chloroplast</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IEA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000044
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="A6Q0K5" data-a="GO:0009507" data-r="GO_REF:0000044" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Chloroplast localization is well-supported by multiple lines of evidence. CP12 has a 27-residue chloroplast transit peptide confirmed by direct protein sequencing (PMID:12846565), and IDA evidence from CAFA also supports this localization. This IEA annotation from UniProt subcellular location mapping is consistent with all other evidence.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Although this is an IEA annotation, it is fully consistent with the IDA evidence (PMID:12846565) showing chloroplast localization via transit peptide identification and direct protein sequencing. The UniProt record confirms chloroplast transit peptide residues 1-27 with experimental evidence.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" target="_blank" class="term-link">
+                                        PMID:12846565
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">CP12 is an 8.5-kDa nuclear-encoded chloroplast protein</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16259044" target="_blank" class="term-link">
+                                        PMID:16259044
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The small chloroplast protein CP12</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24863370" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24863370
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Conformational modulation and hydrodynamic radii of CP12 pro...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="A6Q0K5" data-a="GO:0005515" data-r="PMID:24863370" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This annotation records CP12 interaction with PRK (P19824) based on fluorescence correlation spectroscopy (FCS) experiments (PMID:24863370). While the interaction is real and well-documented, GO:0005515 (protein binding) is too generic per curation guidelines. CP12 binds the enzyme PRK as part of its core regulatory function; GO:0019899 (enzyme binding) is more informative and already annotated.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Per curation guidelines, GO:0005515 (protein binding) is uninformative. CP12&#39;s interaction with PRK is its core molecular function -- it acts as a scaffold/linker that binds PRK to form the regulatory PRK/GAPDH/CP12 complex. GO:0019899 (enzyme binding) is already annotated for the GAPDH interaction and is equally appropriate for the PRK interaction, as PRK is an enzyme (phosphoribulokinase, EC 2.7.1.19).
+                        </div>
+                        
+                        
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+                            
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019899" target="_blank" class="term-link">
+                                    enzyme binding
+                                </a>
+                            </span>
+                            
+                        </div>
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24863370" target="_blank" class="term-link">
+                                        PMID:24863370
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">we characterize the diffusion dynamics and hydrodynamic radii of CP12 from Chlamydomonas reinhardtii upon binding to GAPDH and PRK using fluorescence correlation spectroscopy experiments</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" target="_blank" class="term-link">
+                                        PMID:12846565
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">oxidized, but not reduced, CP12 acts as a linker in the assembly of the complex</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24863370" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:24863370
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Conformational modulation and hydrodynamic radii of CP12 pro...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="A6Q0K5" data-a="GO:0005515" data-r="PMID:24863370" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This annotation records CP12 interaction with GAPDH (P50362) based on FCS experiments (PMID:24863370). Same issue as the PRK protein binding annotation -- GO:0005515 is too generic. The GAPDH interaction is already covered by the enzyme binding annotation from PMID:12846565.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> GO:0005515 is uninformative per curation guidelines. CP12&#39;s interaction with GAPDH is its core function as a regulatory linker. GO:0019899 (enzyme binding) is more appropriate, as GAPDH is an enzyme (glyceraldehyde-3-phosphate dehydrogenase, EC 1.2.1.13). This interaction is already annotated as enzyme binding from PMID:12846565.
+                        </div>
+                        
+                        
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+                            
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019899" target="_blank" class="term-link">
+                                    enzyme binding
+                                </a>
+                            </span>
+                            
+                        </div>
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24863370" target="_blank" class="term-link">
+                                        PMID:24863370
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">we characterize the diffusion dynamics and hydrodynamic radii of CP12 from Chlamydomonas reinhardtii upon binding to GAPDH and PRK using fluorescence correlation spectroscopy experiments</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005515" target="_blank" class="term-link">
+                                    GO:0005515
+                                </a>
+                            </span>
+                            <span class="term-label">protein binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12846565
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The small protein CP12: a protein linker for supramolecular ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-modify">
+                            MODIFY
+                        </span>
+                        <span class="vote-buttons" data-g="A6Q0K5" data-a="GO:0005515" data-r="PMID:12846565" data-act="MODIFY">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This annotation records CP12 interaction with both PRK (P19824) and GAPDH (P50362) based on reconstitution assays and SPR binding studies (PMID:12846565). As with the other protein binding annotations, GO:0005515 is too generic. The interactions are real but better captured by GO:0019899 (enzyme binding).
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> GO:0005515 is uninformative per curation guidelines. CP12 acts as a linker for two Calvin cycle enzymes; enzyme binding (GO:0019899) is the appropriate term. The original paper clearly demonstrates CP12 binding to both PRK and GAPDH through reconstitution assays and surface plasmon resonance.
+                        </div>
+                        
+                        
+                        <div style="margin-top: 0.5rem;">
+                            <strong>Proposed replacements:</strong>
+                            
+                            <span class="badge">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019899" target="_blank" class="term-link">
+                                    enzyme binding
+                                </a>
+                            </span>
+                            
+                        </div>
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" target="_blank" class="term-link">
+                                        PMID:12846565
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">oxidized, but not reduced, CP12 acts as a linker in the assembly of the complex, and we propose a model in which CP12 associates with GAPDH, causing its conformation to change. This GAPDH/CP12 complex binds PRK to form a half-complex (one unit).</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009507" target="_blank" class="term-link">
+                                    GO:0009507
+                                </a>
+                            </span>
+                            <span class="term-label">chloroplast</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12846565
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The small protein CP12: a protein linker for supramolecular ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="A6Q0K5" data-a="GO:0009507" data-r="PMID:12846565" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Direct experimental evidence for chloroplast localization. The PMID:12846565 study determined the N-terminal sequence of the mature protein (residues 28-32), confirming cleavage of the chloroplast transit peptide and thereby demonstrating chloroplast import. UniProt lists this as transit peptide residues 1-27 with evidence from PMID:12846565.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Strong IDA evidence from direct protein sequencing confirming the transit peptide cleavage site. This is the primary experimental evidence for chloroplast localization and directly demonstrates that CP12 is imported into the chloroplast.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" target="_blank" class="term-link">
+                                        PMID:12846565
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">CP12 is an 8.5-kDa nuclear-encoded chloroplast protein</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019899" target="_blank" class="term-link">
+                                    GO:0019899
+                                </a>
+                            </span>
+                            <span class="term-label">enzyme binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IPI</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:12846565
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    The small protein CP12: a protein linker for supramolecular ...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="A6Q0K5" data-a="GO:0019899" data-r="PMID:12846565" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Enzyme binding is CP12&#39;s core molecular function. CP12 acts as a regulatory linker that binds two Calvin cycle enzymes: GAPDH (P50362, glyceraldehyde-3-phosphate dehydrogenase) and PRK (P19824, phosphoribulokinase). The WITH column specifies GAPDH (P50362). This was demonstrated through reconstitution assays and SPR binding studies (PMID:12846565), and independently confirmed by FCS (PMID:24863370).
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> This is the most informative molecular function term for CP12&#39;s core activity. CP12 is defined by its ability to bind and regulate GAPDH and PRK through redox-dependent complex assembly. Enzyme binding accurately captures this scaffold/linker function. The evidence is strong, based on multiple in vitro reconstitution approaches.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" target="_blank" class="term-link">
+                                        PMID:12846565
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">oxidized, but not reduced, CP12 acts as a linker in the assembly of the complex, and we propose a model in which CP12 associates with GAPDH, causing its conformation to change</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/24863370" target="_blank" class="term-link">
+                                        PMID:24863370
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">We quantify a hydrodynamic radius of 3.4 ± 0.2 nm for the CP12 protein with an increase up to 5.2 ± 0.3 nm upon complex formation with GAPDH and PRK</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009507" target="_blank" class="term-link">
+                                    GO:0009507
+                                </a>
+                            </span>
+                            <span class="term-label">chloroplast</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000024
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="A6Q0K5" data-a="GO:0009507" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> ISS annotation based on sequence similarity to Arabidopsis thaliana CP12 (O22914). Consistent with the IDA evidence from PMID:12846565 and the IEA annotation. This is redundant with the IDA evidence but not incorrect.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> Fully consistent with the IDA evidence (PMID:12846565). The ISS transfer from A. thaliana CP12 is appropriate given that chloroplast localization is a conserved feature of all CP12 family members, which universally possess chloroplast transit peptides.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" target="_blank" class="term-link">
+                                        PMID:12846565
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">CP12 is an 8.5-kDa nuclear-encoded chloroplast protein</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
+                                    GO:0032991
+                                </a>
+                            </span>
+                            <span class="term-label">protein-containing complex</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000024
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="A6Q0K5" data-a="GO:0032991" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> CP12 is part of the PRK/GAPDH/CP12 supramolecular complex. The annotation to the generic GO:0032991 (protein-containing complex) is correct but very broad. The full complex stoichiometry is 2 PRK dimers + 2 GAPDH tetramers + CP12 (PMID:12846565). A more specific GO complex term would be ideal, but no dedicated term for the PRK/GAPDH/CP12 complex currently exists in GO.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> While GO:0032991 is generic, there is no more specific GO term available for the PRK/GAPDH/CP12 complex. The annotation is accurate -- CP12 is indeed a component of a well-characterized protein-containing complex. The ISS transfer from A. thaliana CP12 is appropriate since the PRK/GAPDH/CP12 complex is conserved across photosynthetic organisms. Proposing a new GO term for this complex could be considered.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" target="_blank" class="term-link">
+                                        PMID:12846565
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">It forms part of a core complex of two dimers of phosphoribulokinase (PRK), two tetramers of glyceraldehyde 3-phosphate dehydrogenase (GAPDH), and CP12</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0080153" target="_blank" class="term-link">
+                                    GO:0080153
+                                </a>
+                            </span>
+                            <span class="term-label">negative regulation of reductive pentose-phosphate cycle</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">ISS</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            GO_REF:0000024
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-accept">
+                            ACCEPT
+                        </span>
+                        <span class="vote-buttons" data-g="A6Q0K5" data-a="GO:0080153" data-r="GO_REF:0000024" data-act="ACCEPT">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> This is the core biological process annotation for CP12. CP12 negatively regulates the Calvin-Benson-Bassham (reductive pentose-phosphate) cycle by sequestering PRK and GAPDH into an inactive complex in the dark. The ISS transfer from A. thaliana CP12 (O22914) is well-justified, as this regulatory function is conserved across all characterized CP12 proteins. CRISPR-Cas9 knockout of CP12 in C. reinhardtii (PMID:35269851) provides direct IMP-grade evidence in the target organism — delta-CP12 cells show abolished DTT-dependent regulation of GAPDH activity and 3-fold reduced PRK specific activity, confirming that CP12 is required in vivo for dark regulation of the Calvin cycle. An upgraded experimental evidence annotation (e.g. IMP from PMID:35269851) should be considered by the curation source.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> GO:0080153 precisely captures CP12&#39;s core biological process function. CP12 coordinates the dark inactivation of GAPDH and PRK, two key Calvin cycle enzymes, by assembling them into an inactive supramolecular complex. This is the most specific and accurate BP term for CP12&#39;s role. The ISS annotation is consistent with strong direct experimental evidence in C. reinhardtii from both reconstitution experiments (PMID:12846565) and CRISPR knockout studies (PMID:35269851), so an IMP upgrade in the source GOA is warranted.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" target="_blank" class="term-link">
+                                        PMID:12846565
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">oxidized, but not reduced, CP12 acts as a linker in the assembly of the complex</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16259044" target="_blank" class="term-link">
+                                        PMID:16259044
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">a PRK/GAPDH/CP12 complex that is involved in CO2 assimilation in photosynthetic organisms. The redox state of CP12 regulates its role as a protein linker.</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35269851" target="_blank" class="term-link">
+                                        PMID:35269851
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The chloroplast protein CP12 is involved in the dark/light regulation of the Calvin-Benson-Bassham cycle, in particular, in the dark inhibition of two enzymes</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35269851" target="_blank" class="term-link">
+                                        PMID:35269851
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">in the ∆CP12-Cr cell extracts, the NADPH-dependent activity of GAPDH displayed a linear curve regardless of DTT</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0005507" target="_blank" class="term-link">
+                                    GO:0005507
+                                </a>
+                            </span>
+                            <span class="term-label">copper ion binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16259044" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16259044
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mass spectrometric analysis of the interactions between CP12...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="A6Q0K5" data-a="GO:0005507" data-r="PMID:16259044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA evidence from ESI-MS experiments demonstrating specific Cu2+ binding by CP12 with Kd = 26 +/- 1 uM (PMID:16259044). Importantly, Cu2+ also catalyzes re-formation of CP12 disulfide bonds, potentially linking copper to Calvin cycle regulation. The authors note sequence similarity between CP12 and copper chaperones from A. thaliana. However, the primary biological function of CP12 is as a regulatory scaffold, not as a dedicated copper-binding protein; the in vivo significance of copper binding remains uncertain.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The copper binding is real (IDA evidence, specific binding with measured Kd), but it represents a secondary/potential moonlighting function rather than CP12&#39;s core evolved function. CP12&#39;s primary role is as a redox-dependent linker for the PRK/GAPDH complex. The copper-catalyzed thiol oxidation may be physiologically relevant as it could promote CP12&#39;s active (oxidized) conformation, but this remains speculative. Retaining as non-core appropriately reflects the evidence.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16259044" target="_blank" class="term-link">
+                                        PMID:16259044
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The oxidized protein bound specifically Cu2+ and Ni2+ (Kd of 26+/-1 microM and 11+/-1 microM, respectively); other cations such as Fe2+ and Zn2+ did not bind</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16259044" target="_blank" class="term-link">
+                                        PMID:16259044
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Cu2+ catalyzes the re-formation of the disulfide bonds of the reduced CP12, leading to recovery of the fully oxidized CP12 that is then able to bind a Cu2+ ion</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0016151" target="_blank" class="term-link">
+                                    GO:0016151
+                                </a>
+                            </span>
+                            <span class="term-label">nickel cation binding</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IDA</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/16259044" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:16259044
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Mass spectrometric analysis of the interactions between CP12...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-keepasnoncore">
+                            KEEP AS NON CORE
+                        </span>
+                        <span class="vote-buttons" data-g="A6Q0K5" data-a="GO:0016151" data-r="PMID:16259044" data-act="KEEP_AS_NON_CORE">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> IDA evidence from ESI-MS experiments showing specific Ni2+ binding by CP12 with Kd = 11 +/- 1 uM (PMID:16259044). The binding is more specific than Cu2+ (lower Kd) but the biological relevance is even less clear. Nickel is not known to play a significant role in chloroplast metabolism in green algae. The His74 mutation had no impact on metal binding, suggesting the binding site may involve other residues.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> The nickel binding is experimentally demonstrated (IDA) with good specificity (Kd = 11 uM, no binding of Fe2+ or Zn2+), but there is no evidence for an in vivo role. Unlike copper, nickel does not catalyze CP12 disulfide bond formation, so a regulatory connection to CP12&#39;s primary function is not established. This is a secondary characteristic best kept as non-core.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16259044" target="_blank" class="term-link">
+                                        PMID:16259044
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">The oxidized protein bound specifically Cu2+ and Ni2+ (Kd of 26+/-1 microM and 11+/-1 microM, respectively); other cations such as Fe2+ and Zn2+ did not bind</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/16259044" target="_blank" class="term-link">
+                                        PMID:16259044
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">the high similarity between CP12 and copper chaperones from Arabidopsis thaliana, as judged by hydrophobic cluster analysis, provides additional evidence for the relevance of metal binding for the in vivo situation</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+                <tr>
+                    <td>
+                        <div class="term-info">
+                            
+                            <span class="term-id">
+                                <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0050821" target="_blank" class="term-link">
+                                    GO:0050821
+                                </a>
+                            </span>
+                            <span class="term-label">protein stabilization</span>
+                            
+                        </div>
+                    </td>
+                    <td>
+                        <span class="evidence-code">IMP</span>
+                        
+                        
+                        
+                        <br>
+                        <span style="font-size: 0.75rem;">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35269851" target="_blank" class="term-link" style="font-size: 0.75rem;">
+                                PMID:35269851
+                            </a>
+                            
+                                
+                                
+                                <br>
+                                <span style="font-size: 0.7rem; color: #666; font-style: italic;">
+                                    Reduction in Phosphoribulokinase Amount and Re-Routing Metab...
+                                </span>
+                                
+                            
+                            
+                        </span>
+                        
+                    </td>
+                    <td>
+                        <span class="action-badge action-new">
+                            NEW
+                        </span>
+                        <span class="vote-buttons" data-g="A6Q0K5" data-a="GO:0050821" data-r="PMID:35269851" data-act="NEW">
+                            <button class="vote-btn" data-v="up" title="Agree with this decision">👍</button>
+                            <button class="vote-btn" data-v="down" title="Disagree with this decision">👎</button>
+                        </span>
+                    </td>
+                    <td>
+                        
+                        <div style="margin-bottom: 0.5rem;">
+                            <strong>Summary:</strong> Proposed new annotation reflecting a redox-independent moonlighting function of CP12. PMID:35269851 demonstrates that CP12 stabilizes PRK against irreversible inactivation both in vitro (recombinant CP12 prevents irreversible loss of PRK activity in a redox-independent manner; DTT can restore activity only when CP12 is present) and in vivo (ΔCP12 cells show 6.5-fold reduction in PRK protein abundance with no change in mRNA, consistent with loss of post-translational stabilization). Site-directed mutagenesis identifies specific residues (D36, E39, E40, W35, H47) required for this protective function.
+                        </div>
+                        
+                        
+                        <div>
+                            <strong>Reason:</strong> PMID:35269851 provides both in vivo (knockout) and in vitro (recombinant protein + mutagenesis) evidence that CP12 specifically protects PRK from irreversible inactivation in a redox-independent manner. This is mechanistically distinct from CP12&#39;s redox-dependent regulatory role in the PRK/GAPDH/CP12 complex and warrants a separate annotation. GO:0050821 (protein stabilization) accurately captures this function as the term covers maintenance of protein structure/integrity and prevention of aggregation/degradation.
+                        </div>
+                        
+                        
+                        
+                        <div class="supported-by">
+                            <div class="supported-by-title">Supporting Evidence:</div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35269851" target="_blank" class="term-link">
+                                        PMID:35269851
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">Isolated PRK lost irreversibly its activity over-time in vitro, which was prevented in the presence of recombinant CP12 in a redox-independent manner</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35269851" target="_blank" class="term-link">
+                                        PMID:35269851
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">in the presence of CP12, the addition of DTT restored the initial PRK activity, indicating that CP12 prevented this irreversible inactivation</div>
+                                
+                            </div>
+                            
+                            <div class="support-item">
+                                <span class="support-ref">
+                                    
+                                    <a href="https://pubmed.ncbi.nlm.nih.gov/35269851" target="_blank" class="term-link">
+                                        PMID:35269851
+                                    </a>
+                                    
+                                </span>
+                                
+                                <div class="support-text">a significant difference was observed for PRK amount, with a 6.5-fold decrease of PRK amount in ΔCP12-Cr compared to the WT-Cr strain</div>
+                                
+                            </div>
+                            
+                        </div>
+                        
+                    </td>
+                </tr>
+                
+            </tbody>
+        </table>
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Core Functions</h2>
+        
+        <div class="core-function-card">
+            
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <h3>Redox-dependent scaffold/linker that binds GAPDH and PRK to assemble an inactive PRK/GAPDH/CP12 supramolecular complex, negatively regulating the Calvin-Benson-Bassham cycle in the dark</h3>
+                <span class="vote-buttons" data-g="A6Q0K5" data-a="FUNCTION: Redox-dependent scaffold/linker that binds GAPDH a..." data-r="" data-act="CORE_FUNCTION">
+                    <button class="vote-btn" data-v="up" title="Agree with this core function">👍</button>
+                    <button class="vote-btn" data-v="down" title="Disagree with this core function">👎</button>
+                </span>
+            </div>
+            
+
+            <div class="core-function-terms">
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Molecular Function:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0019899" target="_blank" class="term-link">
+                            enzyme binding
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Directly Involved In:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0080153" target="_blank" class="term-link">
+                                negative regulation of reductive pentose-phosphate cycle
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">Cellular Locations:</div>
+                    <div class="function-annotations">
+                        
+                        <span class="badge">
+                            <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0009507" target="_blank" class="term-link">
+                                chloroplast
+                            </a>
+                        </span>
+                        
+                    </div>
+                </div>
+                
+
+                
+                <div class="function-term-group">
+                    <div class="function-term-label">In Complex:</div>
+                    <span class="badge">
+                        <a href="https://www.ebi.ac.uk/QuickGO/term/GO:0032991" target="_blank" class="term-link">
+                            protein-containing complex
+                        </a>
+                    </span>
+                </div>
+                
+
+                
+            </div>
+
+            
+            <div style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+                <strong>Supporting Evidence:</strong>
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" target="_blank" class="term-link">
+                                PMID:12846565
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">oxidized, but not reduced, CP12 acts as a linker in the assembly of the complex, and we propose a model in which CP12 associates with GAPDH, causing its conformation to change. This GAPDH/CP12 complex binds PRK to form a half-complex (one unit).</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/24863370" target="_blank" class="term-link">
+                                PMID:24863370
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">We quantify a hydrodynamic radius of 3.4 +/- 0.2 nm for the CP12 protein with an increase up to 5.2 +/- 0.3 nm upon complex formation with GAPDH and PRK</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <span class="reference-id">
+                            
+                            <a href="https://pubmed.ncbi.nlm.nih.gov/35269851" target="_blank" class="term-link">
+                                PMID:35269851
+                            </a>
+                            
+                        </span>
+                        
+                        <div class="finding-text">the abundance of PRK and its specific activity were significantly reduced in deltaCP12, as revealed by relative quantitative proteomics</div>
+                        
+                    </li>
+                    
+                </ul>
+            </div>
+            
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title collapsible">References</h2>
+        <div class="collapse-content">
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000024.md" target="_blank" class="term-link">
+                            GO_REF:0000024
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Manual transfer of experimentally-verified manual GO annotation data to orthologs by curator judgment of sequence similarity</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://github.com/geneontology/go-site/blob/master/metadata/gorefs/goref-0000044.md" target="_blank" class="term-link">
+                            GO_REF:0000044
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by conservative changes to GO terms applied by UniProt</div>
+                
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" target="_blank" class="term-link">
+                            PMID:12846565
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">The small protein CP12: a protein linker for supramolecular complex assembly.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Oxidized CP12 acts as a redox-sensitive linker for assembly of the PRK/GAPDH/CP12 supramolecular complex; reduced CP12 cannot reconstitute the complex.</div>
+                        
+                        <div class="finding-text">"oxidized, but not reduced, CP12 acts as a linker in the assembly of the complex"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">The complex has a stoichiometry of 2 PRK dimers, 2 GAPDH tetramers, and CP12. CP12 first binds GAPDH, then PRK is recruited.</div>
+                        
+                        <div class="finding-text">"It forms part of a core complex of two dimers of phosphoribulokinase (PRK), two tetramers of glyceraldehyde 3-phosphate dehydrogenase (GAPDH), and CP12"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Oxidized CP12 is mainly alpha-helical and flexible; reduced CP12 is mainly unstructured, consistent with intrinsically disordered protein properties.</div>
+                        
+                        <div class="finding-text">"Oxidized CP12 is mainly composed of alpha helix and coil segments, and is extremely flexible, while reduced CP12 is mainly unstructured"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">CP12 is a nuclear-encoded chloroplast protein with a transit peptide confirmed by N-terminal sequencing of the mature protein (residues 28-32).</div>
+                        
+                        <div class="finding-text">"CP12 is an 8.5-kDa nuclear-encoded chloroplast protein"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/16259044" target="_blank" class="term-link">
+                            PMID:16259044
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Mass spectrometric analysis of the interactions between CP12, a chloroplast protein, and metal ions: a possible regulatory role within a PRK/GAPDH/CP12 complex.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">CP12 specifically binds Cu2+ (Kd = 26 uM) and Ni2+ (Kd = 11 uM) but not Fe2+ or Zn2+, as shown by ESI-MS.</div>
+                        
+                        <div class="finding-text">"The oxidized protein bound specifically Cu2+ and Ni2+ (Kd of 26+/-1 microM and 11+/-1 microM, respectively); other cations such as Fe2+ and Zn2+ did not bind"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Cu2+ catalyzes re-oxidation of reduced CP12, promoting formation of the disulfide bonds required for linker activity.</div>
+                        
+                        <div class="finding-text">"Cu2+ catalyzes the re-formation of the disulfide bonds of the reduced CP12, leading to recovery of the fully oxidized CP12"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">CP12 shows sequence similarity to copper chaperones from Arabidopsis thaliana by hydrophobic cluster analysis, suggesting in vivo relevance of metal binding.</div>
+                        
+                        <div class="finding-text">"the high similarity between CP12 and copper chaperones from Arabidopsis thaliana, as judged by hydrophobic cluster analysis, provides additional evidence for the relevance of metal binding for the in vivo situation"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24863370" target="_blank" class="term-link">
+                            PMID:24863370
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Conformational modulation and hydrodynamic radii of CP12 protein and its complexes probed by fluorescence correlation spectroscopy.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">FCS confirms CP12 binding to GAPDH and PRK, with hydrodynamic radius increasing from 3.4 nm (free CP12) to 5.2 nm upon complex formation.</div>
+                        
+                        <div class="finding-text">"We quantify a hydrodynamic radius of 3.4 ± 0.2 nm for the CP12 protein with an increase up to 5.2 ± 0.3 nm upon complex formation with GAPDH and PRK"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">N-terminal and C-terminal cysteine mutants show different structural behavior during unfolding, suggesting distinct roles for the two disulfide bonds in mediating GAPDH vs PRK binding.</div>
+                        
+                        <div class="finding-text">"The different behavior of the CP12 mutant proteins during hydrophobic collapse transition is a direct clue to different structural orientations of the CP12 mutant proteins"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/35269851" target="_blank" class="term-link">
+                            PMID:35269851
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Reduction in Phosphoribulokinase Amount and Re-Routing Metabolism in Chlamydomonas reinhardtii CP12 Mutants.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">CRISPR-Cas9 knockout of CP12 in C. reinhardtii results in reduced PRK abundance and activity but normal GAPDH levels and near-normal growth.</div>
+                        
+                        <div class="finding-text">"the abundance of PRK and its specific activity were significantly reduced in ΔCP12, as revealed by relative quantitative proteomics"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">CP12 protects PRK from irreversible inactivation in a redox-independent manner, suggesting functions beyond Calvin cycle regulation.</div>
+                        
+                        <div class="finding-text">"in the presence of CP12, the addition of DTT restored the initial PRK activity, indicating that CP12 prevented this irreversible inactivation"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/24523724" target="_blank" class="term-link">
+                            PMID:24523724
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">The CP12 protein family: a thioredoxin-mediated metabolic switch?</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Review establishing CP12 as a conserved redox-sensitive protein found across all oxygenic phototrophs whose only clearly defined function is thioredoxin-mediated regulation of the Calvin cycle via GAPDH/PRK/CP12 complex assembly/disassembly.</div>
+                        
+                        <div class="finding-text">"The only clearly defined function for CP12 in any organism is in the thioredoxin-mediated regulation of the Calvin-Benson cycle"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">CP12 may have broader regulatory roles beyond Calvin cycle regulation, with evidence suggesting involvement in stress responses and additional metabolic functions.</div>
+                        
+                        <div class="finding-text">"CP12 may have a broader role in the regulation of metabolism, over and above the well established role of CP12 in the regulation of the Calvin-Benson cycle"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/30923119" target="_blank" class="term-link">
+                            PMID:30923119
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Arabidopsis and Chlamydomonas phosphoribulokinase crystal structures complete the redox structural proteome of the Calvin-Benson cycle.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Crystal structures of PRK from both Arabidopsis and Chlamydomonas reveal that the regulatory cysteines are connected by a flexible clamp loop unique to eukaryotic PRKs, completing the structural understanding of all redox-regulated Calvin cycle enzymes.</div>
+                        
+                        <div class="finding-text">"the regulatory cysteines are 13 Å apart and connected by a flexible region exclusive to photosynthetic eukaryotes-the clamp loop-which is believed to be essential for oxidation-induced structural rearrangements"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/39036361" target="_blank" class="term-link">
+                            PMID:39036361
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">The primary carbon metabolism in cyanobacteria and its regulation.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Review positioning CP12 as a principal redox regulator of the Calvin cycle especially in cyanobacteria, noting new metabolomics evidence that CP12 variants affect acclimation to external glucose under diurnal conditions and CO2 fluctuations.</div>
+                        
+                        <div class="finding-text">"New results of metabolomic and redox level analyses on strains with Cp12 variants extend the known role of Cp12 regulation towards the acclimation to external glucose supply under diurnal conditions as well as to fluctuations in CO2 levels in the light"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/37298260" target="_blank" class="term-link">
+                            PMID:37298260
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Conformational Disorder Analysis of the Conditionally Disordered Protein CP12 from Arabidopsis thaliana in Its Different Redox States.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">SAXS analysis of Arabidopsis CP12 confirms it is a conditionally disordered protein; reduced CP12 is highly disordered while oxidized CP12 gains partial structural order through disulfide bond formation but remains flexible.</div>
+                        
+                        <div class="finding-text">"a small angle X-ray scattering (SAXS) analysis of recombinant Arabidopsis CP12 (AtCP12) in a reduced and oxidized form confirmed the highly disordered nature of this regulatory protein"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/37719215" target="_blank" class="term-link">
+                            PMID:37719215
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Phosphoribulokinase abundance is not limiting the Calvin-Benson-Bassham cycle in Chlamydomonas reinhardtii.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">PRK is present in moderate excess in C. reinhardtii; approximately 86% of wild-type PRK content is sufficient for full photoautotrophic growth, and overexpression does not increase growth.</div>
+                        
+                        <div class="finding-text">"Immunoblot and growth assays revealed that a PRK content of ≈86% is sufficient to fully restore photoautotrophic growth"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+            <div class="reference-item">
+                <div class="reference-header">
+                    <span class="reference-id">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/31570616" target="_blank" class="term-link">
+                            PMID:31570616
+                        </a>
+                        
+                    </span>
+                </div>
+                
+                <div class="reference-title">Structural basis of light-induced redox regulation in the Calvin-Benson cycle in cyanobacteria.</div>
+                
+                
+                <ul class="findings-list">
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">Cryo-EM structure of the cyanobacterial GAPDH-CP12-PRK ternary complex reveals that CP12&#39;s N-terminal disulfide-stabilized helical hairpin plugs the PRK active-site cleft, while the C-terminal region binds GAPDH and influences substrate accessibility of all GAPDH active sites.</div>
+                        
+                        <div class="finding-text">"CP12 binding to GAPDH influences substrate accessibility of all GAPDH active sites in the binary and ternary inhibited complexes"</div>
+                        
+                    </li>
+                    
+                    <li class="finding-item">
+                        <div class="finding-statement">CP12 integrates responses from both the redox state (via disulfide bonds) and metabolite availability (NAD(H)/NADP(H) cofactor preference) to coordinate inhibition of GAPDH and PRK in the dark.</div>
+                        
+                        <div class="finding-text">"Our structural and biochemical data explain how CP12 integrates responses from both redox state and nicotinamide dinucleotide availability to regulate carbon fixation"</div>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </div>
+            
+        </div>
+    </div>
+    
+
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Questions for Experts</h2>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Is the copper ion binding by CP12 physiologically relevant in vivo, or is it an in vitro artifact? Does copper-catalyzed re-oxidation of CP12 thiols contribute to dark regulation of the Calvin cycle under normal conditions?</p>
+                    
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Gontero B, Launay H</em></p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="A6Q0K5" data-a="Q: Is the copper ion binding by CP12 physiologically ..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="question-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    <p><strong>Q:</strong> Should CP12&#39;s role in protecting PRK from irreversible inactivation (redox-independent) be annotated separately from its role in dark/light regulation of the Calvin cycle (redox-dependent)?</p>
+                    
+                    <p style="margin-top: 0.5rem;"><em>Suggested experts: Gontero B</em></p>
+                    
+                </div>
+                <span class="vote-buttons" data-g="A6Q0K5" data-a="Q: Should CP12&#39;s role in protecting PRK from irrevers..." data-r="" data-act="QUESTION">
+                    <button class="vote-btn" data-v="up" title="Good question to ask">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful question">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+    <div class="section">
+        <h2 class="section-title">Suggested Experiments</h2>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Measure Calvin cycle enzyme activity and PRK/GAPDH/CP12 complex formation in C. reinhardtii cells grown under copper-depleted vs. copper-replete conditions, comparing wild-type and ΔCP12 strains. Use immunoprecipitation to assess complex formation kinetics during light-to-dark transitions.</p>
+                    
+                    
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: CP12 copper binding is relevant in vivo for Calvin cycle regulation</em></p>
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="A6Q0K5" data-a="EXPERIMENT: Measure Calvin cycle enzyme activity and PRK/GAPDH..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+        <div class="experiment-card">
+            <div style="display: flex; justify-content: space-between; align-items: start;">
+                <div style="flex: 1;">
+                    
+                    <p><strong>Experiment:</strong> Perform in vivo crosslinking mass spectrometry (XL-MS) or proximity labeling (BioID/TurboID) with tagged CP12 in C. reinhardtii to identify the full interactome, including reported interactions with aldolase and malate dehydrogenase.</p>
+                    
+                    
+                    <p style="margin-top: 0.5rem;"><em>Hypothesis: CP12 has additional interaction partners beyond GAPDH and PRK</em></p>
+                    
+                    
+                </div>
+                <span class="vote-buttons" data-g="A6Q0K5" data-a="EXPERIMENT: Perform in vivo crosslinking mass spectrometry (XL..." data-r="" data-act="EXPERIMENT">
+                    <button class="vote-btn" data-v="up" title="Useful experiment">👍</button>
+                    <button class="vote-btn" data-v="down" title="Not a useful experiment">👎</button>
+                </span>
+            </div>
+        </div>
+        
+    </div>
+    
+
+    
+
+    <!-- Computational Predictions Section -->
+    
+
+    <!-- Deep Research Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">Deep Research</h2>
+        
+        <details class="deep-research-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Falcon</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CP12-deep-research-falcon.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="A6Q0K5" data-a="DEEP_RESEARCH: Falcon" data-r="" data-act="DEEP_RESEARCH" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This deep research is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This deep research needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                
+                <div class="report-meta">
+                    
+                    <span class="report-meta-text">this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</span>
+                    
+                    
+                    <span class="report-badge">Falcon</span>
+                    
+                    
+                    <span class="report-badge">Edison Scientific Literature</span>
+                    
+                    
+                    <span class="report-badge">25 citations</span>
+                    
+                    
+                    
+                    <span class="report-meta-text">2026-03-12T23:27:04.245221</span>
+                    
+                    
+                    
+                </div>
+                
+                
+                <p>The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.</p>
+<p>You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement<br />
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.</p>
+<p>We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.</p>
+<p>We are interested in where in or outside the cell the gene product carries out its function.</p>
+<p>We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.</p>
+<p>Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.</p>
+<h2 id="research-report-cp12-uniprot-a6q0k5-in-chlamydomonas-reinhardtii">Research report: CP12 (UniProt A6Q0K5) in <em>Chlamydomonas reinhardtii</em></h2>
+<h3 id="0-target-verification-mandatory-disambiguation">0) Target verification (mandatory disambiguation)</h3>
+<p>The symbol <strong>CP12</strong> is used across oxygenic phototrophs for “Calvin cycle protein 12,” a small chloroplast redox-regulatory protein. For the <strong>specific target</strong> provided (UniProt <strong>A6Q0K5</strong>, <em>Chlamydomonas reinhardtii</em>), the literature matches the UniProt description: CP12 is a small, nuclear-encoded <strong>chloroplast</strong> protein of the <strong>CP12 family</strong> that regulates the Calvin–Benson–Bassham cycle (CBBC) by forming a <strong>redox-controlled inhibitory complex</strong> with <strong>GAPDH</strong> and <strong>PRK</strong>. Primary Chlamydomonas genetic work explicitly states CP12 is encoded by a <strong>unique/single CP12 gene/isoform</strong> in <em>C. reinhardtii</em> and describes ΔCP12 mutants. (gerard2022reductioninphosphoribulokinase pages 1-2, gerard2022reductioninphosphoribulokinase pages 8-10, lopezcalcagno2014thecp12protein pages 2-3)</p>
+<h3 id="1-key-concepts-and-definitions-current-understanding">1) Key concepts and definitions (current understanding)</h3>
+<h4 id="11-cp12-as-a-calvinbenson-cycle-regulatory-switch">1.1 CP12 as a Calvin–Benson cycle regulatory “switch”</h4>
+<p>CP12 is best understood as a <strong>thioredoxin (Trx)-linked, light/dark-responsive metabolic switch</strong> that turns off key CBBC steps in the dark/oxidizing conditions by promoting formation of a <strong>GAPDH–CP12–PRK</strong> ternary complex that inhibits both enzymes; in the light/reducing conditions, Trx reduces regulatory disulfides and the complex dissociates, restoring enzymatic activity. (lopezcalcagno2014thecp12protein pages 2-3, gerard2022reductioninphosphoribulokinase pages 1-2)</p>
+<h4 id="12-conditionally-disordered-protein-cdpidp-behavior">1.2 Conditionally disordered protein (CDP/IDP behavior)</h4>
+<p>A defining modern concept is that CP12 is a <strong>redox-dependent conditionally disordered protein</strong>: reduced CP12 is highly disordered, whereas oxidation (disulfide formation) partially orders CP12 but does not necessarily create a fully compact folded free state—partner binding completes functional structuring. This “disorder-to-partial-order” logic is central to how CP12 can rapidly engage/disengage partners. (giudice2023conformationaldisorderanalysis pages 1-2, mcfarlane2019structuralbasisof pages 1-2)</p>
+<h4 id="13-canonical-sequencestructural-hallmarks">1.3 Canonical sequence/structural hallmarks</h4>
+<p>Across the green lineage, canonical CP12 proteins are ~80 aa and contain an <strong>N-terminal cysteine pair</strong>, a <strong>C-terminal cysteine pair</strong>, and a conserved central <strong>AWD_VEEL</strong>-like motif; the two cysteine pairs form <strong>two intramolecular disulfide bridges</strong> in oxidizing conditions. (giudice2023conformationaldisorderanalysis pages 1-2, lopezcalcagno2014thecp12protein pages 2-3)</p>
+<h3 id="2-molecular-mechanism-structure-redox-control-and-inhibition-of-gapdhprk">2) Molecular mechanism: structure, redox control, and inhibition of GAPDH/PRK</h3>
+<h4 id="21-domain-organization-and-disulfide-priming">2.1 Domain organization and disulfide “priming”</h4>
+<p>High-resolution structural work (cyanobacterial homologs; mechanism conserved across algae/plants) describes CP12 as bipartite with:<br />
+- An <strong>N-terminal PRK-binding domain</strong> (two α-helices forming a hairpin/2-helix bundle) stabilized by an N-terminal disulfide (example: <strong>Cys19–Cys29</strong>), and<br />
+- A <strong>C-terminal GAPDH-binding domain</strong>,<br />
+connected by a flexible linker. Oxidation “preorders” the N-terminus for PRK binding. (mcfarlane2019structuralbasisof pages 2-3, mcfarlane2019structuralbasisof pages 1-2)</p>
+<h4 id="22-how-cp12-inhibits-prk-and-gapdh">2.2 How CP12 inhibits PRK and GAPDH</h4>
+<p>In the inhibited ternary complex, CP12 <strong>sterically blocks</strong> enzyme active sites: the <strong>CP12 N-terminal helical bundle plugs the PRK active-site cleft</strong>, and the CP12 C-terminus occupies/affects GAPDH active-site regions and alters substrate access. (mcfarlane2019structuralbasisof pages 2-3, mcfarlane2019structuralbasisof pages 1-2)</p>
+<p>Structural evidence for the ternary complex is visually summarized in cropped figure regions from McFarlane et al. 2019 (PNAS), showing CP12 bridging PRK and GAPDH and the disulfide-stabilized PRK-binding hairpin. (mcfarlane2019structuralbasisof media e719c995, mcfarlane2019structuralbasisof media c7aae535, mcfarlane2019structuralbasisof media 44ce9d30)</p>
+<h4 id="23-sequential-complex-assembly-gapdh-prk">2.3 Sequential complex assembly (GAPDH → PRK)</h4>
+<p>Multiple sources support a <strong>sequential assembly</strong> model in which CP12 first binds GAPDH to form a GAPDH–CP12 binary complex, which then recruits PRK to form the ternary complex. (gerard2022reductioninphosphoribulokinase pages 1-2, mcfarlane2019structuralbasisof pages 1-2)</p>
+<h4 id="24-stoichiometry-and-metabolite-nadhnadph-bpga-coupling">2.4 Stoichiometry and metabolite (NAD(H)/NADP(H), BPGA) coupling</h4>
+<p>CP12 also integrates <strong>nicotinamide dinucleotide availability</strong>:<br />
+- In one described binary complex, each GAPDH tetramer <strong>typically binds two CP12</strong> molecules physiologically (though higher occupancy can be obtained in vitro under CP12 excess). (mcfarlane2019structuralbasisof pages 2-3)<br />
+- A plant-type inhibited complex architecture is described as <strong>GAPDH2–CP124–PRK2</strong>, and complex stability can depend on metabolites: <strong>NAD(H) stabilizes</strong> inhibited assemblies, while <strong>NADP(H)</strong> and <strong>BPGA (1,3-bisphosphoglycerate)</strong> destabilize; reduced thioredoxins also destabilize the complex. (giudice2023conformationaldisorderanalysis pages 1-2)<br />
+- Structural contacts suggest CP12 can be <strong>incompatible with NADP(H)</strong> at certain sites (e.g., CP12 Glu69 disfavors NADP(H) binding). (mcfarlane2019structuralbasisof pages 2-3)</p>
+<h3 id="3-subcellular-localization-and-pathway-context-where-cp12-acts">3) Subcellular localization and pathway context (where CP12 acts)</h3>
+<h4 id="31-cellular-compartment">3.1 Cellular compartment</h4>
+<p>In <em>C. reinhardtii</em>, CP12 is described as a <strong>nuclear-encoded chloroplast protein</strong>. Functionally it acts in the chloroplast where the CBBC enzymes GAPDH and PRK operate (classically in the <strong>chloroplast stroma</strong>). (gerard2022reductioninphosphoribulokinase pages 1-2)</p>
+<h4 id="32-pathway-placement-and-primary-function">3.2 Pathway placement and “primary function”</h4>
+<p>CP12 does <strong>not catalyze a reaction</strong>. Its primary function is <strong>regulatory/scaffolding</strong>: to control CBBC flux by inhibiting (and in some cases stabilizing) two key enzymes:<br />
+- <strong>GAPDH</strong> (the NADPH-dependent reductive step producing glyceraldehyde-3-phosphate), and<br />
+- <strong>PRK</strong> (ATP-dependent phosphorylation producing RuBP from Ru5P).<br />
+The literature explicitly frames CP12 as a coordinator (“conductor”) of these two key steps that represent the unique reduction and a key phosphorylation step in the CBBC. (gerard2022reductioninphosphoribulokinase pages 8-10)</p>
+<h3 id="4-chlamydomonas-specific-functional-genetics-phenotypes-and-quantitative-data">4) Chlamydomonas-specific functional genetics, phenotypes, and quantitative data</h3>
+<h4 id="41-unique-geneisoform-in-c-reinhardtii">4.1 Unique gene/isoform in <em>C. reinhardtii</em></h4>
+<p>Unlike land plants that often encode multiple CP12 isoforms, <em>C. reinhardtii</em> is reported to possess a <strong>single/unique canonical CP12 isoform</strong>, enabling relatively clean functional genetics. (gerard2022reductioninphosphoribulokinase pages 8-10, lopezcalcagno2014thecp12protein pages 2-3)</p>
+<h4 id="42-cp12-phenotypes-growth-and-regulation">4.2 ΔCP12 phenotypes: growth and regulation</h4>
+<p>A CRISPR-Cas9 knockout of CP12 (ΔCP12) showed:<br />
+- <strong>No major growth defect</strong> under tested conditions (including continuous light and a light/dark cycle in the referenced study),<br />
+- <strong>Loss of the typical redox-dependent GAPDH regulation signature</strong> in extracts (WT extracts show behavior consistent with an inhibited ternary complex that can be relieved by reductants; ΔCP12 extracts show linear NADPH-dependent GAPDH activity),<br />
+- <strong>PRK activity reduction</strong> and lower PRK abundance. (gerard2022reductioninphosphoribulokinase pages 2-4, gerard2022reductioninphosphoribulokinase pages 1-2)</p>
+<p>A separate dissertation source reports a <strong>diurnal growth phenotype</strong> (slower growth under 12 h light/12 h dark but not under continuous light) and proposes that in CP12 knockouts PRK/GAPDH protein levels fluctuate (accumulation–degradation) across the cycle, delaying response to changing conditions. (teh2021regulationofcp12mediated pages 63-65)</p>
+<h4 id="43-key-quantitative-statistics-recentnear-recent">4.3 Key quantitative statistics (recent/near-recent)</h4>
+<ul>
+<li><strong>PRK activity in Chlamydomonas ΔCP12</strong>: WT 1143 ± 328 vs ΔCP12 430 ± 94 µM·min−1·mg−1 (~3-fold reduction; p = 0.0004 reported). (gerard2022reductioninphosphoribulokinase pages 2-4)</li>
+<li><strong>PRK protein abundance in ΔCP12</strong>: reported ~<strong>6-fold lower</strong> PRK levels in ΔCP12 under continuous light (quantitative proteomics). (gerard2022reductioninphosphoribulokinase pages 10-11)</li>
+<li><strong>PRK stability/chaperone-like role</strong>: purified PRK loses activity over time in vitro, and recombinant CP12 prevents this loss in a manner described as <strong>redox-independent</strong>, supporting an additional “moonlighting” protective function (beyond redox gating). (gerard2022reductioninphosphoribulokinase pages 1-2, gerard2022reductioninphosphoribulokinase pages 10-11)</li>
+<li><strong>CP12 structural pre-organization in vivo context</strong>: CP12 is discussed as intrinsically disordered with a small preformed helical fraction <strong>below ~20%</strong>, proposed to facilitate low-affinity PRK interaction. (gerard2022reductioninphosphoribulokinase pages 10-11)</li>
+</ul>
+<h3 id="5-recent-developments-prioritizing-20232024">5) Recent developments (prioritizing 2023–2024)</h3>
+<h4 id="51-2023-quantitative-engineering-framework-around-prk-a-cp12-regulated-node">5.1 2023: quantitative engineering framework around PRK (a CP12-regulated node)</h4>
+<p>A 2023 <em>Frontiers in Plant Science</em> study engineered <em>C. reinhardtii</em> strains with PRK levels spanning <strong>~16% to 250%</strong> of WT, showing that <strong>~86% PRK</strong> content is sufficient to fully restore photoautotrophic growth and that PRK is present in <strong>moderate excess</strong> under optimal conditions. This work explicitly notes PRK is regulated by thioredoxin and also by dark formation of the inhibitory <strong>GAPDH–CP12–PRK</strong> complex, emphasizing that regulation (not only abundance) matters for CBBC control and synthetic design. (boisset2023phosphoribulokinaseabundanceis pages 1-2, boisset2023phosphoribulokinaseabundanceis pages 2-3)</p>
+<h4 id="52-2023-updated-biophysical-view-of-cp12-disorder-and-metabolite-regulation">5.2 2023: updated biophysical view of CP12 disorder and metabolite regulation</h4>
+<p>A 2023 SAXS-focused study (Arabidopsis CP12) provides contemporary experimental support for CP12 as a redox-dependent conditionally disordered protein, and it compiles mechanistic consensus that the inhibited GAPDH–CP12–PRK assembly is sensitive to <strong>thioredoxin</strong>, <strong>NAD(H)/NADP(H)</strong> and <strong>BPGA</strong>. While not Chlamydomonas-specific, these are conserved principles directly relevant to interpreting the CP12 family protein A6Q0K5. (giudice2023conformationaldisorderanalysis pages 1-2)</p>
+<h4 id="53-2024-expert-synthesis-connecting-cp12-variants-to-metabolomeredox-phenotypes-and-biotechnology">5.3 2024: expert synthesis connecting CP12 variants to metabolome/redox phenotypes and biotechnology</h4>
+<p>A 2024 expert review on cyanobacterial primary carbon metabolism highlights that “new results” from <strong>metabolomic and redox analyses</strong> on strains with <strong>Cp12 variants</strong> extend CP12’s role toward acclimation to <strong>external glucose under diurnal conditions</strong> and to <strong>CO2 fluctuations in the light</strong>. The review explicitly frames such regulatory discoveries as enabling <strong>targeted redirection of carbon flow</strong> and helping establish cyanobacteria as <strong>green cell factories</strong> powered by sunlight and CO2. (lucius2024theprimarycarbon pages 1-2)</p>
+<h3 id="6-current-applications-and-real-world-implementations">6) Current applications and real-world implementations</h3>
+<h4 id="61-synthetic-biology-metabolic-engineering-in-microalgae">6.1 Synthetic biology / metabolic engineering in microalgae</h4>
+<p>The 2023 PRK engineering work in <em>C. reinhardtii</em> provides a concrete example of real-world implementation: modular redesign of transcriptional units (promoters/introns) to tune enzyme abundance across a wide range (16–250% WT) and identify sufficiency thresholds for growth (≈86% WT PRK). Because PRK is a CP12-regulated enzyme (complex formation in the dark; thioredoxin-dependent dissociation), this engineering framework is directly relevant to designing strains where <strong>regulatory dynamics</strong> are optimized rather than only boosting protein levels. (boisset2023phosphoribulokinaseabundanceis pages 1-2, boisset2023phosphoribulokinaseabundanceis pages 2-3)</p>
+<h4 id="62-prospective-applications-tuning-switchable-cbbc-control-points">6.2 Prospective applications: tuning “switchable” CBBC control points</h4>
+<p>Structural and mechanistic insights highlight CP12 as a rational engineering target: because CP12 integrates <strong>redox state</strong> and <strong>dinucleotide availability</strong>, altering CP12–partner interfaces (or CP12 cysteines) could tune the on/off kinetics of carbon fixation across light regimes, with implications for productivity under fluctuating light. The PNAS structural study explicitly notes that understanding this regulation provides a starting point for modulating redox regulation with potential applications in improving productivity. (mcfarlane2019structuralbasisof pages 1-2)</p>
+<h4 id="63-systemsbioprocess-framing-green-cell-factories">6.3 Systems/bioprocess framing: green cell factories</h4>
+<p>The 2024 review explicitly links CP12-mediated regulation to the broader goal of <strong>redirecting carbon allocation toward desired compounds</strong>, i.e., a design goal in industrial phototrophic biotechnology. CP12’s position at a major control point (PRK + GAPDH inhibition) makes it a plausible “valve” for balancing storage vs growth vs product formation under diurnal or mixotrophic regimes. (lucius2024theprimarycarbon pages 1-2)</p>
+<h3 id="7-expert-opinions-and-analysis-authoritative-sources">7) Expert opinions and analysis (authoritative sources)</h3>
+<ul>
+<li>A widely cited review describes CP12 as the <strong>only clearly defined function</strong> for CP12 in any organism being its role in <strong>thioredoxin-mediated regulation of the Calvin–Benson cycle</strong> through assembly/disassembly of the GAPDH/PRK/CP12 complex; it highlights rapid (minute-scale) light-responsive switching and proposes broader “metabolic switch” roles. (lopezcalcagno2014thecp12protein pages 2-3)</li>
+<li>The 2024 cyanobacterial carbon metabolism review positions CP12 as a principal redox regulator (especially in cyanobacteria where many CBBC enzymes lack direct thioredoxin regulation) and emphasizes new metabolomics/redox evidence expanding CP12 function to additional acclimation contexts relevant to biotechnology. (lucius2024theprimarycarbon pages 1-2, lucius2024theprimarycarbon pages 9-10)</li>
+</ul>
+<h3 id="8-key-statisticsdata-summary-selected">8) Key statistics/data summary (selected)</h3>
+<ul>
+<li>PRK engineering range in <em>C. reinhardtii</em>: <strong>~16–250% of WT PRK</strong>, with <strong>~86% WT PRK sufficient</strong> for fully restored photoautotrophic growth (Aug 2023). (boisset2023phosphoribulokinaseabundanceis pages 1-2)</li>
+<li>ΔCP12 effects on PRK (Feb 2022): PRK activity <strong>1143 ± 328 → 430 ± 94 µM·min−1·mg−1</strong> (~3× decrease); PRK abundance reported <strong>~6-fold lower</strong>; broad proteome remodeling including photosynthetic components. (gerard2022reductioninphosphoribulokinase pages 10-11, gerard2022reductioninphosphoribulokinase pages 2-4)</li>
+<li>Complex architecture: CP12 N-terminal disulfide-stabilized helical hairpin blocks PRK active site; CP12–GAPDH interactions can be incompatible with NADP(H) at certain sites; typical binary complex has <strong>two CP12 per GAPDH tetramer</strong> (Sep 2019). (mcfarlane2019structuralbasisof pages 2-3)</li>
+</ul>
+<h3 id="9-evidence-backed-annotation-summary-table">9) Evidence-backed annotation summary table</h3>
+<table>
+<thead>
+<tr>
+<th>Annotation aspect</th>
+<th>Specific claim</th>
+<th>Key evidence sources (year, DOI URL)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Role (GAPDH/PRK complex)</td>
+<td>CP12 assembles an inhibitory GAPDH–CP12–PRK ternary complex in the dark, sequentially binding GAPDH then PRK; complex dissociates in the light via thioredoxin, activating both enzymes.</td>
+<td>López-Calcagno 2014 — https://doi.org/10.3389/fpls.2014.00009 (lopezcalcagno2014thecp12protein pages 2-3); McFarlane 2019 — https://doi.org/10.1073/pnas.1906722116 (mcfarlane2019structuralbasisof pages 1-2); Gérard 2022 — https://doi.org/10.3390/ijms23052710 (gerard2022reductioninphosphoribulokinase pages 8-10)</td>
+</tr>
+<tr>
+<td>Redox regulation</td>
+<td>CP12 is a conditionally disordered protein: reduced CP12 is highly disordered; oxidation forms two intramolecular disulfides that partially order domains and enable binding, with thioredoxin and pyridine nucleotides modulating complex stability.</td>
+<td>Del Giudice 2023 — https://doi.org/10.3390/ijms24119308 (giudice2023conformationaldisorderanalysis pages 1-2); McFarlane 2019 — https://doi.org/10.1073/pnas.1906722116 (mcfarlane2019structuralbasisof pages 2-3); López-Calcagno 2014 — https://doi.org/10.3389/fpls.2014.00009 (lopezcalcagno2014thecp12protein pages 2-3)</td>
+</tr>
+<tr>
+<td>Localization (chloroplast stroma)</td>
+<td>CP12 is a nuclear-encoded chloroplast protein; the PRK/CP12/GAPDH supracomplex (~550 kDa) forms in the chloroplast stroma.</td>
+<td>Teh 2021 — https://doi.org/10.5282/edoc.29016 (teh2021regulationofcp12mediated pages 18-20); Gérard 2022 — https://doi.org/10.3390/ijms23052710 (gerard2022reductioninphosphoribulokinase pages 1-2)</td>
+</tr>
+<tr>
+<td>Genetics (copy number; mutant)</td>
+<td>Chlamydomonas reinhardtii possesses a single/unique canonical CP12 gene; a ΔCP12 knockout was generated for functional analysis.</td>
+<td>Gérard 2022 — https://doi.org/10.3390/ijms23052710 (gerard2022reductioninphosphoribulokinase pages 1-2, gerard2022reductioninphosphoribulokinase pages 8-10); López-Calcagno 2014 — https://doi.org/10.3389/fpls.2014.00009 (lopezcalcagno2014thecp12protein pages 2-3)</td>
+</tr>
+<tr>
+<td>Quantitative stats — PRK decrease in ΔCP12</td>
+<td>In ΔCP12, PRK protein amount is reduced ~6-fold and PRK activity declines; CP12 protects PRK from irreversible inactivation in vitro in a redox-independent manner.</td>
+<td>Gérard 2022 — https://doi.org/10.3390/ijms23052710 (gerard2022reductioninphosphoribulokinase pages 10-11)</td>
+</tr>
+<tr>
+<td>Quantitative stats — PRK abundance window</td>
+<td>Engineered PRK levels spanning ~16–250% of WT show that ~86% of WT PRK suffices to fully restore photoautotrophic growth; PRK is not limiting under optimal conditions.</td>
+<td>Boisset 2023 — https://doi.org/10.3389/fpls.2023.1230723 (boisset2023phosphoribulokinaseabundanceis pages 1-2, boisset2023phosphoribulokinaseabundanceis pages 2-3)</td>
+</tr>
+<tr>
+<td>Structural notes</td>
+<td>CP12 carries two conserved cysteine pairs (N-terminal disulfide preorders a helix-hairpin for PRK binding; C-terminal region binds GAPDH); CP12 remains largely disordered with a small preformed helical fraction (&lt;20%).</td>
+<td>McFarlane 2019 — https://doi.org/10.1073/pnas.1906722116 (mcfarlane2019structuralbasisof pages 2-3); Gérard 2022 — https://doi.org/10.3390/ijms23052710 (gerard2022reductioninphosphoribulokinase pages 10-11); Del Giudice 2023 — https://doi.org/10.3390/ijms24119308 (giudice2023conformationaldisorderanalysis pages 1-2)</td>
+</tr>
+</tbody>
+</table>
+<p><em>Table: Concise, evidence-backed annotations for CP12 (UniProt A6Q0K5) in Chlamydomonas reinhardtii, covering function, redox control, localization, genetics, quantitative impacts, and structural features. Useful for rapid verification and for guiding functional studies or engineering of Calvin cycle regulation.</em></p>
+<h3 id="10-notes-on-evidence-limitations">10) Notes on evidence limitations</h3>
+<ul>
+<li>Direct 2023–2024 primary experimental studies on <strong>Chlamydomonas CP12 itself</strong> (as opposed to PRK engineering or general CP12 biophysics) are relatively sparse in the retrieved corpus; most Chlamydomonas CP12 functional genetics evidence is from 2022, with 2023–2024 advances mainly providing (i) engineering frameworks around CP12-regulated nodes (e.g., PRK) and (ii) updated conserved mechanistic/biophysical insights and metabolomics/redox expansions in other phototrophs. (boisset2023phosphoribulokinaseabundanceis pages 1-2, giudice2023conformationaldisorderanalysis pages 1-2, lucius2024theprimarycarbon pages 1-2)</li>
+</ul>
+<h3 id="key-cited-sources-with-dates-and-urls-selection">Key cited sources with dates and URLs (selection)</h3>
+<ul>
+<li>Gérard et al., <strong>Feb 2022</strong>, <em>Int. J. Mol. Sci.</em> “Reduction in Phosphoribulokinase Amount and Re-Routing Metabolism in <em>Chlamydomonas reinhardtii</em> CP12 Mutants” https://doi.org/10.3390/ijms23052710 (gerard2022reductioninphosphoribulokinase pages 1-2, gerard2022reductioninphosphoribulokinase pages 2-4)</li>
+<li>Boisset et al., <strong>Aug 2023</strong>, <em>Frontiers in Plant Science</em> “Phosphoribulokinase abundance is not limiting the Calvin-Benson-Bassham cycle in <em>Chlamydomonas reinhardtii</em>” https://doi.org/10.3389/fpls.2023.1230723 (boisset2023phosphoribulokinaseabundanceis pages 1-2)</li>
+<li>Del Giudice et al., <strong>May 2023</strong>, <em>Int. J. Mol. Sci.</em> “Conformational Disorder Analysis of… CP12… in different redox states” https://doi.org/10.3390/ijms24119308 (giudice2023conformationaldisorderanalysis pages 1-2)</li>
+<li>Lucius &amp; Hagemann, <strong>Jul 2024</strong>, <em>Frontiers in Plant Science</em> “The primary carbon metabolism in cyanobacteria and its regulation” https://doi.org/10.3389/fpls.2024.1417680 (lucius2024theprimarycarbon pages 1-2)</li>
+<li>McFarlane et al., <strong>Sep 2019</strong>, <em>PNAS</em> “Structural basis of light-induced redox regulation…” https://doi.org/10.1073/pnas.1906722116 (mcfarlane2019structuralbasisof pages 1-2, mcfarlane2019structuralbasisof media e719c995)</li>
+<li>López-Calcagno et al., <strong>Jan 2014</strong>, <em>Frontiers in Plant Science</em> “The CP12 protein family: a thioredoxin-mediated metabolic switch?” https://doi.org/10.3389/fpls.2014.00009 (lopezcalcagno2014thecp12protein pages 2-3)</li>
+</ul>
+<p>References</p>
+<ol>
+<li>
+<p>(gerard2022reductioninphosphoribulokinase pages 1-2): Cassy Gérard, Régine Lebrun, Erwan Lemesle, Luisana Avilan, Kwang Suk Chang, EonSeon Jin, Frédéric Carrière, Brigitte Gontero, and Hélène Launay. Reduction in phosphoribulokinase amount and re-routing metabolism in chlamydomonas reinhardtii cp12 mutants. International Journal of Molecular Sciences, 23:2710, Feb 2022. URL: https://doi.org/10.3390/ijms23052710, doi:10.3390/ijms23052710. This article has 13 citations.</p>
+</li>
+<li>
+<p>(gerard2022reductioninphosphoribulokinase pages 8-10): Cassy Gérard, Régine Lebrun, Erwan Lemesle, Luisana Avilan, Kwang Suk Chang, EonSeon Jin, Frédéric Carrière, Brigitte Gontero, and Hélène Launay. Reduction in phosphoribulokinase amount and re-routing metabolism in chlamydomonas reinhardtii cp12 mutants. International Journal of Molecular Sciences, 23:2710, Feb 2022. URL: https://doi.org/10.3390/ijms23052710, doi:10.3390/ijms23052710. This article has 13 citations.</p>
+</li>
+<li>
+<p>(lopezcalcagno2014thecp12protein pages 2-3): Patricia E. López-Calcagno, Thomas P. Howard, and Christine A. Raines. The cp12 protein family: a thioredoxin-mediated metabolic switch? Frontiers in Plant Science, Jan 2014. URL: https://doi.org/10.3389/fpls.2014.00009, doi:10.3389/fpls.2014.00009. This article has 111 citations.</p>
+</li>
+<li>
+<p>(giudice2023conformationaldisorderanalysis pages 1-2): Alessandra Del Giudice, Libero Gurrieri, Luciano Galantini, Silvia Fanti, Paolo Trost, Francesca Sparla, and Simona Fermani. Conformational disorder analysis of the conditionally disordered protein cp12 from arabidopsis thaliana in its different redox states. International Journal of Molecular Sciences, 24:9308, May 2023. URL: https://doi.org/10.3390/ijms24119308, doi:10.3390/ijms24119308. This article has 3 citations.</p>
+</li>
+<li>
+<p>(mcfarlane2019structuralbasisof pages 1-2): Ciaran R. McFarlane, Nita R. Shah, Burak V. Kabasakal, Blanca Echeverria, Charles A. R. Cotton, Doryen Bubeck, and James W. Murray. Structural basis of light-induced redox regulation in the calvin–benson cycle in cyanobacteria. Proceedings of the National Academy of Sciences of the United States of America, 116:20984-20990, Sep 2019. URL: https://doi.org/10.1073/pnas.1906722116, doi:10.1073/pnas.1906722116. This article has 99 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mcfarlane2019structuralbasisof pages 2-3): Ciaran R. McFarlane, Nita R. Shah, Burak V. Kabasakal, Blanca Echeverria, Charles A. R. Cotton, Doryen Bubeck, and James W. Murray. Structural basis of light-induced redox regulation in the calvin–benson cycle in cyanobacteria. Proceedings of the National Academy of Sciences of the United States of America, 116:20984-20990, Sep 2019. URL: https://doi.org/10.1073/pnas.1906722116, doi:10.1073/pnas.1906722116. This article has 99 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mcfarlane2019structuralbasisof media e719c995): Ciaran R. McFarlane, Nita R. Shah, Burak V. Kabasakal, Blanca Echeverria, Charles A. R. Cotton, Doryen Bubeck, and James W. Murray. Structural basis of light-induced redox regulation in the calvin–benson cycle in cyanobacteria. Proceedings of the National Academy of Sciences of the United States of America, 116:20984-20990, Sep 2019. URL: https://doi.org/10.1073/pnas.1906722116, doi:10.1073/pnas.1906722116. This article has 99 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mcfarlane2019structuralbasisof media c7aae535): Ciaran R. McFarlane, Nita R. Shah, Burak V. Kabasakal, Blanca Echeverria, Charles A. R. Cotton, Doryen Bubeck, and James W. Murray. Structural basis of light-induced redox regulation in the calvin–benson cycle in cyanobacteria. Proceedings of the National Academy of Sciences of the United States of America, 116:20984-20990, Sep 2019. URL: https://doi.org/10.1073/pnas.1906722116, doi:10.1073/pnas.1906722116. This article has 99 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(mcfarlane2019structuralbasisof media 44ce9d30): Ciaran R. McFarlane, Nita R. Shah, Burak V. Kabasakal, Blanca Echeverria, Charles A. R. Cotton, Doryen Bubeck, and James W. Murray. Structural basis of light-induced redox regulation in the calvin–benson cycle in cyanobacteria. Proceedings of the National Academy of Sciences of the United States of America, 116:20984-20990, Sep 2019. URL: https://doi.org/10.1073/pnas.1906722116, doi:10.1073/pnas.1906722116. This article has 99 citations and is from a highest quality peer-reviewed journal.</p>
+</li>
+<li>
+<p>(gerard2022reductioninphosphoribulokinase pages 2-4): Cassy Gérard, Régine Lebrun, Erwan Lemesle, Luisana Avilan, Kwang Suk Chang, EonSeon Jin, Frédéric Carrière, Brigitte Gontero, and Hélène Launay. Reduction in phosphoribulokinase amount and re-routing metabolism in chlamydomonas reinhardtii cp12 mutants. International Journal of Molecular Sciences, 23:2710, Feb 2022. URL: https://doi.org/10.3390/ijms23052710, doi:10.3390/ijms23052710. This article has 13 citations.</p>
+</li>
+<li>
+<p>(teh2021regulationofcp12mediated pages 63-65): Jing Tsong Teh. Regulation of cp12-mediated carbon metabolism by ntrc during cold acclimation. Dissertation, Jan 2021. URL: https://doi.org/10.5282/edoc.29016, doi:10.5282/edoc.29016. This article has 0 citations.</p>
+</li>
+<li>
+<p>(gerard2022reductioninphosphoribulokinase pages 10-11): Cassy Gérard, Régine Lebrun, Erwan Lemesle, Luisana Avilan, Kwang Suk Chang, EonSeon Jin, Frédéric Carrière, Brigitte Gontero, and Hélène Launay. Reduction in phosphoribulokinase amount and re-routing metabolism in chlamydomonas reinhardtii cp12 mutants. International Journal of Molecular Sciences, 23:2710, Feb 2022. URL: https://doi.org/10.3390/ijms23052710, doi:10.3390/ijms23052710. This article has 13 citations.</p>
+</li>
+<li>
+<p>(boisset2023phosphoribulokinaseabundanceis pages 1-2): Nicolas D. Boisset, Giusi Favoino, Maria Meloni, Lucile Jomat, Corinne Cassier-Chauvat, Mirko Zaffagnini, Stéphane D. Lemaire, and Pierre Crozet. Phosphoribulokinase abundance is not limiting the calvin-benson-bassham cycle in chlamydomonas reinhardtii. Frontiers in Plant Science, Aug 2023. URL: https://doi.org/10.3389/fpls.2023.1230723, doi:10.3389/fpls.2023.1230723. This article has 8 citations.</p>
+</li>
+<li>
+<p>(boisset2023phosphoribulokinaseabundanceis pages 2-3): Nicolas D. Boisset, Giusi Favoino, Maria Meloni, Lucile Jomat, Corinne Cassier-Chauvat, Mirko Zaffagnini, Stéphane D. Lemaire, and Pierre Crozet. Phosphoribulokinase abundance is not limiting the calvin-benson-bassham cycle in chlamydomonas reinhardtii. Frontiers in Plant Science, Aug 2023. URL: https://doi.org/10.3389/fpls.2023.1230723, doi:10.3389/fpls.2023.1230723. This article has 8 citations.</p>
+</li>
+<li>
+<p>(lucius2024theprimarycarbon pages 1-2): Stefan Lucius and Martin Hagemann. The primary carbon metabolism in cyanobacteria and its regulation. Frontiers in Plant Science, Jul 2024. URL: https://doi.org/10.3389/fpls.2024.1417680, doi:10.3389/fpls.2024.1417680. This article has 66 citations.</p>
+</li>
+<li>
+<p>(lucius2024theprimarycarbon pages 9-10): Stefan Lucius and Martin Hagemann. The primary carbon metabolism in cyanobacteria and its regulation. Frontiers in Plant Science, Jul 2024. URL: https://doi.org/10.3389/fpls.2024.1417680, doi:10.3389/fpls.2024.1417680. This article has 66 citations.</p>
+</li>
+<li>
+<p>(teh2021regulationofcp12mediated pages 18-20): Jing Tsong Teh. Regulation of cp12-mediated carbon metabolism by ntrc during cold acclimation. Dissertation, Jan 2021. URL: https://doi.org/10.5282/edoc.29016, doi:10.5282/edoc.29016. This article has 0 citations.</p>
+</li>
+</ol>
+<h2 id="citations">Citations</h2>
+<ol>
+<li>mcfarlane2019structuralbasisof pages 2-3</li>
+<li>giudice2023conformationaldisorderanalysis pages 1-2</li>
+<li>gerard2022reductioninphosphoribulokinase pages 1-2</li>
+<li>gerard2022reductioninphosphoribulokinase pages 8-10</li>
+<li>gerard2022reductioninphosphoribulokinase pages 2-4</li>
+<li>gerard2022reductioninphosphoribulokinase pages 10-11</li>
+<li>lucius2024theprimarycarbon pages 1-2</li>
+<li>mcfarlane2019structuralbasisof pages 1-2</li>
+<li>boisset2023phosphoribulokinaseabundanceis pages 1-2</li>
+<li>boisset2023phosphoribulokinaseabundanceis pages 2-3</li>
+<li>lucius2024theprimarycarbon pages 9-10</li>
+<li>https://doi.org/10.3389/fpls.2014.00009</li>
+<li>https://doi.org/10.1073/pnas.1906722116</li>
+<li>https://doi.org/10.3390/ijms23052710</li>
+<li>https://doi.org/10.3390/ijms24119308</li>
+<li>https://doi.org/10.5282/edoc.29016</li>
+<li>https://doi.org/10.3389/fpls.2023.1230723</li>
+<li>https://doi.org/10.3389/fpls.2024.1417680</li>
+<li>https://doi.org/10.3390/ijms23052710,</li>
+<li>https://doi.org/10.3389/fpls.2014.00009,</li>
+<li>https://doi.org/10.3390/ijms24119308,</li>
+<li>https://doi.org/10.1073/pnas.1906722116,</li>
+<li>https://doi.org/10.5282/edoc.29016,</li>
+<li>https://doi.org/10.3389/fpls.2023.1230723,</li>
+<li>https://doi.org/10.3389/fpls.2024.1417680,</li>
+</ol>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- Additional Documentation Sections -->
+    
+    <div class="section">
+        <h2 class="section-title">📚 Additional Documentation</h2>
+        
+        <details class="markdown-section">
+            <summary style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
+                <div style="flex: 1;">
+                    <h3 style="display: inline;">Notes</h3>
+                    <span style="font-size: 0.8rem; color: #666; margin-left: 1rem;">(CP12-notes.md)</span>
+                </div>
+                <div class="vote-buttons" data-g="A6Q0K5" data-a="DOC: Notes" data-r="" data-act="DOCUMENTATION" style="display: flex; gap: 0.25rem;">
+                    <button class="vote-btn" data-v="up" title="This documentation is helpful">👍</button>
+                    <button class="vote-btn" data-v="down" title="This documentation needs improvement">👎</button>
+                </div>
+            </summary>
+            <div class="markdown-content">
+                <h1 id="cp12-chlamydomonas-reinhardtii-research-notes">CP12 (Chlamydomonas reinhardtii) - Research Notes</h1>
+<h2 id="gene-overview">Gene Overview</h2>
+<p>CP12 (UniProt: A6Q0K5) is a small (~8.5 kDa, 107 aa with transit peptide, 80 aa mature), nuclear-encoded chloroplast protein in <em>Chlamydomonas reinhardtii</em>. It is a conditionally disordered protein (CDP) that acts as a linker/scaffold mediating the formation of a supramolecular PRK/GAPDH/CP12 complex, thereby regulating the Calvin-Benson-Bassham (CBB) cycle in response to light/dark transitions.</p>
+<h2 id="core-function-darklight-regulation-of-the-calvin-cycle">Core Function: Dark/Light Regulation of the Calvin Cycle</h2>
+<p>CP12 coordinates the reversible inactivation of two CBB cycle enzymes during darkness:<br />
+- <strong>Glyceraldehyde-3-phosphate dehydrogenase (GAPDH)</strong> (A4 form, EC 1.2.1.13)<br />
+- <strong>Phosphoribulokinase (PRK)</strong> (EC 2.7.1.19)</p>
+<p>The mechanism is redox-dependent:<br />
+- In the <strong>dark</strong> (oxidizing conditions): CP12's four cysteine residues form two disulfide bonds (Cys50-Cys58, Cys93-Cys102 in the precursor), conferring partial structure. Oxidized CP12 first binds GAPDH (forming a binary complex), then PRK is recruited to form a ternary PRK/GAPDH/CP12 complex. Both enzymes are inactive in this complex. <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" title="oxidized, but not reduced, CP12 acts as a linker in the assembly of the complex">PMID:12846565</a></p>
+<ul>
+<li>In the <strong>light</strong> (reducing conditions via thioredoxin/NADPH): Disulfide bonds are reduced, CP12 becomes fully disordered, and the complex dissociates, releasing active GAPDH and PRK. <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" title="Reduced CP12 being unable to reconstitute the complex">PMID:12846565</a></li>
+</ul>
+<p>The stoichiometry of the full complex: 2 PRK dimers + 2 GAPDH tetramers + CP12 <a href="https://pubmed.ncbi.nlm.nih.gov/12846565">PMID:12846565</a></p>
+<h2 id="intrinsically-disordered-protein-idp-properties">Intrinsically Disordered Protein (IDP) Properties</h2>
+<p>CP12 is a conditionally disordered protein (CDP):<br />
+- <strong>Reduced</strong> CP12: fully intrinsically disordered, no stable secondary structure <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" title="reduced CP12 is mainly unstructured">PMID:12846565</a><br />
+- <strong>Oxidized</strong> CP12: gains alpha-helical content and partial structure from disulfide bonds, but remains highly flexible <a href="https://pubmed.ncbi.nlm.nih.gov/12846565" title="Oxidized CP12 is mainly composed of alpha helix and coil segments, and is extremely flexible">PMID:12846565</a><br />
+- CP12 has properties similar to "intrinsically unstructured proteins" involved in regulating macromolecular complexes <a href="https://pubmed.ncbi.nlm.nih.gov/12846565">PMID:12846565</a></p>
+<h2 id="metal-ion-binding">Metal Ion Binding</h2>
+<p>CP12 binds copper (Cu2+) and nickel (Ni2+) ions:<br />
+- Cu2+ binding: Kd = 26 ± 1 μM <a href="https://pubmed.ncbi.nlm.nih.gov/16259044">PMID:16259044</a><br />
+- Ni2+ binding: Kd = 11 ± 1 μM <a href="https://pubmed.ncbi.nlm.nih.gov/16259044">PMID:16259044</a><br />
+- Does NOT bind Fe2+ or Zn2+ <a href="https://pubmed.ncbi.nlm.nih.gov/16259044">PMID:16259044</a><br />
+- Cu2+ catalyzes re-formation of disulfide bonds in reduced CP12, promoting the oxidized (active linker) form <a href="https://pubmed.ncbi.nlm.nih.gov/16259044" title="Cu2+ catalyzes the re-formation of the disulfide bonds of the reduced CP12">PMID:16259044</a><br />
+- Similarity to copper chaperones from Arabidopsis thaliana noted <a href="https://pubmed.ncbi.nlm.nih.gov/16259044">PMID:16259044</a><br />
+- His74 mutation to Leu has no impact on metal-ion binding <a href="https://pubmed.ncbi.nlm.nih.gov/16259044">PMID:16259044</a></p>
+<p><strong>Important note on metal binding</strong>: While CP12 binds Cu2+ and Ni2+ in vitro, the biological significance of this metal binding is debated. The copper-catalyzed oxidation of CP12 thiols may be relevant in vivo, but the primary known function of CP12 is as a regulatory scaffold, not as a dedicated metal-binding protein. The metal binding annotations should be viewed as secondary/moonlighting characteristics.</p>
+<h2 id="protein-protein-interactions">Protein-Protein Interactions</h2>
+<ul>
+<li>CP12 interacts with GAPDH (P50362, GAPA in C. reinhardtii): confirmed by reconstitution assays, SPR, and fluorescence correlation spectroscopy [PMID:12846565, PMID:24863370]</li>
+<li>CP12 interacts with PRK (P19824, PRKA in C. reinhardtii): confirmed by reconstitution assays [PMID:12846565, PMID:24863370]</li>
+<li>C-terminal region of CP12 is at the GAPDH interaction site [PMID:24863370 based on Mileo et al. 2013]</li>
+<li>Key residues: WXXVEE motif (residues 35-47 of mature protein), Glu74 essential for GAPDH binding [Erales et al. 2012, PMID:22955105]</li>
+<li>CP12 may also interact with aldolase and malate dehydrogenase (promiscuous interactions) [Gontero &amp; Maberly 2012]</li>
+</ul>
+<h2 id="cp12-knockout-studies-cp12">CP12 Knockout Studies (ΔCP12)</h2>
+<p>CRISPR-Cas9 knockout of the single CP12 gene in C. reinhardtii <a href="https://pubmed.ncbi.nlm.nih.gov/35269851">PMID:35269851</a>:<br />
+- Growth rates: nearly identical between WT and ΔCP12<br />
+- GAPDH: abundance and activity unchanged in ΔCP12<br />
+- PRK: abundance and specific activity significantly reduced in ΔCP12<br />
+- CP12 protects PRK from irreversible inactivation in vitro (redox-independent)<br />
+- Multiple proteins in redox homeostasis and stress response were more abundant in ΔCP12<br />
+- CP12 described as a "moonlighting protein" with functions beyond CBB regulation</p>
+<h2 id="subcellular-localization">Subcellular Localization</h2>
+<ul>
+<li>Chloroplast (transit peptide residues 1-27) [PMID:12846565, confirmed by protein sequencing]</li>
+</ul>
+<h2 id="key-points-for-annotation-review">Key Points for Annotation Review</h2>
+<ol>
+<li><strong>Protein binding (GO:0005515)</strong>: Too generic; CP12's interactions with GAPDH and PRK are the core function. "Enzyme binding" (GO:0019899) is more informative.</li>
+<li><strong>Copper/nickel binding</strong>: Real but likely secondary to the primary scaffold/linker function. The copper-catalyzed thiol oxidation may be physiologically relevant.</li>
+<li><strong>Negative regulation of reductive pentose-phosphate cycle (GO:0080153)</strong>: This is the core biological process - CP12 inactivates CBB enzymes in the dark.</li>
+<li><strong>Chloroplast localization</strong>: Well-supported by direct protein sequencing evidence.</li>
+<li><strong>Protein-containing complex (GO:0032991)</strong>: Valid - CP12 is part of the PRK/GAPDH/CP12 complex.</li>
+</ol>
+<h2 id="key-references">Key References</h2>
+<ul>
+<li>PMID:12846565 - Graciet et al. 2003 - CP12 as protein linker, reconstitution, NMR structure</li>
+<li>PMID:16259044 - Delobel et al. 2005 - Metal ion binding, mass spectrometry</li>
+<li>PMID:24863370 - Moparthi et al. 2014 - FCS dynamics, hydrodynamic radii</li>
+<li>PMID:22955105 - Erales et al. 2012 - Key residues for complex formation</li>
+<li>PMID:35269851 - Gérard et al. 2022 - CP12 knockout, PRK protection</li>
+<li>PMID:9699636 - Wedel &amp; Soll 1998 - Evolutionary conservation of PRK/CP12/GAPDH regulation</li>
+<li>PMID:12492483 - Graciet et al. 2003 - GAPDH kinetics with CP12</li>
+</ul>
+            </div>
+        </details>
+        
+    </div>
+    
+
+    <!-- YAML Preview Section -->
+    <div class="section">
+        <details class="yaml-preview">
+            <summary>
+                <h2 style="display: inline;">📄 View Raw YAML</h2>
+            </summary>
+            <div class="yaml-content">
+                <pre><code>id: A6Q0K5
+gene_symbol: CP12
+product_type: PROTEIN
+status: DRAFT
+taxon:
+  id: NCBITaxon:3055
+  label: Chlamydomonas reinhardtii
+description: CP12 is a small (~8.5 kDa), nuclear-encoded, conditionally disordered
+  chloroplast protein that functions as a redox-sensitive linker/scaffold mediating
+  the assembly of a supramolecular PRK/GAPDH/CP12 complex. In the dark, oxidized CP12
+  (with two intramolecular disulfide bonds) sequentially binds GAPDH then PRK, forming
+  a ternary complex that inactivates both Calvin cycle enzymes. In the light, thioredoxin-mediated
+  reduction of CP12 disulfide bonds causes the complex to dissociate, releasing active
+  enzymes. CP12 also binds Cu2+ and Ni2+ ions in vitro; Cu2+ catalyzes re-oxidation
+  of CP12 thiols, potentially linking metal homeostasis to Calvin cycle regulation.
+existing_annotations:
+- term:
+    id: GO:0009507
+    label: chloroplast
+  evidence_type: IEA
+  original_reference_id: GO_REF:0000044
+  review:
+    summary: Chloroplast localization is well-supported by multiple lines of evidence.
+      CP12 has a 27-residue chloroplast transit peptide confirmed by direct protein
+      sequencing (PMID:12846565), and IDA evidence from CAFA also supports this localization.
+      This IEA annotation from UniProt subcellular location mapping is consistent
+      with all other evidence.
+    action: ACCEPT
+    reason: Although this is an IEA annotation, it is fully consistent with the IDA
+      evidence (PMID:12846565) showing chloroplast localization via transit peptide
+      identification and direct protein sequencing. The UniProt record confirms chloroplast
+      transit peptide residues 1-27 with experimental evidence.
+    supported_by:
+    - reference_id: PMID:12846565
+      supporting_text: CP12 is an 8.5-kDa nuclear-encoded chloroplast protein
+    - reference_id: PMID:16259044
+      supporting_text: The small chloroplast protein CP12
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:24863370
+  review:
+    summary: This annotation records CP12 interaction with PRK (P19824) based on fluorescence
+      correlation spectroscopy (FCS) experiments (PMID:24863370). While the interaction
+      is real and well-documented, GO:0005515 (protein binding) is too generic per
+      curation guidelines. CP12 binds the enzyme PRK as part of its core regulatory
+      function; GO:0019899 (enzyme binding) is more informative and already annotated.
+    action: MODIFY
+    reason: Per curation guidelines, GO:0005515 (protein binding) is uninformative.
+      CP12&#39;s interaction with PRK is its core molecular function -- it acts as a scaffold/linker
+      that binds PRK to form the regulatory PRK/GAPDH/CP12 complex. GO:0019899 (enzyme
+      binding) is already annotated for the GAPDH interaction and is equally appropriate
+      for the PRK interaction, as PRK is an enzyme (phosphoribulokinase, EC 2.7.1.19).
+    proposed_replacement_terms:
+    - id: GO:0019899
+      label: enzyme binding
+    supported_by:
+    - reference_id: PMID:24863370
+      supporting_text: we characterize the diffusion dynamics and hydrodynamic radii
+        of CP12 from Chlamydomonas reinhardtii upon binding to GAPDH and PRK using
+        fluorescence correlation spectroscopy experiments
+    - reference_id: PMID:12846565
+      supporting_text: oxidized, but not reduced, CP12 acts as a linker in the assembly
+        of the complex
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:24863370
+  review:
+    summary: This annotation records CP12 interaction with GAPDH (P50362) based on
+      FCS experiments (PMID:24863370). Same issue as the PRK protein binding annotation
+      -- GO:0005515 is too generic. The GAPDH interaction is already covered by the
+      enzyme binding annotation from PMID:12846565.
+    action: MODIFY
+    reason: GO:0005515 is uninformative per curation guidelines. CP12&#39;s interaction
+      with GAPDH is its core function as a regulatory linker. GO:0019899 (enzyme binding)
+      is more appropriate, as GAPDH is an enzyme (glyceraldehyde-3-phosphate dehydrogenase,
+      EC 1.2.1.13). This interaction is already annotated as enzyme binding from PMID:12846565.
+    proposed_replacement_terms:
+    - id: GO:0019899
+      label: enzyme binding
+    supported_by:
+    - reference_id: PMID:24863370
+      supporting_text: we characterize the diffusion dynamics and hydrodynamic radii
+        of CP12 from Chlamydomonas reinhardtii upon binding to GAPDH and PRK using
+        fluorescence correlation spectroscopy experiments
+- term:
+    id: GO:0005515
+    label: protein binding
+  evidence_type: IPI
+  original_reference_id: PMID:12846565
+  review:
+    summary: This annotation records CP12 interaction with both PRK (P19824) and GAPDH
+      (P50362) based on reconstitution assays and SPR binding studies (PMID:12846565).
+      As with the other protein binding annotations, GO:0005515 is too generic. The
+      interactions are real but better captured by GO:0019899 (enzyme binding).
+    action: MODIFY
+    reason: GO:0005515 is uninformative per curation guidelines. CP12 acts as a linker
+      for two Calvin cycle enzymes; enzyme binding (GO:0019899) is the appropriate
+      term. The original paper clearly demonstrates CP12 binding to both PRK and GAPDH
+      through reconstitution assays and surface plasmon resonance.
+    proposed_replacement_terms:
+    - id: GO:0019899
+      label: enzyme binding
+    supported_by:
+    - reference_id: PMID:12846565
+      supporting_text: oxidized, but not reduced, CP12 acts as a linker in the assembly
+        of the complex, and we propose a model in which CP12 associates with GAPDH,
+        causing its conformation to change. This GAPDH/CP12 complex binds PRK to form
+        a half-complex (one unit).
+- term:
+    id: GO:0009507
+    label: chloroplast
+  evidence_type: IDA
+  original_reference_id: PMID:12846565
+  review:
+    summary: Direct experimental evidence for chloroplast localization. The PMID:12846565
+      study determined the N-terminal sequence of the mature protein (residues 28-32),
+      confirming cleavage of the chloroplast transit peptide and thereby demonstrating
+      chloroplast import. UniProt lists this as transit peptide residues 1-27 with
+      evidence from PMID:12846565.
+    action: ACCEPT
+    reason: Strong IDA evidence from direct protein sequencing confirming the transit
+      peptide cleavage site. This is the primary experimental evidence for chloroplast
+      localization and directly demonstrates that CP12 is imported into the chloroplast.
+    supported_by:
+    - reference_id: PMID:12846565
+      supporting_text: CP12 is an 8.5-kDa nuclear-encoded chloroplast protein
+- term:
+    id: GO:0019899
+    label: enzyme binding
+  evidence_type: IPI
+  original_reference_id: PMID:12846565
+  review:
+    summary: &#39;Enzyme binding is CP12&#39;&#39;s core molecular function. CP12 acts as a regulatory
+      linker that binds two Calvin cycle enzymes: GAPDH (P50362, glyceraldehyde-3-phosphate
+      dehydrogenase) and PRK (P19824, phosphoribulokinase). The WITH column specifies
+      GAPDH (P50362). This was demonstrated through reconstitution assays and SPR
+      binding studies (PMID:12846565), and independently confirmed by FCS (PMID:24863370).&#39;
+    action: ACCEPT
+    reason: This is the most informative molecular function term for CP12&#39;s core activity.
+      CP12 is defined by its ability to bind and regulate GAPDH and PRK through redox-dependent
+      complex assembly. Enzyme binding accurately captures this scaffold/linker function.
+      The evidence is strong, based on multiple in vitro reconstitution approaches.
+    supported_by:
+    - reference_id: PMID:12846565
+      supporting_text: oxidized, but not reduced, CP12 acts as a linker in the assembly
+        of the complex, and we propose a model in which CP12 associates with GAPDH,
+        causing its conformation to change
+    - reference_id: PMID:24863370
+      supporting_text: We quantify a hydrodynamic radius of 3.4 ± 0.2 nm for the CP12
+        protein with an increase up to 5.2 ± 0.3 nm upon complex formation with GAPDH
+        and PRK
+- term:
+    id: GO:0009507
+    label: chloroplast
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: ISS annotation based on sequence similarity to Arabidopsis thaliana CP12
+      (O22914). Consistent with the IDA evidence from PMID:12846565 and the IEA annotation.
+      This is redundant with the IDA evidence but not incorrect.
+    action: ACCEPT
+    reason: Fully consistent with the IDA evidence (PMID:12846565). The ISS transfer
+      from A. thaliana CP12 is appropriate given that chloroplast localization is
+      a conserved feature of all CP12 family members, which universally possess chloroplast
+      transit peptides.
+    supported_by:
+    - reference_id: PMID:12846565
+      supporting_text: CP12 is an 8.5-kDa nuclear-encoded chloroplast protein
+- term:
+    id: GO:0032991
+    label: protein-containing complex
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: CP12 is part of the PRK/GAPDH/CP12 supramolecular complex. The annotation
+      to the generic GO:0032991 (protein-containing complex) is correct but very broad.
+      The full complex stoichiometry is 2 PRK dimers + 2 GAPDH tetramers + CP12 (PMID:12846565).
+      A more specific GO complex term would be ideal, but no dedicated term for the
+      PRK/GAPDH/CP12 complex currently exists in GO.
+    action: ACCEPT
+    reason: While GO:0032991 is generic, there is no more specific GO term available
+      for the PRK/GAPDH/CP12 complex. The annotation is accurate -- CP12 is indeed
+      a component of a well-characterized protein-containing complex. The ISS transfer
+      from A. thaliana CP12 is appropriate since the PRK/GAPDH/CP12 complex is conserved
+      across photosynthetic organisms. Proposing a new GO term for this complex could
+      be considered.
+    supported_by:
+    - reference_id: PMID:12846565
+      supporting_text: It forms part of a core complex of two dimers of phosphoribulokinase
+        (PRK), two tetramers of glyceraldehyde 3-phosphate dehydrogenase (GAPDH),
+        and CP12
+- term:
+    id: GO:0080153
+    label: negative regulation of reductive pentose-phosphate cycle
+  evidence_type: ISS
+  original_reference_id: GO_REF:0000024
+  review:
+    summary: &#39;This is the core biological process annotation for CP12. CP12 negatively
+      regulates the Calvin-Benson-Bassham (reductive pentose-phosphate) cycle by sequestering
+      PRK and GAPDH into an inactive complex in the dark. The ISS transfer from A.
+      thaliana CP12 (O22914) is well-justified, as this regulatory function is conserved
+      across all characterized CP12 proteins. CRISPR-Cas9 knockout of CP12 in C. reinhardtii
+      (PMID:35269851) provides direct IMP-grade evidence in the target organism — delta-CP12
+      cells show abolished DTT-dependent regulation of GAPDH activity and 3-fold reduced
+      PRK specific activity, confirming that CP12 is required in vivo for dark regulation
+      of the Calvin cycle. An upgraded experimental evidence annotation (e.g. IMP
+      from PMID:35269851) should be considered by the curation source.&#39;
+    action: ACCEPT
+    reason: GO:0080153 precisely captures CP12&#39;s core biological process function.
+      CP12 coordinates the dark inactivation of GAPDH and PRK, two key Calvin cycle
+      enzymes, by assembling them into an inactive supramolecular complex. This is
+      the most specific and accurate BP term for CP12&#39;s role. The ISS annotation is
+      consistent with strong direct experimental evidence in C. reinhardtii from both
+      reconstitution experiments (PMID:12846565) and CRISPR knockout studies (PMID:35269851),
+      so an IMP upgrade in the source GOA is warranted.
+    supported_by:
+    - reference_id: PMID:12846565
+      supporting_text: oxidized, but not reduced, CP12 acts as a linker in the assembly
+        of the complex
+    - reference_id: PMID:16259044
+      supporting_text: a PRK/GAPDH/CP12 complex that is involved in CO2 assimilation
+        in photosynthetic organisms. The redox state of CP12 regulates its role as
+        a protein linker.
+    - reference_id: PMID:35269851
+      supporting_text: The chloroplast protein CP12 is involved in the dark/light
+        regulation of the Calvin-Benson-Bassham cycle, in particular, in the dark
+        inhibition of two enzymes
+    - reference_id: PMID:35269851
+      supporting_text: in the ∆CP12-Cr cell extracts, the NADPH-dependent activity
+        of GAPDH displayed a linear curve regardless of DTT
+- term:
+    id: GO:0005507
+    label: copper ion binding
+  evidence_type: IDA
+  original_reference_id: PMID:16259044
+  review:
+    summary: IDA evidence from ESI-MS experiments demonstrating specific Cu2+ binding
+      by CP12 with Kd = 26 +/- 1 uM (PMID:16259044). Importantly, Cu2+ also catalyzes
+      re-formation of CP12 disulfide bonds, potentially linking copper to Calvin cycle
+      regulation. The authors note sequence similarity between CP12 and copper chaperones
+      from A. thaliana. However, the primary biological function of CP12 is as a regulatory
+      scaffold, not as a dedicated copper-binding protein; the in vivo significance
+      of copper binding remains uncertain.
+    action: KEEP_AS_NON_CORE
+    reason: The copper binding is real (IDA evidence, specific binding with measured
+      Kd), but it represents a secondary/potential moonlighting function rather than
+      CP12&#39;s core evolved function. CP12&#39;s primary role is as a redox-dependent linker
+      for the PRK/GAPDH complex. The copper-catalyzed thiol oxidation may be physiologically
+      relevant as it could promote CP12&#39;s active (oxidized) conformation, but this
+      remains speculative. Retaining as non-core appropriately reflects the evidence.
+    supported_by:
+    - reference_id: PMID:16259044
+      supporting_text: The oxidized protein bound specifically Cu2+ and Ni2+ (Kd of
+        26+/-1 microM and 11+/-1 microM, respectively); other cations such as Fe2+
+        and Zn2+ did not bind
+    - reference_id: PMID:16259044
+      supporting_text: Cu2+ catalyzes the re-formation of the disulfide bonds of the
+        reduced CP12, leading to recovery of the fully oxidized CP12 that is then
+        able to bind a Cu2+ ion
+- term:
+    id: GO:0016151
+    label: nickel cation binding
+  evidence_type: IDA
+  original_reference_id: PMID:16259044
+  review:
+    summary: IDA evidence from ESI-MS experiments showing specific Ni2+ binding by
+      CP12 with Kd = 11 +/- 1 uM (PMID:16259044). The binding is more specific than
+      Cu2+ (lower Kd) but the biological relevance is even less clear. Nickel is not
+      known to play a significant role in chloroplast metabolism in green algae. The
+      His74 mutation had no impact on metal binding, suggesting the binding site may
+      involve other residues.
+    action: KEEP_AS_NON_CORE
+    reason: The nickel binding is experimentally demonstrated (IDA) with good specificity
+      (Kd = 11 uM, no binding of Fe2+ or Zn2+), but there is no evidence for an in
+      vivo role. Unlike copper, nickel does not catalyze CP12 disulfide bond formation,
+      so a regulatory connection to CP12&#39;s primary function is not established. This
+      is a secondary characteristic best kept as non-core.
+    supported_by:
+    - reference_id: PMID:16259044
+      supporting_text: The oxidized protein bound specifically Cu2+ and Ni2+ (Kd of
+        26+/-1 microM and 11+/-1 microM, respectively); other cations such as Fe2+
+        and Zn2+ did not bind
+    - reference_id: PMID:16259044
+      supporting_text: the high similarity between CP12 and copper chaperones from
+        Arabidopsis thaliana, as judged by hydrophobic cluster analysis, provides
+        additional evidence for the relevance of metal binding for the in vivo situation
+- term:
+    id: GO:0050821
+    label: protein stabilization
+  evidence_type: IMP
+  original_reference_id: PMID:35269851
+  review:
+    summary: Proposed new annotation reflecting a redox-independent moonlighting function
+      of CP12. PMID:35269851 demonstrates that CP12 stabilizes PRK against irreversible
+      inactivation both in vitro (recombinant CP12 prevents irreversible loss of PRK
+      activity in a redox-independent manner; DTT can restore activity only when CP12
+      is present) and in vivo (ΔCP12 cells show 6.5-fold reduction in PRK protein
+      abundance with no change in mRNA, consistent with loss of post-translational
+      stabilization). Site-directed mutagenesis identifies specific residues (D36,
+      E39, E40, W35, H47) required for this protective function.
+    action: NEW
+    reason: PMID:35269851 provides both in vivo (knockout) and in vitro (recombinant
+      protein + mutagenesis) evidence that CP12 specifically protects PRK from irreversible
+      inactivation in a redox-independent manner. This is mechanistically distinct
+      from CP12&#39;s redox-dependent regulatory role in the PRK/GAPDH/CP12 complex and
+      warrants a separate annotation. GO:0050821 (protein stabilization) accurately
+      captures this function as the term covers maintenance of protein structure/integrity
+      and prevention of aggregation/degradation.
+    supported_by:
+    - reference_id: PMID:35269851
+      supporting_text: Isolated PRK lost irreversibly its activity over-time in vitro,
+        which was prevented in the presence of recombinant CP12 in a redox-independent
+        manner
+    - reference_id: PMID:35269851
+      supporting_text: in the presence of CP12, the addition of DTT restored the initial
+        PRK activity, indicating that CP12 prevented this irreversible inactivation
+    - reference_id: PMID:35269851
+      supporting_text: a significant difference was observed for PRK amount, with
+        a 6.5-fold decrease of PRK amount in ΔCP12-Cr compared to the WT-Cr strain
+core_functions:
+- description: Redox-dependent scaffold/linker that binds GAPDH and PRK to assemble
+    an inactive PRK/GAPDH/CP12 supramolecular complex, negatively regulating the Calvin-Benson-Bassham
+    cycle in the dark
+  molecular_function:
+    id: GO:0019899
+    label: enzyme binding
+  directly_involved_in:
+  - id: GO:0080153
+    label: negative regulation of reductive pentose-phosphate cycle
+  locations:
+  - id: GO:0009507
+    label: chloroplast
+  in_complex:
+    id: GO:0032991
+    label: protein-containing complex
+  supported_by:
+  - reference_id: PMID:12846565
+    supporting_text: oxidized, but not reduced, CP12 acts as a linker in the assembly
+      of the complex, and we propose a model in which CP12 associates with GAPDH,
+      causing its conformation to change. This GAPDH/CP12 complex binds PRK to form
+      a half-complex (one unit).
+  - reference_id: PMID:24863370
+    supporting_text: We quantify a hydrodynamic radius of 3.4 +/- 0.2 nm for the CP12
+      protein with an increase up to 5.2 +/- 0.3 nm upon complex formation with GAPDH
+      and PRK
+  - reference_id: PMID:35269851
+    supporting_text: the abundance of PRK and its specific activity were significantly
+      reduced in deltaCP12, as revealed by relative quantitative proteomics
+references:
+- id: GO_REF:0000024
+  title: Manual transfer of experimentally-verified manual GO annotation data to orthologs
+    by curator judgment of sequence similarity
+  findings: []
+- id: GO_REF:0000044
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
+    vocabulary mapping, accompanied by conservative changes to GO terms applied by
+    UniProt
+  findings: []
+- id: PMID:12846565
+  title: &#39;The small protein CP12: a protein linker for supramolecular complex assembly.&#39;
+  findings:
+  - statement: Oxidized CP12 acts as a redox-sensitive linker for assembly of the
+      PRK/GAPDH/CP12 supramolecular complex; reduced CP12 cannot reconstitute the
+      complex.
+    supporting_text: oxidized, but not reduced, CP12 acts as a linker in the assembly
+      of the complex
+  - statement: The complex has a stoichiometry of 2 PRK dimers, 2 GAPDH tetramers,
+      and CP12. CP12 first binds GAPDH, then PRK is recruited.
+    supporting_text: It forms part of a core complex of two dimers of phosphoribulokinase
+      (PRK), two tetramers of glyceraldehyde 3-phosphate dehydrogenase (GAPDH), and
+      CP12
+  - statement: Oxidized CP12 is mainly alpha-helical and flexible; reduced CP12 is
+      mainly unstructured, consistent with intrinsically disordered protein properties.
+    supporting_text: Oxidized CP12 is mainly composed of alpha helix and coil segments,
+      and is extremely flexible, while reduced CP12 is mainly unstructured
+  - statement: CP12 is a nuclear-encoded chloroplast protein with a transit peptide
+      confirmed by N-terminal sequencing of the mature protein (residues 28-32).
+    supporting_text: CP12 is an 8.5-kDa nuclear-encoded chloroplast protein
+- id: PMID:16259044
+  title: &#39;Mass spectrometric analysis of the interactions between CP12, a chloroplast
+    protein, and metal ions: a possible regulatory role within a PRK/GAPDH/CP12 complex.&#39;
+  findings:
+  - statement: CP12 specifically binds Cu2+ (Kd = 26 uM) and Ni2+ (Kd = 11 uM) but
+      not Fe2+ or Zn2+, as shown by ESI-MS.
+    supporting_text: The oxidized protein bound specifically Cu2+ and Ni2+ (Kd of
+      26+/-1 microM and 11+/-1 microM, respectively); other cations such as Fe2+ and
+      Zn2+ did not bind
+  - statement: Cu2+ catalyzes re-oxidation of reduced CP12, promoting formation of
+      the disulfide bonds required for linker activity.
+    supporting_text: Cu2+ catalyzes the re-formation of the disulfide bonds of the
+      reduced CP12, leading to recovery of the fully oxidized CP12
+  - statement: CP12 shows sequence similarity to copper chaperones from Arabidopsis
+      thaliana by hydrophobic cluster analysis, suggesting in vivo relevance of metal
+      binding.
+    supporting_text: the high similarity between CP12 and copper chaperones from Arabidopsis
+      thaliana, as judged by hydrophobic cluster analysis, provides additional evidence
+      for the relevance of metal binding for the in vivo situation
+- id: PMID:24863370
+  title: Conformational modulation and hydrodynamic radii of CP12 protein and its
+    complexes probed by fluorescence correlation spectroscopy.
+  findings:
+  - statement: FCS confirms CP12 binding to GAPDH and PRK, with hydrodynamic radius
+      increasing from 3.4 nm (free CP12) to 5.2 nm upon complex formation.
+    supporting_text: We quantify a hydrodynamic radius of 3.4 ± 0.2 nm for the CP12
+      protein with an increase up to 5.2 ± 0.3 nm upon complex formation with GAPDH
+      and PRK
+  - statement: N-terminal and C-terminal cysteine mutants show different structural
+      behavior during unfolding, suggesting distinct roles for the two disulfide bonds
+      in mediating GAPDH vs PRK binding.
+    supporting_text: The different behavior of the CP12 mutant proteins during hydrophobic
+      collapse transition is a direct clue to different structural orientations of
+      the CP12 mutant proteins
+- id: PMID:35269851
+  title: Reduction in Phosphoribulokinase Amount and Re-Routing Metabolism in Chlamydomonas
+    reinhardtii CP12 Mutants.
+  findings:
+  - statement: CRISPR-Cas9 knockout of CP12 in C. reinhardtii results in reduced PRK
+      abundance and activity but normal GAPDH levels and near-normal growth.
+    supporting_text: the abundance of PRK and its specific activity were significantly
+      reduced in ΔCP12, as revealed by relative quantitative proteomics
+  - statement: CP12 protects PRK from irreversible inactivation in a redox-independent
+      manner, suggesting functions beyond Calvin cycle regulation.
+    supporting_text: in the presence of CP12, the addition of DTT restored the initial
+      PRK activity, indicating that CP12 prevented this irreversible inactivation
+- id: PMID:24523724
+  title: &#39;The CP12 protein family: a thioredoxin-mediated metabolic switch?&#39;
+  findings:
+  - statement: Review establishing CP12 as a conserved redox-sensitive protein found
+      across all oxygenic phototrophs whose only clearly defined function is thioredoxin-mediated
+      regulation of the Calvin cycle via GAPDH/PRK/CP12 complex assembly/disassembly.
+    supporting_text: The only clearly defined function for CP12 in any organism is
+      in the thioredoxin-mediated regulation of the Calvin-Benson cycle
+  - statement: CP12 may have broader regulatory roles beyond Calvin cycle regulation,
+      with evidence suggesting involvement in stress responses and additional metabolic
+      functions.
+    supporting_text: CP12 may have a broader role in the regulation of metabolism,
+      over and above the well established role of CP12 in the regulation of the Calvin-Benson
+      cycle
+- id: PMID:30923119
+  title: Arabidopsis and Chlamydomonas phosphoribulokinase crystal structures complete
+    the redox structural proteome of the Calvin-Benson cycle.
+  findings:
+  - statement: Crystal structures of PRK from both Arabidopsis and Chlamydomonas reveal
+      that the regulatory cysteines are connected by a flexible clamp loop unique to
+      eukaryotic PRKs, completing the structural understanding of all redox-regulated
+      Calvin cycle enzymes.
+    supporting_text: the regulatory cysteines are 13 Å apart and connected by a flexible
+      region exclusive to photosynthetic eukaryotes-the clamp loop-which is believed
+      to be essential for oxidation-induced structural rearrangements
+- id: PMID:39036361
+  title: The primary carbon metabolism in cyanobacteria and its regulation.
+  findings:
+  - statement: Review positioning CP12 as a principal redox regulator of the Calvin
+      cycle especially in cyanobacteria, noting new metabolomics evidence that CP12
+      variants affect acclimation to external glucose under diurnal conditions and
+      CO2 fluctuations.
+    supporting_text: New results of metabolomic and redox level analyses on strains
+      with Cp12 variants extend the known role of Cp12 regulation towards the acclimation
+      to external glucose supply under diurnal conditions as well as to fluctuations
+      in CO2 levels in the light
+- id: PMID:37298260
+  title: Conformational Disorder Analysis of the Conditionally Disordered Protein CP12
+    from Arabidopsis thaliana in Its Different Redox States.
+  findings:
+  - statement: SAXS analysis of Arabidopsis CP12 confirms it is a conditionally disordered
+      protein; reduced CP12 is highly disordered while oxidized CP12 gains partial
+      structural order through disulfide bond formation but remains flexible.
+    supporting_text: a small angle X-ray scattering (SAXS) analysis of recombinant
+      Arabidopsis CP12 (AtCP12) in a reduced and oxidized form confirmed the highly
+      disordered nature of this regulatory protein
+- id: PMID:37719215
+  title: Phosphoribulokinase abundance is not limiting the Calvin-Benson-Bassham cycle
+    in Chlamydomonas reinhardtii.
+  findings:
+  - statement: PRK is present in moderate excess in C. reinhardtii; approximately 86%
+      of wild-type PRK content is sufficient for full photoautotrophic growth, and
+      overexpression does not increase growth.
+    supporting_text: Immunoblot and growth assays revealed that a PRK content of ≈86%
+      is sufficient to fully restore photoautotrophic growth
+- id: PMID:31570616
+  title: Structural basis of light-induced redox regulation in the Calvin-Benson cycle
+    in cyanobacteria.
+  findings:
+  - statement: Cryo-EM structure of the cyanobacterial GAPDH-CP12-PRK ternary complex
+      reveals that CP12&#39;s N-terminal disulfide-stabilized helical hairpin plugs the
+      PRK active-site cleft, while the C-terminal region binds GAPDH and influences
+      substrate accessibility of all GAPDH active sites.
+    supporting_text: CP12 binding to GAPDH influences substrate accessibility of all
+      GAPDH active sites in the binary and ternary inhibited complexes
+  - statement: CP12 integrates responses from both the redox state (via disulfide bonds)
+      and metabolite availability (NAD(H)/NADP(H) cofactor preference) to coordinate
+      inhibition of GAPDH and PRK in the dark.
+    supporting_text: Our structural and biochemical data explain how CP12 integrates
+      responses from both redox state and nicotinamide dinucleotide availability to
+      regulate carbon fixation
+proposed_new_terms:
+- proposed_name: PRK-GAPDH-CP12 complex
+  proposed_definition: &#39;A protein complex consisting of phosphoribulokinase (PRK),
+    glyceraldehyde-3-phosphate dehydrogenase (GAPDH), and the linker protein CP12.
+    The complex forms in the dark under oxidizing conditions and sequesters PRK and
+    GAPDH in an inactive state, thereby negatively regulating the Calvin-Benson-Bassham
+    cycle. Stoichiometry: 2 PRK dimers + 2 GAPDH tetramers + CP12.&#39;
+  justification: No GO complex term currently exists for this well-characterized supramolecular
+    complex, which is conserved across photosynthetic organisms from cyanobacteria
+    to higher plants. The current annotation uses the generic GO:0032991 (protein-containing
+    complex).
+  proposed_parent:
+    id: GO:0032991
+    label: protein-containing complex
+  supported_by:
+  - reference_id: PMID:12846565
+    supporting_text: It forms part of a core complex of two dimers of phosphoribulokinase
+      (PRK), two tetramers of glyceraldehyde 3-phosphate dehydrogenase (GAPDH), and
+      CP12
+suggested_questions:
+- question: Is the copper ion binding by CP12 physiologically relevant in vivo, or
+    is it an in vitro artifact? Does copper-catalyzed re-oxidation of CP12 thiols
+    contribute to dark regulation of the Calvin cycle under normal conditions?
+  experts:
+  - Gontero B
+  - Launay H
+- question: Should CP12&#39;s role in protecting PRK from irreversible inactivation (redox-independent)
+    be annotated separately from its role in dark/light regulation of the Calvin cycle
+    (redox-dependent)?
+  experts:
+  - Gontero B
+suggested_experiments:
+- hypothesis: CP12 copper binding is relevant in vivo for Calvin cycle regulation
+  description: Measure Calvin cycle enzyme activity and PRK/GAPDH/CP12 complex formation
+    in C. reinhardtii cells grown under copper-depleted vs. copper-replete conditions,
+    comparing wild-type and ΔCP12 strains. Use immunoprecipitation to assess complex
+    formation kinetics during light-to-dark transitions.
+- hypothesis: CP12 has additional interaction partners beyond GAPDH and PRK
+  description: Perform in vivo crosslinking mass spectrometry (XL-MS) or proximity
+    labeling (BioID/TurboID) with tagged CP12 in C. reinhardtii to identify the full
+    interactome, including reported interactions with aldolase and malate dehydrogenase.
+</code></pre>
+            </div>
+        </details>
+    </div>
+
+    <!-- Pathway Visualization Link -->
+    
+
+    <style>
+        /* Markdown Section Styles */
+        .markdown-section {
+            margin-bottom: 1rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .markdown-section summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .markdown-section summary h3 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.1rem;
+        }
+
+        .markdown-section summary:hover h3 {
+            color: #007bff;
+        }
+
+        .markdown-section[open] {
+            background-color: #fff;
+        }
+
+        .markdown-content {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-top: 1px solid #dee2e6;
+        }
+
+        /* Markdown content styling */
+        .markdown-content h1 { font-size: 1.5rem; margin-top: 1.5rem; }
+        .markdown-content h2 { font-size: 1.3rem; margin-top: 1.3rem; }
+        .markdown-content h3 { font-size: 1.1rem; margin-top: 1.1rem; }
+        .markdown-content h4 { font-size: 1rem; margin-top: 1rem; }
+
+        .markdown-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .markdown-content code {
+            background-color: #f8f9fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+        }
+
+        .markdown-content pre code {
+            background: none;
+            padding: 0;
+        }
+
+        .markdown-content table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1rem 0;
+        }
+
+        .markdown-content table th,
+        .markdown-content table td {
+            border: 1px solid #dee2e6;
+            padding: 0.5rem;
+            text-align: left;
+        }
+
+        .markdown-content table th {
+            background-color: #f8f9fa;
+            font-weight: bold;
+        }
+
+        .markdown-content blockquote {
+            border-left: 4px solid #007bff;
+            padding-left: 1rem;
+            margin-left: 0;
+            color: #666;
+        }
+
+        /* YAML Preview Styles */
+        .yaml-preview {
+            margin-top: 2rem;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 1rem;
+            background-color: #f8f9fa;
+        }
+
+        .yaml-preview summary {
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .yaml-preview summary h2 {
+            margin: 0;
+            color: #495057;
+            font-size: 1.3rem;
+        }
+
+        .yaml-preview summary:hover h2 {
+            color: #007bff;
+        }
+
+        .yaml-preview[open] {
+            background-color: #fff;
+        }
+
+        .yaml-content {
+            margin-top: 1rem;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+
+        .yaml-content pre {
+            margin: 0;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 0.9rem;
+            line-height: 1.4;
+        }
+
+        .yaml-content code {
+            color: #333;
+            background: none;
+            padding: 0;
+        }
+
+        /* Pathway Link Styles */
+        .pathway-link {
+            margin: 1rem 0;
+        }
+
+        .btn-link {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background-color: #007bff;
+            color: white !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: 500;
+            transition: background-color 0.2s;
+        }
+
+        .btn-link:hover {
+            background-color: #0056b3;
+            text-decoration: none;
+        }
+
+        /* Voting buttons */
+        .vote-buttons {
+            display: inline-block;
+            margin-left: 0.5rem;
+        }
+
+        .vote-btn {
+            background: none;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            padding: 2px 6px;
+            margin: 0 2px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+            opacity: 0.6;
+        }
+
+        .vote-btn:hover {
+            opacity: 1;
+            transform: scale(1.1);
+        }
+
+        .vote-btn.voted {
+            opacity: 1;
+            border-color: #28a745;
+            background-color: #d4edda;
+        }
+
+        .vote-btn.voted-down {
+            border-color: #dc3545;
+            background-color: #f8d7da;
+        }
+
+        .vote-btn-small {
+            font-size: 0.7rem;
+            padding: 1px 4px;
+            margin: 0 1px;
+        }
+    </style>
+
+    <script>
+        // Add collapsible functionality
+        document.querySelectorAll('.collapsible').forEach(element => {
+            element.addEventListener('click', function() {
+                this.classList.toggle('collapsed');
+            });
+        });
+
+        // Voting functionality
+        const VOTE_URL = 'https://script.google.com/macros/s/AKfycbwPKH7d3seuPNBtB0ugVjqGeTiByyOGD5vkqB_Ck6K8eOcPQYbJqBOuz6GFgXHKBNWK/exec';
+
+        // Get or create session ID
+        let sessionId = localStorage.getItem('review_session_id');
+        if (!sessionId) {
+            sessionId = 's' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+            localStorage.setItem('review_session_id', sessionId);
+        }
+
+        // Show previous votes on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.vote-buttons').forEach(container => {
+                const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+                const previousVote = localStorage.getItem(key);
+                if (previousVote) {
+                    const btn = container.querySelector(`[data-v="${previousVote}"]`);
+                    if (btn) btn.classList.add(previousVote === 'up' ? 'voted' : 'voted-down');
+                }
+            });
+        });
+
+        // Handle vote clicks - Simple image beacon approach
+        document.addEventListener('click', function(e) {
+            if (!e.target.classList.contains('vote-btn')) return;
+
+            // Prevent the click from bubbling to parent elements (like summary)
+            e.preventDefault();
+            e.stopPropagation();
+
+            const btn = e.target;
+            const container = btn.closest('.vote-buttons');
+            if (!container) return;
+
+            const voteType = btn.dataset.v;
+
+            // Check if already voted (locally)
+            const key = `vote_${container.dataset.g}_${container.dataset.a}_${container.dataset.act}`;
+            const previousVote = localStorage.getItem(key);
+
+            if (previousVote === voteType) {
+                // Same vote - do nothing
+                btn.style.animation = 'shake 0.5s';
+                setTimeout(() => btn.style.animation = '', 500);
+                return;
+            }
+
+            // Build URL
+            const params = new URLSearchParams({
+                gene_id: container.dataset.g,
+                annotation_id: container.dataset.a,
+                ref_id: container.dataset.r || '',
+                action: container.dataset.act,
+                vote: voteType,
+                session_id: sessionId,
+                ua: navigator.userAgent.substring(0, 100)
+            });
+
+            // Clear previous vote styling
+            container.querySelectorAll('.vote-btn').forEach(b => {
+                b.classList.remove('voted', 'voted-down');
+            });
+
+            // Apply new vote styling immediately (optimistic UI)
+            btn.classList.add(voteType === 'up' ? 'voted' : 'voted-down');
+
+            // Store locally
+            localStorage.setItem(key, voteType);
+
+            // Send vote using fetch with no-cors mode (fire and forget)
+            const fullUrl = VOTE_URL + '?' + params;
+            console.log('Sending vote to:', fullUrl);
+
+            // Use fetch in no-cors mode - we won't get a response but the request will be sent
+            fetch(fullUrl, {
+                mode: 'no-cors',
+                method: 'GET'
+            }).then(() => {
+                console.log('Vote request sent (no response due to no-cors mode)');
+            }).catch(err => {
+                console.warn('Vote may not have been recorded, but saved locally:', err);
+
+                // Fallback: try image beacon as well
+                const img = new Image();
+                img.src = fullUrl;
+            });
+        });
+
+        // Optional: Add shake animation for feedback
+        const style = document.createElement('style');
+        style.textContent = `
+            @keyframes shake {
+                0%, 100% { transform: translateX(0); }
+                25% { transform: translateX(-5px); }
+                75% { transform: translateX(5px); }
+            }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body>
+</html>

--- a/pages/projects/MITOCHONDRION_TARGETING_SEQUENCE_BINDING_OBSOLETION.html
+++ b/pages/projects/MITOCHONDRION_TARGETING_SEQUENCE_BINDING_OBSOLETION.html
@@ -1,0 +1,733 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mitochondrion Targeting Sequence Binding — Obsoletion &amp; Replacement - AI Gene Review Projects</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-primary: #3498db;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .breadcrumb {
+            margin-bottom: 1.5rem;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .breadcrumb a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        .breadcrumb a:hover {
+            text-decoration: underline;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        h2 {
+            font-size: 1.75rem;
+            font-weight: 600;
+            margin-top: 2rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        h3 {
+            font-size: 1.25rem;
+            font-weight: 600;
+            margin-top: 1.5rem;
+            margin-bottom: 0.75rem;
+            color: #374151;
+        }
+
+        h4 {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-top: 1.25rem;
+            margin-bottom: 0.5rem;
+            color: #4b5563;
+        }
+
+        p {
+            margin-bottom: 1rem;
+        }
+
+        a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        /* Gene symbol links */
+        .content a[href*="/genes/"] {
+            background-color: #dbeafe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-weight: 500;
+        }
+
+        .content a[href*="/genes/"]:hover {
+            background-color: #bfdbfe;
+        }
+
+        ul, ol {
+            margin-bottom: 1rem;
+            padding-left: 2rem;
+        }
+
+        li {
+            margin-bottom: 0.25rem;
+        }
+
+        code {
+            background: #f4f4f4;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 0.875em;
+        }
+
+        pre {
+            background: #1f2937;
+            color: #f9fafb;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+
+        pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+
+        blockquote {
+            border-left: 4px solid var(--color-primary);
+            margin-left: 0;
+            padding-left: 1.5rem;
+            color: #4b5563;
+            font-style: italic;
+            margin-bottom: 1rem;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1.5rem 0;
+        }
+
+        th, td {
+            border: 1px solid var(--border-color);
+            padding: 0.75rem;
+            text-align: left;
+        }
+
+        th {
+            background-color: var(--bg-light);
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            letter-spacing: 0.05em;
+        }
+
+        tr:nth-child(even) {
+            background-color: #f9fafb;
+        }
+
+        tr:hover {
+            background-color: #f3f4f6;
+        }
+
+        /* Mermaid diagrams */
+        .mermaid {
+            text-align: center;
+            margin: 2rem 0;
+            background: white;
+            padding: 1.5rem;
+            border-radius: 0.5rem;
+            border: 1px solid var(--border-color);
+        }
+
+        .mermaid svg {
+            max-width: 100%;
+            height: auto;
+        }
+
+        /* Warnings section */
+        .warnings {
+            background-color: #fef3c7;
+            border: 1px solid #fde68a;
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 2rem;
+        }
+
+        .warnings h3 {
+            color: #92400e;
+            margin-top: 0;
+            margin-bottom: 0.5rem;
+            font-size: 1rem;
+        }
+
+        .warnings ul {
+            margin-bottom: 0;
+            color: #78350f;
+        }
+
+        /* Task lists (checkboxes) */
+        li input[type="checkbox"] {
+            margin-right: 0.5rem;
+        }
+
+        /* Status badges */
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.625rem;
+            border-radius: 9999px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .badge-success {
+            background-color: #d1fae5;
+            color: #065f46;
+        }
+
+        .badge-warning {
+            background-color: #fef3c7;
+            color: #92400e;
+        }
+
+        .badge-info {
+            background-color: #dbeafe;
+            color: #1e40af;
+        }
+
+        /* Content wrapper */
+        .content {
+            margin-bottom: 2rem;
+        }
+
+        /* Footer */
+        footer {
+            margin-top: 3rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--border-color);
+            color: var(--text-muted);
+            font-size: 0.875rem;
+            text-align: center;
+        }
+
+        footer small {
+            display: block;
+        }
+    </style>
+    <!-- Mermaid.js for diagram rendering -->
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <script>
+        mermaid.initialize({
+            startOnLoad: true,
+            theme: 'default',
+            themeVariables: {
+                primaryColor: '#3498db',
+                primaryTextColor: '#fff',
+                primaryBorderColor: '#2c3e50',
+                lineColor: '#333',
+                secondaryColor: '#ecf0f1',
+                tertiaryColor: '#f39c12'
+            },
+            flowchart: {
+                htmlLabels: true,
+                curve: 'basis'
+            }
+        });
+    </script>
+</head>
+<body>
+    <nav class="breadcrumb">
+        <a href="../index.html">Home</a> &raquo;
+        <a href="index.html">Projects</a> &raquo;
+        Mitochondrion Targeting Sequence Binding — Obsoletion &amp; Replacement
+    </nav>
+
+    <header class="header">
+        <h1>Mitochondrion Targeting Sequence Binding — Obsoletion &amp; Replacement</h1>
+        
+    </header>
+
+    
+
+    <div class="content">
+        <h1 id="mitochondrion-targeting-sequence-binding-obsoletion-replacement">Mitochondrion Targeting Sequence Binding — Obsoletion &amp; Replacement</h1>
+<h2 id="overview">Overview</h2>
+<p>A GO obsoletion proposal will obsolete the molecular-function term<br />
+<code>GO:0030943 mitochondrion targeting sequence binding</code> (defined as "Binding to a<br />
+mitochondrion targeting sequence, a specific peptide sequence that acts as a<br />
+signal to localize the protein within the mitochondrion"). The upstream<br />
+rationale is that the curated content is better captured by a <strong>non-binding<br />
+receptor activity</strong> term rather than a generic "binding" term: the ontology<br />
+ticket proposes a New Term Request (NTR) for<br />
+<strong><code>mitochondrial signal sequence receptor activity</code></strong> as the replacement,<br />
+mirroring the existing nuclear/vacuolar pattern<br />
+(<code>GO:0061608 nuclear import signal receptor activity</code>,<br />
+<code>GO:0005049 nuclear export signal receptor activity</code>,<br />
+<code>GO:0010209 vacuolar sorting signal receptor activity</code>).</p>
+<p>Crucially, the go-annotation curators note that <strong>a simple <code>replaced_by</code><br />
+cannot be applied</strong>, because the existing annotations are <em>not only to the<br />
+receptor</em> — they span TOM cytosolic receptors, inner-membrane TIM<br />
+channel/receptor components, the TIM23 holo-complex, and at least one<br />
+non-canonical plant protein. Each annotation therefore needs individual review<br />
+to decide whether the new receptor MF is appropriate or whether a different<br />
+term (or removal) is the right outcome.</p>
+<p>This is part of the broader mitochondrial-import GO-CAM reorganization<br />
+(go-ontology#31711) and is a sibling of the "signal sequence binding and<br />
+children" review (go-ontology#31419, which also drives the<br />
+<code>GO:0008139 nuclear localization sequence binding</code> obsoletion in<br />
+go-annotation#6435). It complements — but does not overlap with — the<br />
+BP-focused [[MITOCHONDRIAL_IMPORT_PATHWAYS]] project, which covers the import<br />
+<em>pathway</em> terms rather than this MF term.</p>
+<h2 id="upstream-tickets">Upstream tickets</h2>
+<ul>
+<li>Annotation tracker: <a href="https://github.com/geneontology/go-annotation/issues/6437">geneontology/go-annotation#6437</a></li>
+<li>Ontology ticket (NTR + obsoletion): <a href="https://github.com/geneontology/go-ontology/issues/32142">geneontology/go-ontology#32142</a></li>
+<li>Parent reorganization: <a href="https://github.com/geneontology/go-ontology/issues/31711">geneontology/go-ontology#31711</a> (CLOSED — "Reorganization of mitochondrial import pathways based on GO-CAM modelling")</li>
+<li>Sibling "signal sequence binding" review: <a href="https://github.com/geneontology/go-ontology/issues/31419">geneontology/go-ontology#31419</a></li>
+</ul>
+<h2 id="obsoletion-plan-per-upstream">Obsoletion plan (per upstream)</h2>
+<table>
+<thead>
+<tr>
+<th>Obsoleted term</th>
+<th>ID</th>
+<th>Proposed replacement</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>mitochondrion targeting sequence binding (MF)</td>
+<td><a href="http://amigo.geneontology.org/amigo/term/GO:0030943">GO:0030943</a></td>
+<td>NTR <code>mitochondrial signal sequence receptor activity</code> (a <em>receptor</em>, non-binding MF) — applied per-annotation, not as a blanket <code>replaced_by</code></td>
+</tr>
+</tbody>
+</table>
+<p>Term labels verified in OLS on 2026-05-<a href="../../genes/BPT4/28/28-ai-review.html">28</a>:</p>
+<ul>
+<li><code>GO:0030943</code> (<code>mitochondrion targeting sequence binding</code>) — live, slated for<br />
+  obsoletion. Parent is <code>GO:0005048 signal sequence binding</code>. Synonym:<br />
+  "mitochondrial targeting sequence binding".</li>
+<li><code>GO:0005048</code> (<code>signal sequence binding</code>) — live parent MF.</li>
+<li><code>GO:0061608</code> (<code>nuclear import signal receptor activity</code>) — live; the model<br />
+  the NTR is patterned on.</li>
+<li><code>GO:0010209</code> (<code>vacuolar sorting signal receptor activity</code>) — live; analogous<br />
+  receptor MF.</li>
+<li><strong><code>mitochondrial signal sequence receptor activity</code></strong> — the proposed NTR was<br />
+<strong>not yet present in OLS as of 2026-05-<a href="../../genes/BPT4/28/28-ai-review.html">28</a></strong> (no GO ID minted). This is the<br />
+  key open dependency: nothing can be remapped until the new MF is created.</li>
+</ul>
+<h2 id="affected-experimental-curated-annotations-18">Affected experimental / curated annotations (<a href="../../genes/BPT4/18/18-ai-review.html">18</a>)</h2>
+<p>Retrieved from the QuickGO annotation API on 2026-05-<a href="../../genes/BPT4/28/28-ai-review.html">28</a><br />
+(<code>goId=GO:0030943</code>, manual / experimental + ComplexPortal NAS). Matches the<br />
+upstream group tally (ComplexPortal 4, FlyBase <a href="../../genes/BPT4/2/2-ai-review.html">2</a>, HGNC-UCL 1, RGD <a href="../../genes/BPT4/2/2-ai-review.html">2</a>, SGD <a href="../../genes/BPT4/7/7-ai-review.html">7</a>,<br />
+TAIR <a href="../../genes/BPT4/2/2-ai-review.html">2</a> = <a href="../../genes/BPT4/18/18-ai-review.html">18</a>).</p>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Source</th>
+<th>Accession</th>
+<th>Symbol</th>
+<th>Organism</th>
+<th>Evidence</th>
+<th>Reference</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td>RGD</td>
+<td>UniProtKB:A4F267</td>
+<td>Tomm40l</td>
+<td>Rat</td>
+<td>IDA</td>
+<td>PMID:17437969</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/2/2-ai-review.html">2</a></td>
+<td>RGD</td>
+<td>UniProtKB:Q62760</td>
+<td>Tomm20</td>
+<td>Rat</td>
+<td>IDA</td>
+<td>PMID:16511083</td>
+</tr>
+<tr>
+<td>3</td>
+<td>SGD</td>
+<td>UniProtKB:P07213</td>
+<td>TOM70</td>
+<td><em>S. cerevisiae</em></td>
+<td>IMP</td>
+<td>PMID:11054285</td>
+</tr>
+<tr>
+<td>4</td>
+<td>SGD</td>
+<td>UniProtKB:P32897</td>
+<td>TIM23</td>
+<td><em>S. cerevisiae</em></td>
+<td>IDA</td>
+<td>PMID:8858146</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/5/5-ai-review.html">5</a></td>
+<td>SGD</td>
+<td>UniProtKB:P32897</td>
+<td>TIM23</td>
+<td><em>S. cerevisiae</em></td>
+<td>IMP</td>
+<td>PMID:8858146</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/6/6-ai-review.html">6</a></td>
+<td>SGD</td>
+<td>UniProtKB:P35180</td>
+<td>TOM20</td>
+<td><em>S. cerevisiae</em></td>
+<td>IDA</td>
+<td>PMID:9252394</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/7/7-ai-review.html">7</a></td>
+<td>SGD</td>
+<td>UniProtKB:Q02776</td>
+<td>TIM50</td>
+<td><em>S. cerevisiae</em></td>
+<td>IDA</td>
+<td>PMID:18418384</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/8/8-ai-review.html">8</a></td>
+<td>SGD</td>
+<td>UniProtKB:Q02776</td>
+<td>TIM50</td>
+<td><em>S. cerevisiae</em></td>
+<td>IDA</td>
+<td>PMID:19144822</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/9/9-ai-review.html">9</a></td>
+<td>SGD</td>
+<td>UniProtKB:Q12328</td>
+<td><a href="../../genes/yeast/TIM22/TIM22-ai-review.html">TIM22</a></td>
+<td><em>S. cerevisiae</em></td>
+<td>IDA</td>
+<td>PMID:11864609</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/10/10-ai-review.html">10</a></td>
+<td>HGNC-UCL</td>
+<td>UniProtKB:Q15388</td>
+<td><a href="../../genes/human/TOMM20/TOMM20-ai-review.html">TOMM20</a></td>
+<td>Human</td>
+<td>IDA</td>
+<td>PMID:14557246</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/11/11-ai-review.html">11</a></td>
+<td>FlyBase</td>
+<td>UniProtKB:Q15388</td>
+<td><a href="../../genes/human/TOMM20/TOMM20-ai-review.html">TOMM20</a></td>
+<td>Human</td>
+<td>IDA</td>
+<td>PMID:35733257</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/12/12-ai-review.html">12</a></td>
+<td>FlyBase</td>
+<td>UniProtKB:Q9NS69</td>
+<td><a href="../../genes/human/TOMM22/TOMM22-ai-review.html">TOMM22</a></td>
+<td>Human</td>
+<td>IDA</td>
+<td>PMID:35733257</td>
+</tr>
+<tr>
+<td>13</td>
+<td>TAIR</td>
+<td>UniProtKB:Q9LMG7</td>
+<td><a href="../../genes/yeast/PAP2/PAP2-ai-review.html">PAP2</a></td>
+<td><em>A. thaliana</em></td>
+<td>IPI</td>
+<td>PMID:26304849</td>
+</tr>
+<tr>
+<td>14</td>
+<td>TAIR</td>
+<td>UniProtKB:Q9LMG7</td>
+<td><a href="../../genes/yeast/PAP2/PAP2-ai-review.html">PAP2</a></td>
+<td><em>A. thaliana</em></td>
+<td>IPI</td>
+<td>PMID:26304849</td>
+</tr>
+<tr>
+<td>15</td>
+<td>ComplexPortal</td>
+<td>ComplexPortal:CPX-539</td>
+<td>TIM23 complex (yeast)</td>
+<td><em>S. cerevisiae</em></td>
+<td>NAS</td>
+<td>PMID:16107694</td>
+</tr>
+<tr>
+<td>16</td>
+<td>ComplexPortal</td>
+<td>ComplexPortal:CPX-6127</td>
+<td>TIM23 complex (yeast)</td>
+<td><em>S. cerevisiae</em></td>
+<td>NAS</td>
+<td>PMID:16107694</td>
+</tr>
+<tr>
+<td>17</td>
+<td>ComplexPortal</td>
+<td>ComplexPortal:CPX-6129</td>
+<td>TIM23 complex (human)</td>
+<td>Human</td>
+<td>NAS</td>
+<td>PMID:10339406</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/18/18-ai-review.html">18</a></td>
+<td>ComplexPortal</td>
+<td>ComplexPortal:CPX-6130</td>
+<td>TIM23 complex (human)</td>
+<td>Human</td>
+<td>NAS</td>
+<td>PMID:10339406</td>
+</tr>
+</tbody>
+</table>
+<p>Note: rows <a href="../../genes/BPT4/11/11-ai-review.html">11</a>–<a href="../../genes/BPT4/12/12-ai-review.html">12</a> carry <code>assignedBy=FlyBase</code> on human accessions — confirmed<br />
+directly from QuickGO, presumably a cross-organism assertion; flagged here for<br />
+the curator's awareness.</p>
+<p>On top of these <a href="../../genes/BPT4/18/18-ai-review.html">18</a> curated records, <a href="http://amigo.geneontology.org/amigo/term/GO:0030943">GO:0030943</a> currently has <strong>~<a href="../../genes/BPT4/12/12-ai-review.html">12</a>,091 total<br />
+annotations</strong> (QuickGO, 2026-05-<a href="../../genes/BPT4/28/28-ai-review.html">28</a>), overwhelmingly IEA (TreeGrafter,<br />
+<code>GO_REF:0000118</code>) and IBA (<code>GO_REF:0000033</code>). These will be retired/redirected<br />
+automatically once the term is obsoleted, but the volume illustrates how far a<br />
+small set of curated TOM-receptor annotations has propagated.</p>
+<h2 id="why-a-blanket-replaced_by-does-not-work">Why a blanket <code>replaced_by</code> does not work</h2>
+<p>The annotations fall into biologically distinct classes, only some of which are<br />
+true presequence <em>receptors</em>:</p>
+<ul>
+<li><strong>Cytosolic TOM receptors</strong> — <a href="https://www.uniprot.org/uniprotkb/TOMM20/entry">TOMM20</a>/<code>TOM20</code> (human/rat/yeast), <a href="https://www.uniprot.org/uniprotkb/TOMM22/entry">TOMM22</a>,<br />
+  rat <code>Tomm40l</code>, yeast <code>TOM70</code>. These directly recognize the amphipathic<br />
+  N-terminal presequence on the cytosolic face. The NTR<br />
+<code>mitochondrial signal sequence receptor activity</code> is a clean fit here.</li>
+<li><strong>Trans-side (IMS) receptor</strong> — yeast <code>TIM50</code> hands the presequence from TOM<br />
+  to the TIM23 channel; receptor-like, the NTR likely fits.</li>
+<li><strong>Channel components</strong> — yeast <code>TIM23</code> (presequence translocation channel).<br />
+  Whether a "receptor activity" MF is the right home, versus modelling TIM23 as<br />
+  a transporter that is an input to the matrix-import BP, needs curator input.</li>
+<li><strong>Carrier-pathway channel</strong> — yeast <code>TIM22</code>. Carrier substrates (e.g.,<br />
+  metabolite carriers) use <strong>internal</strong> targeting signals, not cleavable<br />
+  N-terminal presequences. Annotating <a href="../../genes/yeast/TIM22/TIM22-ai-review.html">TIM22</a> to "mitochondrion targeting<br />
+  sequence binding" is already noted as a loose fit in this repo's<br />
+<code>genes/yeast/TIM22</code> review; the new presequence-receptor MF may <strong>not</strong> be<br />
+  the correct replacement for <a href="../../genes/yeast/TIM22/TIM22-ai-review.html">TIM22</a>.</li>
+<li><strong>Non-canonical / plant</strong> — Arabidopsis <code>PAP2</code> (purple acid phosphatase <a href="../../genes/BPT4/2/2-ai-review.html">2</a>,<br />
+  Q9LMG7), an IPI annotation (PMID:26304849). Needs individual review to decide<br />
+  whether a receptor MF applies at all.</li>
+<li><strong>Complex-level</strong> — ComplexPortal TIM23 holo-complex entries (CPX-539,<br />
+  CPX-6127, CPX-6129, CPX-6130). Map to the complex's receptor/transporter<br />
+  activity once the NTR exists.</li>
+</ul>
+<h2 id="impact-on-this-repo">Impact on this repo</h2>
+<p>Several affected gene products — or their human orthologs — already have<br />
+<code>*-ai-review.yaml</code> files that annotate <code>GO:0030943</code> (verified 2026-05-<a href="../../genes/BPT4/28/28-ai-review.html">28</a>):</p>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>Path</th>
+<th>Relation to affected set</th>
+<th>Current handling of <a href="http://amigo.geneontology.org/amigo/term/GO:0030943">GO:0030943</a></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="../../genes/human/TOMM20/TOMM20-ai-review.html">TOMM20</a> (human, Q15388)</td>
+<td><code>genes/human/TOMM20</code></td>
+<td>Directly affected (rows <a href="../../genes/BPT4/10/10-ai-review.html">10</a>–<a href="../../genes/BPT4/11/11-ai-review.html">11</a>)</td>
+<td><a href="https://www.uniprot.org/uniprotkb/ACCEPT/entry">ACCEPT</a> (core MF — presequence receptor)</td>
+</tr>
+<tr>
+<td><a href="../../genes/human/TOMM22/TOMM22-ai-review.html">TOMM22</a> (human, Q9NS69)</td>
+<td><code>genes/human/TOMM22</code></td>
+<td>Directly affected (row <a href="../../genes/BPT4/12/12-ai-review.html">12</a>)</td>
+<td>present (IDA + IBA)</td>
+</tr>
+<tr>
+<td><a href="../../genes/yeast/TIM22/TIM22-ai-review.html">TIM22</a> (yeast, Q12328)</td>
+<td><code>genes/yeast/TIM22</code></td>
+<td>Directly affected (row <a href="../../genes/BPT4/9/9-ai-review.html">9</a>)</td>
+<td>retained as "best available", with a caveat that the term is broader than the internal-signal binding it actually does</td>
+</tr>
+<tr>
+<td><a href="../../genes/human/TOMM70/TOMM70-ai-review.html">TOMM70</a> (human)</td>
+<td><code>genes/human/TOMM70</code></td>
+<td>Ortholog of affected yeast TOM70</td>
+<td>present (IBA)</td>
+</tr>
+<tr>
+<td><a href="../../genes/human/TOMM40/TOMM40-ai-review.html">TOMM40</a> (human)</td>
+<td><code>genes/human/TOMM40</code></td>
+<td>TOM channel; carries term via IBA</td>
+<td>present (IBA)</td>
+</tr>
+<tr>
+<td><a href="../../genes/human/TIMM50/TIMM50-ai-review.html">TIMM50</a> (human)</td>
+<td><code>genes/human/TIMM50</code></td>
+<td>Ortholog of affected yeast TIM50</td>
+<td>present</td>
+</tr>
+<tr>
+<td><a href="../../genes/human/TIMM22/TIMM22-ai-review.html">TIMM22</a> (human)</td>
+<td><code>genes/human/TIMM22</code></td>
+<td>Ortholog of affected yeast <a href="../../genes/yeast/TIM22/TIM22-ai-review.html">TIM22</a></td>
+<td>present</td>
+</tr>
+<tr>
+<td><a href="../../genes/yeast/ACL4/ACL4-ai-review.html">ACL4</a> (yeast)</td>
+<td><code>genes/yeast/ACL4</code></td>
+<td>Not in curated set; IBA over-propagation</td>
+<td>already <a href="https://www.uniprot.org/uniprotkb/REMOVE/entry">REMOVE</a> (Acl4 is an Rpl4 chaperone; no MTS binding) — a worked example of the IBA fallout</td>
+</tr>
+</tbody>
+</table>
+<p>When the obsoletion + NTR land, these reviews will need a <a href="https://www.uniprot.org/uniprotkb/MODIFY/entry">MODIFY</a> pass:<br />
+remap the TOM-receptor annotations to the new<br />
+<code>mitochondrial signal sequence receptor activity</code> MF, and handle <a href="../../genes/yeast/TIM22/TIM22-ai-review.html">TIM22</a> and any<br />
+complex/plant cases per the considerations above.</p>
+<h2 id="scope">Scope</h2>
+<ul>
+<li><strong>GO branch:</strong> Molecular Function (single term obsoletion + one NTR).</li>
+<li><strong>Organisms:</strong> Human, rat, <em>Saccharomyces cerevisiae</em>, <em>Arabidopsis<br />
+  thaliana</em> (curated set); plus the large IEA/IBA tail across all eukaryotes.</li>
+<li><strong>Gene set:</strong> TOM complex receptors (TOM20/TOMM20, <a href="../../genes/human/TOMM22/TOMM22-ai-review.html">TOMM22</a>, TOM70/TOMM70,<br />
+  Tomm40l), TIM23-complex components (TIM23, TIM50), the <a href="../../genes/yeast/TIM22/TIM22-ai-review.html">TIM22</a> carrier channel,<br />
+  the TIM23 holo-complexes (ComplexPortal), and Arabidopsis <a href="../../genes/yeast/PAP2/PAP2-ai-review.html">PAP2</a>.</li>
+<li><strong>Type of fix:</strong> Curation hygiene / refactor. The biology is well established<br />
+  (TOM20/TOM22 are the canonical presequence receptors); the work is about<br />
+  moving from a generic "binding" MF to a precise "receptor activity" MF and<br />
+  triaging the annotations that are not really receptor functions.</li>
+</ul>
+<h2 id="candidate-genes-for-initial-review">Candidate genes for initial review</h2>
+<p>Listed in priority order. The first three are the clean, high-value receptor<br />
+cases that already have reviews in this repo and would directly exercise the<br />
+new MF once minted.</p>
+<ol>
+<li><strong><a href="../../genes/human/TOMM20/TOMM20-ai-review.html">TOMM20</a> (human, Q15388)</strong> — canonical N-terminal presequence receptor;<br />
+   directly affected by two of the <a href="../../genes/BPT4/18/18-ai-review.html">18</a> annotations; review already<br />
+<a href="https://www.uniprot.org/uniprotkb/ACCEPT/entry">ACCEPT</a>s <a href="http://amigo.geneontology.org/amigo/term/GO:0030943">GO:0030943</a> as the core MF. Best positive control for the new<br />
+<code>mitochondrial signal sequence receptor activity</code>.<br />
+<a href="../../genes/BPT4/2/2-ai-review.html">2</a>. <strong><a href="../../genes/human/TOMM22/TOMM22-ai-review.html">TOMM22</a> (human, Q9NS69)</strong> — TOM central/co-receptor; directly affected.</li>
+<li><strong><a href="../../genes/human/TOMM70/TOMM70-ai-review.html">TOMM70</a> (human)</strong> — receptor for carrier/hydrophobic precursors; ortholog<br />
+   of the affected yeast TOM70 (P07213, IMP).</li>
+<li><strong>TIM50 / <a href="../../genes/human/TIMM50/TIMM50-ai-review.html">TIMM50</a></strong> — trans-side presequence handoff receptor; affected yeast<br />
+   TIM50 (Q02776) plus the human ortholog review here.<br />
+<a href="../../genes/BPT4/5/5-ai-review.html">5</a>. <strong><a href="../../genes/yeast/TIM22/TIM22-ai-review.html">TIM22</a> (yeast, Q12328)</strong> — special case: carrier pathway uses internal<br />
+   signals; decide whether the new receptor MF applies or whether the<br />
+   annotation should be removed/replaced with a carrier-import term.<br />
+<a href="../../genes/BPT4/6/6-ai-review.html">6</a>. <strong><a href="../../genes/yeast/PAP2/PAP2-ai-review.html">PAP2</a> (Arabidopsis, Q9LMG7)</strong> — non-canonical IPI annotation; case-by-case.<br />
+<a href="../../genes/BPT4/7/7-ai-review.html">7</a>. <strong>TIM23 complex (ComplexPortal CPX-539/6127/6129/6130)</strong> — complex-level<br />
+   handling once the NTR exists.</li>
+</ol>
+<h2 id="proposed-approach">Proposed approach</h2>
+<ol>
+<li><strong>Wait for the NTR + obsoletion to land.</strong> The replacement MF<br />
+   (<code>mitochondrial signal sequence receptor activity</code>) is not yet minted in GO<br />
+   (OLS, 2026-05-<a href="../../genes/BPT4/28/28-ai-review.html">28</a>). go-ontology#32142 is closed but the new GO ID must be<br />
+   confirmed before any remapping.<br />
+<a href="../../genes/BPT4/2/2-ai-review.html">2</a>. <strong>Pre-stage MODIFY proposals</strong> on the existing repo reviews (<a href="../../genes/human/TOMM20/TOMM20-ai-review.html">TOMM20</a>, <a href="../../genes/human/TOMM22/TOMM22-ai-review.html">TOMM22</a>,<br />
+<a href="../../genes/human/TOMM70/TOMM70-ai-review.html">TOMM70</a>, <a href="../../genes/human/TIMM50/TIMM50-ai-review.html">TIMM50</a>, <a href="../../genes/human/TIMM22/TIMM22-ai-review.html">TIMM22</a>, <a href="../../genes/human/TOMM40/TOMM40-ai-review.html">TOMM40</a>), changing <code>GO:0030943</code> → the new receptor MF<br />
+   for the genuine cytosolic/trans-side receptors.</li>
+<li><strong>Triage the non-receptor cases</strong> explicitly: <a href="../../genes/yeast/TIM22/TIM22-ai-review.html">TIM22</a> (internal-signal carrier<br />
+   channel), <a href="../../genes/yeast/PAP2/PAP2-ai-review.html">PAP2</a> (plant IPI), and the TIM23 holo-complex records. These are<br />
+   the reason upstream avoided a blanket <code>replaced_by</code>.</li>
+<li><strong>Note the IBA/IEA fallout</strong> (~12k annotations): once <a href="http://amigo.geneontology.org/amigo/term/GO:0030943">GO:0030943</a> is<br />
+   obsoleted, the GO_Central IBA and TreeGrafter IEA pipelines will need to be<br />
+   reseeded against the new MF. The yeast <code>ACL4</code> review (already <a href="https://www.uniprot.org/uniprotkb/REMOVE/entry">REMOVE</a>) is a<br />
+   concrete example of an IBA that should <em>not</em> be carried over to the new<br />
+   receptor term.<br />
+<a href="../../genes/BPT4/5/5-ai-review.html">5</a>. <strong>Coordinate with [[MITOCHONDRIAL_IMPORT_PATHWAYS]]</strong> so MF remapping and the<br />
+   BP pathway model stay consistent for shared TOM/TIM genes.</li>
+</ol>
+<h2 id="priority">Priority</h2>
+<p>Medium. Only <a href="../../genes/BPT4/18/18-ai-review.html">18</a> curated annotations, and several of the key genes already have<br />
+reviews here, so the marginal curation effort is low. The receptor biology is<br />
+uncontroversial, so the main blocker is external (the NTR GO ID is not yet<br />
+minted). The large IEA/IBA tail makes this more impactful than the very small<br />
+obsoletions, but no curator group is blocked waiting on AI Gene Review.</p>
+<h2 id="status">Status</h2>
+<ul>
+<li>2026-05-<a href="../../genes/BPT4/28/28-ai-review.html">28</a> — Project file created. Tracking go-annotation#6437 (opened<br />
+  2026-05-<a href="../../genes/BPT4/27/27-ai-review.html">27</a>) and go-ontology#32142 (closed; NTR + obsoletion request). The <a href="../../genes/BPT4/18/18-ai-review.html">18</a><br />
+  affected curated annotations were retrieved from QuickGO and reconciled<br />
+  against the upstream group tally. <a href="http://amigo.geneontology.org/amigo/term/GO:0030943">GO:0030943</a> confirmed live in OLS (parent<br />
+<code>GO:0005048</code>); the proposed replacement MF<br />
+<code>mitochondrial signal sequence receptor activity</code> is <strong>not yet in OLS</strong> — the<br />
+  key open dependency. Eight existing repo reviews already touch <a href="http://amigo.geneontology.org/amigo/term/GO:0030943">GO:0030943</a> and<br />
+  will need a MODIFY pass once the new term exists. No InterPro2GO / UniRule /<br />
+  UniProt-Keyword mappings to <a href="http://amigo.geneontology.org/amigo/term/GO:0030943">GO:0030943</a> were listed by upstream.</li>
+</ul>
+    </div>
+
+    <footer>
+        <small>Generated from MITOCHONDRION_TARGETING_SEQUENCE_BINDING_OBSOLETION.md</small>
+        <small>AI Gene Review Project</small>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Automated regeneration of static assets after gene review or template changes.

## Generated Assets

| Asset | Count/Status |
|-------|--------------|
| Gene review YAML files | 1942 |
| Gene review HTML pages | 1942 |
| Project pages | 125 |
| Browser app (data.js) | Updated |
| Validation report | Updated |

## Trigger

This PR was triggered by changes to:
- genes/**/*.yaml - gene review data files
- src/ai_gene_review/schema/** - LinkML schema files
- src/ai_gene_review/templates/** - Jinja2 templates
- src/ai_gene_review/render.py - rendering code
- src/ai_gene_review/export/** - export code
- src/ai_gene_review/browser/** - browser app assets
- src/ai_gene_review/tools/minify_linkml_browser_data.py - browser data compaction
- projects/*.md - project definitions
- project.justfile - just recipes used by CI
- .github/workflows/generate-pages.yaml - workflow definition

## Review

- [ ] Spot-check a few gene review HTML pages render correctly
- [ ] Verify browser app loads and filters work
- [ ] Check validation report for new issues