### PR TITLE
Add ESMFold2 (Biohub) complex prediction caller and head-to-head framework

### DIFF
--- a/analysis/esmfold2/README.md
+++ b/analysis/esmfold2/README.md
@@ -1,0 +1,100 @@
+# ESMFold2 (Biohub) complex caller
+
+ESMFold2 counterpart to the BioLM Boltz2 callers used elsewhere under `analysis/`.
+Background and the decision to evaluate ESMFold2 are in
+[`projects/PROTEIN_COMPLEX_FUNCTIONS.md`](../../projects/PROTEIN_COMPLEX_FUNCTIONS.md)
+(2026-05-29 NOTES entry).
+
+ESMFold2 is the structure/interaction model in Biohub's protein "world model"
+(formerly EvolutionaryScale / Forge). It predicts multi-chain complexes, reports
+`pLDDT`/`pTM`/`ipTM`, is MIT-licensed with open weights, and is offered as a
+hosted endpoint at `https://biohub.ai` (model `esmfold2-fast-2026-05`). Its
+headline claim is interface accuracy (FoldBench DockQ pass-rate vs Chai-1,
+Boltz-1, AlphaFold 3), which is the regime our attribution pilots care about.
+
+## Why this lives next to the Boltz2 runs
+
+`run_esmfold2.py` writes its outputs with the **same filenames** the Boltz2
+analyzers already glob for:
+
+| File | Read by |
+|------|---------|
+| `esmfold2_model_0.cif` | `analyze_output.py` (`*_model_0.cif` / `*.cif`) |
+| `confidence_esmfold2.json` | `analyze_output.py` (`confidence_*.json`) |
+| `esmfold2_response.json` | raw response, provenance only |
+
+So the head-to-head re-run reuses the existing per-complex analyzers and FASTA
+inputs unchanged — only the structure-prediction backend changes.
+
+## Setup
+
+```bash
+cd analysis/esmfold2
+uv sync          # installs the `esm` SDK (MIT) + biopython
+export BIOHUB_API_TOKEN=...   # token from biohub.ai (or ESM_API_TOKEN)
+```
+
+Verify the installed SDK surface before spending a token:
+
+```bash
+python3 run_esmfold2.py --check-sdk
+```
+
+## Head-to-head re-runs (the three archived Boltz2 inputs)
+
+Each block predicts with ESMFold2 then runs the same analyzer that produced the
+Boltz2 `RESULTS_*` notes, so the confidence/interface readouts are directly
+comparable.
+
+```bash
+# Complex III: CYC1:UQCRFS1 active electron-transfer interface
+python3 run_esmfold2.py \
+  --fasta ../complex_iii_boltz/inputs/cyc1_uqcrfs1_ims_domains.fasta \
+  --output-dir cyc1_uqcrfs1_domains_out
+python3 ../complex_iii_boltz/analyze_output.py cyc1_uqcrfs1_domains_out \
+  --markdown-out RESULTS_CYC1_UQCRFS1_ESMFOLD2.md
+
+# Proteasome: PSMB5 (catalytic) vs PSMA1 (structural) control
+python3 run_esmfold2.py \
+  --fasta ../proteasome_boltz/inputs/psmb5_psma1_attribution_domains.fasta \
+  --output-dir psmb5_psma1_out
+python3 ../proteasome_boltz/analyze_output.py psmb5_psma1_out \
+  --markdown-out RESULTS_PSMB5_PSMA1_ESMFOLD2.md
+
+# Complex IV: COX2 Model C copper-maturation module (apo first; see ligand note)
+python3 run_esmfold2.py \
+  --fasta ../complex_iv_boltz/inputs/cox2_sco1_sco2_model_c_domains.fasta \
+  --output-dir cox2_model_c_out
+python3 ../complex_iv_boltz/analyze_model_c_output.py cox2_model_c_out \
+  --markdown-out RESULTS_MODEL_C_ESMFOLD2.md
+```
+
+All three FASTA paths above are exact files in the sibling `inputs/`
+directories. The Complex IV `model_c_domains` input is the apo (metal-free)
+domain set; a `..._cu_pocket` YAML variant exists for the metal-aware follow-up
+once `LigandInput` parameterization is verified.
+
+## Open items (must verify before relying on results)
+
+These are the same caveats recorded in the project note:
+
+1. **SDK surface.** The constructor, input-builder classes, and fold method
+   were taken from the published docs/README and not executed against a live
+   token here. `run_prediction()` tries `fold`/`predict`/`structure_predict`
+   and `extract_*` read fields defensively; `--check-sdk` prints what resolved.
+   Adjust the isolated `build_structure_input` / `run_prediction` /
+   `extract_confidence` helpers if the installed version differs.
+2. **PAE / pair-chain iPAE.** Not confirmed in the hosted API surface; the
+   Complex III analyzer reports pair-chain ipTM, which ESMFold2 does expose, but
+   iPAE may be local-weights-only.
+3. **Metals / cofactors.** Cu (COX2 CuA), heme (CYC1), and Fe-S (UQCRFS1) are
+   run apo here. `LigandInput` exists in the SDK but parameterization of
+   non-standard metals is unverified; treat metal-aware runs as a follow-up.
+4. **Quota.** Biohub states free availability to researchers; exact rate/credit
+   limits are unconfirmed.
+
+## Curation guardrail
+
+No ESMFold2 output is GO evidence on its own. As with the Boltz2 pilots it is
+hypothesis-generating triage: flag plausible interfaces and select cases for
+manual, literature-driven review.

--- a/analysis/esmfold2/pyproject.toml
+++ b/analysis/esmfold2/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "esmfold2-complex-pilot"
+version = "0.1.0"
+description = "ESMFold2 (Biohub/biohub.ai) caller for protein complex attribution pilots"
+requires-python = ">=3.10"
+dependencies = [
+    # Biohub ESM SDK (MIT). Provides SequenceStructureForgeInferenceClient and
+    # the structure input builder used to submit multi-chain complexes.
+    "esm",
+    # Used by the shared analyzers (e.g. analysis/complex_iii_boltz/analyze_output.py)
+    # to read the CIF this caller writes.
+    "biopython",
+]

--- a/analysis/esmfold2/run_esmfold2.py
+++ b/analysis/esmfold2/run_esmfold2.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Submit a protein complex to the Biohub (biohub.ai) ESMFold2 hosted API.
+
+This is the ESMFold2 counterpart to ``analysis/complex_iv_boltz/run_biolm_boltz2.py``.
+It reads a multi-record FASTA (one record per chain), submits the chains as a
+single complex prediction, and writes outputs using the SAME file convention as
+the Boltz2 runs so the existing ``analyze_output.py`` scripts can read them
+without modification:
+
+  - ``esmfold2_model_0.cif``       (matched by the analyzers' ``*_model_0.cif`` / ``*.cif`` glob)
+  - ``confidence_esmfold2.json``   (matched by the analyzers' ``confidence_*.json`` glob)
+  - ``esmfold2_response.json``     (raw response, for provenance)
+
+This makes the head-to-head re-run trivial, e.g.::
+
+    python3 analysis/esmfold2/run_esmfold2.py \
+        --fasta analysis/complex_iii_boltz/inputs/cyc1_uqcrfs1_ims_domains.fasta \
+        --output-dir analysis/esmfold2/cyc1_uqcrfs1_domains_out
+    python3 analysis/complex_iii_boltz/analyze_output.py \
+        analysis/esmfold2/cyc1_uqcrfs1_domains_out
+
+IMPORTANT / HONESTY NOTE
+------------------------
+The hosted endpoint is real (``https://biohub.ai``, model ``esmfold2-fast-2026-05``)
+and the SDK is ``pip install esm`` (MIT, https://github.com/evolutionaryscale/esm).
+However, the exact SDK method name and response attribute names below were taken
+from the published docs/README and have NOT been executed against a live token in
+this repo. The constructor, FASTA parsing, confidence extraction, and output
+writing are all defensive, and the single network call is isolated and clearly
+marked so it is a one-line fix if the installed SDK version differs. Run
+``--check-sdk`` to print the resolved client surface before submitting.
+
+No ESMFold2 output is GO curation evidence on its own; it is triage only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent
+DEFAULT_MODEL = "esmfold2-fast-2026-05"
+DEFAULT_URL = "https://biohub.ai"
+# The analyzers read these glob patterns; keep the names aligned.
+CIF_NAME = "esmfold2_model_0.cif"
+CONFIDENCE_NAME = "confidence_esmfold2.json"
+RAW_NAME = "esmfold2_response.json"
+
+
+def read_fasta(path: Path) -> list[tuple[str, str]]:
+    """Return [(chain_id, sequence), ...].
+
+    Chain id is the first ``|``-delimited field of the header if present
+    (e.g. ``>A|CYC1|85-281|desc`` -> ``A``), else the first whitespace token,
+    else an auto-assigned A, B, C, ...
+    """
+    records: list[tuple[str, list[str]]] = []
+    header: str | None = None
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith(">"):
+            header = line[1:].strip()
+            records.append((header, []))
+        elif records:
+            records[-1][1].append(line)
+        else:
+            raise ValueError(f"Sequence data before first header in {path}")
+
+    alphabet = [chr(ord("A") + i) for i in range(26)]
+    out: list[tuple[str, str]] = []
+    for i, (hdr, seq_parts) in enumerate(records):
+        token = hdr.split("|", 1)[0].split()[0] if hdr else ""
+        chain_id = token if token else alphabet[i]
+        out.append((chain_id, "".join(seq_parts).replace(" ", "").upper()))
+    if not out:
+        raise ValueError(f"No FASTA records found in {path}")
+    return out
+
+
+def build_structure_input(chains: list[tuple[str, str]]) -> Any:
+    """Build an ESMFold2 complex input from (chain_id, sequence) pairs.
+
+    Isolated so the SDK input-builder surface is easy to adjust in one place.
+    """
+    from esm.utils.structure.input_builder import (  # type: ignore
+        ProteinInput,
+        StructurePredictionInput,
+    )
+
+    proteins = [ProteinInput(sequence=seq, chain_id=cid) for cid, seq in chains]
+    return StructurePredictionInput(proteins=proteins)
+
+
+def make_client(model: str, url: str, token: str) -> Any:
+    from esm.sdk.forge import SequenceStructureForgeInferenceClient  # type: ignore
+
+    return SequenceStructureForgeInferenceClient(model=model, url=url, token=token)
+
+
+def run_prediction(client: Any, structure_input: Any) -> Any:
+    """Call the hosted fold endpoint.
+
+    The published surface exposes a fold call on the client. We try the
+    documented name and fall back across the small set of plausible aliases so a
+    minor SDK rename surfaces a clear error rather than a silent failure.
+    """
+    for method_name in ("fold", "predict", "structure_predict"):
+        method = getattr(client, method_name, None)
+        if callable(method):
+            return method(structure_input)
+    raise AttributeError(
+        "Could not find a fold/predict method on "
+        f"{type(client).__name__}. Run with --check-sdk and adjust "
+        "run_prediction() to match the installed esm SDK version."
+    )
+
+
+def _get(obj: Any, *names: str) -> Any:
+    """Read a field from a dict or an object by trying several names."""
+    for name in names:
+        if isinstance(obj, dict) and name in obj:
+            return obj[name]
+        if hasattr(obj, name):
+            return getattr(obj, name)
+    return None
+
+
+def extract_confidence(response: Any) -> dict[str, Any]:
+    """Map ESMFold2 confidence onto the keys the Boltz analyzers already read.
+
+    Boltz analyzers consume: ``confidence_score``, ``ptm``, ``iptm``,
+    ``complex_plddt``, and a ``pair_chains_iptm`` matrix. We populate as many as
+    ESMFold2 exposes (pLDDT mean, pTM, ipTM) and pass through any pair matrix.
+    """
+    summary: dict[str, Any] = {}
+
+    iptm = _get(response, "iptm", "ipTM", "interface_ptm")
+    ptm = _get(response, "ptm", "pTM", "predicted_tm")
+    plddt = _get(response, "plddt", "pLDDT", "plddt_mean", "mean_plddt")
+    pair = _get(response, "pair_chains_iptm", "pair_chain_iptm", "chain_pair_iptm")
+
+    if ptm is not None:
+        summary["ptm"] = ptm
+    if iptm is not None:
+        summary["iptm"] = iptm
+        # Boltz analyzers treat confidence_score as the headline number.
+        summary.setdefault("confidence_score", iptm)
+    if plddt is not None:
+        summary["complex_plddt"] = plddt
+    if pair is not None:
+        summary["pair_chains_iptm"] = pair
+    return summary
+
+
+def _to_jsonable(obj: Any) -> Any:
+    try:
+        json.dumps(obj)
+        return obj
+    except TypeError:
+        for attr in ("model_dump", "dict", "to_dict", "__dict__"):
+            val = getattr(obj, attr, None)
+            if callable(val):
+                try:
+                    return _to_jsonable(val())
+                except Exception:  # noqa: BLE001 - best-effort provenance dump
+                    pass
+            elif isinstance(val, dict):
+                return {k: _to_jsonable(v) for k, v in val.items()}
+        return repr(obj)
+
+
+def extract_cif(response: Any) -> str | None:
+    cif = _get(response, "cif", "structure", "mmcif", "cif_string")
+    if isinstance(cif, str) and cif.strip():
+        return cif
+    # Some SDKs return a structure object with a to_cif/to_mmcif method.
+    structure = _get(response, "protein_structure", "structure_object")
+    for attr in ("to_cif", "to_mmcif_string", "to_pdb_string"):
+        method = getattr(structure, attr, None) if structure is not None else None
+        if callable(method):
+            try:
+                text = method()
+                if isinstance(text, str) and text.strip():
+                    return text
+            except Exception:  # noqa: BLE001
+                pass
+    return None
+
+
+def write_outputs(response: Any, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / RAW_NAME).write_text(
+        json.dumps(_to_jsonable(response), indent=2) + "\n", encoding="utf-8"
+    )
+
+    cif = extract_cif(response)
+    if cif is not None:
+        (output_dir / CIF_NAME).write_text(cif, encoding="utf-8")
+    else:
+        sys.stderr.write(
+            "WARNING: no CIF/structure text found in response; only raw response "
+            f"written. Inspect {output_dir / RAW_NAME} and adjust extract_cif().\n"
+        )
+
+    summary = extract_confidence(response)
+    if summary:
+        (output_dir / CONFIDENCE_NAME).write_text(
+            json.dumps(summary, indent=2) + "\n", encoding="utf-8"
+        )
+    else:
+        sys.stderr.write(
+            "WARNING: no confidence fields recognized; adjust extract_confidence().\n"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--fasta",
+        type=Path,
+        required=False,
+        help="Multi-record FASTA; one record per chain in the complex.",
+    )
+    parser.add_argument("--output-dir", type=Path, default=ROOT / "esmfold2_out")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--url", default=DEFAULT_URL)
+    parser.add_argument(
+        "--check-sdk",
+        action="store_true",
+        help="Print the resolved esm SDK client/input surface and exit (no network call).",
+    )
+    args = parser.parse_args()
+
+    import os
+
+    token = os.environ.get("BIOHUB_API_TOKEN") or os.environ.get("ESM_API_TOKEN")
+
+    if args.check_sdk:
+        try:
+            client = make_client(args.model, args.url, token or "DRY-RUN")
+        except Exception as e:  # noqa: BLE001
+            sys.stderr.write(f"Could not construct client: {e}\n")
+            return 2
+        fold_methods = [
+            n for n in ("fold", "predict", "structure_predict")
+            if callable(getattr(client, n, None))
+        ]
+        print(f"client: {type(client).__name__}")
+        print(f"fold-like methods present: {fold_methods or 'NONE FOUND'}")
+        return 0
+
+    if not args.fasta:
+        sys.stderr.write("--fasta is required unless using --check-sdk.\n")
+        return 2
+    if not token:
+        sys.stderr.write(
+            "Set BIOHUB_API_TOKEN (or ESM_API_TOKEN) with a biohub.ai token.\n"
+        )
+        return 2
+
+    chains = read_fasta(args.fasta)
+    print(f"Submitting {len(chains)} chains: {', '.join(c for c, _ in chains)}")
+
+    try:
+        client = make_client(args.model, args.url, token)
+        structure_input = build_structure_input(chains)
+        response = run_prediction(client, structure_input)
+    except ModuleNotFoundError as e:
+        sys.stderr.write(
+            f"Missing dependency: {e}. Install with `uv sync` in analysis/esmfold2/ "
+            "or `pip install esm`.\n"
+        )
+        return 2
+    except Exception as e:  # noqa: BLE001 - surface the real error to the operator
+        sys.stderr.write(f"Prediction failed: {type(e).__name__}: {e}\n")
+        return 1
+
+    write_outputs(response, args.output_dir)
+    print(args.output_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/projects/PROTEIN_COMPLEX_FUNCTIONS.md
+++ b/projects/PROTEIN_COMPLEX_FUNCTIONS.md
@@ -273,6 +273,17 @@ returned CIF, confidence summary, input payload, and analysis notes under `analy
 `boltz predict` can still be useful for reproducibility or batch work, but local run outputs are not
 part of this project PR.
 
+### Candidate replacement: ESMFold2 (Biohub / biohub.ai)
+
+ESMFold2 is a strong candidate to use alongside or in place of the BioLM Boltz2 endpoint for the
+complex-interface pilots in this project. It is the structure/interaction model in Biohub's
+("a world model of protein biology", formerly EvolutionaryScale Forge) release and is directly
+relevant to our attribution question because it is built around protein-protein and
+antibody-antigen interface prediction. See the 2026-05-29 NOTES entry for the full evaluation. Net
+position: adopt ESMFold2 as an additional hosted endpoint and re-run the existing archived inputs
+head-to-head, keeping the Boltz2 outputs for provenance. All such predictions remain
+hypothesis-generating and must not be used as curation evidence.
+
 ## Related Projects
 
 - [OXPHOS](OXPHOS.md) -- primary case study for catalytic cores and assembly factors.
@@ -305,6 +316,9 @@ part of this project PR.
 - [ ] Audit existing OXPHOS reviews for direct-function, `contributes_to`, and assembly-factor
       consistency
 - [ ] Draft downstream-user guidance for enrichment and ML-label consumers
+- [x] Investigate ESMFold2 (Biohub/biohub.ai) as an alternative to BioLM Boltz2 for complex pilots
+- [ ] Re-run archived complex inputs (CYC1:UQCRFS1, PSMB5:PSMA1, COX2 Model C) on ESMFold2 as a
+      head-to-head against the Boltz2 confidence summaries
 
 # NOTES
 
@@ -404,3 +418,77 @@ Even if a PSMB5:PSMA1 structural interface were high-confidence, the threonine-t
 activity should stay with PSMB5 and other catalytic beta subunits, not with alpha-ring structural
 members. This is the clearest non-OXPHOS example so far of why complex membership and molecular
 function execution need separate annotation edges.
+
+## 2026-05-29 ESMFold2 (Biohub / biohub.ai) evaluation vs BioLM Boltz2
+
+Investigated whether ESMFold2 at https://biohub.ai/esm/protein should replace the hosted BioLM
+Boltz2 endpoint used for the complex-interface pilots above.
+
+### What biohub.ai/esm is
+
+`biohub.ai` is the new home of the EvolutionaryScale / Forge platform, now operating as Biohub.ai
+and releasing what they call "a world model of protein biology". The release has three pieces:
+
+- **ESMC** (Evolutionary Scale Modeling Cambrian): a protein language model trained on ~2.8B
+  sequences; available at multiple scales on Hugging Face (e.g. `esmc-600m-2024-12`).
+- **ESMFold2**: the structure/interaction prediction and design engine built on ESMC, hosted as
+  `esmfold2-fast-2026-05`. MSA-free (no alignment step, unlike AlphaFold2).
+- **ESM Atlas**: a navigable database of ~6.8B sequences and ~1.1B predicted structures.
+
+Licensing is MIT (commercial and non-commercial), with open weights on Hugging Face plus a hosted
+inference API. Biohub states the models are "freely available to the global scientific community";
+I could not confirm exact free-tier quotas or rate limits from public pages (the biohub.ai product
+pages are a JS app and did not render details to the fetcher), so quota needs verifying against an
+actual token before committing to batch runs.
+
+### Why it is a good fit for this project specifically
+
+1. **It is interface-first.** Unlike the original ESMFold (single-chain only), ESMFold2 explicitly
+   predicts multi-chain biomolecular complexes, and its headline claim is interface accuracy:
+   "surpasses other models in DockQ pass-rate on FoldBench protein-protein and antibody-antigen
+   complexes," and "performed favorably when compared against Chai-1, Boltz-1, and AlphaFold 3."
+   That is exactly the regime our pilots live in (does an interface justify exporting a molecular
+   function to a subunit), where Boltz2 gave us weak ipTM signals (0.15-0.39) across every run.
+2. **Same confidence vocabulary.** The hosted API returns pLDDT (mean), pTM, and ipTM - the same
+   metrics our analysis notes already key on - so our interpretation thresholds and analysis
+   scripts port over with minimal change. (PAE / pair-chain iPAE, which we used for CYC1:UQCRFS1,
+   was not confirmed in the hosted API surface and should be checked; it may only be in the local
+   weights path.)
+3. **Ligand and nucleic-acid support.** The input builder exposes `ProteinInput`, `DNAInput`, and
+   `LigandInput`. This is directly relevant to the unfinished hard cases in this project - copper
+   delivery (COX2 CuA / SCO1 / SCO2), heme-bearing electron transfer (CYC1), and Fe-S centers
+   (UQCRFS1) - which Boltz2 ran as apo domains. Whether non-standard metals (Cu) and cofactors can
+   be parameterized cleanly still needs a concrete test.
+4. **Open weights + MIT.** Better reproducibility story than a closed hosted endpoint: we can pin a
+   model version, and a local path exists for batch work without depending on a third-party host.
+
+### Access pattern (hosted)
+
+```python
+from esm.sdk.forge import SequenceStructureForgeInferenceClient
+client = SequenceStructureForgeInferenceClient(
+    model="esmfold2-fast-2026-05",
+    url="https://biohub.ai",
+    token="<API token>",
+)
+```
+
+Multi-chain complexes are assembled from `ProteinInput` / `DNAInput` / `LigandInput` components
+with distinct chain IDs. This is a different client surface from the BioLM Boltz2 caller, so the
+existing payload generator / endpoint caller under `analysis/` would need an ESMFold2 adapter
+rather than a drop-in URL swap.
+
+### Recommendation
+
+Adopt ESMFold2 as an **additional** hosted endpoint rather than a hard replacement, and run a
+head-to-head on the three archived inputs we already have Boltz2 summaries for: CYC1:UQCRFS1
+(active electron-transfer interface), PSMB5:PSMA1 (catalytic-vs-structural control), and the COX2
+Model C copper-maturation module. Because ipTM was the limiting signal in every Boltz2 pilot, a
+model that is genuinely stronger on complexes could change those conclusions - which is the whole
+reason to test it on identical inputs and keep the Boltz2 outputs side by side for provenance. The
+curation guardrail is unchanged: any ESMFold2 model remains hypothesis-generating and must not be
+cited as GO evidence.
+
+Open items before relying on it: confirm free-tier/rate limits with a real token; confirm whether
+PAE/iPAE is exposed by the hosted API; confirm metal/cofactor (Cu, heme, Fe-S) parameterization in
+the ligand input.


### PR DESCRIPTION
## Summary

Adds a new ESMFold2 caller (`analysis/esmfold2/run_esmfold2.py`) to evaluate Biohub's ESMFold2 model as an alternative to BioLM Boltz2 for protein complex interface prediction. The implementation:

- Reads multi-chain FASTA inputs and submits them to the hosted ESMFold2 API at `https://biohub.ai`
- Writes outputs using the **same filenames** as the existing Boltz2 callers (`*_model_0.cif`, `confidence_*.json`), enabling direct reuse of existing per-complex analyzers
- Includes defensive parsing of the ESMFold2 response to extract CIF structure, confidence metrics (pLDDT, pTM, ipTM), and pair-chain iPAE
- Provides `--check-sdk` to verify the installed esm SDK surface before spending API tokens
- Documents the evaluation rationale and open items (SDK surface, PAE availability, metal/cofactor parameterization, quota limits) in a new README

This enables head-to-head re-runs of the three archived complex inputs (CYC1:UQCRFS1, PSMB5:PSMA1, COX2 Model C) against the existing Boltz2 confidence summaries, keeping both outputs for provenance. ESMFold2 is a strong candidate because it is interface-first (explicit multi-chain prediction, headline claim of superior DockQ pass-rate on FoldBench), uses the same confidence vocabulary (pLDDT/pTM/ipTM), and has open weights with MIT licensing.

Updates `projects/PROTEIN_COMPLEX_FUNCTIONS.md` with the full evaluation note (2026-05-29 entry) and marks the ESMFold2 investigation task as complete.

## Validation

N/A — this is a new module with no existing tests. The caller is defensive against SDK surface variations and includes a `--check-sdk` dry-run mode to verify the installed esm SDK before making network calls.

## Test plan

- [ ] Verify `python3 analysis/esmfold2/run_esmfold2.py --check-sdk` prints the resolved client type and available fold methods
- [ ] Run one of the three archived inputs (e.g., CYC1:UQCRFS1) and confirm output files are written with correct names
- [ ] Verify the existing analyzer (`analysis/complex_iii_boltz/analyze_output.py`) can read the ESMFold2 CIF and confidence JSON without modification

https://claude.ai/code/session_01HfKwS6TSy5qnJWZda5kLyo