### PR TITLE
Track GO:0070973 protein localization to ER exit site obsoletion (go-annotation#6434)

### DIFF
--- a/pages/projects/ER_EXIT_SITE_LOCALIZATION_OBSOLETION.html
+++ b/pages/projects/ER_EXIT_SITE_LOCALIZATION_OBSOLETION.html
@@ -1,0 +1,685 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Protein Localization to ER Exit Site — Obsoletion - AI Gene Review Projects</title>
+    <style>
+        :root {
+            --color-accept: #22c55e;
+            --color-remove: #ef4444;
+            --color-modify: #f97316;
+            --color-primary: #3498db;
+            --bg-light: #f9fafb;
+            --border-color: #e5e7eb;
+            --text-muted: #6b7280;
+            --text-primary: #111827;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text-primary);
+            background-color: #ffffff;
+            padding: 2rem;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .breadcrumb {
+            margin-bottom: 1.5rem;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+
+        .breadcrumb a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        .breadcrumb a:hover {
+            text-decoration: underline;
+        }
+
+        .header {
+            border-bottom: 2px solid var(--border-color);
+            padding-bottom: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            color: #1f2937;
+        }
+
+        h2 {
+            font-size: 1.75rem;
+            font-weight: 600;
+            margin-top: 2rem;
+            margin-bottom: 1rem;
+            color: #1f2937;
+            border-bottom: 1px solid var(--border-color);
+            padding-bottom: 0.5rem;
+        }
+
+        h3 {
+            font-size: 1.25rem;
+            font-weight: 600;
+            margin-top: 1.5rem;
+            margin-bottom: 0.75rem;
+            color: #374151;
+        }
+
+        h4 {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-top: 1.25rem;
+            margin-bottom: 0.5rem;
+            color: #4b5563;
+        }
+
+        p {
+            margin-bottom: 1rem;
+        }
+
+        a {
+            color: var(--color-primary);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        /* Gene symbol links */
+        .content a[href*="/genes/"] {
+            background-color: #dbeafe;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-weight: 500;
+        }
+
+        .content a[href*="/genes/"]:hover {
+            background-color: #bfdbfe;
+        }
+
+        ul, ol {
+            margin-bottom: 1rem;
+            padding-left: 2rem;
+        }
+
+        li {
+            margin-bottom: 0.25rem;
+        }
+
+        code {
+            background: #f4f4f4;
+            padding: 0.125rem 0.375rem;
+            border-radius: 0.25rem;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 0.875em;
+        }
+
+        pre {
+            background: #1f2937;
+            color: #f9fafb;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            overflow-x: auto;
+            margin-bottom: 1rem;
+        }
+
+        pre code {
+            background: none;
+            padding: 0;
+            color: inherit;
+        }
+
+        blockquote {
+            border-left: 4px solid var(--color-primary);
+            margin-left: 0;
+            padding-left: 1.5rem;
+            color: #4b5563;
+            font-style: italic;
+            margin-bottom: 1rem;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1.5rem 0;
+        }
+
+        th, td {
+            border: 1px solid var(--border-color);
+            padding: 0.75rem;
+            text-align: left;
+        }
+
+        th {
+            background-color: var(--bg-light);
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            letter-spacing: 0.05em;
+        }
+
+        tr:nth-child(even) {
+            background-color: #f9fafb;
+        }
+
+        tr:hover {
+            background-color: #f3f4f6;
+        }
+
+        /* Mermaid diagrams */
+        .mermaid {
+            text-align: center;
+            margin: 2rem 0;
+            background: white;
+            padding: 1.5rem;
+            border-radius: 0.5rem;
+            border: 1px solid var(--border-color);
+        }
+
+        .mermaid svg {
+            max-width: 100%;
+            height: auto;
+        }
+
+        /* Warnings section */
+        .warnings {
+            background-color: #fef3c7;
+            border: 1px solid #fde68a;
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin-bottom: 2rem;
+        }
+
+        .warnings h3 {
+            color: #92400e;
+            margin-top: 0;
+            margin-bottom: 0.5rem;
+            font-size: 1rem;
+        }
+
+        .warnings ul {
+            margin-bottom: 0;
+            color: #78350f;
+        }
+
+        /* Task lists (checkboxes) */
+        li input[type="checkbox"] {
+            margin-right: 0.5rem;
+        }
+
+        /* Status badges */
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.625rem;
+            border-radius: 9999px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .badge-success {
+            background-color: #d1fae5;
+            color: #065f46;
+        }
+
+        .badge-warning {
+            background-color: #fef3c7;
+            color: #92400e;
+        }
+
+        .badge-info {
+            background-color: #dbeafe;
+            color: #1e40af;
+        }
+
+        /* Content wrapper */
+        .content {
+            margin-bottom: 2rem;
+        }
+
+        /* Footer */
+        footer {
+            margin-top: 3rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--border-color);
+            color: var(--text-muted);
+            font-size: 0.875rem;
+            text-align: center;
+        }
+
+        footer small {
+            display: block;
+        }
+    </style>
+    <!-- Mermaid.js for diagram rendering -->
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <script>
+        mermaid.initialize({
+            startOnLoad: true,
+            theme: 'default',
+            themeVariables: {
+                primaryColor: '#3498db',
+                primaryTextColor: '#fff',
+                primaryBorderColor: '#2c3e50',
+                lineColor: '#333',
+                secondaryColor: '#ecf0f1',
+                tertiaryColor: '#f39c12'
+            },
+            flowchart: {
+                htmlLabels: true,
+                curve: 'basis'
+            }
+        });
+    </script>
+</head>
+<body>
+    <nav class="breadcrumb">
+        <a href="../index.html">Home</a> &raquo;
+        <a href="index.html">Projects</a> &raquo;
+        Protein Localization to ER Exit Site — Obsoletion
+    </nav>
+
+    <header class="header">
+        <h1>Protein Localization to ER Exit Site — Obsoletion</h1>
+        
+    </header>
+
+    
+
+    <div class="content">
+        <h1 id="protein-localization-to-er-exit-site-obsoletion">Protein Localization to ER Exit Site — Obsoletion</h1>
+<h2 id="overview">Overview</h2>
+<p>A GO obsoletion proposal will obsolete the biological-process term<br />
+<code>GO:0070973 protein localization to endoplasmic reticulum exit site</code><br />
+(defined as "A process in which a protein is transported to, or maintained in, a<br />
+location at an endoplasmic reticulum exit site"). The upstream rationale<br />
+(ValWood, go-ontology#19122) is that the term <strong>says nothing about the process<br />
+itself and conflates several distinct biological roles</strong> — it has been used for<br />
+COPII coat assembly factors, anterograde ER→Golgi transport cargo, regulators of<br />
+that transport, and ER quality-control proteins. Because the existing<br />
+annotations sit in <strong>different pathway contexts</strong>, a single blanket<br />
+<code>replaced_by</code> cannot be applied; each annotation needs an individually chosen<br />
+process term.</p>
+<p>This term sits alongside the related "protein exit from endoplasmic reticulum"<br />
+family (<code>GO:0032527</code> and its regulation children <code>GO:0070861/0070862/0070863</code>,<br />
+plus <code>GO:1904211</code>) that the same ontology ticket proposes to obsolete; that<br />
+sibling set is reviewed in go-annotation#6172. <a href="http://amigo.geneontology.org/amigo/term/GO:0070973">GO:0070973</a> was added to the same<br />
+ticket because it has the same conflation problem.</p>
+<h2 id="upstream-tickets">Upstream tickets</h2>
+<ul>
+<li>Annotation tracker: <a href="https://github.com/geneontology/go-annotation/issues/6434">geneontology/go-annotation#6434</a></li>
+<li>Ontology ticket (obsoletion): <a href="https://github.com/geneontology/go-ontology/issues/19122">geneontology/go-ontology#19122</a> (OPEN; labels: obsoletion, ready, vesicle-mediated-transport) — originally "obsoletion 'protein exit from endoplasmic reticulum'", with <a href="http://amigo.geneontology.org/amigo/term/GO:0070973">GO:0070973</a> added in the Jan/May 2026 discussion.</li>
+<li>Sibling "protein exit from ER" annotation review: <a href="https://github.com/geneontology/go-annotation/issues/6172">geneontology/go-annotation#6172</a></li>
+</ul>
+<h2 id="obsoletion-plan-per-upstream">Obsoletion plan (per upstream)</h2>
+<p>There is <strong>no single <code>replaced_by</code></strong>. The proposed per-annotation remapping<br />
+(ValWood, go-annotation/go-ontology#19122 comment, 2026-05-21) is:</p>
+<table>
+<thead>
+<tr>
+<th>Accession</th>
+<th>Symbol</th>
+<th>Source</th>
+<th>Organism</th>
+<th>Proposed action</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>O15027</td>
+<td>SEC16A</td>
+<td>UniProt</td>
+<td>Human</td>
+<td>→ <code>GO:0048208</code> COPII vesicle coating (syn. "COPII vesicle coat assembly")</td>
+</tr>
+<tr>
+<td>P34643</td>
+<td>sec-16A.1</td>
+<td>WB</td>
+<td><em>C. elegans</em></td>
+<td>→ <code>GO:0048208</code> COPII vesicle coating</td>
+</tr>
+<tr>
+<td>P48415</td>
+<td>SEC16</td>
+<td>SGD</td>
+<td><em>S. cerevisiae</em></td>
+<td>→ <code>GO:0048208</code> COPII vesicle coating</td>
+</tr>
+<tr>
+<td>Q5JRA6</td>
+<td>MIA3</td>
+<td>UniProt</td>
+<td>Human</td>
+<td>→ <code>GO:0006888</code> ER to Golgi vesicle-mediated transport</td>
+</tr>
+<tr>
+<td>Q5S007</td>
+<td><a href="../../genes/human/LRRK2/LRRK2-ai-review.html">LRRK2</a></td>
+<td>UniProt</td>
+<td>Human</td>
+<td>→ <code>GO:0060628</code> regulation of ER to Golgi vesicle-mediated transport</td>
+</tr>
+<tr>
+<td>Q5S006</td>
+<td>Lrrk2</td>
+<td>UniProt</td>
+<td>Mouse</td>
+<td><strong>delete</strong> — redundant; already carries <code>GO:0060628</code> from the same paper (PMID:25201882)</td>
+</tr>
+<tr>
+<td>Q57WC1</td>
+<td>Tb03.28C22.610</td>
+<td>GeneDB</td>
+<td><em>T. brucei</em></td>
+<td><strong>delete</strong> — already carries <code>GO:0006888</code> ER to Golgi vesicle-mediated transport</td>
+</tr>
+<tr>
+<td>Q61334</td>
+<td>Bcap29</td>
+<td>MGI</td>
+<td>Mouse</td>
+<td>→ ER quality control, likely <code>GO:0034976</code> response to endoplasmic reticulum stress (or descendant)</td>
+</tr>
+<tr>
+<td>Q61335</td>
+<td>Bcap31</td>
+<td>MGI</td>
+<td>Mouse</td>
+<td>→ ER quality control, likely <code>GO:0034976</code> response to endoplasmic reticulum stress (or descendant)</td>
+</tr>
+<tr>
+<td>Q92538</td>
+<td>GBF1</td>
+<td>UniProt</td>
+<td>Human</td>
+<td>→ vesicle-mediated transport or a descendant</td>
+</tr>
+</tbody>
+</table>
+<p>ValWood notes that for the forward (ER-export) direction generally,<br />
+<strong><code>GO:0090114</code> COPII-coated vesicle budding</strong> (synonym "ER exit") is often the<br />
+best replacement, since it is the COPII vesicle that drives exit from the ER.</p>
+<p>Term labels verified in OLS on 2026-05-<a href="../../genes/BPT4/29/29-ai-review.html">29</a>:</p>
+<ul>
+<li><code>GO:0070973</code> (<code>protein localization to endoplasmic reticulum exit site</code>) — live BP, slated for obsoletion. No children.</li>
+<li><code>GO:0048208</code> (<code>COPII vesicle coating</code>) — live; synonym "COPII vesicle coat assembly".</li>
+<li><code>GO:0090114</code> (<code>COPII-coated vesicle budding</code>) — live; synonym "ER exit".</li>
+<li><code>GO:0006888</code> (<code>endoplasmic reticulum to Golgi vesicle-mediated transport</code>) — live.</li>
+<li><code>GO:0060628</code> (<code>regulation of ER to Golgi vesicle-mediated transport</code>) — live.</li>
+<li><code>GO:0034976</code> (<code>response to endoplasmic reticulum stress</code>) — live.</li>
+</ul>
+<h2 id="affected-experimental-curated-annotations">Affected experimental / curated annotations</h2>
+<p>Retrieved from the QuickGO annotation API on 2026-05-<a href="../../genes/BPT4/29/29-ai-review.html">29</a> (<code>goId=GO:0070973</code>,<br />
+restricted to the named accessions). The curated (non-IEA) records:</p>
+<table>
+<thead>
+<tr>
+<th>#</th>
+<th>Source</th>
+<th>Accession</th>
+<th>Symbol</th>
+<th>Organism</th>
+<th>Evidence</th>
+<th>Qualifier</th>
+<th>Reference</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td>UniProt</td>
+<td>O15027</td>
+<td>SEC16A</td>
+<td>Human</td>
+<td>IMP</td>
+<td>involved_in</td>
+<td>PMID:28442536</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/2/2-ai-review.html">2</a></td>
+<td>WB</td>
+<td>P34643</td>
+<td>sec-16A.1</td>
+<td><em>C. elegans</em></td>
+<td>IMP</td>
+<td>involved_in</td>
+<td>PMID:21478858</td>
+</tr>
+<tr>
+<td>3</td>
+<td>SGD</td>
+<td>P48415</td>
+<td>SEC16</td>
+<td><em>S. cerevisiae</em></td>
+<td>IMP</td>
+<td>involved_in</td>
+<td>PMID:22675024</td>
+</tr>
+<tr>
+<td>4</td>
+<td>GeneDB</td>
+<td>Q57WC1</td>
+<td>Tb03.28C22.610</td>
+<td><em>T. brucei</em></td>
+<td>IMP</td>
+<td>acts_upstream_of_or_within</td>
+<td>PMID:24612401</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/5/5-ai-review.html">5</a></td>
+<td>UniProt</td>
+<td>Q5JRA6</td>
+<td>MIA3</td>
+<td>Human</td>
+<td>IMP</td>
+<td>involved_in</td>
+<td>PMID:28442536</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/6/6-ai-review.html">6</a></td>
+<td>UniProt</td>
+<td>Q5S006</td>
+<td>Lrrk2</td>
+<td>Mouse</td>
+<td>IMP</td>
+<td>involved_in</td>
+<td>PMID:25201882</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/7/7-ai-review.html">7</a></td>
+<td>UniProt</td>
+<td>Q5S007</td>
+<td><a href="../../genes/human/LRRK2/LRRK2-ai-review.html">LRRK2</a></td>
+<td>Human</td>
+<td>IMP</td>
+<td>involved_in</td>
+<td>PMID:25201882</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/8/8-ai-review.html">8</a></td>
+<td>MGI</td>
+<td>Q61334</td>
+<td>Bcap29</td>
+<td>Mouse</td>
+<td>IGI</td>
+<td>acts_upstream_of_or_within</td>
+<td>PMID:15187134</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/9/9-ai-review.html">9</a></td>
+<td>MGI</td>
+<td>Q61335</td>
+<td>Bcap31</td>
+<td>Mouse</td>
+<td>IGI</td>
+<td>acts_upstream_of_or_within</td>
+<td>PMID:15187134</td>
+</tr>
+<tr>
+<td><a href="../../genes/BPT4/10/10-ai-review.html">10</a></td>
+<td>UniProt</td>
+<td>Q92538</td>
+<td>GBF1</td>
+<td>Human</td>
+<td>IMP</td>
+<td>involved_in</td>
+<td>PMID:17956946</td>
+</tr>
+</tbody>
+</table>
+<p>The upstream group tally is GeneDB 1, MGI <a href="../../genes/BPT4/2/2-ai-review.html">2</a>, SGD 1, WB 1, ~UniProt <a href="../../genes/BPT4/7/7-ai-review.html">7</a>~ (the<br />
+UniProt portion is struck through in the issue, i.e. already handled by UniProt).<br />
+The minor count difference vs. the <a href="../../genes/BPT4/10/10-ai-review.html">10</a> rows above (UniProt tally of <a href="../../genes/BPT4/7/7-ai-review.html">7</a> vs. <a href="../../genes/BPT4/5/5-ai-review.html">5</a><br />
+distinct UniProt rows here) is likely spreadsheet rows for annotation extensions<br />
+or duplicates; flagged for the curator's awareness.</p>
+<p>On top of these curated records, <a href="http://amigo.geneontology.org/amigo/term/GO:0070973">GO:0070973</a> currently carries <strong>~14,414 total<br />
+annotations</strong> (QuickGO, 2026-05-<a href="../../genes/BPT4/29/29-ai-review.html">29</a>), overwhelmingly IEA (TreeGrafter<br />
+<code>GO_REF:0000118</code>; UniProt <a href="https://www.uniprot.org/uniprotkb/0000120/entry">GO_REF:0000104/0000120</a>) and IBA (<code>GO_REF:0000033</code>).<br />
+These will be retired/redirected automatically once the term is obsoleted, but<br />
+the volume shows how far a handful of curated annotations has propagated.</p>
+<h2 id="why-a-blanket-replaced_by-does-not-work">Why a blanket <code>replaced_by</code> does not work</h2>
+<p>The curated annotations fall into biologically distinct classes:</p>
+<ul>
+<li><strong>COPII coat-assembly scaffolds</strong> — SEC16A / SEC16 / sec-16A.1 organize ER<br />
+  exit sites and template the COPII coat. The right MF/BP is COPII vesicle<br />
+  coating (<code>GO:0048208</code>), not a "localization" term.</li>
+<li><strong>Anterograde transport cargo/machinery</strong> — MIA3/TANGO1 (<code>GO:0006888</code>),<br />
+  GBF1 (general vesicle-mediated transport). These are about the transport step<br />
+  itself.</li>
+<li><strong>Regulators of transport</strong> — <a href="../../genes/human/LRRK2/LRRK2-ai-review.html">LRRK2</a> regulates Sec16A at ER exit sites<br />
+  (<code>GO:0060628</code>, regulation of ER→Golgi transport). The mouse ortholog<br />
+  annotation is redundant with an existing regulation annotation from the same<br />
+  paper and should be deleted.</li>
+<li><strong>ER quality control</strong> — mouse Bcap29/Bcap31 (BAP29/BAP31) act upstream of ER<br />
+  export as translocon-associated sorting/QC chaperones; the upstream<br />
+  recommendation is an ER-stress / quality-control term (<code>GO:0034976</code>), not an<br />
+  ER-exit-site localization.</li>
+<li><strong>Already-redundant</strong> — the <em>T. brucei</em> GeneDB annotation already has<br />
+<code>GO:0006888</code> and should simply be deleted.</li>
+</ul>
+<h2 id="mappings-to-review">Mappings to review</h2>
+<ul>
+<li><code>GO:0070973</code> <strong>unirule2go</strong> <code>UniRule:UR001349783</code> &gt; protein localization to<br />
+  endoplasmic reticulum exit site. This UniRule mapping must be retargeted or<br />
+  removed when the term is obsoleted (otherwise the large IEA tail re-propagates).</li>
+</ul>
+<h2 id="impact-on-this-repo">Impact on this repo</h2>
+<p>Two affected gene products already have <code>*-ai-review.yaml</code> files that annotate<br />
+<code>GO:0070973</code> (verified 2026-05-<a href="../../genes/BPT4/29/29-ai-review.html">29</a>):</p>
+<table>
+<thead>
+<tr>
+<th>Gene</th>
+<th>Path</th>
+<th>Relation to affected set</th>
+<th>Current handling of <a href="http://amigo.geneontology.org/amigo/term/GO:0070973">GO:0070973</a></th>
+<th>Action when obsoletion lands</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="../../genes/human/LRRK2/LRRK2-ai-review.html">LRRK2</a> (human, Q5S007)</td>
+<td><code>genes/human/LRRK2</code></td>
+<td>Directly affected (row <a href="../../genes/BPT4/7/7-ai-review.html">7</a>)</td>
+<td>Two annotations — IEA (<code>GO_REF:0000120</code>) and IMP (PMID:25201882) — both <a href="https://www.uniprot.org/uniprotkb/ACCEPT/entry">ACCEPT</a> with summary "<a href="../../genes/human/LRRK2/LRRK2-ai-review.html">LRRK2</a> regulates Sec16A at ER exit sites"</td>
+<td><strong>MODIFY</strong> → <code>GO:0060628</code> regulation of ER to Golgi vesicle-mediated transport, matching the upstream Q5S007 plan</td>
+</tr>
+<tr>
+<td><a href="../../genes/human/BCAP31/BCAP31-ai-review.html">BCAP31</a> (human, Q61335 is the mouse ortholog)</td>
+<td><code>genes/human/BCAP31</code></td>
+<td>Ortholog of affected mouse Bcap31 (row <a href="../../genes/BPT4/9/9-ai-review.html">9</a>); the human record's <a href="http://amigo.geneontology.org/amigo/term/GO:0070973">GO:0070973</a> is an IBA over-propagation</td>
+<td>IBA already <code>MARK_AS_OVER_ANNOTATED</code> per go-annotation#6385 (over-propagation from PANTHER PTN000294723; core role is ER QC / translocon chaperone)</td>
+<td>No change needed — already flagged; obsoletion removes the IBA. The curated mouse Bcap29/Bcap31 records remap to <code>GO:0034976</code>, consistent with the existing "ER quality control" rationale</td>
+</tr>
+</tbody>
+</table>
+<p>The human <a href="../../genes/human/LRRK2/LRRK2-ai-review.html">LRRK2</a> review will need a <a href="https://www.uniprot.org/uniprotkb/MODIFY/entry">MODIFY</a> pass once the obsoletion lands; the<br />
+human <a href="../../genes/human/BCAP31/BCAP31-ai-review.html">BCAP31</a> review is already aligned with the upstream direction.</p>
+<h2 id="scope">Scope</h2>
+<ul>
+<li><strong>GO branch:</strong> Biological Process (single-term obsoletion, no <code>replaced_by</code>).</li>
+<li><strong>Organisms:</strong> Human, mouse, <em>S. cerevisiae</em>, <em>C. elegans</em>, <em>T. brucei</em><br />
+  (curated set); plus the large IEA/IBA tail across all eukaryotes.</li>
+<li><strong>Gene set:</strong> COPII coat scaffolds (SEC16A/SEC16/sec-16A.1), anterograde<br />
+  transport machinery (MIA3, GBF1), the transport regulator <a href="../../genes/human/LRRK2/LRRK2-ai-review.html">LRRK2</a>, and the ER<br />
+  quality-control proteins BAP29/BAP31.</li>
+<li><strong>Type of fix:</strong> Curation hygiene / refactor. The biology of each gene is well<br />
+  established; the work is splitting one over-loaded "localization" term into the<br />
+  correct process terms per annotation.</li>
+</ul>
+<h2 id="candidate-genes-for-initial-review">Candidate genes for initial review</h2>
+<p>Listed in priority order. The first two already have reviews here and would be<br />
+directly exercised by the obsoletion.</p>
+<ol>
+<li><strong><a href="../../genes/human/LRRK2/LRRK2-ai-review.html">LRRK2</a> (human, Q5S007)</strong> — already reviewed; needs a <a href="https://www.uniprot.org/uniprotkb/MODIFY/entry">MODIFY</a> of <a href="http://amigo.geneontology.org/amigo/term/GO:0070973">GO:0070973</a> →<br />
+<code>GO:0060628</code> (regulation of ER→Golgi transport). Highest-value, lowest-effort.<br />
+<a href="../../genes/BPT4/2/2-ai-review.html">2</a>. <strong><a href="../../genes/human/BCAP31/BCAP31-ai-review.html">BCAP31</a> (human)</strong> — already reviewed and <code>MARK_AS_OVER_ANNOTATED</code>; confirm<br />
+   alignment once obsoletion lands.</li>
+<li><strong>SEC16A (human, O15027)</strong> — clean COPII coat-assembly case → <code>GO:0048208</code>;<br />
+   not yet in this repo. A good positive control for the COPII-coating remap.</li>
+<li><strong>MIA3 / TANGO1 (human, Q5JRA6)</strong> — anterograde transport of bulky cargo →<br />
+<code>GO:0006888</code>; not yet in this repo.<br />
+<a href="../../genes/BPT4/5/5-ai-review.html">5</a>. <strong>GBF1 (human, Q92538)</strong> — Arf-GEF at the ER-Golgi interface → vesicle-mediated<br />
+   transport; not yet in this repo.<br />
+<a href="../../genes/BPT4/6/6-ai-review.html">6</a>. <strong>SEC16 (yeast, P48415)</strong> — canonical ER-exit-site organizer; cross-check<br />
+   against the human SEC16A handling.</li>
+</ol>
+<h2 id="proposed-approach">Proposed approach</h2>
+<ol>
+<li><strong>Track the obsoletion.</strong> go-ontology#19122 is OPEN and labeled "ready"; the<br />
+   replacement terms already exist in GO (<code>GO:0048208</code>, <code>GO:0090114</code>,<br />
+<code>GO:0006888</code>, <code>GO:0060628</code>, <code>GO:0034976</code>), so no NTR blocks this — unlike the<br />
+   mitochondrion-targeting-sequence-binding case.<br />
+<a href="../../genes/BPT4/2/2-ai-review.html">2</a>. <strong>Pre-stage the <a href="../../genes/human/LRRK2/LRRK2-ai-review.html">LRRK2</a> MODIFY</strong> (<a href="http://amigo.geneontology.org/amigo/term/GO:0070973">GO:0070973</a> → <code>GO:0060628</code>) so the repo review<br />
+   is ready the moment the term is obsoleted. Both <a href="../../genes/human/LRRK2/LRRK2-ai-review.html">LRRK2</a> <a href="http://amigo.geneontology.org/amigo/term/GO:0070973">GO:0070973</a> annotations<br />
+   (IEA and IMP) should move together.</li>
+<li><strong>Confirm <a href="../../genes/human/BCAP31/BCAP31-ai-review.html">BCAP31</a></strong> stays <code>MARK_AS_OVER_ANNOTATED</code>; the curated mouse<br />
+   Bcap29/Bcap31 remap to <code>GO:0034976</code> is consistent with the human review.</li>
+<li><strong>Optionally seed SEC16A / MIA3 / GBF1 reviews</strong> as the clean COPII / secretory<br />
+   cases, since they exercise the three main replacement terms.<br />
+<a href="../../genes/BPT4/5/5-ai-review.html">5</a>. <strong>Flag the UniRule mapping</strong> (<code>UR001349783</code>) for retargeting/removal to stop<br />
+   IEA re-propagation after obsoletion.</li>
+</ol>
+<h2 id="priority">Priority</h2>
+<p>Low–medium. Only ~<a href="../../genes/BPT4/10/10-ai-review.html">10</a> curated annotations, replacement terms already exist, and<br />
+the two repo-resident genes (<a href="../../genes/human/LRRK2/LRRK2-ai-review.html">LRRK2</a>, <a href="../../genes/human/BCAP31/BCAP31-ai-review.html">BCAP31</a>) are already reviewed — <a href="../../genes/human/LRRK2/LRRK2-ai-review.html">LRRK2</a> just<br />
+needs a one-line MODIFY and <a href="../../genes/human/BCAP31/BCAP31-ai-review.html">BCAP31</a> is already aligned. No curator group is<br />
+blocked waiting on AI Gene Review. The large IEA/IBA tail (driven by the<br />
+UniRule mapping) makes the cleanup more impactful than the small curated count<br />
+suggests.</p>
+<h2 id="status">Status</h2>
+<ul>
+<li>2026-05-<a href="../../genes/BPT4/29/29-ai-review.html">29</a> — Project file created. Tracking go-annotation#6434 and<br />
+  go-ontology#19122 (OPEN, "ready"). The <a href="../../genes/BPT4/10/10-ai-review.html">10</a> curated annotations were retrieved<br />
+  from QuickGO and reconciled against ValWood's per-annotation remapping plan and<br />
+  the upstream group tally. All five replacement terms (<code>GO:0048208</code>,<br />
+<code>GO:0090114</code>, <code>GO:0006888</code>, <code>GO:0060628</code>, <code>GO:0034976</code>) confirmed live in OLS,<br />
+  so no NTR is blocking. Two existing repo reviews touch <a href="http://amigo.geneontology.org/amigo/term/GO:0070973">GO:0070973</a>: human <a href="../../genes/human/LRRK2/LRRK2-ai-review.html">LRRK2</a><br />
+  (needs MODIFY → <code>GO:0060628</code>) and human <a href="../../genes/human/BCAP31/BCAP31-ai-review.html">BCAP31</a> (already<br />
+<code>MARK_AS_OVER_ANNOTATED</code> per go-annotation#6385). One UniRule mapping<br />
+  (<code>UR001349783</code>) needs retargeting/removal.</li>
+</ul>
+    </div>
+
+    <footer>
+        <small>Generated from ER_EXIT_SITE_LOCALIZATION_OBSOLETION.md</small>
+        <small>AI Gene Review Project</small>
+    </footer>
+</body>
+</html>

--- a/pages/projects/ER_EXIT_SITE_LOCALIZATION_OBSOLETION.html
+++ b/pages/projects/ER_EXIT_SITE_LOCALIZATION_OBSOLETION.html
@@ -345,21 +345,21 @@ ticket because it has the same conflation problem.</p>
 <td>SEC16A</td>
 <td>UniProt</td>
 <td>Human</td>
-<td>→ <code>GO:0048208</code> COPII vesicle coating (syn. "COPII vesicle coat assembly")</td>
+<td>→ <code>GO:0048208</code> COPII vesicle coat assembly (syn. "COPII vesicle coating")</td>
 </tr>
 <tr>
 <td>P34643</td>
 <td>sec-16A.1</td>
 <td>WB</td>
 <td><em>C. elegans</em></td>
-<td>→ <code>GO:0048208</code> COPII vesicle coating</td>
+<td>→ <code>GO:0048208</code> COPII vesicle coat assembly</td>
 </tr>
 <tr>
 <td>P48415</td>
 <td>SEC16</td>
 <td>SGD</td>
 <td><em>S. cerevisiae</em></td>
-<td>→ <code>GO:0048208</code> COPII vesicle coating</td>
+<td>→ <code>GO:0048208</code> COPII vesicle coat assembly</td>
 </tr>
 <tr>
 <td>Q5JRA6</td>
@@ -418,7 +418,7 @@ best replacement, since it is the COPII vesicle that drives exit from the ER.</p
 <p>Term labels verified in OLS on 2026-05-<a href="../../genes/BPT4/29/29-ai-review.html">29</a>:</p>
 <ul>
 <li><code>GO:0070973</code> (<code>protein localization to endoplasmic reticulum exit site</code>) — live BP, slated for obsoletion. No children.</li>
-<li><code>GO:0048208</code> (<code>COPII vesicle coating</code>) — live; synonym "COPII vesicle coat assembly".</li>
+<li><code>GO:0048208</code> (<code>COPII vesicle coat assembly</code>) — live; renamed from "COPII vesicle coating" (go-ontology PR #32013).</li>
 <li><code>GO:0090114</code> (<code>COPII-coated vesicle budding</code>) — live; synonym "ER exit".</li>
 <li><code>GO:0006888</code> (<code>endoplasmic reticulum to Golgi vesicle-mediated transport</code>) — live.</li>
 <li><code>GO:0060628</code> (<code>regulation of ER to Golgi vesicle-mediated transport</code>) — live.</li>
@@ -558,7 +558,7 @@ the volume shows how far a handful of curated annotations has propagated.</p>
 <ul>
 <li><strong>COPII coat-assembly scaffolds</strong> — SEC16A / SEC16 / sec-16A.1 organize ER<br />
   exit sites and template the COPII coat. The right MF/BP is COPII vesicle<br />
-  coating (<code>GO:0048208</code>), not a "localization" term.</li>
+  coat assembly (<code>GO:0048208</code>), not a "localization" term.</li>
 <li><strong>Anterograde transport cargo/machinery</strong> — MIA3/TANGO1 (<code>GO:0006888</code>),<br />
   GBF1 (general vesicle-mediated transport). These are about the transport step<br />
   itself.</li>

--- a/pages/projects/index.html
+++ b/pages/projects/index.html
@@ -254,6 +254,9 @@
             <a href="VESICLE_TARGETING_OBSOLETION.html">Vesicle Targeting (GO:0006903 obsoletion)</a>
         </div>
         <div class="project-card">
+            <a href="ER_EXIT_SITE_LOCALIZATION_OBSOLETION.html">Protein Localization to ER Exit Site (GO:0070973 obsoletion)</a>
+        </div>
+        <div class="project-card">
             <a href="SDH_GP2TERM_CONTRIBUTES_TO.html">Succinate Dehydrogenase gp2term (GO:0008177 enables→contributes_to)</a>
         </div>
     </div>

--- a/projects/ER_EXIT_SITE_LOCALIZATION_OBSOLETION.md
+++ b/projects/ER_EXIT_SITE_LOCALIZATION_OBSOLETION.md
@@ -33,9 +33,9 @@ There is **no single `replaced_by`**. The proposed per-annotation remapping
 
 | Accession | Symbol | Source | Organism | Proposed action |
 |---|---|---|---|---|
-| O15027 | SEC16A | UniProt | Human | → `GO:0048208` COPII vesicle coating (syn. "COPII vesicle coat assembly") |
-| P34643 | sec-16A.1 | WB | *C. elegans* | → `GO:0048208` COPII vesicle coating |
-| P48415 | SEC16 | SGD | *S. cerevisiae* | → `GO:0048208` COPII vesicle coating |
+| O15027 | SEC16A | UniProt | Human | → `GO:0048208` COPII vesicle coat assembly (syn. "COPII vesicle coating") |
+| P34643 | sec-16A.1 | WB | *C. elegans* | → `GO:0048208` COPII vesicle coat assembly |
+| P48415 | SEC16 | SGD | *S. cerevisiae* | → `GO:0048208` COPII vesicle coat assembly |
 | Q5JRA6 | MIA3 | UniProt | Human | → `GO:0006888` ER to Golgi vesicle-mediated transport |
 | Q5S007 | LRRK2 | UniProt | Human | → `GO:0060628` regulation of ER to Golgi vesicle-mediated transport |
 | Q5S006 | Lrrk2 | UniProt | Mouse | **delete** — redundant; already carries `GO:0060628` from the same paper (PMID:25201882) |
@@ -51,7 +51,7 @@ best replacement, since it is the COPII vesicle that drives exit from the ER.
 Term labels verified in OLS on 2026-05-29:
 
 - `GO:0070973` (`protein localization to endoplasmic reticulum exit site`) — live BP, slated for obsoletion. No children.
-- `GO:0048208` (`COPII vesicle coating`) — live; synonym "COPII vesicle coat assembly".
+- `GO:0048208` (`COPII vesicle coat assembly`) — live; renamed from "COPII vesicle coating" (go-ontology PR #32013).
 - `GO:0090114` (`COPII-coated vesicle budding`) — live; synonym "ER exit".
 - `GO:0006888` (`endoplasmic reticulum to Golgi vesicle-mediated transport`) — live.
 - `GO:0060628` (`regulation of ER to Golgi vesicle-mediated transport`) — live.
@@ -93,7 +93,7 @@ The curated annotations fall into biologically distinct classes:
 
 - **COPII coat-assembly scaffolds** — SEC16A / SEC16 / sec-16A.1 organize ER
   exit sites and template the COPII coat. The right MF/BP is COPII vesicle
-  coating (`GO:0048208`), not a "localization" term.
+  coat assembly (`GO:0048208`), not a "localization" term.
 - **Anterograde transport cargo/machinery** — MIA3/TANGO1 (`GO:0006888`),
   GBF1 (general vesicle-mediated transport). These are about the transport step
   itself.

--- a/projects/ER_EXIT_SITE_LOCALIZATION_OBSOLETION.md
+++ b/projects/ER_EXIT_SITE_LOCALIZATION_OBSOLETION.md
@@ -1,0 +1,195 @@
+# Protein Localization to ER Exit Site — Obsoletion
+
+## Overview
+
+A GO obsoletion proposal will obsolete the biological-process term
+`GO:0070973 protein localization to endoplasmic reticulum exit site`
+(defined as "A process in which a protein is transported to, or maintained in, a
+location at an endoplasmic reticulum exit site"). The upstream rationale
+(ValWood, go-ontology#19122) is that the term **says nothing about the process
+itself and conflates several distinct biological roles** — it has been used for
+COPII coat assembly factors, anterograde ER→Golgi transport cargo, regulators of
+that transport, and ER quality-control proteins. Because the existing
+annotations sit in **different pathway contexts**, a single blanket
+`replaced_by` cannot be applied; each annotation needs an individually chosen
+process term.
+
+This term sits alongside the related "protein exit from endoplasmic reticulum"
+family (`GO:0032527` and its regulation children `GO:0070861/0070862/0070863`,
+plus `GO:1904211`) that the same ontology ticket proposes to obsolete; that
+sibling set is reviewed in go-annotation#6172. GO:0070973 was added to the same
+ticket because it has the same conflation problem.
+
+## Upstream tickets
+
+- Annotation tracker: [geneontology/go-annotation#6434](https://github.com/geneontology/go-annotation/issues/6434)
+- Ontology ticket (obsoletion): [geneontology/go-ontology#19122](https://github.com/geneontology/go-ontology/issues/19122) (OPEN; labels: obsoletion, ready, vesicle-mediated-transport) — originally "obsoletion 'protein exit from endoplasmic reticulum'", with GO:0070973 added in the Jan/May 2026 discussion.
+- Sibling "protein exit from ER" annotation review: [geneontology/go-annotation#6172](https://github.com/geneontology/go-annotation/issues/6172)
+
+## Obsoletion plan (per upstream)
+
+There is **no single `replaced_by`**. The proposed per-annotation remapping
+(ValWood, go-annotation/go-ontology#19122 comment, 2026-05-21) is:
+
+| Accession | Symbol | Source | Organism | Proposed action |
+|---|---|---|---|---|
+| O15027 | SEC16A | UniProt | Human | → `GO:0048208` COPII vesicle coating (syn. "COPII vesicle coat assembly") |
+| P34643 | sec-16A.1 | WB | *C. elegans* | → `GO:0048208` COPII vesicle coating |
+| P48415 | SEC16 | SGD | *S. cerevisiae* | → `GO:0048208` COPII vesicle coating |
+| Q5JRA6 | MIA3 | UniProt | Human | → `GO:0006888` ER to Golgi vesicle-mediated transport |
+| Q5S007 | LRRK2 | UniProt | Human | → `GO:0060628` regulation of ER to Golgi vesicle-mediated transport |
+| Q5S006 | Lrrk2 | UniProt | Mouse | **delete** — redundant; already carries `GO:0060628` from the same paper (PMID:25201882) |
+| Q57WC1 | Tb03.28C22.610 | GeneDB | *T. brucei* | **delete** — already carries `GO:0006888` ER to Golgi vesicle-mediated transport |
+| Q61334 | Bcap29 | MGI | Mouse | → ER quality control, likely `GO:0034976` response to endoplasmic reticulum stress (or descendant) |
+| Q61335 | Bcap31 | MGI | Mouse | → ER quality control, likely `GO:0034976` response to endoplasmic reticulum stress (or descendant) |
+| Q92538 | GBF1 | UniProt | Human | → vesicle-mediated transport or a descendant |
+
+ValWood notes that for the forward (ER-export) direction generally,
+**`GO:0090114` COPII-coated vesicle budding** (synonym "ER exit") is often the
+best replacement, since it is the COPII vesicle that drives exit from the ER.
+
+Term labels verified in OLS on 2026-05-29:
+
+- `GO:0070973` (`protein localization to endoplasmic reticulum exit site`) — live BP, slated for obsoletion. No children.
+- `GO:0048208` (`COPII vesicle coating`) — live; synonym "COPII vesicle coat assembly".
+- `GO:0090114` (`COPII-coated vesicle budding`) — live; synonym "ER exit".
+- `GO:0006888` (`endoplasmic reticulum to Golgi vesicle-mediated transport`) — live.
+- `GO:0060628` (`regulation of ER to Golgi vesicle-mediated transport`) — live.
+- `GO:0034976` (`response to endoplasmic reticulum stress`) — live.
+
+## Affected experimental / curated annotations
+
+Retrieved from the QuickGO annotation API on 2026-05-29 (`goId=GO:0070973`,
+restricted to the named accessions). The curated (non-IEA) records:
+
+| # | Source | Accession | Symbol | Organism | Evidence | Qualifier | Reference |
+|---|---|---|---|---|---|---|---|
+| 1 | UniProt | O15027 | SEC16A | Human | IMP | involved_in | PMID:28442536 |
+| 2 | WB | P34643 | sec-16A.1 | *C. elegans* | IMP | involved_in | PMID:21478858 |
+| 3 | SGD | P48415 | SEC16 | *S. cerevisiae* | IMP | involved_in | PMID:22675024 |
+| 4 | GeneDB | Q57WC1 | Tb03.28C22.610 | *T. brucei* | IMP | acts_upstream_of_or_within | PMID:24612401 |
+| 5 | UniProt | Q5JRA6 | MIA3 | Human | IMP | involved_in | PMID:28442536 |
+| 6 | UniProt | Q5S006 | Lrrk2 | Mouse | IMP | involved_in | PMID:25201882 |
+| 7 | UniProt | Q5S007 | LRRK2 | Human | IMP | involved_in | PMID:25201882 |
+| 8 | MGI | Q61334 | Bcap29 | Mouse | IGI | acts_upstream_of_or_within | PMID:15187134 |
+| 9 | MGI | Q61335 | Bcap31 | Mouse | IGI | acts_upstream_of_or_within | PMID:15187134 |
+| 10 | UniProt | Q92538 | GBF1 | Human | IMP | involved_in | PMID:17956946 |
+
+The upstream group tally is GeneDB 1, MGI 2, SGD 1, WB 1, ~UniProt 7~ (the
+UniProt portion is struck through in the issue, i.e. already handled by UniProt).
+The minor count difference vs. the 10 rows above (UniProt tally of 7 vs. 5
+distinct UniProt rows here) is likely spreadsheet rows for annotation extensions
+or duplicates; flagged for the curator's awareness.
+
+On top of these curated records, GO:0070973 currently carries **~14,414 total
+annotations** (QuickGO, 2026-05-29), overwhelmingly IEA (TreeGrafter
+`GO_REF:0000118`; UniProt `GO_REF:0000104/0000120`) and IBA (`GO_REF:0000033`).
+These will be retired/redirected automatically once the term is obsoleted, but
+the volume shows how far a handful of curated annotations has propagated.
+
+## Why a blanket `replaced_by` does not work
+
+The curated annotations fall into biologically distinct classes:
+
+- **COPII coat-assembly scaffolds** — SEC16A / SEC16 / sec-16A.1 organize ER
+  exit sites and template the COPII coat. The right MF/BP is COPII vesicle
+  coating (`GO:0048208`), not a "localization" term.
+- **Anterograde transport cargo/machinery** — MIA3/TANGO1 (`GO:0006888`),
+  GBF1 (general vesicle-mediated transport). These are about the transport step
+  itself.
+- **Regulators of transport** — LRRK2 regulates Sec16A at ER exit sites
+  (`GO:0060628`, regulation of ER→Golgi transport). The mouse ortholog
+  annotation is redundant with an existing regulation annotation from the same
+  paper and should be deleted.
+- **ER quality control** — mouse Bcap29/Bcap31 (BAP29/BAP31) act upstream of ER
+  export as translocon-associated sorting/QC chaperones; the upstream
+  recommendation is an ER-stress / quality-control term (`GO:0034976`), not an
+  ER-exit-site localization.
+- **Already-redundant** — the *T. brucei* GeneDB annotation already has
+  `GO:0006888` and should simply be deleted.
+
+## Mappings to review
+
+- `GO:0070973` **unirule2go** `UniRule:UR001349783` > protein localization to
+  endoplasmic reticulum exit site. This UniRule mapping must be retargeted or
+  removed when the term is obsoleted (otherwise the large IEA tail re-propagates).
+
+## Impact on this repo
+
+Two affected gene products already have `*-ai-review.yaml` files that annotate
+`GO:0070973` (verified 2026-05-29):
+
+| Gene | Path | Relation to affected set | Current handling of GO:0070973 | Action when obsoletion lands |
+|---|---|---|---|---|
+| LRRK2 (human, Q5S007) | `genes/human/LRRK2` | Directly affected (row 7) | Two annotations — IEA (`GO_REF:0000120`) and IMP (PMID:25201882) — both `ACCEPT` with summary "LRRK2 regulates Sec16A at ER exit sites" | **MODIFY** → `GO:0060628` regulation of ER to Golgi vesicle-mediated transport, matching the upstream Q5S007 plan |
+| BCAP31 (human, Q61335 is the mouse ortholog) | `genes/human/BCAP31` | Ortholog of affected mouse Bcap31 (row 9); the human record's GO:0070973 is an IBA over-propagation | IBA already `MARK_AS_OVER_ANNOTATED` per go-annotation#6385 (over-propagation from PANTHER PTN000294723; core role is ER QC / translocon chaperone) | No change needed — already flagged; obsoletion removes the IBA. The curated mouse Bcap29/Bcap31 records remap to `GO:0034976`, consistent with the existing "ER quality control" rationale |
+
+The human LRRK2 review will need a `MODIFY` pass once the obsoletion lands; the
+human BCAP31 review is already aligned with the upstream direction.
+
+## Scope
+
+- **GO branch:** Biological Process (single-term obsoletion, no `replaced_by`).
+- **Organisms:** Human, mouse, *S. cerevisiae*, *C. elegans*, *T. brucei*
+  (curated set); plus the large IEA/IBA tail across all eukaryotes.
+- **Gene set:** COPII coat scaffolds (SEC16A/SEC16/sec-16A.1), anterograde
+  transport machinery (MIA3, GBF1), the transport regulator LRRK2, and the ER
+  quality-control proteins BAP29/BAP31.
+- **Type of fix:** Curation hygiene / refactor. The biology of each gene is well
+  established; the work is splitting one over-loaded "localization" term into the
+  correct process terms per annotation.
+
+## Candidate genes for initial review
+
+Listed in priority order. The first two already have reviews here and would be
+directly exercised by the obsoletion.
+
+1. **LRRK2 (human, Q5S007)** — already reviewed; needs a `MODIFY` of GO:0070973 →
+   `GO:0060628` (regulation of ER→Golgi transport). Highest-value, lowest-effort.
+2. **BCAP31 (human)** — already reviewed and `MARK_AS_OVER_ANNOTATED`; confirm
+   alignment once obsoletion lands.
+3. **SEC16A (human, O15027)** — clean COPII coat-assembly case → `GO:0048208`;
+   not yet in this repo. A good positive control for the COPII-coating remap.
+4. **MIA3 / TANGO1 (human, Q5JRA6)** — anterograde transport of bulky cargo →
+   `GO:0006888`; not yet in this repo.
+5. **GBF1 (human, Q92538)** — Arf-GEF at the ER-Golgi interface → vesicle-mediated
+   transport; not yet in this repo.
+6. **SEC16 (yeast, P48415)** — canonical ER-exit-site organizer; cross-check
+   against the human SEC16A handling.
+
+## Proposed approach
+
+1. **Track the obsoletion.** go-ontology#19122 is OPEN and labeled "ready"; the
+   replacement terms already exist in GO (`GO:0048208`, `GO:0090114`,
+   `GO:0006888`, `GO:0060628`, `GO:0034976`), so no NTR blocks this — unlike the
+   mitochondrion-targeting-sequence-binding case.
+2. **Pre-stage the LRRK2 MODIFY** (GO:0070973 → `GO:0060628`) so the repo review
+   is ready the moment the term is obsoleted. Both LRRK2 GO:0070973 annotations
+   (IEA and IMP) should move together.
+3. **Confirm BCAP31** stays `MARK_AS_OVER_ANNOTATED`; the curated mouse
+   Bcap29/Bcap31 remap to `GO:0034976` is consistent with the human review.
+4. **Optionally seed SEC16A / MIA3 / GBF1 reviews** as the clean COPII / secretory
+   cases, since they exercise the three main replacement terms.
+5. **Flag the UniRule mapping** (`UR001349783`) for retargeting/removal to stop
+   IEA re-propagation after obsoletion.
+
+## Priority
+
+Low–medium. Only ~10 curated annotations, replacement terms already exist, and
+the two repo-resident genes (LRRK2, BCAP31) are already reviewed — LRRK2 just
+needs a one-line MODIFY and BCAP31 is already aligned. No curator group is
+blocked waiting on AI Gene Review. The large IEA/IBA tail (driven by the
+UniRule mapping) makes the cleanup more impactful than the small curated count
+suggests.
+
+## Status
+
+- 2026-05-29 — Project file created. Tracking go-annotation#6434 and
+  go-ontology#19122 (OPEN, "ready"). The 10 curated annotations were retrieved
+  from QuickGO and reconciled against ValWood's per-annotation remapping plan and
+  the upstream group tally. All five replacement terms (`GO:0048208`,
+  `GO:0090114`, `GO:0006888`, `GO:0060628`, `GO:0034976`) confirmed live in OLS,
+  so no NTR is blocking. Two existing repo reviews touch GO:0070973: human LRRK2
+  (needs MODIFY → `GO:0060628`) and human BCAP31 (already
+  `MARK_AS_OVER_ANNOTATED` per go-annotation#6385). One UniRule mapping
+  (`UR001349783`) needs retargeting/removal.


### PR DESCRIPTION
## Summary

Adds a tracking project for the proposed obsoletion of **GO:0070973 protein localization to endoplasmic reticulum exit site**.

Addresses geneontology/go-annotation#6434 (ontology ticket geneontology/go-ontology#19122).

- The term **conflates several distinct processes** — COPII coat assembly (SEC16A/SEC16/sec-16A.1), anterograde ER→Golgi transport (MIA3, GBF1), regulation of that transport (LRRK2), and ER quality control (BAP29/BAP31) — so upstream cannot apply a blanket `replaced_by`. The project records the **per-annotation remap plan** (ValWood, go-ontology#19122).
- The **10 curated annotations** were pulled from QuickGO (2026-05-29) and reconciled against the upstream group tally (GeneDB 1, MGI 2, SGD 1, WB 1, ~UniProt 7~).
- All five replacement terms (`GO:0048208`, `GO:0090114`, `GO:0006888`, `GO:0060628`, `GO:0034976`) were confirmed live in OLS, so **no NTR blocks this** obsoletion.
- **Impact on this repo:** human `LRRK2` (GO:0070973 ×2, currently `ACCEPT`) needs a `MODIFY` → `GO:0060628` regulation of ER→Golgi transport; human `BCAP31` is already `MARK_AS_OVER_ANNOTATED` (per go-annotation#6385) and aligned with the upstream direction.
- One UniRule mapping (`UR001349783` → GO:0070973) flagged for retargeting/removal.

Includes the rendered project HTML and a new index card alongside the other vesicle-trafficking obsoletion entries.

## Test plan

- [x] `projects/ER_EXIT_SITE_LOCALIZATION_OBSOLETION.md` created
- [x] Replacement term IDs/labels verified in OLS
- [x] Curated annotation set verified via QuickGO
- [x] Project rendered to `pages/projects/ER_EXIT_SITE_LOCALIZATION_OBSOLETION.html`
- [x] Index card added to `pages/projects/index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)