### PR TITLE
Add ABCE1 bioinformatics analysis (no TM region; two NBDs; di-[4Fe-4S])

### DIFF
--- a/genes/human/ABCE1/ABCE1-ai-review.yaml
+++ b/genes/human/ABCE1/ABCE1-ai-review.yaml
@@ -87,6 +87,12 @@ existing_annotations:
         **RNase L inhibitor/RLI**) is an essential, highly conserved **Fe–S
         ABC-family ATPase** that acts as the principal **eukaryotic ribosome
         recycling (splitting) factor**.
+    - reference_id: file:human/ABCE1/ABCE1-bioinformatics/RESULTS.md
+      supporting_text: >-
+        The N-terminal region (residues 1-80) contains nine cysteines arranged
+        across the two UniProt-annotated 4Fe-4S ferredoxin-type domains (7-37
+        and 46-75), consistent with coordination of two [4Fe-4S] clusters
+        rather than mononuclear iron.
 - term:
     id: GO:0005524
     label: ATP binding
@@ -700,6 +706,13 @@ existing_annotations:
         The remaining species were largely involved in cellular processes and
         molecular functions that could be predicted to be transiently associated
         with membranes.
+    - reference_id: file:human/ABCE1/ABCE1-bioinformatics/RESULTS.md
+      supporting_text: >-
+        The curated UniProt feature table for P61221 lists zero TRANSMEM
+        features, and an independent Kyte-Doolittle scan (window 19) finds no
+        window reaching the 1.6 transmembrane-helix threshold (global maximum
+        1.54 at residue 64), confirming ABCE1 has no transmembrane region and
+        is a soluble cytosolic protein.
 - term:
     id: GO:0005759
     label: mitochondrial matrix
@@ -923,6 +936,18 @@ references:
   - statement: ABCE1 is a conserved Fe-S ABC ATPase whose core function is ATP-driven eukaryotic ribosome recycling.
   - statement: ABCE1 functions with eRF1/eRF3 in canonical post-termination recycling and with PELO/HBS1L in stalled-ribosome rescue.
   - statement: RNase L inhibition and mitochondrial stress-associated relocalization are supported but are not the central conserved function.
+- id: file:human/ABCE1/ABCE1-bioinformatics/RESULTS.md
+  title: Sequence-level bioinformatics analysis of ABCE1 (transmembrane, NBD, and Fe-S architecture)
+  findings:
+  - statement: ABCE1 has no transmembrane region (0 UniProt TRANSMEM features; Kyte-Doolittle max 19-residue window 1.54, below the 1.6 TM-helix threshold), consistent with a soluble cytosolic ATPase rather than a membrane transporter.
+    supporting_text: >-
+      The curated UniProt feature table for P61221 lists zero TRANSMEM
+      features, and an independent Kyte-Doolittle scan (window 19) finds no
+      window reaching the 1.6 transmembrane-helix threshold (global maximum
+      1.54 at residue 64), confirming ABCE1 has no transmembrane region and is
+      a soluble cytosolic protein.
+  - statement: Two Walker A P-loop motifs map to the UniProt ATP-binding sites (110-117 and 379-386), confirming two nucleotide-binding domains.
+  - statement: The N-terminal region carries nine cysteines across the two UniProt-annotated ferredoxin-type domains, consistent with coordination of two [4Fe-4S] clusters.
 core_functions:
 - molecular_function:
     id: GO:0016887

--- a/genes/human/ABCE1/ABCE1-bioinformatics/RESULTS.md
+++ b/genes/human/ABCE1/ABCE1-bioinformatics/RESULTS.md
@@ -1,0 +1,101 @@
+# ABCE1 (P61221) — sequence-level bioinformatics analysis
+
+Reproducible support for three curation decisions in `ABCE1-ai-review.yaml`.
+All numbers below are produced by `analyze.py`, which parses the curated
+UniProt record `../ABCE1-uniprot.txt` at run time. Nothing is hardcoded.
+
+## How to reproduce
+
+```bash
+cd genes/human/ABCE1/ABCE1-bioinformatics
+python3 analyze.py            # pure standard library, no dependencies
+# or, for a pinned environment:
+uv run python analyze.py
+```
+
+## Methods
+
+- **Input:** UniProt/Swiss-Prot record P61221 (`ABCE1-uniprot.txt`), 599 aa.
+- **Transmembrane assessment:**
+  1. Count of curated `TRANSMEM` feature keys in the UniProt feature table
+     (authoritative line of evidence).
+  2. Confirmatory Kyte–Doolittle (1982) hydropathy scan, sliding window 19,
+     flagging any window whose mean hydropathy reaches the conventional
+     transmembrane-helix threshold of 1.6.
+- **Nucleotide-binding domains:** Walker A / P-loop consensus `[AG]-x(4)-G-K-[ST]`
+  and a strict Walker B pattern `[ILVFM]{3,4}-D-E`.
+- **Iron–sulfur architecture:** cysteine inventory and `CxxC` motifs in the
+  N-terminal 80 residues, compared against the two UniProt-annotated
+  `4Fe-4S ferredoxin-type` domains.
+
+These are heuristics. The Kyte–Doolittle scan and the regular-expression motif
+searches are corroborating, not definitive; the curated UniProt feature table
+and the experimental literature cited in the review remain the primary evidence.
+
+## Results
+
+### 1. No transmembrane region — ABCE1 is a soluble cytosolic protein
+
+The curated UniProt feature table for P61221 lists zero TRANSMEM features, and an independent Kyte-Doolittle scan (window 19) finds no window reaching the 1.6 transmembrane-helix threshold (global maximum 1.54 at residue 64), confirming ABCE1 has no transmembrane region and is a soluble cytosolic protein.
+
+| Metric | Value |
+|--------|-------|
+| UniProt `TRANSMEM` features | **0** |
+| Max 19-residue Kyte–Doolittle window mean | **1.54** (centered on residue 64) |
+| Windows at/above the 1.6 TM-helix threshold | **0** |
+
+The modest hydropathy peak at residue 64 lies inside the N-terminal Fe–S
+ferredoxin fold (domain 2, residues 46–75), i.e. it is a buried hydrophobic
+core, not a candidate membrane-spanning helix. This is consistent with the
+UniProt subcellular location (`Cytoplasm`) and with the UniProt note that
+*"The ABC transporter domains seem not to be functional"* — ABCE1 is an
+ABC-family **ATPase that acts on cytosolic ribosomes**, not a membrane
+transporter. This supports `REMOVE` of `GO:0016020` (membrane) and the
+broader interpretation that transporter/membrane-style annotations are
+over-annotations driven by the misleading "ABC sub-family E" name.
+
+### 2. Two nucleotide-binding domains (Walker A / Walker B)
+
+Two Walker A / P-loop motifs were found, at exactly the two ATP-binding sites
+annotated by UniProt (`BINDING 110..117` and `BINDING 379..386`):
+
+| NBD | Walker A position | Motif | Matches UniProt ATP `BINDING` |
+|-----|-------------------|-------|-------------------------------|
+| NBD1 | 110–117 | `GTNGIGKS` | 110–117 ✓ |
+| NBD2 | 379–386 | `GENGTGKT` | 379–386 ✓ |
+
+A canonical Walker B (`IFMFDE`, residues 237–242) is present in NBD1. NBD2's
+Walker B (preceding residue ~486) carries an aromatic residue in its
+hydrophobic run and so is not captured by the strict `[ILVFM]{3,4}DE` pattern —
+consistent with the well-documented asymmetry/degeneracy of the two ABCE1 NBDs.
+Together these confirm two intact nucleotide-binding domains, supporting the
+`ATP binding` (GO:0005524) and `ATP hydrolysis activity` (GO:0016887)
+annotations retained in the review.
+
+### 3. N-terminal di-cluster [4Fe-4S] (ferredoxin) architecture
+
+The N-terminal region (residues 1-80) contains nine cysteines arranged across the two UniProt-annotated 4Fe-4S ferredoxin-type domains (7-37 and 46-75), consistent with coordination of two [4Fe-4S] clusters rather than mononuclear iron.
+
+| Metric | Value |
+|--------|-------|
+| Cysteines in residues 1–80 | **9** (positions 16, 21, 25, 29, 38, 55, 58, 61, 65) |
+| `CxxC` motif starts | 55, 58 |
+| UniProt ferredoxin domains | 7–37, 46–75 |
+| UniProt/InterPro support | SUPFAM SSF54862 "4Fe-4S ferredoxins"; keyword `4Fe-4S` |
+
+Eight cysteines are sufficient to coordinate two [4Fe-4S] clusters
+(four per cluster); nine are observed. This supports the review's `MODIFY` of
+`GO:0005506` (iron ion binding) to the more informative
+`GO:0051539` (4 iron, 4 sulfur cluster binding).
+
+## Limitations
+
+- Kyte–Doolittle with a fixed window/threshold is a coarse predictor; a
+  dedicated tool (DeepTMHMM, Phobius) would be more sensitive. Here it only
+  corroborates the curated `TRANSMEM = 0`, which is the authoritative result.
+- Motif regular expressions can miss divergent sites (as seen for NBD2 Walker B)
+  and can in principle produce incidental matches; positions were cross-checked
+  against the UniProt feature table.
+- Cysteine counting does not prove cluster occupancy; it is consistent with,
+  not proof of, two [4Fe-4S] clusters. Cluster occupancy is established
+  experimentally and by structure in the cited literature.

--- a/genes/human/ABCE1/ABCE1-bioinformatics/analyze.py
+++ b/genes/human/ABCE1/ABCE1-bioinformatics/analyze.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Sequence-level analysis of human ABCE1 (UniProt P61221).
+
+Purpose: provide reproducible, programmatic support for three curation
+decisions in ABCE1-ai-review.yaml that otherwise rest on assertion or on
+the UniProt feature table alone:
+
+  1. ABCE1 has no transmembrane region (supports REMOVE of GO:0016020
+     "membrane" and the broader "ABC transporter domains are non-functional"
+     interpretation -> ABCE1 is a soluble cytosolic ATPase, not a transporter).
+  2. ABCE1 has two nucleotide-binding-domain (NBD) Walker A / Walker B motifs
+     (supports ATP binding / ATP hydrolysis activity).
+  3. ABCE1 has an N-terminal cysteine-rich region consistent with two
+     ferredoxin-type [4Fe-4S] clusters (supports MODIFY of GO:0005506
+     "iron ion binding" -> GO:0051539 "4 iron, 4 sulfur cluster binding").
+
+The script is pure standard library and parses the curated UniProt record
+(../ABCE1-uniprot.txt) at run time. Nothing is hardcoded: the sequence,
+the TRANSMEM feature count, and all motif positions are derived from the
+input file. Methods are heuristics and are clearly bounded in RESULTS.md;
+the authoritative line of evidence remains the curated UniProt feature table.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# Kyte & Doolittle (1982) hydropathy values.
+KD = {
+    "I": 4.5, "V": 4.2, "L": 3.8, "F": 2.8, "C": 2.5, "M": 1.9, "A": 1.8,
+    "G": -0.4, "T": -0.7, "S": -0.8, "W": -0.9, "Y": -1.3, "P": -1.6,
+    "H": -3.2, "E": -3.5, "Q": -3.5, "D": -3.5, "N": -3.5, "K": -3.9, "R": -4.5,
+}
+
+# Window and threshold conventions for putative TM-helix detection.
+TM_WINDOW = 19
+TM_THRESHOLD = 1.6  # mean KD score above which a window is flagged as TM-like
+
+UNIPROT = Path(__file__).resolve().parent.parent / "ABCE1-uniprot.txt"
+
+
+def parse_uniprot(path: Path) -> tuple[str, int, int]:
+    """Return (sequence, declared_length, transmem_feature_count)."""
+    text = path.read_text()
+    # Sequence: lines between the "SQ" line and the terminating "//".
+    seq_lines: list[str] = []
+    in_seq = False
+    declared_len = -1
+    for line in text.splitlines():
+        if line.startswith("SQ"):
+            in_seq = True
+            m = re.search(r"SEQUENCE\s+(\d+)\s+AA", line)
+            if m:
+                declared_len = int(m.group(1))
+            continue
+        if in_seq:
+            if line.startswith("//"):
+                break
+            seq_lines.append(line.strip())
+    sequence = re.sub(r"[^A-Z]", "", "".join(seq_lines).upper())
+    # Count curated TRANSMEM feature keys in the feature table.
+    transmem = len(re.findall(r"^FT\s+TRANSMEM\b", text, flags=re.MULTILINE))
+    return sequence, declared_len, transmem
+
+
+def hydropathy_scan(seq: str, window: int, threshold: float) -> dict:
+    if len(seq) < window:
+        return {"max_mean": None, "max_center": None, "tm_like_windows": 0}
+    scores = [KD.get(aa, 0.0) for aa in seq]
+    best_mean = float("-inf")
+    best_center = -1
+    tm_like = 0
+    half = window // 2
+    for start in range(0, len(seq) - window + 1):
+        mean = sum(scores[start:start + window]) / window
+        if mean >= threshold:
+            tm_like += 1
+        if mean > best_mean:
+            best_mean = mean
+            best_center = start + half + 1  # 1-based residue index
+    return {
+        "max_mean": round(best_mean, 3),
+        "max_center": best_center,
+        "tm_like_windows": tm_like,
+    }
+
+
+def find_walker_a(seq: str) -> list[dict]:
+    """P-loop / Walker A consensus [AG]-x(4)-G-K-[ST]."""
+    hits = []
+    for m in re.finditer(r"[AG].{4}GK[ST]", seq):
+        hits.append({"start": m.start() + 1, "end": m.end(), "motif": m.group()})
+    return hits
+
+
+def find_walker_b(seq: str) -> list[dict]:
+    """Walker B-like consensus: 3-4 hydrophobic residues followed by DE."""
+    hits = []
+    for m in re.finditer(r"[ILVFM]{3,4}DE", seq):
+        hits.append({"start": m.start() + 1, "end": m.end(), "motif": m.group()})
+    return hits
+
+
+def nterminal_cysteines(seq: str, region_end: int = 80) -> dict:
+    region = seq[:region_end]
+    positions = [i + 1 for i, aa in enumerate(region) if aa == "C"]
+    cxxc = [m.start() + 1 for m in re.finditer(r"(?=C..C)", region)]
+    return {
+        "region": f"1-{region_end}",
+        "cysteine_count": len(positions),
+        "cysteine_positions": positions,
+        "cxxc_motif_starts": cxxc,
+    }
+
+
+def main() -> int:
+    if not UNIPROT.exists():
+        print(f"ERROR: UniProt record not found at {UNIPROT}", file=sys.stderr)
+        return 1
+    seq, declared_len, transmem = parse_uniprot(UNIPROT)
+    result = {
+        "uniprot_id": "P61221",
+        "gene_symbol": "ABCE1",
+        "source_file": str(UNIPROT.name),
+        "sequence_length": len(seq),
+        "declared_length": declared_len,
+        "length_matches_header": len(seq) == declared_len,
+        "uniprot_transmem_features": transmem,
+        "hydropathy": hydropathy_scan(seq, TM_WINDOW, TM_THRESHOLD),
+        "tm_window": TM_WINDOW,
+        "tm_threshold": TM_THRESHOLD,
+        "walker_a_motifs": find_walker_a(seq),
+        "walker_b_motifs": find_walker_b(seq),
+        "n_terminal_fe_s": nterminal_cysteines(seq),
+    }
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/genes/human/ABCE1/ABCE1-bioinformatics/pyproject.toml
+++ b/genes/human/ABCE1/ABCE1-bioinformatics/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "abce1-bioinformatics"
+version = "0.1.0"
+description = "Sequence-level analysis of human ABCE1 (P61221) supporting its gene review"
+requires-python = ">=3.10"
+dependencies = []
+
+# analyze.py uses only the Python standard library, so there are no
+# third-party dependencies. Run with `uv run python analyze.py` or `python3 analyze.py`.


### PR DESCRIPTION
## Summary

Adds a small, reproducible bioinformatics analysis for **human ABCE1 (P61221)** that provides citable support for two curation decisions in `ABCE1-ai-review.yaml` which previously rested on assertion, and corroborates a third. New folder `genes/human/ABCE1/ABCE1-bioinformatics/` (`analyze.py` + `RESULTS.md` + `pyproject.toml`).

`analyze.py` is pure standard library and parses the curated UniProt record at run time — nothing is hardcoded.

### Findings (all computed from the local UniProt record)
- **No transmembrane region** → supports `REMOVE` of `GO:0016020` (membrane). 0 UniProt `TRANSMEM` features; Kyte–Doolittle (window 19) has **no window reaching the 1.6 TM-helix threshold** (global max 1.54, inside the N-terminal Fe–S fold). Consistent with `Cytoplasm` localization and the UniProt note that *"the ABC transporter domains seem not to be functional"* — ABCE1 is a soluble ATPase, not a membrane transporter.
- **Di-cluster [4Fe-4S] architecture** → supports `MODIFY` `GO:0005506` → `GO:0051539`. Nine N-terminal cysteines spanning the two ferredoxin-type domains (7–37, 46–75).
- **Two nucleotide-binding domains** (corroborating `ATP binding` / `ATP hydrolysis activity`): two Walker A P-loops mapping **exactly** to the UniProt ATP-binding sites (110–117, 379–386).

`RESULTS.md` is wired into the review as `supported_by` references on the membrane-REMOVE and Fe-S-MODIFY decisions. The review's curation decisions were independently audited (all 38 annotations) and found sound; this PR strengthens the evidence base rather than changing any action.

`just validate human ABCE1` → ✓ Valid (0 warnings, 0 errors).

Draft for maintainer review of the analysis approach (Kyte–Doolittle is a corroborating heuristic; the authoritative TM evidence is the curated `TRANSMEM = 0`).

## Test plan
- [ ] `cd genes/human/ABCE1/ABCE1-bioinformatics && python3 analyze.py` reproduces the reported numbers
- [ ] `just validate human ABCE1` passes
- [ ] Maintainer review of analysis methods / limitations in `RESULTS.md`

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)