### PR TITLE
BRAF: add reference findings for 18 key papers + suggested Q&E (#344)

### DIFF
--- a/genes/human/BRAF/BRAF-ai-review.yaml
+++ b/genes/human/BRAF/BRAF-ai-review.yaml
@@ -5,21 +5,16 @@ status: COMPLETE
 taxon:
   id: NCBITaxon:9606
   label: Homo sapiens
-description: 'BRAF encodes a RAF-family serine/threonine protein kinase (EC 2.7.11.1)
-  that is the canonical mitogen-activated protein kinase kinase kinase (MAP3K) of the
-  RAS-RAF-MEK-ERK signaling cascade. In quiescent cells BRAF is autoinhibited by an
-  intramolecular interaction between its N-terminal regulatory region and the C-terminal
-  kinase domain. Mitogenic stimulation generates GTP-loaded RAS, which binds the BRAF
-  RAS-binding domain (RBD), relieves autoinhibition, and recruits BRAF to the plasma
-  membrane. Activation requires side-to-side dimerization — BRAF homodimers and, most
-  potently, BRAF-RAF1 (CRAF) heterodimers — stabilized by 14-3-3 proteins and the
-  HSP90/CDC37 chaperone system. Activated BRAF phosphorylates and activates MAP2K1/MAP2K2
-  (MEK1/MEK2), the committed step that propagates mitogenic signaling through ERK1/ERK2
-  to control proliferation, differentiation and survival. BRAF localizes to the
-  cytoplasm/cytosol and to the plasma membrane in its active RAS-bound state. It is a
-  major oncogenic driver: the V600E activating mutation, which renders the kinase
-  constitutively active as a RAS-independent monomer, is recurrent in melanoma,
-  papillary thyroid carcinoma, colorectal cancer, hairy-cell leukemia and other tumors,
+description: 'BRAF encodes a RAF-family serine/threonine protein kinase (EC 2.7.11.1) that is the canonical mitogen-activated
+  protein kinase kinase kinase (MAP3K) of the RAS-RAF-MEK-ERK signaling cascade. In quiescent cells BRAF is autoinhibited
+  by an intramolecular interaction between its N-terminal regulatory region and the C-terminal kinase domain. Mitogenic stimulation
+  generates GTP-loaded RAS, which binds the BRAF RAS-binding domain (RBD), relieves autoinhibition, and recruits BRAF to the
+  plasma membrane. Activation requires side-to-side dimerization — BRAF homodimers and, most potently, BRAF-RAF1 (CRAF) heterodimers
+  — stabilized by 14-3-3 proteins and the HSP90/CDC37 chaperone system. Activated BRAF phosphorylates and activates MAP2K1/MAP2K2
+  (MEK1/MEK2), the committed step that propagates mitogenic signaling through ERK1/ERK2 to control proliferation, differentiation
+  and survival. BRAF localizes to the cytoplasm/cytosol and to the plasma membrane in its active RAS-bound state. It is a
+  major oncogenic driver: the V600E activating mutation, which renders the kinase constitutively active as a RAS-independent
+  monomer, is recurrent in melanoma, papillary thyroid carcinoma, colorectal cancer, hairy-cell leukemia and other tumors,
   and germline BRAF mutations cause cardiofaciocutaneous syndrome.'
 existing_annotations:
 - term:
@@ -28,1157 +23,1928 @@ existing_annotations:
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'IBA annotation for cytoplasmic localization, propagated by PAINT from PANTHER family PTHR44329 (Ser/Thr Kinases-Pseudokinases). Consistent with direct evidence on cytoplasm in this file (PMID:19710016, EXP) and the 59 Reactome TAS cytosol rows already ACCEPTed in PR #440.'
+    summary: 'IBA annotation for cytoplasmic localization, propagated by PAINT from PANTHER family PTHR44329 (Ser/Thr Kinases-Pseudokinases).
+      Consistent with direct evidence on cytoplasm in this file (PMID:19710016, EXP) and the 59 Reactome TAS cytosol rows
+      already ACCEPTed in PR #440.'
     action: ACCEPT
-    reason: 'PAINT/IBA propagation from the PANTHER PTHR44329 reference family supports canonical BRAF cytoplasmic localization, which is also directly demonstrated experimentally (PMID:19710016) and via Reactome TAS evidence on the more specific child term GO:0005829 cytosol. Mechanically consolidated to ACCEPT with a uniform template across the 5 canonical IBA rows (cytoplasm, plasma membrane, MAPK cascade, MAP3K activity, cytosol); the 6th IBA row (GO:0005739 mitochondrion) is held back for separate per-row consideration in a later batch.'
+    reason: 'PAINT/IBA propagation from the PANTHER PTHR44329 reference family supports canonical BRAF cytoplasmic localization,
+      which is also directly demonstrated experimentally (PMID:19710016) and via Reactome TAS evidence on the more specific
+      child term GO:0005829 cytosol. Mechanically consolidated to ACCEPT with a uniform template across the 5 canonical IBA
+      rows (cytoplasm, plasma membrane, MAPK cascade, MAP3K activity, cytosol); the 6th IBA row (GO:0005739 mitochondrion)
+      is held back for separate per-row consideration in a later batch.'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'IBA annotation for plasma membrane localization, propagated by PAINT from PANTHER family PTHR44329 (Ser/Thr Kinases-Pseudokinases). BRAF is recruited to the PM by RAS-GTP upon receptor activation. Consistent with direct evidence on PM in this file (PMID:19710016, EXP) and the 13 Reactome TAS PM rows already ACCEPTed in PR #440.'
+    summary: 'IBA annotation for plasma membrane localization, propagated by PAINT from PANTHER family PTHR44329 (Ser/Thr
+      Kinases-Pseudokinases). BRAF is recruited to the PM by RAS-GTP upon receptor activation. Consistent with direct evidence
+      on PM in this file (PMID:19710016, EXP) and the 13 Reactome TAS PM rows already ACCEPTed in PR #440.'
     action: ACCEPT
-    reason: 'PAINT/IBA propagation from the PANTHER PTHR44329 reference family supports canonical BRAF plasma membrane localization (the RAS-GTP-recruited activated state), which is also directly demonstrated experimentally (PMID:19710016) and via Reactome TAS evidence in this file. Mechanically consolidated to ACCEPT with a uniform template across the 5 canonical IBA rows (cytoplasm, plasma membrane, MAPK cascade, MAP3K activity, cytosol); the 6th IBA row (GO:0005739 mitochondrion) is held back for separate per-row consideration in a later batch.'
+    reason: 'PAINT/IBA propagation from the PANTHER PTHR44329 reference family supports canonical BRAF plasma membrane localization
+      (the RAS-GTP-recruited activated state), which is also directly demonstrated experimentally (PMID:19710016) and via
+      Reactome TAS evidence in this file. Mechanically consolidated to ACCEPT with a uniform template across the 5 canonical
+      IBA rows (cytoplasm, plasma membrane, MAPK cascade, MAP3K activity, cytosol); the 6th IBA row (GO:0005739 mitochondrion)
+      is held back for separate per-row consideration in a later batch.'
 - term:
     id: GO:0000165
     label: MAPK cascade
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'IBA annotation for canonical BRAF participation in the MAPK cascade, propagated by PAINT from PANTHER family PTHR44329 (Ser/Thr Kinases-Pseudokinases). BRAF is the canonical RAF kinase phosphorylating MEK1/MEK2 in the RAS-RAF-MEK-ERK cascade; consistent with the IDA evidence on the same term in this file (PMID:18567582, PMID:29433126).'
+    summary: 'IBA annotation for canonical BRAF participation in the MAPK cascade, propagated by PAINT from PANTHER family
+      PTHR44329 (Ser/Thr Kinases-Pseudokinases). BRAF is the canonical RAF kinase phosphorylating MEK1/MEK2 in the RAS-RAF-MEK-ERK
+      cascade; consistent with the IDA evidence on the same term in this file (PMID:18567582, PMID:29433126).'
     action: ACCEPT
-    reason: 'PAINT/IBA propagation from the PANTHER PTHR44329 reference family supports BRAF participation in the canonical MAPK cascade, which is also directly demonstrated experimentally on the same term in this file (PMID:18567582, PMID:29433126). Mechanically consolidated to ACCEPT with a uniform template across the 5 canonical IBA rows (cytoplasm, plasma membrane, MAPK cascade, MAP3K activity, cytosol); the 6th IBA row (GO:0005739 mitochondrion) is held back for separate per-row consideration in a later batch.'
+    reason: 'PAINT/IBA propagation from the PANTHER PTHR44329 reference family supports BRAF participation in the canonical
+      MAPK cascade, which is also directly demonstrated experimentally on the same term in this file (PMID:18567582, PMID:29433126).
+      Mechanically consolidated to ACCEPT with a uniform template across the 5 canonical IBA rows (cytoplasm, plasma membrane,
+      MAPK cascade, MAP3K activity, cytosol); the 6th IBA row (GO:0005739 mitochondrion) is held back for separate per-row
+      consideration in a later batch.'
 - term:
     id: GO:0004709
     label: MAP kinase kinase kinase activity
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'IBA annotation for MAP kinase kinase kinase (MAP3K) activity, propagated by PAINT from PANTHER family PTHR44329 (Ser/Thr Kinases-Pseudokinases). This is BRAF''s canonical molecular function — phosphorylating MEK1/MEK2 (MAP2Ks) in the RAS-RAF-MEK-ERK cascade. Consistent with IDA/EXP evidence on related kinase terms in this file (PMID:18567582, PMID:29433126, PMID:21441910).'
+    summary: 'IBA annotation for MAP kinase kinase kinase (MAP3K) activity, propagated by PAINT from PANTHER family PTHR44329
+      (Ser/Thr Kinases-Pseudokinases). This is BRAF''s canonical molecular function — phosphorylating MEK1/MEK2 (MAP2Ks) in
+      the RAS-RAF-MEK-ERK cascade. Consistent with IDA/EXP evidence on related kinase terms in this file (PMID:18567582, PMID:29433126,
+      PMID:21441910).'
     action: ACCEPT
-    reason: 'PAINT/IBA propagation from the PANTHER PTHR44329 reference family supports BRAF as a canonical MAP3K. This is the gene''s defining molecular function; extensive direct experimental evidence on the closely-related kinase terms (GO:0004674 protein serine/threonine kinase activity, GO:0106310 protein serine kinase activity) is already present in this file. Mechanically consolidated to ACCEPT with a uniform template across the 5 canonical IBA rows (cytoplasm, plasma membrane, MAPK cascade, MAP3K activity, cytosol); the 6th IBA row (GO:0005739 mitochondrion) is held back for separate per-row consideration in a later batch.'
+    reason: 'PAINT/IBA propagation from the PANTHER PTHR44329 reference family supports BRAF as a canonical MAP3K. This is
+      the gene''s defining molecular function; extensive direct experimental evidence on the closely-related kinase terms
+      (GO:0004674 protein serine/threonine kinase activity, GO:0106310 protein serine kinase activity) is already present
+      in this file. Mechanically consolidated to ACCEPT with a uniform template across the 5 canonical IBA rows (cytoplasm,
+      plasma membrane, MAPK cascade, MAP3K activity, cytosol); the 6th IBA row (GO:0005739 mitochondrion) is held back for
+      separate per-row consideration in a later batch.'
     supported_by:
     - reference_id: file:human/BRAF/BRAF-deep-research-falcon.md
-      supporting_text: BRAF is a RAF-family kinase whose primary role in the ERK
-        pathway is to act as a MAP kinase kinase kinase (MAP3K) that phosphorylates
-        and activates MEK1/MEK2.
+      supporting_text: BRAF is a RAF-family kinase whose primary role in the ERK pathway is to act as a MAP kinase 
+        kinase kinase (MAP3K) that phosphorylates and activates MEK1/MEK2.
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'IBA annotation for cytosolic localization, propagated by PAINT from PANTHER family PTHR44329 (Ser/Thr Kinases-Pseudokinases). BRAF in the autoinhibited 14-3-3-bound resting state is cytosolic; consistent with the 59 Reactome TAS cytosol rows already ACCEPTed in PR #440 and direct evidence on cytoplasm/PM in this file (PMID:19710016).'
+    summary: 'IBA annotation for cytosolic localization, propagated by PAINT from PANTHER family PTHR44329 (Ser/Thr Kinases-Pseudokinases).
+      BRAF in the autoinhibited 14-3-3-bound resting state is cytosolic; consistent with the 59 Reactome TAS cytosol rows
+      already ACCEPTed in PR #440 and direct evidence on cytoplasm/PM in this file (PMID:19710016).'
     action: ACCEPT
-    reason: 'PAINT/IBA propagation from the PANTHER PTHR44329 reference family supports canonical BRAF cytosolic localization (the autoinhibited 14-3-3/Hsp90/CDC37-bound resting state), which is also directly demonstrated experimentally and via Reactome TAS evidence on the same term in this file. Mechanically consolidated to ACCEPT with a uniform template across the 5 canonical IBA rows (cytoplasm, plasma membrane, MAPK cascade, MAP3K activity, cytosol); the 6th IBA row (GO:0005739 mitochondrion) is held back for separate per-row consideration in a later batch.'
+    reason: 'PAINT/IBA propagation from the PANTHER PTHR44329 reference family supports canonical BRAF cytosolic localization
+      (the autoinhibited 14-3-3/Hsp90/CDC37-bound resting state), which is also directly demonstrated experimentally and via
+      Reactome TAS evidence on the same term in this file. Mechanically consolidated to ACCEPT with a uniform template across
+      the 5 canonical IBA rows (cytoplasm, plasma membrane, MAPK cascade, MAP3K activity, cytosol); the 6th IBA row (GO:0005739
+      mitochondrion) is held back for separate per-row consideration in a later batch.'
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IBA
   original_reference_id: GO_REF:0000033
   review:
-    summary: 'IBA annotation for mitochondrial localization, propagated by PAINT from PANTHER family PTHR44329 (Ser/Thr Kinases-Pseudokinases). BRAF is not listed under mitochondrion in the UniProt subcellular location (only Nucleus, Cytoplasm, Cell membrane); mitochondrial localization is best characterized for the RAF-family paralog CRAF/RAF-1 (regulating BAD phosphorylation), so this is a minor context-specific RAF-family role rather than a core BRAF function in the canonical RAS-RAF-MEK-ERK cascade.'
+    summary: 'IBA annotation for mitochondrial localization, propagated by PAINT from PANTHER family PTHR44329 (Ser/Thr Kinases-Pseudokinases).
+      BRAF is not listed under mitochondrion in the UniProt subcellular location (only Nucleus, Cytoplasm, Cell membrane);
+      mitochondrial localization is best characterized for the RAF-family paralog CRAF/RAF-1 (regulating BAD phosphorylation),
+      so this is a minor context-specific RAF-family role rather than a core BRAF function in the canonical RAS-RAF-MEK-ERK
+      cascade.'
     action: KEEP_AS_NON_CORE
-    reason: 'Mitochondrial localization is a minor, context-specific role best described for the RAF-family paralog CRAF/RAF-1, not a core BRAF function; the dominant BRAF localization is cytosolic/plasma-membrane where the canonical RAS-RAF-MEK-ERK cascade operates (already captured via direct experimental and Reactome TAS evidence in this file). This resolves the 6th canonical IBA row held back from PR #448 for separate per-row consideration, and is consistent with the parallel IEA Ensembl Compara mitochondrion row (GO_REF:0000107, line 591) already resolved to KEEP_AS_NON_CORE with the explicit note that the IBA row should resolve the same way.'
+    reason: 'Mitochondrial localization is a minor, context-specific role best described for the RAF-family paralog CRAF/RAF-1,
+      not a core BRAF function; the dominant BRAF localization is cytosolic/plasma-membrane where the canonical RAS-RAF-MEK-ERK
+      cascade operates (already captured via direct experimental and Reactome TAS evidence in this file). This resolves the
+      6th canonical IBA row held back from PR #448 for separate per-row consideration, and is consistent with the parallel
+      IEA Ensembl Compara mitochondrion row (GO_REF:0000107, line 591) already resolved to KEEP_AS_NON_CORE with the explicit
+      note that the IBA row should resolve the same way.'
 - term:
     id: GO:0004672
     label: protein kinase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'IEA annotation for protein kinase activity from GO_REF:0000120 (combined ECO/GO mapping). BRAF is a canonical Ser/Thr protein kinase phosphorylating MEK1/MEK2 in the RAS-RAF-MEK-ERK cascade — directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and supported by IBA on the more specific child term GO:0004709 MAP3K activity (PR #448).'
+    summary: 'IEA annotation for protein kinase activity from GO_REF:0000120 (combined ECO/GO mapping). BRAF is a canonical
+      Ser/Thr protein kinase phosphorylating MEK1/MEK2 in the RAS-RAF-MEK-ERK cascade — directly demonstrated experimentally
+      in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and supported by IBA on the more specific
+      child term GO:0004709 MAP3K activity (PR #448).'
     action: ACCEPT
-    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM, signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
+    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally
+      in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed
+      via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with
+      a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM,
+      signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row
+      consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA
+      rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic
+      transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
 - term:
     id: GO:0004674
     label: protein serine/threonine kinase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000003
   review:
-    summary: 'IEA annotation from GO_REF:0000003 (UniProt keyword KW-0723 Serine/threonine-protein kinase). BRAF is a canonical Ser/Thr kinase — directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and supported by IBA on the more specific child term GO:0004709 MAP3K activity (PR #448).'
+    summary: 'IEA annotation from GO_REF:0000003 (UniProt keyword KW-0723 Serine/threonine-protein kinase). BRAF is a canonical
+      Ser/Thr kinase — directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126
+      IDA/IMP) and supported by IBA on the more specific child term GO:0004709 MAP3K activity (PR #448).'
     action: ACCEPT
-    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM, signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
+    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally
+      in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed
+      via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with
+      a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM,
+      signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row
+      consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA
+      rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic
+      transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
 - term:
     id: GO:0005524
     label: ATP binding
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'IEA annotation from GO_REF:0000002 (InterPro2GO) for ATP binding. BRAF binds ATP via the kinase-domain glycine-rich loop and DFG motif — a defining feature of the protein kinase fold; directly supported by IDA/EXP evidence on kinase activity terms in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP).'
+    summary: 'IEA annotation from GO_REF:0000002 (InterPro2GO) for ATP binding. BRAF binds ATP via the kinase-domain glycine-rich
+      loop and DFG motif — a defining feature of the protein kinase fold; directly supported by IDA/EXP evidence on kinase
+      activity terms in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP).'
     action: ACCEPT
-    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM, signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
+    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally
+      in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed
+      via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with
+      a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM,
+      signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row
+      consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA
+      rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic
+      transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
 - term:
     id: GO:0005634
     label: nucleus
   evidence_type: IEA
   original_reference_id: GO_REF:0000044
   review:
-    summary: 'IEA annotation for nuclear localization from GO_REF:0000044. UniProt lists Nucleus for BRAF only by similarity (ECO:0000250), whereas Cytoplasm and Cell membrane have direct experimental support (PMID:19710016). Nuclear localization is reported but tissue/context-specific and is not where BRAF''s core RAS-RAF-MEK-ERK kinase function operates.'
+    summary: 'IEA annotation for nuclear localization from GO_REF:0000044. UniProt lists Nucleus for BRAF only by similarity
+      (ECO:0000250), whereas Cytoplasm and Cell membrane have direct experimental support (PMID:19710016). Nuclear localization
+      is reported but tissue/context-specific and is not where BRAF''s core RAS-RAF-MEK-ERK kinase function operates.'
     action: KEEP_AS_NON_CORE
-    reason: 'Nuclear localization is recognized in UniProt only by similarity (ECO:0000250) and is tissue/context-specific rather than the site of BRAF''s defining function; the core RAS-RAF-MEK-ERK kinase activity operates at the cytoplasm/plasma membrane (captured via direct experimental evidence PMID:19710016 EXP and Reactome TAS rows in this file). Kept rather than removed because UniProt records the nuclear localization, but flagged non-core. This resolves the GO:0005634 nucleus IEA row explicitly held back from the canonical IEA consolidation in PR #456 for separate per-row consideration.'
+    reason: 'Nuclear localization is recognized in UniProt only by similarity (ECO:0000250) and is tissue/context-specific
+      rather than the site of BRAF''s defining function; the core RAS-RAF-MEK-ERK kinase activity operates at the cytoplasm/plasma
+      membrane (captured via direct experimental evidence PMID:19710016 EXP and Reactome TAS rows in this file). Kept rather
+      than removed because UniProt records the nuclear localization, but flagged non-core. This resolves the GO:0005634 nucleus
+      IEA row explicitly held back from the canonical IEA consolidation in PR #456 for separate per-row consideration.'
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'IEA annotation from GO_REF:0000120 for cytoplasmic localization. Already ACCEPTed via IBA propagation in PR #448 and consistent with direct experimental evidence in this file (PMID:19710016 EXP) — BRAF in the autoinhibited 14-3-3-bound resting state is cytosolic prior to RAS-GTP-mediated PM recruitment.'
+    summary: 'IEA annotation from GO_REF:0000120 for cytoplasmic localization. Already ACCEPTed via IBA propagation in PR
+      #448 and consistent with direct experimental evidence in this file (PMID:19710016 EXP) — BRAF in the autoinhibited 14-3-3-bound
+      resting state is cytosolic prior to RAS-GTP-mediated PM recruitment.'
     action: ACCEPT
-    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM, signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
+    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally
+      in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed
+      via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with
+      a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM,
+      signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row
+      consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA
+      rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic
+      transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: 'IEA annotation from GO_REF:0000120 for plasma membrane localization. Already ACCEPTed via IBA propagation in PR #448 and on 13 Reactome TAS rows in PR #440. Directly demonstrated experimentally in this file (PMID:19710016 EXP) — BRAF is recruited to the PM by RAS-GTP upon receptor activation.'
+    summary: 'IEA annotation from GO_REF:0000120 for plasma membrane localization. Already ACCEPTed via IBA propagation in
+      PR #448 and on 13 Reactome TAS rows in PR #440. Directly demonstrated experimentally in this file (PMID:19710016 EXP)
+      — BRAF is recruited to the PM by RAS-GTP upon receptor activation.'
     action: ACCEPT
-    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM, signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
+    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally
+      in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed
+      via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with
+      a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM,
+      signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row
+      consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA
+      rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic
+      transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
 - term:
     id: GO:0007165
     label: signal transduction
   evidence_type: IEA
   original_reference_id: GO_REF:0000002
   review:
-    summary: 'IEA annotation from GO_REF:0000002 (InterPro2GO) for signal transduction. BRAF is the canonical RAF kinase in the RAS-RAF-MEK-ERK signaling cascade — directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:29433126 IDA/IMP) and supported by IBA on the more specific child term GO:0000165 MAPK cascade (PR #448).'
+    summary: 'IEA annotation from GO_REF:0000002 (InterPro2GO) for signal transduction. BRAF is the canonical RAF kinase in
+      the RAS-RAF-MEK-ERK signaling cascade — directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:29433126
+      IDA/IMP) and supported by IBA on the more specific child term GO:0000165 MAPK cascade (PR #448).'
     action: ACCEPT
-    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM, signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
+    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally
+      in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed
+      via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with
+      a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM,
+      signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row
+      consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA
+      rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic
+      transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
 - term:
     id: GO:0043066
     label: negative regulation of apoptotic process
   evidence_type: IEA
   original_reference_id: GO_REF:0000117
   review:
-    summary: 'IEA annotation from GO_REF:0000117 (ARBA propagation). BRAF activates MEK/ERK signaling, leading to phosphorylation of pro-apoptotic factors (e.g. BAD on Ser112/Ser155 by RSK downstream of ERK; BIM via ERK-mediated proteasomal degradation), and is well-established as anti-apoptotic in canonical RAS-RAF-MEK-ERK signaling. Consistent with the canonical RAF survival role and the Reactome RAS-MAPK signaling rows already ACCEPTed in PR #440.'
+    summary: 'IEA annotation from GO_REF:0000117 (ARBA propagation). BRAF activates MEK/ERK signaling, leading to phosphorylation
+      of pro-apoptotic factors (e.g. BAD on Ser112/Ser155 by RSK downstream of ERK; BIM via ERK-mediated proteasomal degradation),
+      and is well-established as anti-apoptotic in canonical RAS-RAF-MEK-ERK signaling. Consistent with the canonical RAF
+      survival role and the Reactome RAS-MAPK signaling rows already ACCEPTed in PR #440.'
     action: ACCEPT
-    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM, signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
+    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally
+      in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed
+      via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with
+      a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM,
+      signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row
+      consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA
+      rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic
+      transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
 - term:
     id: GO:0098794
     label: postsynapse
   evidence_type: IEA
   original_reference_id: GO_REF:0000108
   review:
-    summary: 'IEA annotation from GO_REF:0000108 (logical-inference-based IEA via inter-ontology links; the postsynapse term is reachable via SynGO axioms). BRAF is expressed in neurons and germline BRAF activating mutations cause cardio-facio-cutaneous syndrome with neurological features, so a postsynaptic localization in specific neuronal contexts is plausible. However, this represents a tissue/cell-type-specific localization rather than a constitutive cellular function, and is not a core BRAF function — the canonical RAS-RAF-MEK-ERK signaling activity at the cytoplasm/cytosol/plasma membrane is what defines BRAF.'
+    summary: 'IEA annotation from GO_REF:0000108 (logical-inference-based IEA via inter-ontology links; the postsynapse term
+      is reachable via SynGO axioms). BRAF is expressed in neurons and germline BRAF activating mutations cause cardio-facio-cutaneous
+      syndrome with neurological features, so a postsynaptic localization in specific neuronal contexts is plausible. However,
+      this represents a tissue/cell-type-specific localization rather than a constitutive cellular function, and is not a
+      core BRAF function — the canonical RAS-RAF-MEK-ERK signaling activity at the cytoplasm/cytosol/plasma membrane is what
+      defines BRAF.'
     action: KEEP_AS_NON_CORE
-    reason: 'Tissue/cell-type-specific neuronal/synaptic localization rather than a core BRAF function. Canonical BRAF localization (cytosol, plasma membrane, cytoplasm) is already captured via direct experimental evidence in this file (PMID:19710016 EXP, PMID:18567582, PMID:21441910) and via the IBA propagation batch (PR #448) and Reactome TAS rows (PR #440). Mechanically consolidated to KEEP_AS_NON_CORE with a uniform template across the neuronal/synaptic CC rows held back from earlier batches (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic transmission).'
+    reason: 'Tissue/cell-type-specific neuronal/synaptic localization rather than a core BRAF function. Canonical BRAF localization
+      (cytosol, plasma membrane, cytoplasm) is already captured via direct experimental evidence in this file (PMID:19710016
+      EXP, PMID:18567582, PMID:21441910) and via the IBA propagation batch (PR #448) and Reactome TAS rows (PR #440). Mechanically
+      consolidated to KEEP_AS_NON_CORE with a uniform template across the neuronal/synaptic CC rows held back from earlier
+      batches (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic
+      transmission).'
 - term:
     id: GO:0106310
     label: protein serine kinase activity
   evidence_type: IEA
   original_reference_id: GO_REF:0000116
   review:
-    summary: 'IEA annotation from GO_REF:0000116 for protein serine kinase activity — the most specific MF child of GO:0004674. BRAF phosphorylates MEK1/MEK2 on serine residues — directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP).'
+    summary: 'IEA annotation from GO_REF:0000116 for protein serine kinase activity — the most specific MF child of GO:0004674.
+      BRAF phosphorylates MEK1/MEK2 on serine residues — directly demonstrated experimentally in this file (PMID:18567582
+      IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP).'
     action: ACCEPT
-    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM, signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
+    reason: 'IEA mechanical propagation supports a canonical BRAF function or localization directly demonstrated experimentally
+      in this file (PMID:18567582 IDA, PMID:19710016 EXP, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and/or already ACCEPTed
+      via the IBA propagation batch (PR #448) or the Reactome TAS rows (PR #440). Mechanically consolidated to ACCEPT with
+      a uniform template across the 8 canonical IEA rows (protein kinase activity, S/T kinase, ATP binding, cytoplasm, PM,
+      signal transduction, neg-reg apoptosis, S kinase); the GO:0005634 nucleus IEA row is held back for separate per-row
+      consideration (BRAF nuclear localization is reported but tissue/context-specific), and the 6 SynGO/tissue-specific IEA
+      rows (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic
+      transmission, mitochondrion) are held back for a uniform KEEP_AS_NON_CORE batch.'
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:12620389
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:15161933
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:15778465
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16810323
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:16888650
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:17380122
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:17563371
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:17979178
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:20130576
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:20141835
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:21441910
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:21478863
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:21625473
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:22169110
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:22510884
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:22939624
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23153539
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23680146
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:23934108
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24255178
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24441586
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:24746704
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25155755
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25241761
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25437913
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:25600339
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:26165597
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:26466569
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:26496610
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:28514442
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:30194290
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:31980649
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:32707033
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:33961781
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:34591642
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:35512704
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:35839996
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:36241744
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:36931259
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:37045861
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:40205054
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:16858395
   review:
-    summary: 'IPI annotation supporting BRAF homodimerization (and hetero-dimerization with CRAF), demonstrated experimentally as Ca2+-dependent and mediated by the N-terminal BRAF-specific region (Terai & Matsuda 2006, EMBO J). BRAF homodimerization is a canonical and required step in RAF kinase activation in the RAS-RAF-MEK-ERK cascade.'
+    summary: 'IPI annotation supporting BRAF homodimerization (and hetero-dimerization with CRAF), demonstrated experimentally
+      as Ca2+-dependent and mediated by the N-terminal BRAF-specific region (Terai & Matsuda 2006, EMBO J). BRAF homodimerization
+      is a canonical and required step in RAF kinase activation in the RAS-RAF-MEK-ERK cascade.'
     action: ACCEPT
-    reason: 'BRAF homodimerization (side-by-side kinase-domain dimer plus N-terminal Ca2+-dependent dimerization) is a canonical and required step in RAF activation. The GO:0042802 ''identical protein binding'' annotation is biologically informative for BRAF — more so than the generic GO:0005515 ''protein binding'' rows already demoted in PR #437 — and is supported by extensive direct experimental evidence across X-ray crystallography (PMID:19727074, PMID:25155755, PMID:25437913), mutational dissection of the dimer interface (PMID:22510884), and biochemical/cell-based dimerization assays (PMID:16858395, PMID:22169110). Mechanically consolidated to ACCEPT with a uniform template across the 6 BRAF dimerization PMIDs; PMID:35512704 is held back for separate per-row consideration (that paper''s primary focus is BRAF V600E heterotypic neoPPI with KEAP1 rather than BRAF homodimerization).'
+    reason: 'BRAF homodimerization (side-by-side kinase-domain dimer plus N-terminal Ca2+-dependent dimerization) is a canonical
+      and required step in RAF activation. The GO:0042802 ''identical protein binding'' annotation is biologically informative
+      for BRAF — more so than the generic GO:0005515 ''protein binding'' rows already demoted in PR #437 — and is supported
+      by extensive direct experimental evidence across X-ray crystallography (PMID:19727074, PMID:25155755, PMID:25437913),
+      mutational dissection of the dimer interface (PMID:22510884), and biochemical/cell-based dimerization assays (PMID:16858395,
+      PMID:22169110). Mechanically consolidated to ACCEPT with a uniform template across the 6 BRAF dimerization PMIDs; PMID:35512704
+      is held back for separate per-row consideration (that paper''s primary focus is BRAF V600E heterotypic neoPPI with KEAP1
+      rather than BRAF homodimerization).'
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:19727074
   review:
-    summary: 'IPI annotation supporting BRAF homodimerization, derived from the canonical Rajakulendran et al. 2009 Nature paper establishing that a side-by-side RAF kinase-domain dimer is required for catalytic activation. This paper defined the dimer interface (the alphaC-out conformation and arginine-mediated contacts) that has become the textbook model for RAF activation in the RAS-RAF-MEK-ERK cascade.'
+    summary: 'IPI annotation supporting BRAF homodimerization, derived from the canonical Rajakulendran et al. 2009 Nature
+      paper establishing that a side-by-side RAF kinase-domain dimer is required for catalytic activation. This paper defined
+      the dimer interface (the alphaC-out conformation and arginine-mediated contacts) that has become the textbook model
+      for RAF activation in the RAS-RAF-MEK-ERK cascade.'
     action: ACCEPT
-    reason: 'BRAF homodimerization (side-by-side kinase-domain dimer plus N-terminal Ca2+-dependent dimerization) is a canonical and required step in RAF activation. The GO:0042802 ''identical protein binding'' annotation is biologically informative for BRAF — more so than the generic GO:0005515 ''protein binding'' rows already demoted in PR #437 — and is supported by extensive direct experimental evidence across X-ray crystallography (PMID:19727074, PMID:25155755, PMID:25437913), mutational dissection of the dimer interface (PMID:22510884), and biochemical/cell-based dimerization assays (PMID:16858395, PMID:22169110). Mechanically consolidated to ACCEPT with a uniform template across the 6 BRAF dimerization PMIDs; PMID:35512704 is held back for separate per-row consideration (that paper''s primary focus is BRAF V600E heterotypic neoPPI with KEAP1 rather than BRAF homodimerization).'
+    reason: 'BRAF homodimerization (side-by-side kinase-domain dimer plus N-terminal Ca2+-dependent dimerization) is a canonical
+      and required step in RAF activation. The GO:0042802 ''identical protein binding'' annotation is biologically informative
+      for BRAF — more so than the generic GO:0005515 ''protein binding'' rows already demoted in PR #437 — and is supported
+      by extensive direct experimental evidence across X-ray crystallography (PMID:19727074, PMID:25155755, PMID:25437913),
+      mutational dissection of the dimer interface (PMID:22510884), and biochemical/cell-based dimerization assays (PMID:16858395,
+      PMID:22169110). Mechanically consolidated to ACCEPT with a uniform template across the 6 BRAF dimerization PMIDs; PMID:35512704
+      is held back for separate per-row consideration (that paper''s primary focus is BRAF V600E heterotypic neoPPI with KEAP1
+      rather than BRAF homodimerization).'
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:22169110
   review:
-    summary: 'IPI annotation supporting BRAF homodimerization, derived from Packer et al. 2011 Cancer Cell on paradoxical RAF activation in nilotinib-resistant CML. The mechanism documented in this paper — kinase-inhibitor-induced trans-activation of MAPK signaling via RAF dimer formation — directly depends on BRAF self-association at the dimer interface.'
+    summary: 'IPI annotation supporting BRAF homodimerization, derived from Packer et al. 2011 Cancer Cell on paradoxical
+      RAF activation in nilotinib-resistant CML. The mechanism documented in this paper — kinase-inhibitor-induced trans-activation
+      of MAPK signaling via RAF dimer formation — directly depends on BRAF self-association at the dimer interface.'
     action: ACCEPT
-    reason: 'BRAF homodimerization (side-by-side kinase-domain dimer plus N-terminal Ca2+-dependent dimerization) is a canonical and required step in RAF activation. The GO:0042802 ''identical protein binding'' annotation is biologically informative for BRAF — more so than the generic GO:0005515 ''protein binding'' rows already demoted in PR #437 — and is supported by extensive direct experimental evidence across X-ray crystallography (PMID:19727074, PMID:25155755, PMID:25437913), mutational dissection of the dimer interface (PMID:22510884), and biochemical/cell-based dimerization assays (PMID:16858395, PMID:22169110). Mechanically consolidated to ACCEPT with a uniform template across the 6 BRAF dimerization PMIDs; PMID:35512704 is held back for separate per-row consideration (that paper''s primary focus is BRAF V600E heterotypic neoPPI with KEAP1 rather than BRAF homodimerization).'
+    reason: 'BRAF homodimerization (side-by-side kinase-domain dimer plus N-terminal Ca2+-dependent dimerization) is a canonical
+      and required step in RAF activation. The GO:0042802 ''identical protein binding'' annotation is biologically informative
+      for BRAF — more so than the generic GO:0005515 ''protein binding'' rows already demoted in PR #437 — and is supported
+      by extensive direct experimental evidence across X-ray crystallography (PMID:19727074, PMID:25155755, PMID:25437913),
+      mutational dissection of the dimer interface (PMID:22510884), and biochemical/cell-based dimerization assays (PMID:16858395,
+      PMID:22169110). Mechanically consolidated to ACCEPT with a uniform template across the 6 BRAF dimerization PMIDs; PMID:35512704
+      is held back for separate per-row consideration (that paper''s primary focus is BRAF V600E heterotypic neoPPI with KEAP1
+      rather than BRAF homodimerization).'
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:22510884
   review:
-    summary: 'IPI annotation supporting BRAF homodimerization, derived from Röring et al. 2012 EMBO J. Direct mutational dissection showing that an intact BRAF kinase-domain dimer interface (the same side-by-side interface identified in PMID:19727074) is required for WT BRAF MAPK signaling, and that the kinase-dead/V600E paradoxical activation phenotype also depends on dimer formation. Strongest single piece of evidence in this set that the BRAF homodimer is a load-bearing functional unit rather than an incidental interaction.'
+    summary: 'IPI annotation supporting BRAF homodimerization, derived from Röring et al. 2012 EMBO J. Direct mutational dissection
+      showing that an intact BRAF kinase-domain dimer interface (the same side-by-side interface identified in PMID:19727074)
+      is required for WT BRAF MAPK signaling, and that the kinase-dead/V600E paradoxical activation phenotype also depends
+      on dimer formation. Strongest single piece of evidence in this set that the BRAF homodimer is a load-bearing functional
+      unit rather than an incidental interaction.'
     action: ACCEPT
-    reason: 'BRAF homodimerization (side-by-side kinase-domain dimer plus N-terminal Ca2+-dependent dimerization) is a canonical and required step in RAF activation. The GO:0042802 ''identical protein binding'' annotation is biologically informative for BRAF — more so than the generic GO:0005515 ''protein binding'' rows already demoted in PR #437 — and is supported by extensive direct experimental evidence across X-ray crystallography (PMID:19727074, PMID:25155755, PMID:25437913), mutational dissection of the dimer interface (PMID:22510884), and biochemical/cell-based dimerization assays (PMID:16858395, PMID:22169110). Mechanically consolidated to ACCEPT with a uniform template across the 6 BRAF dimerization PMIDs; PMID:35512704 is held back for separate per-row consideration (that paper''s primary focus is BRAF V600E heterotypic neoPPI with KEAP1 rather than BRAF homodimerization).'
+    reason: 'BRAF homodimerization (side-by-side kinase-domain dimer plus N-terminal Ca2+-dependent dimerization) is a canonical
+      and required step in RAF activation. The GO:0042802 ''identical protein binding'' annotation is biologically informative
+      for BRAF — more so than the generic GO:0005515 ''protein binding'' rows already demoted in PR #437 — and is supported
+      by extensive direct experimental evidence across X-ray crystallography (PMID:19727074, PMID:25155755, PMID:25437913),
+      mutational dissection of the dimer interface (PMID:22510884), and biochemical/cell-based dimerization assays (PMID:16858395,
+      PMID:22169110). Mechanically consolidated to ACCEPT with a uniform template across the 6 BRAF dimerization PMIDs; PMID:35512704
+      is held back for separate per-row consideration (that paper''s primary focus is BRAF V600E heterotypic neoPPI with KEAP1
+      rather than BRAF homodimerization).'
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:25155755
   review:
-    summary: 'IPI annotation supporting BRAF homodimerization, derived from Haling et al. 2014 Cancer Cell — the X-ray crystal structure of the BRAF-MEK complex, in which BRAF is captured as a side-by-side homodimer with MEK bound to each protomer. Directly visualizes the BRAF kinase-domain homodimer interface in a productive signaling complex.'
+    summary: 'IPI annotation supporting BRAF homodimerization, derived from Haling et al. 2014 Cancer Cell — the X-ray crystal
+      structure of the BRAF-MEK complex, in which BRAF is captured as a side-by-side homodimer with MEK bound to each protomer.
+      Directly visualizes the BRAF kinase-domain homodimer interface in a productive signaling complex.'
     action: ACCEPT
-    reason: 'BRAF homodimerization (side-by-side kinase-domain dimer plus N-terminal Ca2+-dependent dimerization) is a canonical and required step in RAF activation. The GO:0042802 ''identical protein binding'' annotation is biologically informative for BRAF — more so than the generic GO:0005515 ''protein binding'' rows already demoted in PR #437 — and is supported by extensive direct experimental evidence across X-ray crystallography (PMID:19727074, PMID:25155755, PMID:25437913), mutational dissection of the dimer interface (PMID:22510884), and biochemical/cell-based dimerization assays (PMID:16858395, PMID:22169110). Mechanically consolidated to ACCEPT with a uniform template across the 6 BRAF dimerization PMIDs; PMID:35512704 is held back for separate per-row consideration (that paper''s primary focus is BRAF V600E heterotypic neoPPI with KEAP1 rather than BRAF homodimerization).'
+    reason: 'BRAF homodimerization (side-by-side kinase-domain dimer plus N-terminal Ca2+-dependent dimerization) is a canonical
+      and required step in RAF activation. The GO:0042802 ''identical protein binding'' annotation is biologically informative
+      for BRAF — more so than the generic GO:0005515 ''protein binding'' rows already demoted in PR #437 — and is supported
+      by extensive direct experimental evidence across X-ray crystallography (PMID:19727074, PMID:25155755, PMID:25437913),
+      mutational dissection of the dimer interface (PMID:22510884), and biochemical/cell-based dimerization assays (PMID:16858395,
+      PMID:22169110). Mechanically consolidated to ACCEPT with a uniform template across the 6 BRAF dimerization PMIDs; PMID:35512704
+      is held back for separate per-row consideration (that paper''s primary focus is BRAF V600E heterotypic neoPPI with KEAP1
+      rather than BRAF homodimerization).'
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:25437913
   review:
-    summary: 'IPI annotation supporting BRAF homodimerization, derived from Thevakumaran et al. 2015 Nat Struct Mol Biol. Although the title emphasizes a BRAF kinase-domain monomer structure, the paper''s mechanistic conclusion is that BRAF activation requires the monomer-to-side-by-side-dimer transition, and the asymmetric unit captures inactive-state contacts directly informative for dimer-based allosteric regulation. Together with PMID:19727074 and PMID:25155755 this represents the structural literature establishing the BRAF dimer interface.'
+    summary: 'IPI annotation supporting BRAF homodimerization, derived from Thevakumaran et al. 2015 Nat Struct Mol Biol.
+      Although the title emphasizes a BRAF kinase-domain monomer structure, the paper''s mechanistic conclusion is that BRAF
+      activation requires the monomer-to-side-by-side-dimer transition, and the asymmetric unit captures inactive-state contacts
+      directly informative for dimer-based allosteric regulation. Together with PMID:19727074 and PMID:25155755 this represents
+      the structural literature establishing the BRAF dimer interface.'
     action: ACCEPT
-    reason: 'BRAF homodimerization (side-by-side kinase-domain dimer plus N-terminal Ca2+-dependent dimerization) is a canonical and required step in RAF activation. The GO:0042802 ''identical protein binding'' annotation is biologically informative for BRAF — more so than the generic GO:0005515 ''protein binding'' rows already demoted in PR #437 — and is supported by extensive direct experimental evidence across X-ray crystallography (PMID:19727074, PMID:25155755, PMID:25437913), mutational dissection of the dimer interface (PMID:22510884), and biochemical/cell-based dimerization assays (PMID:16858395, PMID:22169110). Mechanically consolidated to ACCEPT with a uniform template across the 6 BRAF dimerization PMIDs; PMID:35512704 is held back for separate per-row consideration (that paper''s primary focus is BRAF V600E heterotypic neoPPI with KEAP1 rather than BRAF homodimerization).'
+    reason: 'BRAF homodimerization (side-by-side kinase-domain dimer plus N-terminal Ca2+-dependent dimerization) is a canonical
+      and required step in RAF activation. The GO:0042802 ''identical protein binding'' annotation is biologically informative
+      for BRAF — more so than the generic GO:0005515 ''protein binding'' rows already demoted in PR #437 — and is supported
+      by extensive direct experimental evidence across X-ray crystallography (PMID:19727074, PMID:25155755, PMID:25437913),
+      mutational dissection of the dimer interface (PMID:22510884), and biochemical/cell-based dimerization assays (PMID:16858395,
+      PMID:22169110). Mechanically consolidated to ACCEPT with a uniform template across the 6 BRAF dimerization PMIDs; PMID:35512704
+      is held back for separate per-row consideration (that paper''s primary focus is BRAF V600E heterotypic neoPPI with KEAP1
+      rather than BRAF homodimerization).'
 - term:
     id: GO:0042802
     label: identical protein binding
   evidence_type: IPI
   original_reference_id: PMID:35512704
   review:
-    summary: 'IPI annotation for GO:0042802 identical protein binding, derived from Mo et al. 2022 Cell (PMID:35512704 — systematic discovery of mutation-directed neo-protein-protein interactions in cancer). The BRAF-specific finding in this high-throughput BRET screen is the BRAF V600E/KEAP1 neoPPI: a mutant-allele-specific heterotypic interaction between BRAF V600E and KEAP1 (a different protein) that rewires a BRAF V600E/KEAP1/NRF2 redox-signaling axis. The paper does not demonstrate BRAF self-association / homodimerization.'
+    summary: 'IPI annotation for GO:0042802 identical protein binding, derived from Mo et al. 2022 Cell (PMID:35512704 — systematic
+      discovery of mutation-directed neo-protein-protein interactions in cancer). The BRAF-specific finding in this high-throughput
+      BRET screen is the BRAF V600E/KEAP1 neoPPI: a mutant-allele-specific heterotypic interaction between BRAF V600E and
+      KEAP1 (a different protein) that rewires a BRAF V600E/KEAP1/NRF2 redox-signaling axis. The paper does not demonstrate
+      BRAF self-association / homodimerization.'
     action: MARK_AS_OVER_ANNOTATED
-    reason: 'BRAF homodimerization is a genuine, canonical core function and GO:0042802 identical protein binding is already ACCEPTed on the five dimerization-focused structural/biochemical rows in this file (PMID:19727074, PMID:25155755, PMID:25437913, PMID:22510884, plus PMID:16858395/PMID:22169110). However, PMID:35512704 does not support identical protein binding for BRAF: its BRAF finding is a V600E-specific heterotypic neoPPI with KEAP1, not BRAF self-dimerization. This reference-derived GO:0042802 row is therefore an over-annotation — the term is correct for BRAF but this particular evidence does not support it, and the homodimer biology is already fully captured by the ACCEPTed structural rows. Held back from the dimerization batch for this per-row consideration.'
+    reason: 'BRAF homodimerization is a genuine, canonical core function and GO:0042802 identical protein binding is already
+      ACCEPTed on the five dimerization-focused structural/biochemical rows in this file (PMID:19727074, PMID:25155755, PMID:25437913,
+      PMID:22510884, plus PMID:16858395/PMID:22169110). However, PMID:35512704 does not support identical protein binding
+      for BRAF: its BRAF finding is a V600E-specific heterotypic neoPPI with KEAP1, not BRAF self-dimerization. This reference-derived
+      GO:0042802 row is therefore an over-annotation — the term is correct for BRAF but this particular evidence does not
+      support it, and the homodimer biology is already fully captured by the ACCEPTed structural rows. Held back from the
+      dimerization batch for this per-row consideration.'
 - term:
     id: GO:0005739
     label: mitochondrion
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'IEA annotation from GO_REF:0000107 (Ensembl Compara ortholog-based propagation). BRAF mitochondrial localization has been reported (e.g. RAF-1/CRAF mitochondrial pool affecting BAD phosphorylation), and an IBA mitochondrion row also propagates from PANTHER PTHR44329, suggesting some RAF-family members localize to mitochondria. However, the dominant BRAF localization is cytosolic/plasma-membrane and the mitochondrial role is not a core BRAF function in the canonical RAS-RAF-MEK-ERK cascade.'
+    summary: 'IEA annotation from GO_REF:0000107 (Ensembl Compara ortholog-based propagation). BRAF mitochondrial localization
+      has been reported (e.g. RAF-1/CRAF mitochondrial pool affecting BAD phosphorylation), and an IBA mitochondrion row also
+      propagates from PANTHER PTHR44329, suggesting some RAF-family members localize to mitochondria. However, the dominant
+      BRAF localization is cytosolic/plasma-membrane and the mitochondrial role is not a core BRAF function in the canonical
+      RAS-RAF-MEK-ERK cascade.'
     action: KEEP_AS_NON_CORE
-    reason: 'Mitochondrial localization is a minor context-specific role for some RAF-family members (best described for CRAF/RAF-1) rather than a core BRAF function. The dominant BRAF localization is cytosolic/plasma-membrane and the canonical RAS-RAF-MEK-ERK cascade is already captured via direct experimental evidence in this file (PMID:19710016 EXP, PMID:18567582, PMID:21441910) and via Reactome TAS rows (PR #440). The parallel IBA mitochondrion row (GO_REF:0000033, line 61) remains PENDING for separate per-row review; keeping the IEA Ensembl Compara row as KEEP_AS_NON_CORE here is consistent with how the IBA row is likely to resolve.'
+    reason: 'Mitochondrial localization is a minor context-specific role for some RAF-family members (best described for CRAF/RAF-1)
+      rather than a core BRAF function. The dominant BRAF localization is cytosolic/plasma-membrane and the canonical RAS-RAF-MEK-ERK
+      cascade is already captured via direct experimental evidence in this file (PMID:19710016 EXP, PMID:18567582, PMID:21441910)
+      and via Reactome TAS rows (PR #440). The parallel IBA mitochondrion row (GO_REF:0000033, line 61) remains PENDING for
+      separate per-row review; keeping the IEA Ensembl Compara row as KEEP_AS_NON_CORE here is consistent with how the IBA
+      row is likely to resolve.'
 - term:
     id: GO:0043005
     label: neuron projection
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'IEA annotation from GO_REF:0000107 (Ensembl Compara ortholog-based propagation). BRAF is expressed in neurons and germline BRAF activating mutations cause cardio-facio-cutaneous syndrome with neurological features, so neuron projection localization in specific neuronal contexts is plausible. However, this represents a tissue/cell-type-specific localization rather than a constitutive cellular function, and is not a core BRAF function — the canonical RAS-RAF-MEK-ERK signaling activity at cytoplasm/cytosol/plasma membrane is what defines BRAF.'
+    summary: 'IEA annotation from GO_REF:0000107 (Ensembl Compara ortholog-based propagation). BRAF is expressed in neurons
+      and germline BRAF activating mutations cause cardio-facio-cutaneous syndrome with neurological features, so neuron projection
+      localization in specific neuronal contexts is plausible. However, this represents a tissue/cell-type-specific localization
+      rather than a constitutive cellular function, and is not a core BRAF function — the canonical RAS-RAF-MEK-ERK signaling
+      activity at cytoplasm/cytosol/plasma membrane is what defines BRAF.'
     action: KEEP_AS_NON_CORE
-    reason: 'Tissue/cell-type-specific neuronal/synaptic localization rather than a core BRAF function. Canonical BRAF localization (cytosol, plasma membrane, cytoplasm) is already captured via direct experimental evidence in this file (PMID:19710016 EXP, PMID:18567582, PMID:21441910) and via the IBA propagation batch (PR #448) and Reactome TAS rows (PR #440). Mechanically consolidated to KEEP_AS_NON_CORE with a uniform template across the neuronal/synaptic CC rows held back from earlier batches (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic transmission).'
+    reason: 'Tissue/cell-type-specific neuronal/synaptic localization rather than a core BRAF function. Canonical BRAF localization
+      (cytosol, plasma membrane, cytoplasm) is already captured via direct experimental evidence in this file (PMID:19710016
+      EXP, PMID:18567582, PMID:21441910) and via the IBA propagation batch (PR #448) and Reactome TAS rows (PR #440). Mechanically
+      consolidated to KEEP_AS_NON_CORE with a uniform template across the neuronal/synaptic CC rows held back from earlier
+      batches (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic
+      transmission).'
 - term:
     id: GO:0044297
     label: cell body
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'IEA annotation from GO_REF:0000107 (Ensembl Compara ortholog-based propagation). BRAF is expressed in neurons and germline BRAF activating mutations cause cardio-facio-cutaneous syndrome with neurological features, so neuronal cell body localization in specific neuronal contexts is plausible. However, this represents a tissue/cell-type-specific localization rather than a constitutive cellular function, and is not a core BRAF function — the canonical RAS-RAF-MEK-ERK signaling activity at cytoplasm/cytosol/plasma membrane is what defines BRAF.'
+    summary: 'IEA annotation from GO_REF:0000107 (Ensembl Compara ortholog-based propagation). BRAF is expressed in neurons
+      and germline BRAF activating mutations cause cardio-facio-cutaneous syndrome with neurological features, so neuronal
+      cell body localization in specific neuronal contexts is plausible. However, this represents a tissue/cell-type-specific
+      localization rather than a constitutive cellular function, and is not a core BRAF function — the canonical RAS-RAF-MEK-ERK
+      signaling activity at cytoplasm/cytosol/plasma membrane is what defines BRAF.'
     action: KEEP_AS_NON_CORE
-    reason: 'Tissue/cell-type-specific neuronal/synaptic localization rather than a core BRAF function. Canonical BRAF localization (cytosol, plasma membrane, cytoplasm) is already captured via direct experimental evidence in this file (PMID:19710016 EXP, PMID:18567582, PMID:21441910) and via the IBA propagation batch (PR #448) and Reactome TAS rows (PR #440). Mechanically consolidated to KEEP_AS_NON_CORE with a uniform template across the neuronal/synaptic CC rows held back from earlier batches (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic transmission).'
+    reason: 'Tissue/cell-type-specific neuronal/synaptic localization rather than a core BRAF function. Canonical BRAF localization
+      (cytosol, plasma membrane, cytoplasm) is already captured via direct experimental evidence in this file (PMID:19710016
+      EXP, PMID:18567582, PMID:21441910) and via the IBA propagation batch (PR #448) and Reactome TAS rows (PR #440). Mechanically
+      consolidated to KEEP_AS_NON_CORE with a uniform template across the neuronal/synaptic CC rows held back from earlier
+      batches (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic
+      transmission).'
 - term:
     id: GO:0098978
     label: glutamatergic synapse
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'IEA annotation from GO_REF:0000107 (Ensembl Compara ortholog-based propagation). BRAF is expressed in neurons and germline BRAF activating mutations cause cardio-facio-cutaneous syndrome with neurological features, so glutamatergic synapse localization in specific neuronal contexts is plausible. However, this represents a tissue/cell-type-specific localization rather than a constitutive cellular function, and is not a core BRAF function.'
+    summary: 'IEA annotation from GO_REF:0000107 (Ensembl Compara ortholog-based propagation). BRAF is expressed in neurons
+      and germline BRAF activating mutations cause cardio-facio-cutaneous syndrome with neurological features, so glutamatergic
+      synapse localization in specific neuronal contexts is plausible. However, this represents a tissue/cell-type-specific
+      localization rather than a constitutive cellular function, and is not a core BRAF function.'
     action: KEEP_AS_NON_CORE
-    reason: 'Tissue/cell-type-specific neuronal/synaptic localization rather than a core BRAF function. Canonical BRAF localization (cytosol, plasma membrane, cytoplasm) is already captured via direct experimental evidence in this file (PMID:19710016 EXP, PMID:18567582, PMID:21441910) and via the IBA propagation batch (PR #448) and Reactome TAS rows (PR #440). Mechanically consolidated to KEEP_AS_NON_CORE with a uniform template across the neuronal/synaptic CC rows held back from earlier batches (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic transmission).'
+    reason: 'Tissue/cell-type-specific neuronal/synaptic localization rather than a core BRAF function. Canonical BRAF localization
+      (cytosol, plasma membrane, cytoplasm) is already captured via direct experimental evidence in this file (PMID:19710016
+      EXP, PMID:18567582, PMID:21441910) and via the IBA propagation batch (PR #448) and Reactome TAS rows (PR #440). Mechanically
+      consolidated to KEEP_AS_NON_CORE with a uniform template across the neuronal/synaptic CC rows held back from earlier
+      batches (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic
+      transmission).'
 - term:
     id: GO:0099170
     label: postsynaptic modulation of chemical synaptic transmission
   evidence_type: IEA
   original_reference_id: GO_REF:0000107
   review:
-    summary: 'IEA annotation from GO_REF:0000107 (Ensembl Compara ortholog-based propagation). BRAF is expressed in neurons and germline BRAF activating mutations cause cardio-facio-cutaneous syndrome with neurological features, so a role in postsynaptic modulation of chemical synaptic transmission in specific neuronal contexts is plausible. However, this represents a tissue/cell-type-specific biological process rather than a constitutive function, and is not a core BRAF function — the canonical RAS-RAF-MEK-ERK signaling cascade is what defines BRAF.'
+    summary: 'IEA annotation from GO_REF:0000107 (Ensembl Compara ortholog-based propagation). BRAF is expressed in neurons
+      and germline BRAF activating mutations cause cardio-facio-cutaneous syndrome with neurological features, so a role in
+      postsynaptic modulation of chemical synaptic transmission in specific neuronal contexts is plausible. However, this
+      represents a tissue/cell-type-specific biological process rather than a constitutive function, and is not a core BRAF
+      function — the canonical RAS-RAF-MEK-ERK signaling cascade is what defines BRAF.'
     action: KEEP_AS_NON_CORE
-    reason: 'Tissue/cell-type-specific neuronal/synaptic biology rather than a core BRAF function. Canonical BRAF activity (MAPK cascade, MAP3K activity, S/T kinase activity) is already captured via direct experimental evidence in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP). Mechanically consolidated to KEEP_AS_NON_CORE with a uniform template across the neuronal/synaptic CC/BP rows held back from earlier batches (postsynapse, neuron projection, cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic transmission).'
+    reason: 'Tissue/cell-type-specific neuronal/synaptic biology rather than a core BRAF function. Canonical BRAF activity
+      (MAPK cascade, MAP3K activity, S/T kinase activity) is already captured via direct experimental evidence in this file
+      (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP). Mechanically consolidated to KEEP_AS_NON_CORE with a
+      uniform template across the neuronal/synaptic CC/BP rows held back from earlier batches (postsynapse, neuron projection,
+      cell body, glutamatergic synapse, postsynaptic modulation of chemical synaptic transmission).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'IDA annotation for cytosolic localization from the Human Protein Atlas antibody-based subcellular localization pipeline (GO_REF:0000052). BRAF in the autoinhibited 14-3-3/Hsp90/CDC37-bound resting state is cytosolic, prior to RAS-GTP-mediated PM recruitment. Already extensively supported in this file via the 59 Reactome TAS cytosol rows ACCEPTed in PR #440 and the IBA propagation row ACCEPTed in PR #448.'
+    summary: 'IDA annotation for cytosolic localization from the Human Protein Atlas antibody-based subcellular localization
+      pipeline (GO_REF:0000052). BRAF in the autoinhibited 14-3-3/Hsp90/CDC37-bound resting state is cytosolic, prior to RAS-GTP-mediated
+      PM recruitment. Already extensively supported in this file via the 59 Reactome TAS cytosol rows ACCEPTed in PR #440
+      and the IBA propagation row ACCEPTed in PR #448.'
     action: ACCEPT
-    reason: 'Canonical BRAF subcellular localization. The cytosolic (autoinhibited 14-3-3-bound resting state) and plasma membrane (RAS-GTP-recruited activated state) localizations are the dominant BRAF distribution and are already extensively captured in this file: 59 Reactome TAS cytosol rows and 13 Reactome TAS plasma membrane rows ACCEPTed in PR #440, IBA propagation rows for cytoplasm/plasma membrane/cytosol ACCEPTed in PR #448, and IEA rows for cytoplasm/plasma membrane ACCEPTed in PR #456. This 4-row batch mechanically consolidates the remaining direct-evidence canonical localization rows (HPA IDA via GO_REF:0000052; primary literature EXP via PMID:19710016) to ACCEPT with a uniform template.'
+    reason: 'Canonical BRAF subcellular localization. The cytosolic (autoinhibited 14-3-3-bound resting state) and plasma
+      membrane (RAS-GTP-recruited activated state) localizations are the dominant BRAF distribution and are already extensively
+      captured in this file: 59 Reactome TAS cytosol rows and 13 Reactome TAS plasma membrane rows ACCEPTed in PR #440, IBA
+      propagation rows for cytoplasm/plasma membrane/cytosol ACCEPTed in PR #448, and IEA rows for cytoplasm/plasma membrane
+      ACCEPTed in PR #456. This 4-row batch mechanically consolidates the remaining direct-evidence canonical localization
+      rows (HPA IDA via GO_REF:0000052; primary literature EXP via PMID:19710016) to ACCEPT with a uniform template.'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: IDA
   original_reference_id: GO_REF:0000052
   review:
-    summary: 'IDA annotation for plasma membrane localization from the Human Protein Atlas antibody-based subcellular localization pipeline (GO_REF:0000052). BRAF is recruited to the PM by RAS-GTP upon receptor activation, where it dimerizes and phosphorylates MEK in the canonical RAS-RAF-MEK-ERK cascade. Already extensively supported in this file via the 13 Reactome TAS plasma membrane rows ACCEPTed in PR #440 and the IBA propagation row ACCEPTed in PR #448.'
+    summary: 'IDA annotation for plasma membrane localization from the Human Protein Atlas antibody-based subcellular localization
+      pipeline (GO_REF:0000052). BRAF is recruited to the PM by RAS-GTP upon receptor activation, where it dimerizes and phosphorylates
+      MEK in the canonical RAS-RAF-MEK-ERK cascade. Already extensively supported in this file via the 13 Reactome TAS plasma
+      membrane rows ACCEPTed in PR #440 and the IBA propagation row ACCEPTed in PR #448.'
     action: ACCEPT
-    reason: 'Canonical BRAF subcellular localization. The cytosolic (autoinhibited 14-3-3-bound resting state) and plasma membrane (RAS-GTP-recruited activated state) localizations are the dominant BRAF distribution and are already extensively captured in this file: 59 Reactome TAS cytosol rows and 13 Reactome TAS plasma membrane rows ACCEPTed in PR #440, IBA propagation rows for cytoplasm/plasma membrane/cytosol ACCEPTed in PR #448, and IEA rows for cytoplasm/plasma membrane ACCEPTed in PR #456. This 4-row batch mechanically consolidates the remaining direct-evidence canonical localization rows (HPA IDA via GO_REF:0000052; primary literature EXP via PMID:19710016) to ACCEPT with a uniform template.'
+    reason: 'Canonical BRAF subcellular localization. The cytosolic (autoinhibited 14-3-3-bound resting state) and plasma
+      membrane (RAS-GTP-recruited activated state) localizations are the dominant BRAF distribution and are already extensively
+      captured in this file: 59 Reactome TAS cytosol rows and 13 Reactome TAS plasma membrane rows ACCEPTed in PR #440, IBA
+      propagation rows for cytoplasm/plasma membrane/cytosol ACCEPTed in PR #448, and IEA rows for cytoplasm/plasma membrane
+      ACCEPTed in PR #456. This 4-row batch mechanically consolidates the remaining direct-evidence canonical localization
+      rows (HPA IDA via GO_REF:0000052; primary literature EXP via PMID:19710016) to ACCEPT with a uniform template.'
 - term:
     id: GO:0005737
     label: cytoplasm
   evidence_type: EXP
   original_reference_id: PMID:19710016
   review:
-    summary: 'EXP annotation for cytoplasmic localization from PMID:19710016 (Yasuda et al. 2009, J Biol Chem), which characterized BRAF/CRAF/DGKeta colocalization and heterodimerization in HeLa cells using immunofluorescence and biochemical fractionation. Already supported via IBA propagation (PR #448), IEA propagation (PR #456), and the 59 Reactome TAS cytosol rows on the more specific child term GO:0005829 (PR #440).'
+    summary: 'EXP annotation for cytoplasmic localization from PMID:19710016 (Yasuda et al. 2009, J Biol Chem), which characterized
+      BRAF/CRAF/DGKeta colocalization and heterodimerization in HeLa cells using immunofluorescence and biochemical fractionation.
+      Already supported via IBA propagation (PR #448), IEA propagation (PR #456), and the 59 Reactome TAS cytosol rows on
+      the more specific child term GO:0005829 (PR #440).'
     action: ACCEPT
-    reason: 'Canonical BRAF subcellular localization. The cytosolic (autoinhibited 14-3-3-bound resting state) and plasma membrane (RAS-GTP-recruited activated state) localizations are the dominant BRAF distribution and are already extensively captured in this file: 59 Reactome TAS cytosol rows and 13 Reactome TAS plasma membrane rows ACCEPTed in PR #440, IBA propagation rows for cytoplasm/plasma membrane/cytosol ACCEPTed in PR #448, and IEA rows for cytoplasm/plasma membrane ACCEPTed in PR #456. This 4-row batch mechanically consolidates the remaining direct-evidence canonical localization rows (HPA IDA via GO_REF:0000052; primary literature EXP via PMID:19710016) to ACCEPT with a uniform template.'
+    reason: 'Canonical BRAF subcellular localization. The cytosolic (autoinhibited 14-3-3-bound resting state) and plasma
+      membrane (RAS-GTP-recruited activated state) localizations are the dominant BRAF distribution and are already extensively
+      captured in this file: 59 Reactome TAS cytosol rows and 13 Reactome TAS plasma membrane rows ACCEPTed in PR #440, IBA
+      propagation rows for cytoplasm/plasma membrane/cytosol ACCEPTed in PR #448, and IEA rows for cytoplasm/plasma membrane
+      ACCEPTed in PR #456. This 4-row batch mechanically consolidates the remaining direct-evidence canonical localization
+      rows (HPA IDA via GO_REF:0000052; primary literature EXP via PMID:19710016) to ACCEPT with a uniform template.'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: EXP
   original_reference_id: PMID:19710016
   review:
-    summary: 'EXP annotation for plasma membrane localization from PMID:19710016 (Yasuda et al. 2009, J Biol Chem), which demonstrated BRAF/CRAF/DGKeta colocalization at the plasma membrane upon EGF stimulation in HeLa cells, supporting BRAF recruitment to the PM in the activated RAS-RAF-MEK-ERK signaling state. Already supported via IBA propagation (PR #448), IEA propagation (PR #456), and the 13 Reactome TAS plasma membrane rows ACCEPTed in PR #440.'
+    summary: 'EXP annotation for plasma membrane localization from PMID:19710016 (Yasuda et al. 2009, J Biol Chem), which
+      demonstrated BRAF/CRAF/DGKeta colocalization at the plasma membrane upon EGF stimulation in HeLa cells, supporting BRAF
+      recruitment to the PM in the activated RAS-RAF-MEK-ERK signaling state. Already supported via IBA propagation (PR #448),
+      IEA propagation (PR #456), and the 13 Reactome TAS plasma membrane rows ACCEPTed in PR #440.'
     action: ACCEPT
-    reason: 'Canonical BRAF subcellular localization. The cytosolic (autoinhibited 14-3-3-bound resting state) and plasma membrane (RAS-GTP-recruited activated state) localizations are the dominant BRAF distribution and are already extensively captured in this file: 59 Reactome TAS cytosol rows and 13 Reactome TAS plasma membrane rows ACCEPTed in PR #440, IBA propagation rows for cytoplasm/plasma membrane/cytosol ACCEPTed in PR #448, and IEA rows for cytoplasm/plasma membrane ACCEPTed in PR #456. This 4-row batch mechanically consolidates the remaining direct-evidence canonical localization rows (HPA IDA via GO_REF:0000052; primary literature EXP via PMID:19710016) to ACCEPT with a uniform template.'
+    reason: 'Canonical BRAF subcellular localization. The cytosolic (autoinhibited 14-3-3-bound resting state) and plasma
+      membrane (RAS-GTP-recruited activated state) localizations are the dominant BRAF distribution and are already extensively
+      captured in this file: 59 Reactome TAS cytosol rows and 13 Reactome TAS plasma membrane rows ACCEPTed in PR #440, IBA
+      propagation rows for cytoplasm/plasma membrane/cytosol ACCEPTed in PR #448, and IEA rows for cytoplasm/plasma membrane
+      ACCEPTed in PR #456. This 4-row batch mechanically consolidates the remaining direct-evidence canonical localization
+      rows (HPA IDA via GO_REF:0000052; primary literature EXP via PMID:19710016) to ACCEPT with a uniform template.'
 - term:
     id: GO:0106310
     label: protein serine kinase activity
   evidence_type: EXP
   original_reference_id: PMID:21441910
   review:
-    summary: 'EXP annotation for protein serine kinase activity from PMID:21441910 (Brennan et al. 2011 Nature — A Raf-induced allosteric transition of KSR stimulates phosphorylation of MEK). Direct experimental measurement of BRAF Ser/Thr kinase activity on the GO:0106310 most-specific MF child term. Already supported via IEA propagation in PR #456 (line 144: GO:0106310 IEA GO_REF:0000116 ACCEPTed) and via the IBA propagation batch in PR #448 on the GO:0004709 MAP3K activity child.'
+    summary: 'EXP annotation for protein serine kinase activity from PMID:21441910 (Brennan et al. 2011 Nature — A Raf-induced
+      allosteric transition of KSR stimulates phosphorylation of MEK). Direct experimental measurement of BRAF Ser/Thr kinase
+      activity on the GO:0106310 most-specific MF child term. Already supported via IEA propagation in PR #456 (line 144:
+      GO:0106310 IEA GO_REF:0000116 ACCEPTed) and via the IBA propagation batch in PR #448 on the GO:0004709 MAP3K activity
+      child.'
     action: ACCEPT
-    reason: 'Canonical BRAF Ser/Thr kinase MF directly demonstrated experimentally. PMID:21441910 is one of the three canonical experimental BRAF kinase activity papers cited as the anchoring evidence across the IEA mechanical consolidation in PR #456 (lines 69, 78, 87, 104, 122, 131, 149) — "directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP)". This batch mechanically consolidates the remaining direct-evidence canonical kinase / MAPK cascade rows from the three canonical experimental papers to ACCEPT with a uniform template (4 rows: 2 GO:0106310 EXP rows + 2 GO:0000165 IDA rows). Held back: GO:0004708 IMP PMID:29433126 (MAP2K vs MAP3K — needs per-row MODIFY review per PR #505 carryover note); GO:0004674 IDA rows on PMID:18567582/PMID:19667065 (more general parent term, separate batch); GO:0005509/GO:0007173/GO:0097110/GO:0071277 PMID:18567582 rows (calcium-response and EGFR-pathway secondary findings, separate per-row review).'
+    reason: 'Canonical BRAF Ser/Thr kinase MF directly demonstrated experimentally. PMID:21441910 is one of the three canonical
+      experimental BRAF kinase activity papers cited as the anchoring evidence across the IEA mechanical consolidation in
+      PR #456 (lines 69, 78, 87, 104, 122, 131, 149) — "directly demonstrated experimentally in this file (PMID:18567582 IDA,
+      PMID:21441910 EXP, PMID:29433126 IDA/IMP)". This batch mechanically consolidates the remaining direct-evidence canonical
+      kinase / MAPK cascade rows from the three canonical experimental papers to ACCEPT with a uniform template (4 rows: 2
+      GO:0106310 EXP rows + 2 GO:0000165 IDA rows). Held back: GO:0004708 IMP PMID:29433126 (MAP2K vs MAP3K — needs per-row
+      MODIFY review per PR #505 carryover note); GO:0004674 IDA rows on PMID:18567582/PMID:19667065 (more general parent term,
+      separate batch); GO:0005509/GO:0007173/GO:0097110/GO:0071277 PMID:18567582 rows (calcium-response and EGFR-pathway secondary
+      findings, separate per-row review).'
 - term:
     id: GO:0106310
     label: protein serine kinase activity
   evidence_type: EXP
   original_reference_id: PMID:29433126
   review:
-    summary: 'EXP annotation for protein serine kinase activity from PMID:29433126, one of the canonical BRAF kinase experimental papers cited across this file as direct evidence (IDA/IMP) for BRAF S/T kinase function. Direct experimental measurement of BRAF Ser-kinase activity on the GO:0106310 most-specific MF child term. Already supported via IEA propagation in PR #456 (line 144: GO:0106310 IEA GO_REF:0000116 ACCEPTed) and via the IBA propagation batch in PR #448 on the GO:0004709 MAP3K activity child.'
+    summary: 'EXP annotation for protein serine kinase activity from PMID:29433126, one of the canonical BRAF kinase experimental
+      papers cited across this file as direct evidence (IDA/IMP) for BRAF S/T kinase function. Direct experimental measurement
+      of BRAF Ser-kinase activity on the GO:0106310 most-specific MF child term. Already supported via IEA propagation in
+      PR #456 (line 144: GO:0106310 IEA GO_REF:0000116 ACCEPTed) and via the IBA propagation batch in PR #448 on the GO:0004709
+      MAP3K activity child.'
     action: ACCEPT
-    reason: 'Canonical BRAF Ser/Thr kinase MF directly demonstrated experimentally. PMID:29433126 is one of the three canonical experimental BRAF kinase activity papers cited as the anchoring evidence across the IEA mechanical consolidation in PR #456 (lines 69, 78, 87, 104, 122, 131, 149) — "directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP)". This batch mechanically consolidates the remaining direct-evidence canonical kinase / MAPK cascade rows from the three canonical experimental papers to ACCEPT with a uniform template (4 rows: 2 GO:0106310 EXP rows + 2 GO:0000165 IDA rows). Held back: GO:0004708 IMP PMID:29433126 (MAP2K vs MAP3K — needs per-row MODIFY review per PR #505 carryover note); GO:0004674 IDA rows on PMID:18567582/PMID:19667065 (more general parent term, separate batch); GO:0005509/GO:0007173/GO:0097110/GO:0071277 PMID:18567582 rows (calcium-response and EGFR-pathway secondary findings, separate per-row review).'
+    reason: 'Canonical BRAF Ser/Thr kinase MF directly demonstrated experimentally. PMID:29433126 is one of the three canonical
+      experimental BRAF kinase activity papers cited as the anchoring evidence across the IEA mechanical consolidation in
+      PR #456 (lines 69, 78, 87, 104, 122, 131, 149) — "directly demonstrated experimentally in this file (PMID:18567582 IDA,
+      PMID:21441910 EXP, PMID:29433126 IDA/IMP)". This batch mechanically consolidates the remaining direct-evidence canonical
+      kinase / MAPK cascade rows from the three canonical experimental papers to ACCEPT with a uniform template (4 rows: 2
+      GO:0106310 EXP rows + 2 GO:0000165 IDA rows). Held back: GO:0004708 IMP PMID:29433126 (MAP2K vs MAP3K — needs per-row
+      MODIFY review per PR #505 carryover note); GO:0004674 IDA rows on PMID:18567582/PMID:19667065 (more general parent term,
+      separate batch); GO:0005509/GO:0007173/GO:0097110/GO:0071277 PMID:18567582 rows (calcium-response and EGFR-pathway secondary
+      findings, separate per-row review).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5672950
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5672951
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5672960
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5672961
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5672966
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5672969
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5672972
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5672973
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5672978
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5672980
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5674130
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5674132
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5674140
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5675417
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5675431
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5675433
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802924
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6803240
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9610152
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9610153
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9610154
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9610156
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9610163
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9653108
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9656209
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9656211
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9656212
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9656213
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9656214
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9656215
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9657599
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9657603
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9657606
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9657608
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9658445
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9660536
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-9660538
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-5675198
   review:
-    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
+    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP
+      interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
     action: ACCEPT
-    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The 13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet
+      binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The
+      13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT
+      with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802908
   review:
-    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
+    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP
+      interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
     action: ACCEPT
-    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The 13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet
+      binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The
+      13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT
+      with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802922
   review:
-    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
+    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP
+      interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
     action: ACCEPT
-    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The 13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet
+      binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The
+      13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT
+      with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802924
   review:
-    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
+    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP
+      interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
     action: ACCEPT
-    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The 13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet
+      binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The
+      13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT
+      with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802925
   review:
-    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
+    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP
+      interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
     action: ACCEPT
-    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The 13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet
+      binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The
+      13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT
+      with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802926
   review:
-    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
+    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP
+      interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
     action: ACCEPT
-    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The 13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet
+      binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The
+      13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT
+      with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6803233
   review:
-    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
+    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP
+      interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
     action: ACCEPT
-    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The 13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet
+      binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The
+      13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT
+      with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6803240
   review:
-    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
+    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP
+      interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
     action: ACCEPT
-    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The 13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet
+      binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The
+      13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT
+      with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802910
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802911
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802912
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802930
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802938
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6803227
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0000165
     label: MAPK cascade
   evidence_type: IDA
   original_reference_id: PMID:29433126
   review:
-    summary: 'IDA annotation for MAPK cascade from PMID:29433126, one of the canonical BRAF kinase experimental papers cited across this file as direct evidence (IDA/IMP) for BRAF function in the RAS-RAF-MEK-ERK cascade. Direct experimental measurement of BRAF participation in the MAPK cascade. Already supported via IBA propagation in PR #448 on GO:0000165 (the IEA ACCEPT for GO:0007165 signal transduction in PR #456 at line 117 explicitly notes "supported by IBA on the more specific child term GO:0000165 MAPK cascade (PR #448)") and via Reactome TAS rows for the RAS-MAPK pathway events ACCEPTed in PR #440.'
+    summary: 'IDA annotation for MAPK cascade from PMID:29433126, one of the canonical BRAF kinase experimental papers cited
+      across this file as direct evidence (IDA/IMP) for BRAF function in the RAS-RAF-MEK-ERK cascade. Direct experimental
+      measurement of BRAF participation in the MAPK cascade. Already supported via IBA propagation in PR #448 on GO:0000165
+      (the IEA ACCEPT for GO:0007165 signal transduction in PR #456 at line 117 explicitly notes "supported by IBA on the
+      more specific child term GO:0000165 MAPK cascade (PR #448)") and via Reactome TAS rows for the RAS-MAPK pathway events
+      ACCEPTed in PR #440.'
     action: ACCEPT
-    reason: 'Canonical BRAF BP directly demonstrated experimentally. PMID:29433126 is one of the three canonical experimental BRAF kinase activity papers cited as the anchoring evidence across the IEA mechanical consolidation in PR #456 (lines 69, 78, 87, 104, 122, 131, 149) — "directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP)". This batch mechanically consolidates the remaining direct-evidence canonical kinase / MAPK cascade rows from the three canonical experimental papers to ACCEPT with a uniform template (4 rows: 2 GO:0106310 EXP rows + 2 GO:0000165 IDA rows). Held back: GO:0004708 IMP PMID:29433126 (MAP2K vs MAP3K — needs per-row MODIFY review per PR #505 carryover note); GO:0004674 IDA rows on PMID:18567582/PMID:19667065 (more general parent term, separate batch); GO:0005509/GO:0007173/GO:0097110/GO:0071277 PMID:18567582 rows (calcium-response and EGFR-pathway secondary findings, separate per-row review).'
+    reason: 'Canonical BRAF BP directly demonstrated experimentally. PMID:29433126 is one of the three canonical experimental
+      BRAF kinase activity papers cited as the anchoring evidence across the IEA mechanical consolidation in PR #456 (lines
+      69, 78, 87, 104, 122, 131, 149) — "directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:21441910
+      EXP, PMID:29433126 IDA/IMP)". This batch mechanically consolidates the remaining direct-evidence canonical kinase /
+      MAPK cascade rows from the three canonical experimental papers to ACCEPT with a uniform template (4 rows: 2 GO:0106310
+      EXP rows + 2 GO:0000165 IDA rows). Held back: GO:0004708 IMP PMID:29433126 (MAP2K vs MAP3K — needs per-row MODIFY review
+      per PR #505 carryover note); GO:0004674 IDA rows on PMID:18567582/PMID:19667065 (more general parent term, separate
+      batch); GO:0005509/GO:0007173/GO:0097110/GO:0071277 PMID:18567582 rows (calcium-response and EGFR-pathway secondary
+      findings, separate per-row review).'
 - term:
     id: GO:0004708
     label: MAP kinase kinase activity
   evidence_type: IMP
   original_reference_id: PMID:29433126
   review:
-    summary: 'IMP annotation for GO:0004708 MAP kinase kinase activity from Lavoie et al. 2018 Nature (PMID:29433126 — MEK drives BRAF activation through allosteric control of KSR proteins). The paper establishes that RAF-family kinase activation depends on kinase-domain dimerization and that BRAF acts on MEK within the RAS-RAF-MEK-ERK cascade. BRAF is a MAP kinase kinase kinase (MAP3K): it phosphorylates MEK1/MEK2 (the MAP2Ks); it does not phosphorylate ERK and does not itself have MAP2K (MAP kinase kinase) activity. GO:0004708 describes the catalytic activity of MEK, not of BRAF.'
+    summary: 'IMP annotation for GO:0004708 MAP kinase kinase activity from Lavoie et al. 2018 Nature (PMID:29433126 — MEK
+      drives BRAF activation through allosteric control of KSR proteins). The paper establishes that RAF-family kinase activation
+      depends on kinase-domain dimerization and that BRAF acts on MEK within the RAS-RAF-MEK-ERK cascade. BRAF is a MAP kinase
+      kinase kinase (MAP3K): it phosphorylates MEK1/MEK2 (the MAP2Ks); it does not phosphorylate ERK and does not itself have
+      MAP2K (MAP kinase kinase) activity. GO:0004708 describes the catalytic activity of MEK, not of BRAF.'
     action: MODIFY
-    reason: 'The essence of the annotation is sound (BRAF is the kinase that drives the MAPK cascade by phosphorylating the next kinase down), but GO:0004708 (MAP kinase kinase activity) is the wrong tier of the MAPK kinase cascade for BRAF. BRAF phosphorylates MEK1/MEK2 — the MAP2Ks — so BRAF''s molecular function is GO:0004709 MAP kinase kinase kinase activity (MAP3K activity), not MAP2K activity. MODIFY to GO:0004709, which is already independently ACCEPTed in this file via IBA propagation from PANTHER PTHR44329 (PR #448, line 38) and consistent with the canonical kinase MF evidence in-file (PMID:21441910 EXP, PMID:18567582 IDA). This resolves the long-standing MAP2K-vs-MAP3K carryover note flagged across earlier batches.'
+    reason: 'The essence of the annotation is sound (BRAF is the kinase that drives the MAPK cascade by phosphorylating the
+      next kinase down), but GO:0004708 (MAP kinase kinase activity) is the wrong tier of the MAPK kinase cascade for BRAF.
+      BRAF phosphorylates MEK1/MEK2 — the MAP2Ks — so BRAF''s molecular function is GO:0004709 MAP kinase kinase kinase activity
+      (MAP3K activity), not MAP2K activity. MODIFY to GO:0004709, which is already independently ACCEPTed in this file via
+      IBA propagation from PANTHER PTHR44329 (PR #448, line 38) and consistent with the canonical kinase MF evidence in-file
+      (PMID:21441910 EXP, PMID:18567582 IDA). This resolves the long-standing MAP2K-vs-MAP3K carryover note flagged across
+      earlier batches.'
     proposed_replacement_terms:
     - id: GO:0004709
       label: MAP kinase kinase kinase activity
@@ -1188,261 +1954,427 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:18567582
   review:
-    summary: 'IDA annotation for MAPK cascade from PMID:18567582 (Ren et al. 2008 J Biol Chem — IQGAP1 integrates Ca2+/calmodulin and B-Raf signaling), one of the canonical BRAF kinase experimental papers cited across this file as direct evidence (IDA) for BRAF function in the RAS-RAF-MEK-ERK cascade. Direct experimental measurement of BRAF participation in the MAPK cascade. Already supported via IBA propagation in PR #448 on GO:0000165 (the IEA ACCEPT for GO:0007165 signal transduction in PR #456 at line 117 explicitly notes "supported by IBA on the more specific child term GO:0000165 MAPK cascade (PR #448)") and via Reactome TAS rows for the RAS-MAPK pathway events ACCEPTed in PR #440.'
+    summary: 'IDA annotation for MAPK cascade from PMID:18567582 (Ren et al. 2008 J Biol Chem — IQGAP1 integrates Ca2+/calmodulin
+      and B-Raf signaling), one of the canonical BRAF kinase experimental papers cited across this file as direct evidence
+      (IDA) for BRAF function in the RAS-RAF-MEK-ERK cascade. Direct experimental measurement of BRAF participation in the
+      MAPK cascade. Already supported via IBA propagation in PR #448 on GO:0000165 (the IEA ACCEPT for GO:0007165 signal transduction
+      in PR #456 at line 117 explicitly notes "supported by IBA on the more specific child term GO:0000165 MAPK cascade (PR
+      #448)") and via Reactome TAS rows for the RAS-MAPK pathway events ACCEPTed in PR #440.'
     action: ACCEPT
-    reason: 'Canonical BRAF BP directly demonstrated experimentally. PMID:18567582 is one of the three canonical experimental BRAF kinase activity papers cited as the anchoring evidence across the IEA mechanical consolidation in PR #456 (lines 69, 78, 87, 104, 122, 131, 149) — "directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP)". This batch mechanically consolidates the remaining direct-evidence canonical kinase / MAPK cascade rows from the three canonical experimental papers to ACCEPT with a uniform template (4 rows: 2 GO:0106310 EXP rows + 2 GO:0000165 IDA rows). Held back: GO:0004708 IMP PMID:29433126 (MAP2K vs MAP3K — needs per-row MODIFY review per PR #505 carryover note); GO:0004674 IDA rows on PMID:18567582/PMID:19667065 (more general parent term, separate batch); GO:0005509/GO:0007173/GO:0097110/GO:0071277 PMID:18567582 rows (calcium-response and EGFR-pathway secondary findings, separate per-row review).'
+    reason: 'Canonical BRAF BP directly demonstrated experimentally. PMID:18567582 is one of the three canonical experimental
+      BRAF kinase activity papers cited as the anchoring evidence across the IEA mechanical consolidation in PR #456 (lines
+      69, 78, 87, 104, 122, 131, 149) — "directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:21441910
+      EXP, PMID:29433126 IDA/IMP)". This batch mechanically consolidates the remaining direct-evidence canonical kinase /
+      MAPK cascade rows from the three canonical experimental papers to ACCEPT with a uniform template (4 rows: 2 GO:0106310
+      EXP rows + 2 GO:0000165 IDA rows). Held back: GO:0004708 IMP PMID:29433126 (MAP2K vs MAP3K — needs per-row MODIFY review
+      per PR #505 carryover note); GO:0004674 IDA rows on PMID:18567582/PMID:19667065 (more general parent term, separate
+      batch); GO:0005509/GO:0007173/GO:0097110/GO:0071277 PMID:18567582 rows (calcium-response and EGFR-pathway secondary
+      findings, separate per-row review).'
 - term:
     id: GO:0004674
     label: protein serine/threonine kinase activity
   evidence_type: IDA
   original_reference_id: PMID:18567582
   review:
-    summary: 'IDA annotation for protein serine/threonine kinase activity from PMID:18567582 (Ren et al. 2008 J Biol Chem — IQGAP1 integrates Ca2+/calmodulin and B-Raf signaling), one of the three canonical BRAF kinase experimental papers cited across this file as direct evidence (IDA/IMP) for BRAF kinase activity. GO:0004674 is the parent of GO:0106310 (protein serine kinase activity), which is already supported via direct EXP evidence in this file (PMID:21441910 ACCEPTed in PR #505) and via IEA propagation in PR #456.'
+    summary: 'IDA annotation for protein serine/threonine kinase activity from PMID:18567582 (Ren et al. 2008 J Biol Chem
+      — IQGAP1 integrates Ca2+/calmodulin and B-Raf signaling), one of the three canonical BRAF kinase experimental papers
+      cited across this file as direct evidence (IDA/IMP) for BRAF kinase activity. GO:0004674 is the parent of GO:0106310
+      (protein serine kinase activity), which is already supported via direct EXP evidence in this file (PMID:21441910 ACCEPTed
+      in PR #505) and via IEA propagation in PR #456.'
     action: ACCEPT
-    reason: 'Canonical BRAF MF directly demonstrated experimentally. Protein kinase activity / protein S/T kinase activity (parent terms of GO:0106310) is BRAF''s defining molecular function — phosphorylating MEK1/MEK2 in the RAS-RAF-MEK-ERK cascade. PMID:17563371 (Ren et al. 2007 PNAS — IQGAP1 modulates B-Raf activation; demonstrates B-Raf kinase activity in vitro), PMID:18567582 (Ren et al. 2008 J Biol Chem — IQGAP1 integrates Ca2+/calmodulin and B-Raf), and PMID:19667065 are direct IDA papers measuring BRAF kinase activity. Already supported via direct EXP evidence on the more specific child term GO:0106310 protein serine kinase activity (PMID:21441910 ACCEPTed in PR #505); via IBA propagation on GO:0004709 MAP3K activity (PR #448); via IEA on GO:0004672 and GO:0004674 (PR #456); via IDA on GO:0000165 MAPK cascade (PR #534). This batch mechanically consolidates the remaining 3 parent-term canonical kinase MF rows to ACCEPT with a uniform template (2 GO:0004674 IDA rows + 1 GO:0004672 IDA row). Held back: GO:0005509/GO:0007173/GO:0097110/GO:0071277 PMID:18567582 rows (calcium-response and EGFR-pathway secondary findings, separate per-row review); PMID:22065586 rows GO:0010628/GO:0070374 (downstream BP, separate batch); PMID:19667065 BP rows GO:0033138/GO:0043066 (separate batch); GO:0005634 IEA nucleus (separate per-row); GO:0042802 IPI PMID:35512704 (KEAP1 neoPPI focus, separate per-row); GO:0005739 IBA mitochondrion (separate per-row); GO:0090150/GO:0010828 PMID:23010278 rows (separate per-row); GO:0031267 NOT|IPI PMID:12194967 (negated row, separate review); GO:0004708 IMP PMID:29433126 (MAP2K vs MAP3K MODIFY, separate per-row).'
+    reason: 'Canonical BRAF MF directly demonstrated experimentally. Protein kinase activity / protein S/T kinase activity
+      (parent terms of GO:0106310) is BRAF''s defining molecular function — phosphorylating MEK1/MEK2 in the RAS-RAF-MEK-ERK
+      cascade. PMID:17563371 (Ren et al. 2007 PNAS — IQGAP1 modulates B-Raf activation; demonstrates B-Raf kinase activity
+      in vitro), PMID:18567582 (Ren et al. 2008 J Biol Chem — IQGAP1 integrates Ca2+/calmodulin and B-Raf), and PMID:19667065
+      are direct IDA papers measuring BRAF kinase activity. Already supported via direct EXP evidence on the more specific
+      child term GO:0106310 protein serine kinase activity (PMID:21441910 ACCEPTed in PR #505); via IBA propagation on GO:0004709
+      MAP3K activity (PR #448); via IEA on GO:0004672 and GO:0004674 (PR #456); via IDA on GO:0000165 MAPK cascade (PR #534).
+      This batch mechanically consolidates the remaining 3 parent-term canonical kinase MF rows to ACCEPT with a uniform template
+      (2 GO:0004674 IDA rows + 1 GO:0004672 IDA row). Held back: GO:0005509/GO:0007173/GO:0097110/GO:0071277 PMID:18567582
+      rows (calcium-response and EGFR-pathway secondary findings, separate per-row review); PMID:22065586 rows GO:0010628/GO:0070374
+      (downstream BP, separate batch); PMID:19667065 BP rows GO:0033138/GO:0043066 (separate batch); GO:0005634 IEA nucleus
+      (separate per-row); GO:0042802 IPI PMID:35512704 (KEAP1 neoPPI focus, separate per-row); GO:0005739 IBA mitochondrion
+      (separate per-row); GO:0090150/GO:0010828 PMID:23010278 rows (separate per-row); GO:0031267 NOT|IPI PMID:12194967 (negated
+      row, separate review); GO:0004708 IMP PMID:29433126 (MAP2K vs MAP3K MODIFY, separate per-row).'
 - term:
     id: GO:0005509
     label: calcium ion binding
   evidence_type: IDA
   original_reference_id: PMID:18567582
   review:
-    summary: 'IDA annotation from PMID:18567582 (Ren et al. 2008 J Biol Chem — IQGAP1 integrates Ca2+/calmodulin and B-Raf signaling). The paper reports "a specific and direct association of Ca2+ with B-Raf", but explicitly notes that "the specific site on B-Raf where Ca2+ binds remains to be determined" and "the biological function of Ca2+ binding to B-Raf is unknown" (chelating Ca2+ in the in vitro kinase assay produced no significant/reproducible change in B-Raf activity). This is a single-paper direct observation with no mapped binding site and no demonstrated functional consequence; BRAF has no canonical calcium-binding domain (EF-hand/C2) and Ca2+ binding is not part of the core RAS-RAF-MEK-ERK kinase mechanism.'
+    summary: 'IDA annotation from PMID:18567582 (Ren et al. 2008 J Biol Chem — IQGAP1 integrates Ca2+/calmodulin and B-Raf
+      signaling). The paper reports "a specific and direct association of Ca2+ with B-Raf", but explicitly notes that "the
+      specific site on B-Raf where Ca2+ binds remains to be determined" and "the biological function of Ca2+ binding to B-Raf
+      is unknown" (chelating Ca2+ in the in vitro kinase assay produced no significant/reproducible change in B-Raf activity).
+      This is a single-paper direct observation with no mapped binding site and no demonstrated functional consequence; BRAF
+      has no canonical calcium-binding domain (EF-hand/C2) and Ca2+ binding is not part of the core RAS-RAF-MEK-ERK kinase
+      mechanism.'
     action: KEEP_AS_NON_CORE
-    reason: 'Genuine direct experimental observation but a peripheral, mechanistically uncharacterized property (binding site unmapped, biological function explicitly stated as unknown by the authors), reported by a single lab and not replicated. BRAF''s core molecular function is its Ser/Thr (MAP3K) kinase activity in the RAS-RAF-MEK-ERK cascade, already captured via ACCEPTed canonical MF rows. Retained as non-core rather than removed because the IDA observation is real; part of the uniform KEEP_AS_NON_CORE treatment of the PMID:18567582 IQGAP1/Ca2+-calmodulin secondary-finding cluster (GO:0005509, GO:0007173, GO:0097110, GO:0071277).'
+    reason: 'Genuine direct experimental observation but a peripheral, mechanistically uncharacterized property (binding site
+      unmapped, biological function explicitly stated as unknown by the authors), reported by a single lab and not replicated.
+      BRAF''s core molecular function is its Ser/Thr (MAP3K) kinase activity in the RAS-RAF-MEK-ERK cascade, already captured
+      via ACCEPTed canonical MF rows. Retained as non-core rather than removed because the IDA observation is real; part of
+      the uniform KEEP_AS_NON_CORE treatment of the PMID:18567582 IQGAP1/Ca2+-calmodulin secondary-finding cluster (GO:0005509,
+      GO:0007173, GO:0097110, GO:0071277).'
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:18567582
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0007173
     label: epidermal growth factor receptor signaling pathway
   evidence_type: IDA
   original_reference_id: PMID:18567582
   review:
-    summary: 'IDA annotation from PMID:18567582 (Ren et al. 2008 J Biol Chem). BRAF was studied as an EGF-stimulated effector — EGF-stimulated B-Raf kinase activity is modulated by intracellular Ca2+ via the IQGAP1 scaffold. BRAF does function downstream of activated EGFR within the canonical RAS-RAF-MEK-ERK cascade, but EGFR is only one of many upstream RTK inputs and "EGFR signaling pathway" is a context-specific upstream-input framing rather than a BRAF-defining process. The core BRAF biological process (the MAPK cascade / RAS-RAF-MEK-ERK signal transduction) is already captured via ACCEPTed canonical rows (GO:0000165 MAPK cascade, GO:0007165 signal transduction).'
+    summary: 'IDA annotation from PMID:18567582 (Ren et al. 2008 J Biol Chem). BRAF was studied as an EGF-stimulated effector
+      — EGF-stimulated B-Raf kinase activity is modulated by intracellular Ca2+ via the IQGAP1 scaffold. BRAF does function
+      downstream of activated EGFR within the canonical RAS-RAF-MEK-ERK cascade, but EGFR is only one of many upstream RTK
+      inputs and "EGFR signaling pathway" is a context-specific upstream-input framing rather than a BRAF-defining process.
+      The core BRAF biological process (the MAPK cascade / RAS-RAF-MEK-ERK signal transduction) is already captured via ACCEPTed
+      canonical rows (GO:0000165 MAPK cascade, GO:0007165 signal transduction).'
     action: KEEP_AS_NON_CORE
-    reason: 'BRAF genuinely participates in EGFR-driven signaling as a canonical downstream MAP3K, so the annotation is not wrong, but it is a context-specific upstream-input pathway rather than BRAF''s core process — the generic RAS-RAF-MEK-ERK / MAPK cascade is the defining BP and is already ACCEPTed. Part of the uniform KEEP_AS_NON_CORE treatment of the PMID:18567582 IQGAP1/Ca2+-calmodulin secondary-finding cluster (GO:0005509, GO:0007173, GO:0097110, GO:0071277).'
+    reason: 'BRAF genuinely participates in EGFR-driven signaling as a canonical downstream MAP3K, so the annotation is not
+      wrong, but it is a context-specific upstream-input pathway rather than BRAF''s core process — the generic RAS-RAF-MEK-ERK
+      / MAPK cascade is the defining BP and is already ACCEPTed. Part of the uniform KEEP_AS_NON_CORE treatment of the PMID:18567582
+      IQGAP1/Ca2+-calmodulin secondary-finding cluster (GO:0005509, GO:0007173, GO:0097110, GO:0071277).'
 - term:
     id: GO:0097110
     label: scaffold protein binding
   evidence_type: IPI
   original_reference_id: PMID:18567582
   review:
-    summary: 'IPI annotation from PMID:18567582 (Ren et al. 2008 J Biol Chem) for direct binding of B-Raf to the MAPK scaffold protein IQGAP1 ("Ca2+ promotes the direct binding of IQGAP1 to B-Raf"; IQGAP1 assembles a B-Raf/MEK/ERK complex and modulates B-Raf activation by EGF). GO:0097110 ''scaffold protein binding'' is an informative, specific MF term (preferred over generic GO:0005515 per CLAUDE.md) and the B-Raf–IQGAP1 interaction is genuine and directly demonstrated. However, IQGAP1 scaffold binding is a regulatory/modulatory interaction rather than BRAF''s core catalytic function, and the principal RAF scaffold biology (KSR) is distinct; the IQGAP1 work is from a single lab (Sacks).'
+    summary: 'IPI annotation from PMID:18567582 (Ren et al. 2008 J Biol Chem) for direct binding of B-Raf to the MAPK scaffold
+      protein IQGAP1 ("Ca2+ promotes the direct binding of IQGAP1 to B-Raf"; IQGAP1 assembles a B-Raf/MEK/ERK complex and
+      modulates B-Raf activation by EGF). GO:0097110 ''scaffold protein binding'' is an informative, specific MF term (preferred
+      over generic GO:0005515 per CLAUDE.md) and the B-Raf–IQGAP1 interaction is genuine and directly demonstrated. However,
+      IQGAP1 scaffold binding is a regulatory/modulatory interaction rather than BRAF''s core catalytic function, and the
+      principal RAF scaffold biology (KSR) is distinct; the IQGAP1 work is from a single lab (Sacks).'
     action: KEEP_AS_NON_CORE
-    reason: 'Specific, informative, directly-demonstrated interaction (correctly avoids the generic protein-binding term), retained because it is biologically real and well-characterized, but it represents a regulatory scaffold interaction rather than BRAF''s core RAS-RAF-MEK-ERK Ser/Thr kinase function (already captured via ACCEPTed canonical MF rows). Part of the uniform KEEP_AS_NON_CORE treatment of the PMID:18567582 IQGAP1/Ca2+-calmodulin secondary-finding cluster (GO:0005509, GO:0007173, GO:0097110, GO:0071277).'
+    reason: 'Specific, informative, directly-demonstrated interaction (correctly avoids the generic protein-binding term),
+      retained because it is biologically real and well-characterized, but it represents a regulatory scaffold interaction
+      rather than BRAF''s core RAS-RAF-MEK-ERK Ser/Thr kinase function (already captured via ACCEPTed canonical MF rows).
+      Part of the uniform KEEP_AS_NON_CORE treatment of the PMID:18567582 IQGAP1/Ca2+-calmodulin secondary-finding cluster
+      (GO:0005509, GO:0007173, GO:0097110, GO:0071277).'
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:31024343
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:29433126
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802914
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802915
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802916
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802918
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802919
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802921
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802937
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802941
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802942
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802943
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6803230
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6803234
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-8936676
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-8936731
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802914
   review:
-    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
+    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP
+      interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
     action: ACCEPT
-    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The 13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet
+      binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The
+      13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT
+      with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802916
   review:
-    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
+    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP
+      interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
     action: ACCEPT
-    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The 13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet
+      binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The
+      13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT
+      with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802919
   review:
-    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
+    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP
+      interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
     action: ACCEPT
-    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The 13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet
+      binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The
+      13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT
+      with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6802921
   review:
-    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
+    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP
+      interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
     action: ACCEPT
-    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The 13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet
+      binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The
+      13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT
+      with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005886
     label: plasma membrane
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-6803230
   review:
-    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
+    summary: 'TAS annotation for plasma membrane localization. BRAF is recruited to the plasma membrane via the RBD-RAS-GTP
+      interaction, where it dimerizes (homo- and with CRAF/ARAF) and phosphorylates MEK1/2 in the MAPK cascade.'
     action: ACCEPT
-    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The 13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Plasma membrane recruitment is the canonical activated-state localization for BRAF. RAS-GTP at the inner leaflet
+      binds the BRAF RBD, releasing 14-3-3-mediated autoinhibition and enabling dimerization and MEK phosphorylation. The
+      13 Reactome events are separate annotations of the same activated-state localization, mechanically consolidated to ACCEPT
+      with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005515
     label: protein binding
   evidence_type: IPI
   original_reference_id: PMID:27353360
   review:
-    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md curation guidelines.
+    summary: This protein binding annotation records a physical interaction (IPI) but uses the uninformative generic 
+      term GO:0005515. BRAF has dozens of well-characterized binding partners — RAS-GTP isoforms (HRAS/KRAS/NRAS) via 
+      the RBD; CRAF/ARAF heterodimers and BRAF homodimers via the kinase domain; MEK1/MEK2 substrates; 14-3-3 proteins 
+      on phospho-S365/S729; and Hsp90/CDC37 chaperones — and specific MF terms should be preferred per CLAUDE.md 
+      curation guidelines.
     action: MARK_AS_OVER_ANNOTATED
-    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows were uniformly demoted.
+    reason: Generic 'protein binding' is uninformative for BRAF's well-characterized RAF-kinase / RAS-effector / 
+      dimerization biology. Same precedent as BAG3 (#313), KRAS (#349), and RB1 (#430) where all GO:0005515 IPI rows 
+      were uniformly demoted.
 - term:
     id: GO:0071277
     label: cellular response to calcium ion
   evidence_type: IDA
   original_reference_id: PMID:18567582
   review:
-    summary: 'IDA annotation from PMID:18567582 (Ren et al. 2008 J Biol Chem). The paper shows that manipulating intracellular Ca2+ modulates B-Raf kinase activity ("chelating [Ca2+]i in fibroblasts markedly increases B-Raf kinase activity"; raising [Ca2+]i blocks EGF-stimulated B-Raf activity), but the effect is indirect — mediated by Ca2+/calmodulin acting on the IQGAP1 scaffold to alter its association with B-Raf, not a cell-autonomous BRAF calcium response. This is a real but context-specific, single-mechanism secondary finding, not a core BRAF process.'
+    summary: 'IDA annotation from PMID:18567582 (Ren et al. 2008 J Biol Chem). The paper shows that manipulating intracellular
+      Ca2+ modulates B-Raf kinase activity ("chelating [Ca2+]i in fibroblasts markedly increases B-Raf kinase activity"; raising
+      [Ca2+]i blocks EGF-stimulated B-Raf activity), but the effect is indirect — mediated by Ca2+/calmodulin acting on the
+      IQGAP1 scaffold to alter its association with B-Raf, not a cell-autonomous BRAF calcium response. This is a real but
+      context-specific, single-mechanism secondary finding, not a core BRAF process.'
     action: KEEP_AS_NON_CORE
-    reason: 'BRAF activity does respond to changes in cellular Ca2+, so the annotation is supported, but the response is indirect (via the IQGAP1/calmodulin scaffold mechanism) and context-specific rather than a core BRAF biological process; the defining RAS-RAF-MEK-ERK signaling is already captured via ACCEPTed canonical rows. Part of the uniform KEEP_AS_NON_CORE treatment of the PMID:18567582 IQGAP1/Ca2+-calmodulin secondary-finding cluster (GO:0005509, GO:0007173, GO:0097110, GO:0071277).'
+    reason: 'BRAF activity does respond to changes in cellular Ca2+, so the annotation is supported, but the response is indirect
+      (via the IQGAP1/calmodulin scaffold mechanism) and context-specific rather than a core BRAF biological process; the
+      defining RAS-RAF-MEK-ERK signaling is already captured via ACCEPTed canonical rows. Part of the uniform KEEP_AS_NON_CORE
+      treatment of the PMID:18567582 IQGAP1/Ca2+-calmodulin secondary-finding cluster (GO:0005509, GO:0007173, GO:0097110,
+      GO:0071277).'
 - term:
     id: GO:0031267
     label: small GTPase binding
@@ -1450,52 +2382,63 @@ existing_annotations:
   original_reference_id: PMID:12194967
   negated: true
   review:
-    summary: 'NOT (negated) IPI annotation for GO:0031267 small GTPase binding from Kontani et al. 2002 J Biol Chem (PMID:12194967 — Di-Ras, a distinct subgroup of Ras family GTPases with unique biochemical properties). Owing to effector-domain substitutions (Ile at the position corresponding to Ha-Ras Asp-33), the paper shows Di-Ras1/Di-Ras2 "fails to interact with the Ras-binding domain of Raf, resulting in no stimulation of mitogen-activated protein kinase." This is a deliberate, experimentally-grounded negative finding: the BRAF RAS-binding domain does not engage the Di-Ras subgroup of small GTPases.'
+    summary: 'NOT (negated) IPI annotation for GO:0031267 small GTPase binding from Kontani et al. 2002 J Biol Chem (PMID:12194967
+      — Di-Ras, a distinct subgroup of Ras family GTPases with unique biochemical properties). Owing to effector-domain substitutions
+      (Ile at the position corresponding to Ha-Ras Asp-33), the paper shows Di-Ras1/Di-Ras2 "fails to interact with the Ras-binding
+      domain of Raf, resulting in no stimulation of mitogen-activated protein kinase." This is a deliberate, experimentally-grounded
+      negative finding: the BRAF RAS-binding domain does not engage the Di-Ras subgroup of small GTPases.'
     action: ACCEPT
-    reason: 'The negated annotation is correct and is a curatorially valuable negative assertion. PMID:12194967 directly and explicitly demonstrates that Di-Ras does not bind the Ras-binding domain of Raf and does not stimulate the MAPK pathway, supporting NOT|small GTPase binding for this specific GTPase subgroup. This does not contradict BRAF''s canonical RAS (HRAS/KRAS/NRAS) engagement via its RBD — it specifically records that the Di-Ras subfamily is not a BRAF RBD ligand. Consistent with the repository convention of retaining experimentally established non-interaction NOT annotations as-is; ACCEPT.'
+    reason: 'The negated annotation is correct and is a curatorially valuable negative assertion. PMID:12194967 directly and
+      explicitly demonstrates that Di-Ras does not bind the Ras-binding domain of Raf and does not stimulate the MAPK pathway,
+      supporting NOT|small GTPase binding for this specific GTPase subgroup. This does not contradict BRAF''s canonical RAS
+      (HRAS/KRAS/NRAS) engagement via its RBD — it specifically records that the Di-Ras subfamily is not a BRAF RBD ligand.
+      Consistent with the repository convention of retaining experimentally established non-interaction NOT annotations as-is;
+      ACCEPT.'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-1295604
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0005829
     label: cytosol
   evidence_type: TAS
   original_reference_id: Reactome:R-HSA-1295634
   review:
-    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state and is recruited to the plasma membrane upon RAS-GTP activation.'
+    summary: 'TAS annotation for cytosol localization. BRAF is cytosolic in the autoinhibited (14-3-3-bound) resting state
+      and is recruited to the plasma membrane upon RAS-GTP activation.'
     action: ACCEPT
-    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
+    reason: 'Cytosolic localization is well supported: BRAF in the autoinhibited closed conformation is bound to 14-3-3 and
+      Hsp90/CDC37 in the cytoplasm, and only translocates to the plasma membrane upon receptor-driven RAS activation. Each
+      of the 59 Reactome events is a separate cytosol annotation describing the same localization context, so they are mechanically
+      consolidated to ACCEPT with a uniform template (KRAS PR #349 precedent).'
 - term:
     id: GO:0090150
     label: establishment of protein localization to membrane
   evidence_type: IDA
   original_reference_id: PMID:23010278
   review:
-    summary: 'IDA annotation from PMID:23010278 (Pakladok et al. 2012, Biochem Biophys
-      Res Commun — Stimulation of the Na(+)-coupled glucose transporter SGLT1 by B-RAF).
-      Chemiluminescence and confocal-microscopy experiments showed that wild-type
-      B-RAF coexpression in Xenopus oocytes enhanced SGLT1 protein abundance in the
-      cell membrane, an effect blocked by the vesicle-insertion inhibitor Brefeldin
-      A, supporting a B-RAF role in establishment of SGLT1 localization to the plasma
-      membrane. This is a heterologous-overexpression, tumor-glucose-metabolism-context-specific
-      regulatory effect on a transporter rather than the defining RAS-RAF-MEK-ERK
-      serine/threonine kinase function that characterizes BRAF.'
+    summary: 'IDA annotation from PMID:23010278 (Pakladok et al. 2012, Biochem Biophys Res Commun — Stimulation of the Na(+)-coupled
+      glucose transporter SGLT1 by B-RAF). Chemiluminescence and confocal-microscopy experiments showed that wild-type B-RAF
+      coexpression in Xenopus oocytes enhanced SGLT1 protein abundance in the cell membrane, an effect blocked by the vesicle-insertion
+      inhibitor Brefeldin A, supporting a B-RAF role in establishment of SGLT1 localization to the plasma membrane. This is
+      a heterologous-overexpression, tumor-glucose-metabolism-context-specific regulatory effect on a transporter rather than
+      the defining RAS-RAF-MEK-ERK serine/threonine kinase function that characterizes BRAF.'
     action: KEEP_AS_NON_CORE
-    reason: 'Genuine but peripheral, context-specific regulatory effect (B-RAF enhancing
-      SGLT1 trafficking and membrane insertion in a Xenopus-oocyte tumor-glucose-uptake
-      model) rather than a core BRAF function. Canonical BRAF biology — the RAS-RAF-MEK-ERK
-      kinase cascade and cytosol/plasma-membrane localization — is already captured
-      via direct experimental evidence in this file (PMID:21441910 EXP, PMID:18567582
-      IDA, PMID:29433126 IDA/IMP) and prior batches (PR #440 Reactome TAS, PR #448
-      IBA, PR #456 IEA). Mechanically consolidated to KEEP_AS_NON_CORE with a uniform
-      template across the 2 PMID:23010278 SGLT1 rows (GO:0090150 establishment of
-      protein localization to membrane; GO:0010828 positive regulation of D-glucose
+    reason: 'Genuine but peripheral, context-specific regulatory effect (B-RAF enhancing SGLT1 trafficking and membrane insertion
+      in a Xenopus-oocyte tumor-glucose-uptake model) rather than a core BRAF function. Canonical BRAF biology — the RAS-RAF-MEK-ERK
+      kinase cascade and cytosol/plasma-membrane localization — is already captured via direct experimental evidence in this
+      file (PMID:21441910 EXP, PMID:18567582 IDA, PMID:29433126 IDA/IMP) and prior batches (PR #440 Reactome TAS, PR #448
+      IBA, PR #456 IEA). Mechanically consolidated to KEEP_AS_NON_CORE with a uniform template across the 2 PMID:23010278
+      SGLT1 rows (GO:0090150 establishment of protein localization to membrane; GO:0010828 positive regulation of D-glucose
       transmembrane transport).'
 - term:
     id: GO:0010828
@@ -1503,25 +2446,19 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:23010278
   review:
-    summary: 'IDA annotation from PMID:23010278 (Pakladok et al. 2012, Biochem Biophys
-      Res Commun — Stimulation of the Na(+)-coupled glucose transporter SGLT1 by B-RAF).
-      Dual-electrode voltage-clamp on SGLT1-expressing Xenopus oocytes showed that
-      wild-type B-RAF coexpression significantly increased the glucose-induced current,
-      enhancing the maximal SGLT1 transport rate without significantly changing carrier
-      affinity, supporting a B-RAF role in positive regulation of D-glucose transmembrane
-      transport. This is a heterologous-overexpression, tumor-glucose-metabolism-context-specific
-      regulatory effect rather than the defining RAS-RAF-MEK-ERK serine/threonine
-      kinase function that characterizes BRAF.'
+    summary: 'IDA annotation from PMID:23010278 (Pakladok et al. 2012, Biochem Biophys Res Commun — Stimulation of the Na(+)-coupled
+      glucose transporter SGLT1 by B-RAF). Dual-electrode voltage-clamp on SGLT1-expressing Xenopus oocytes showed that wild-type
+      B-RAF coexpression significantly increased the glucose-induced current, enhancing the maximal SGLT1 transport rate without
+      significantly changing carrier affinity, supporting a B-RAF role in positive regulation of D-glucose transmembrane transport.
+      This is a heterologous-overexpression, tumor-glucose-metabolism-context-specific regulatory effect rather than the defining
+      RAS-RAF-MEK-ERK serine/threonine kinase function that characterizes BRAF.'
     action: KEEP_AS_NON_CORE
-    reason: 'Genuine but peripheral, context-specific regulatory effect (B-RAF enhancing
-      SGLT1 trafficking and membrane insertion in a Xenopus-oocyte tumor-glucose-uptake
-      model) rather than a core BRAF function. Canonical BRAF biology — the RAS-RAF-MEK-ERK
-      kinase cascade and cytosol/plasma-membrane localization — is already captured
-      via direct experimental evidence in this file (PMID:21441910 EXP, PMID:18567582
-      IDA, PMID:29433126 IDA/IMP) and prior batches (PR #440 Reactome TAS, PR #448
-      IBA, PR #456 IEA). Mechanically consolidated to KEEP_AS_NON_CORE with a uniform
-      template across the 2 PMID:23010278 SGLT1 rows (GO:0090150 establishment of
-      protein localization to membrane; GO:0010828 positive regulation of D-glucose
+    reason: 'Genuine but peripheral, context-specific regulatory effect (B-RAF enhancing SGLT1 trafficking and membrane insertion
+      in a Xenopus-oocyte tumor-glucose-uptake model) rather than a core BRAF function. Canonical BRAF biology — the RAS-RAF-MEK-ERK
+      kinase cascade and cytosol/plasma-membrane localization — is already captured via direct experimental evidence in this
+      file (PMID:21441910 EXP, PMID:18567582 IDA, PMID:29433126 IDA/IMP) and prior batches (PR #440 Reactome TAS, PR #448
+      IBA, PR #456 IEA). Mechanically consolidated to KEEP_AS_NON_CORE with a uniform template across the 2 PMID:23010278
+      SGLT1 rows (GO:0090150 establishment of protein localization to membrane; GO:0010828 positive regulation of D-glucose
       transmembrane transport).'
 - term:
     id: GO:0004672
@@ -1529,9 +2466,26 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:17563371
   review:
-    summary: 'IDA annotation for protein kinase activity from PMID:17563371 (Ren et al. 2007 PNAS — IQGAP1 modulates activation of B-Raf), which directly demonstrates B-Raf kinase activity in vitro and shows that IQGAP1 binding significantly enhances B-Raf activity. GO:0004672 is the most general parent of GO:0004674 (protein S/T kinase activity), GO:0106310 (protein serine kinase activity), and GO:0004709 (MAP3K activity) — all of which are already supported via direct EXP/IDA/IBA/IEA evidence in this file (PMID:21441910 EXP ACCEPTed in PR #505; PR #448 IBA; PR #456 IEA).'
+    summary: 'IDA annotation for protein kinase activity from PMID:17563371 (Ren et al. 2007 PNAS — IQGAP1 modulates activation
+      of B-Raf), which directly demonstrates B-Raf kinase activity in vitro and shows that IQGAP1 binding significantly enhances
+      B-Raf activity. GO:0004672 is the most general parent of GO:0004674 (protein S/T kinase activity), GO:0106310 (protein
+      serine kinase activity), and GO:0004709 (MAP3K activity) — all of which are already supported via direct EXP/IDA/IBA/IEA
+      evidence in this file (PMID:21441910 EXP ACCEPTed in PR #505; PR #448 IBA; PR #456 IEA).'
     action: ACCEPT
-    reason: 'Canonical BRAF MF directly demonstrated experimentally. Protein kinase activity / protein S/T kinase activity (parent terms of GO:0106310) is BRAF''s defining molecular function — phosphorylating MEK1/MEK2 in the RAS-RAF-MEK-ERK cascade. PMID:17563371 (Ren et al. 2007 PNAS — IQGAP1 modulates B-Raf activation; demonstrates B-Raf kinase activity in vitro), PMID:18567582 (Ren et al. 2008 J Biol Chem — IQGAP1 integrates Ca2+/calmodulin and B-Raf), and PMID:19667065 are direct IDA papers measuring BRAF kinase activity. Already supported via direct EXP evidence on the more specific child term GO:0106310 protein serine kinase activity (PMID:21441910 ACCEPTed in PR #505); via IBA propagation on GO:0004709 MAP3K activity (PR #448); via IEA on GO:0004672 and GO:0004674 (PR #456); via IDA on GO:0000165 MAPK cascade (PR #534). This batch mechanically consolidates the remaining 3 parent-term canonical kinase MF rows to ACCEPT with a uniform template (2 GO:0004674 IDA rows + 1 GO:0004672 IDA row). Held back: GO:0005509/GO:0007173/GO:0097110/GO:0071277 PMID:18567582 rows (calcium-response and EGFR-pathway secondary findings, separate per-row review); PMID:22065586 rows GO:0010628/GO:0070374 (downstream BP, separate batch); PMID:19667065 BP rows GO:0033138/GO:0043066 (separate batch); GO:0005634 IEA nucleus (separate per-row); GO:0042802 IPI PMID:35512704 (KEAP1 neoPPI focus, separate per-row); GO:0005739 IBA mitochondrion (separate per-row); GO:0090150/GO:0010828 PMID:23010278 rows (separate per-row); GO:0031267 NOT|IPI PMID:12194967 (negated row, separate review); GO:0004708 IMP PMID:29433126 (MAP2K vs MAP3K MODIFY, separate per-row).'
+    reason: 'Canonical BRAF MF directly demonstrated experimentally. Protein kinase activity / protein S/T kinase activity
+      (parent terms of GO:0106310) is BRAF''s defining molecular function — phosphorylating MEK1/MEK2 in the RAS-RAF-MEK-ERK
+      cascade. PMID:17563371 (Ren et al. 2007 PNAS — IQGAP1 modulates B-Raf activation; demonstrates B-Raf kinase activity
+      in vitro), PMID:18567582 (Ren et al. 2008 J Biol Chem — IQGAP1 integrates Ca2+/calmodulin and B-Raf), and PMID:19667065
+      are direct IDA papers measuring BRAF kinase activity. Already supported via direct EXP evidence on the more specific
+      child term GO:0106310 protein serine kinase activity (PMID:21441910 ACCEPTed in PR #505); via IBA propagation on GO:0004709
+      MAP3K activity (PR #448); via IEA on GO:0004672 and GO:0004674 (PR #456); via IDA on GO:0000165 MAPK cascade (PR #534).
+      This batch mechanically consolidates the remaining 3 parent-term canonical kinase MF rows to ACCEPT with a uniform template
+      (2 GO:0004674 IDA rows + 1 GO:0004672 IDA row). Held back: GO:0005509/GO:0007173/GO:0097110/GO:0071277 PMID:18567582
+      rows (calcium-response and EGFR-pathway secondary findings, separate per-row review); PMID:22065586 rows GO:0010628/GO:0070374
+      (downstream BP, separate batch); PMID:19667065 BP rows GO:0033138/GO:0043066 (separate batch); GO:0005634 IEA nucleus
+      (separate per-row); GO:0042802 IPI PMID:35512704 (KEAP1 neoPPI focus, separate per-row); GO:0005739 IBA mitochondrion
+      (separate per-row); GO:0090150/GO:0010828 PMID:23010278 rows (separate per-row); GO:0031267 NOT|IPI PMID:12194967 (negated
+      row, separate review); GO:0004708 IMP PMID:29433126 (MAP2K vs MAP3K MODIFY, separate per-row).'
 - term:
     id: GO:0010628
     label: positive regulation of gene expression
@@ -1557,21 +2511,46 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:22065586
   review:
-    summary: 'IDA annotation from PMID:22065586 (Oh et al. 2012, J Biol Chem). Oncogenic B-Raf (V600E) directly activates the ERK/RSK MAPK cascade in cancer cells; the paper explicitly demonstrates ERK co-activation downstream of B-Raf as the mechanism upstream of DR5 induction. Positive regulation of the ERK1/2 cascade is the defining canonical BRAF biological-process role.'
+    summary: 'IDA annotation from PMID:22065586 (Oh et al. 2012, J Biol Chem). Oncogenic B-Raf (V600E) directly activates
+      the ERK/RSK MAPK cascade in cancer cells; the paper explicitly demonstrates ERK co-activation downstream of B-Raf as
+      the mechanism upstream of DR5 induction. Positive regulation of the ERK1/2 cascade is the defining canonical BRAF biological-process
+      role.'
     action: ACCEPT
-    reason: 'Canonical BRAF BP directly demonstrated experimentally. Positive regulation of the ERK1/2 cascade is BRAF''s definitive role in the RAS-RAF-MEK-ERK pathway — BRAF directly phosphorylates MEK1/MEK2, which then activates ERK1/ERK2. Already supported via IBA on GO:0000165 MAPK cascade (PR #448), via IDA on GO:0000165 in PR #534, and via Reactome TAS rows for RAS-MAPK pathway events ACCEPTed in PR #440. Mechanically consolidated to ACCEPT with a uniform template across the 4 canonical BRAF→downstream-BP IDA/IMP rows in this batch (PMID:22065586 GO:0010628 IMP, PMID:22065586 GO:0070374 IDA, PMID:19667065 GO:0033138 IDA, PMID:19667065 GO:0043066 IDA). Held back per-row items unchanged from the PMID:22065586 GO:0010628 row above.'
+    reason: 'Canonical BRAF BP directly demonstrated experimentally. Positive regulation of the ERK1/2 cascade is BRAF''s
+      definitive role in the RAS-RAF-MEK-ERK pathway — BRAF directly phosphorylates MEK1/MEK2, which then activates ERK1/ERK2.
+      Already supported via IBA on GO:0000165 MAPK cascade (PR #448), via IDA on GO:0000165 in PR #534, and via Reactome TAS
+      rows for RAS-MAPK pathway events ACCEPTed in PR #440. Mechanically consolidated to ACCEPT with a uniform template across
+      the 4 canonical BRAF→downstream-BP IDA/IMP rows in this batch (PMID:22065586 GO:0010628 IMP, PMID:22065586 GO:0070374
+      IDA, PMID:19667065 GO:0033138 IDA, PMID:19667065 GO:0043066 IDA). Held back per-row items unchanged from the PMID:22065586
+      GO:0010628 row above.'
     supported_by:
     - reference_id: PMID:22065586
-      supporting_text: 'the oncogenic B-Raf (V600E), a commonly mutated form in cancers, activated ERK/RSK signaling, increased DR5 promoter activity, and up-regulated DR5 expression'
+      supporting_text: 'the oncogenic B-Raf (V600E), a commonly mutated form in cancers, activated ERK/RSK signaling, increased
+        DR5 promoter activity, and up-regulated DR5 expression'
 - term:
     id: GO:0004674
     label: protein serine/threonine kinase activity
   evidence_type: IDA
   original_reference_id: PMID:19667065
   review:
-    summary: 'IDA annotation for protein serine/threonine kinase activity from PMID:19667065, a direct experimental paper measuring BRAF kinase activity. GO:0004674 is the parent of GO:0106310 (protein serine kinase activity), which is already supported via direct EXP evidence in this file (PMID:21441910 ACCEPTed in PR #505) and via IEA propagation in PR #456.'
+    summary: 'IDA annotation for protein serine/threonine kinase activity from PMID:19667065, a direct experimental paper
+      measuring BRAF kinase activity. GO:0004674 is the parent of GO:0106310 (protein serine kinase activity), which is already
+      supported via direct EXP evidence in this file (PMID:21441910 ACCEPTed in PR #505) and via IEA propagation in PR #456.'
     action: ACCEPT
-    reason: 'Canonical BRAF MF directly demonstrated experimentally. Protein kinase activity / protein S/T kinase activity (parent terms of GO:0106310) is BRAF''s defining molecular function — phosphorylating MEK1/MEK2 in the RAS-RAF-MEK-ERK cascade. PMID:17563371 (Ren et al. 2007 PNAS — IQGAP1 modulates B-Raf activation; demonstrates B-Raf kinase activity in vitro), PMID:18567582 (Ren et al. 2008 J Biol Chem — IQGAP1 integrates Ca2+/calmodulin and B-Raf), and PMID:19667065 are direct IDA papers measuring BRAF kinase activity. Already supported via direct EXP evidence on the more specific child term GO:0106310 protein serine kinase activity (PMID:21441910 ACCEPTed in PR #505); via IBA propagation on GO:0004709 MAP3K activity (PR #448); via IEA on GO:0004672 and GO:0004674 (PR #456); via IDA on GO:0000165 MAPK cascade (PR #534). This batch mechanically consolidates the remaining 3 parent-term canonical kinase MF rows to ACCEPT with a uniform template (2 GO:0004674 IDA rows + 1 GO:0004672 IDA row). Held back: GO:0005509/GO:0007173/GO:0097110/GO:0071277 PMID:18567582 rows (calcium-response and EGFR-pathway secondary findings, separate per-row review); PMID:22065586 rows GO:0010628/GO:0070374 (downstream BP, separate batch); PMID:19667065 BP rows GO:0033138/GO:0043066 (separate batch); GO:0005634 IEA nucleus (separate per-row); GO:0042802 IPI PMID:35512704 (KEAP1 neoPPI focus, separate per-row); GO:0005739 IBA mitochondrion (separate per-row); GO:0090150/GO:0010828 PMID:23010278 rows (separate per-row); GO:0031267 NOT|IPI PMID:12194967 (negated row, separate review); GO:0004708 IMP PMID:29433126 (MAP2K vs MAP3K MODIFY, separate per-row).'
+    reason: 'Canonical BRAF MF directly demonstrated experimentally. Protein kinase activity / protein S/T kinase activity
+      (parent terms of GO:0106310) is BRAF''s defining molecular function — phosphorylating MEK1/MEK2 in the RAS-RAF-MEK-ERK
+      cascade. PMID:17563371 (Ren et al. 2007 PNAS — IQGAP1 modulates B-Raf activation; demonstrates B-Raf kinase activity
+      in vitro), PMID:18567582 (Ren et al. 2008 J Biol Chem — IQGAP1 integrates Ca2+/calmodulin and B-Raf), and PMID:19667065
+      are direct IDA papers measuring BRAF kinase activity. Already supported via direct EXP evidence on the more specific
+      child term GO:0106310 protein serine kinase activity (PMID:21441910 ACCEPTed in PR #505); via IBA propagation on GO:0004709
+      MAP3K activity (PR #448); via IEA on GO:0004672 and GO:0004674 (PR #456); via IDA on GO:0000165 MAPK cascade (PR #534).
+      This batch mechanically consolidates the remaining 3 parent-term canonical kinase MF rows to ACCEPT with a uniform template
+      (2 GO:0004674 IDA rows + 1 GO:0004672 IDA row). Held back: GO:0005509/GO:0007173/GO:0097110/GO:0071277 PMID:18567582
+      rows (calcium-response and EGFR-pathway secondary findings, separate per-row review); PMID:22065586 rows GO:0010628/GO:0070374
+      (downstream BP, separate batch); PMID:19667065 BP rows GO:0033138/GO:0043066 (separate batch); GO:0005634 IEA nucleus
+      (separate per-row); GO:0042802 IPI PMID:35512704 (KEAP1 neoPPI focus, separate per-row); GO:0005739 IBA mitochondrion
+      (separate per-row); GO:0090150/GO:0010828 PMID:23010278 rows (separate per-row); GO:0031267 NOT|IPI PMID:12194967 (negated
+      row, separate review); GO:0004708 IMP PMID:29433126 (MAP2K vs MAP3K MODIFY, separate per-row).'
 - term:
     id: GO:0033138
     label: positive regulation of peptidyl-serine phosphorylation
@@ -1590,7 +2569,9 @@ existing_annotations:
       process term GO:0018105 peptidyl-serine phosphorylation.
     supported_by:
     - reference_id: PMID:19667065
-      supporting_text: 'RAF kinases represent, besides protein kinase A, PAK, and Akt/protein kinase B, in vivo BAD-phosphorylating kinases. RAF-induced phosphorylation of BAD was reduced to control levels using the RAF inhibitor BAY 43-9006. This phosphorylation was not prevented by MEK inhibitors.'
+      supporting_text: 'RAF kinases represent, besides protein kinase A, PAK, and Akt/protein kinase B, in vivo BAD-phosphorylating
+        kinases. RAF-induced phosphorylation of BAD was reduced to control levels using the RAF inhibitor BAY 43-9006. This
+        phosphorylation was not prevented by MEK inhibitors.'
     proposed_replacement_terms:
     - id: GO:0018105
       label: peptidyl-serine phosphorylation
@@ -1600,21 +2581,42 @@ existing_annotations:
   evidence_type: IDA
   original_reference_id: PMID:19667065
   review:
-    summary: 'IDA annotation from PMID:19667065 (Polzien et al. 2009, J Biol Chem). Constitutively active RAF suppresses BAD-induced apoptosis and rescues colony-formation inhibition by BAD; mechanism is RAF-mediated phosphorylation of BAD-S99 (the major 14-3-3 binding site), which promotes 14-3-3 sequestration of BAD and inhibits BAD''s mitochondrial pore-forming pro-apoptotic activity. This captures BRAF''s canonical pro-survival downstream output via the BAD-Bcl-2 axis.'
+    summary: 'IDA annotation from PMID:19667065 (Polzien et al. 2009, J Biol Chem). Constitutively active RAF suppresses BAD-induced
+      apoptosis and rescues colony-formation inhibition by BAD; mechanism is RAF-mediated phosphorylation of BAD-S99 (the
+      major 14-3-3 binding site), which promotes 14-3-3 sequestration of BAD and inhibits BAD''s mitochondrial pore-forming
+      pro-apoptotic activity. This captures BRAF''s canonical pro-survival downstream output via the BAD-Bcl-2 axis.'
     action: ACCEPT
-    reason: 'Canonical BRAF BP directly demonstrated experimentally via constitutively-active RAF gain-of-function suppression of BAD-induced apoptosis (PMID:19667065). Negative regulation of apoptotic process is an established downstream consequence of BRAF kinase activity through the BAD-Bcl-2 pro-survival axis (and complementary MEK-ERK→90 kDa ribosomal S6 kinase→BAD-S112 phosphorylation in murine BAD). Mechanically consolidated to ACCEPT with a uniform template across the 4 canonical BRAF→downstream-BP IDA/IMP rows in this batch (PMID:22065586 GO:0010628 IMP, PMID:22065586 GO:0070374 IDA, PMID:19667065 GO:0033138 IDA, PMID:19667065 GO:0043066 IDA). Held back per-row items unchanged from the PMID:22065586 GO:0010628 row above. Note: an existing IEA GO_REF:0000044 row on `GO:0043066` was already ACCEPTed in PR #456 — this row provides the direct experimental anchor.'
+    reason: 'Canonical BRAF BP directly demonstrated experimentally via constitutively-active RAF gain-of-function suppression
+      of BAD-induced apoptosis (PMID:19667065). Negative regulation of apoptotic process is an established downstream consequence
+      of BRAF kinase activity through the BAD-Bcl-2 pro-survival axis (and complementary MEK-ERK→90 kDa ribosomal S6 kinase→BAD-S112
+      phosphorylation in murine BAD). Mechanically consolidated to ACCEPT with a uniform template across the 4 canonical BRAF→downstream-BP
+      IDA/IMP rows in this batch (PMID:22065586 GO:0010628 IMP, PMID:22065586 GO:0070374 IDA, PMID:19667065 GO:0033138 IDA,
+      PMID:19667065 GO:0043066 IDA). Held back per-row items unchanged from the PMID:22065586 GO:0010628 row above. Note:
+      an existing IEA GO_REF:0000044 row on `GO:0043066` was already ACCEPTed in PR #456 — this row provides the direct experimental
+      anchor.'
     supported_by:
     - reference_id: PMID:19667065
-      supporting_text: 'expression of constitutively active RAF suppressed apoptosis induced by BAD and the inhibition of colony formation caused by BAD could be prevented by RAF'
+      supporting_text: 'expression of constitutively active RAF suppressed apoptosis induced by BAD and the inhibition of
+        colony formation caused by BAD could be prevented by RAF'
 - term:
     id: GO:0009887
     label: animal organ morphogenesis
   evidence_type: TAS
   original_reference_id: PMID:9207797
   review:
-    summary: 'TAS annotation from Wojnowski et al. 1997 (PMID:9207797), the foundational Braf-knockout paper showing that Braf-/- mice die mid-gestation from vascular defects with increased endothelial precursor cells, dramatically enlarged blood vessels, and apoptotic death of differentiated endothelial cells. The general term GO:0009887 (animal organ morphogenesis) is too broad to capture this specific in vivo phenotype: the paper unambiguously demonstrates a role in blood vessel / vasculature development, not generic organ morphogenesis. GO:0001568 (blood vessel development) is the appropriate replacement, capturing the vasculature-specific progression-to-mature-structure process the knockout phenotype defines.'
+    summary: 'TAS annotation from Wojnowski et al. 1997 (PMID:9207797), the foundational Braf-knockout paper showing that
+      Braf-/- mice die mid-gestation from vascular defects with increased endothelial precursor cells, dramatically enlarged
+      blood vessels, and apoptotic death of differentiated endothelial cells. The general term GO:0009887 (animal organ morphogenesis)
+      is too broad to capture this specific in vivo phenotype: the paper unambiguously demonstrates a role in blood vessel
+      / vasculature development, not generic organ morphogenesis. GO:0001568 (blood vessel development) is the appropriate
+      replacement, capturing the vasculature-specific progression-to-mature-structure process the knockout phenotype defines.'
     action: MODIFY
-    reason: 'The essence of the annotation is correct (BRAF is required for an in vivo developmental process per the Braf-/- vascular-defects phenotype), but the term GO:0009887 (animal organ morphogenesis) is too general. PMID:9207797 specifically demonstrates a role in vascular system formation (increased endothelial precursors, enlarged blood vessels, endothelial apoptosis leading to mid-gestation vascular failure), which is more precisely captured by GO:0001568 (blood vessel development). MODIFY to the more specific child term; this is a non-core developmental/tissue-specific role downstream of the canonical BRAF kinase function and not promoted to core_functions.'
+    reason: 'The essence of the annotation is correct (BRAF is required for an in vivo developmental process per the Braf-/-
+      vascular-defects phenotype), but the term GO:0009887 (animal organ morphogenesis) is too general. PMID:9207797 specifically
+      demonstrates a role in vascular system formation (increased endothelial precursors, enlarged blood vessels, endothelial
+      apoptosis leading to mid-gestation vascular failure), which is more precisely captured by GO:0001568 (blood vessel development).
+      MODIFY to the more specific child term; this is a non-core developmental/tissue-specific role downstream of the canonical
+      BRAF kinase function and not promoted to core_functions.'
     proposed_replacement_terms:
     - id: GO:0001568
       label: blood vessel development
@@ -1624,39 +2626,68 @@ existing_annotations:
   evidence_type: TAS
   original_reference_id: PMID:2284096
   review:
-    summary: 'TAS annotation from the foundational Sithanandam et al. 1990 paper that cloned the complete coding sequence of human B-raf and detected B-raf protein kinase activity using isozyme-specific antibodies (PMID:2284096). BRAF is a canonical Ser/Thr protein kinase phosphorylating MEK1/MEK2 in the RAS-RAF-MEK-ERK cascade — directly demonstrated experimentally elsewhere in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and already ACCEPTed on the IEA row (GO_REF:0000120, PR #456) and via IBA propagation on the more specific child term GO:0004709 MAP3K activity (PR #448).'
+    summary: 'TAS annotation from the foundational Sithanandam et al. 1990 paper that cloned the complete coding sequence
+      of human B-raf and detected B-raf protein kinase activity using isozyme-specific antibodies (PMID:2284096). BRAF is
+      a canonical Ser/Thr protein kinase phosphorylating MEK1/MEK2 in the RAS-RAF-MEK-ERK cascade — directly demonstrated
+      experimentally elsewhere in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and already ACCEPTed
+      on the IEA row (GO_REF:0000120, PR #456) and via IBA propagation on the more specific child term GO:0004709 MAP3K activity
+      (PR #448).'
     action: ACCEPT
-    reason: 'TAS evidence from the foundational 1990 BRAF cloning/kinase-detection paper (PMID:2284096) supports a canonical core BRAF molecular function or core BRAF biological process directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and already ACCEPTed via IEA (PR #456), IBA (PR #448), and Reactome TAS (PR #440) propagation batches. Mechanically consolidated to ACCEPT with a uniform template across the 2 canonical kinase TAS rows from PMID:2284096 (protein kinase activity, protein phosphorylation); the 2 PMID:9207797 Braf-knockout TAS rows (animal organ morphogenesis, negative regulation of apoptotic process) are held back for separate per-row consideration in a later batch because the in vivo vascular-development knockout context warrants a more specific term assessment.'
+    reason: 'TAS evidence from the foundational 1990 BRAF cloning/kinase-detection paper (PMID:2284096) supports a canonical
+      core BRAF molecular function or core BRAF biological process directly demonstrated experimentally in this file (PMID:18567582
+      IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and already ACCEPTed via IEA (PR #456), IBA (PR #448), and Reactome TAS
+      (PR #440) propagation batches. Mechanically consolidated to ACCEPT with a uniform template across the 2 canonical kinase
+      TAS rows from PMID:2284096 (protein kinase activity, protein phosphorylation); the 2 PMID:9207797 Braf-knockout TAS
+      rows (animal organ morphogenesis, negative regulation of apoptotic process) are held back for separate per-row consideration
+      in a later batch because the in vivo vascular-development knockout context warrants a more specific term assessment.'
 - term:
     id: GO:0006468
     label: protein phosphorylation
   evidence_type: TAS
   original_reference_id: PMID:2284096
   review:
-    summary: 'TAS annotation from the foundational Sithanandam et al. 1990 paper that cloned the complete coding sequence of human B-raf and detected B-raf protein kinase activity using isozyme-specific antibodies (PMID:2284096). Protein phosphorylation is the canonical biological process of BRAF kinase activity — BRAF phosphorylates MEK1/MEK2 on activation-loop serines (Ser218/Ser222 of MEK1) in the RAS-RAF-MEK-ERK cascade. Directly demonstrated experimentally elsewhere in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and supported via IBA propagation on the MAP3K activity / MAPK cascade terms (PR #448).'
+    summary: 'TAS annotation from the foundational Sithanandam et al. 1990 paper that cloned the complete coding sequence
+      of human B-raf and detected B-raf protein kinase activity using isozyme-specific antibodies (PMID:2284096). Protein
+      phosphorylation is the canonical biological process of BRAF kinase activity — BRAF phosphorylates MEK1/MEK2 on activation-loop
+      serines (Ser218/Ser222 of MEK1) in the RAS-RAF-MEK-ERK cascade. Directly demonstrated experimentally elsewhere in this
+      file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and supported via IBA propagation on the MAP3K activity
+      / MAPK cascade terms (PR #448).'
     action: ACCEPT
-    reason: 'TAS evidence from the foundational 1990 BRAF cloning/kinase-detection paper (PMID:2284096) supports a canonical core BRAF molecular function or core BRAF biological process directly demonstrated experimentally in this file (PMID:18567582 IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and already ACCEPTed via IEA (PR #456), IBA (PR #448), and Reactome TAS (PR #440) propagation batches. Mechanically consolidated to ACCEPT with a uniform template across the 2 canonical kinase TAS rows from PMID:2284096 (protein kinase activity, protein phosphorylation); the 2 PMID:9207797 Braf-knockout TAS rows (animal organ morphogenesis, negative regulation of apoptotic process) are held back for separate per-row consideration in a later batch because the in vivo vascular-development knockout context warrants a more specific term assessment.'
+    reason: 'TAS evidence from the foundational 1990 BRAF cloning/kinase-detection paper (PMID:2284096) supports a canonical
+      core BRAF molecular function or core BRAF biological process directly demonstrated experimentally in this file (PMID:18567582
+      IDA, PMID:21441910 EXP, PMID:29433126 IDA/IMP) and already ACCEPTed via IEA (PR #456), IBA (PR #448), and Reactome TAS
+      (PR #440) propagation batches. Mechanically consolidated to ACCEPT with a uniform template across the 2 canonical kinase
+      TAS rows from PMID:2284096 (protein kinase activity, protein phosphorylation); the 2 PMID:9207797 Braf-knockout TAS
+      rows (animal organ morphogenesis, negative regulation of apoptotic process) are held back for separate per-row consideration
+      in a later batch because the in vivo vascular-development knockout context warrants a more specific term assessment.'
 - term:
     id: GO:0043066
     label: negative regulation of apoptotic process
   evidence_type: TAS
   original_reference_id: PMID:9207797
   review:
-    summary: 'TAS annotation from Wojnowski et al. 1997 (PMID:9207797) — Braf-knockout mice show apoptotic death of differentiated endothelial cells leading to mid-gestation vascular defects, providing the first genetic evidence for a Raf-family role in regulating programmed cell death. Supports the canonical BRAF anti-apoptotic activity already ACCEPTed via IEA propagation (GO_REF:0000117, PR #456), which is mechanistically grounded in BRAF-driven MEK/ERK phosphorylation of pro-apoptotic factors (BAD on Ser112/Ser155 via RSK; BIM via ERK-mediated proteasomal degradation).'
+    summary: 'TAS annotation from Wojnowski et al. 1997 (PMID:9207797) — Braf-knockout mice show apoptotic death of differentiated
+      endothelial cells leading to mid-gestation vascular defects, providing the first genetic evidence for a Raf-family role
+      in regulating programmed cell death. Supports the canonical BRAF anti-apoptotic activity already ACCEPTed via IEA propagation
+      (GO_REF:0000117, PR #456), which is mechanistically grounded in BRAF-driven MEK/ERK phosphorylation of pro-apoptotic
+      factors (BAD on Ser112/Ser155 via RSK; BIM via ERK-mediated proteasomal degradation).'
     action: ACCEPT
-    reason: 'TAS evidence from PMID:9207797 supports the same canonical BRAF anti-apoptotic function already ACCEPTed via IEA (GO_REF:0000117, PR #456) and consistent with the canonical RAS-RAF-MEK-ERK survival signaling captured in the Reactome TAS batch (PR #440). The in vivo endothelial-apoptosis phenotype of Braf-/- mice provides genetic confirmation of the cellular anti-apoptotic role. Retained as ACCEPT (mirroring the IEA row) rather than KEEP_AS_NON_CORE because the same term is already at ACCEPT elsewhere in the file; the developmental tissue-specific aspect is captured in the paired PMID:9207797 morphogenesis row (MODIFY → GO:0001568 blood vessel development) in this same batch.'
+    reason: 'TAS evidence from PMID:9207797 supports the same canonical BRAF anti-apoptotic function already ACCEPTed via
+      IEA (GO_REF:0000117, PR #456) and consistent with the canonical RAS-RAF-MEK-ERK survival signaling captured in the Reactome
+      TAS batch (PR #440). The in vivo endothelial-apoptosis phenotype of Braf-/- mice provides genetic confirmation of the
+      cellular anti-apoptotic role. Retained as ACCEPT (mirroring the IEA row) rather than KEEP_AS_NON_CORE because the same
+      term is already at ACCEPT elsewhere in the file; the developmental tissue-specific aspect is captured in the paired
+      PMID:9207797 morphogenesis row (MODIFY → GO:0001568 blood vessel development) in this same batch.'
 references:
 - id: file:human/BRAF/BRAF-deep-research-falcon.md
   title: Falcon deep research report for human BRAF
   findings:
-  - statement: Falcon synthesis supports BRAF as the RAF-family MAP3K that directly
-      phosphorylates and activates MEK1/MEK2 in the ERK pathway.
-    supporting_text: BRAF is a RAF-family kinase whose primary role in the ERK
-      pathway is to act as a MAP kinase kinase kinase (MAP3K) that phosphorylates
-      and activates MEK1/MEK2.
+  - statement: Falcon synthesis supports BRAF as the RAF-family MAP3K that directly phosphorylates and activates 
+      MEK1/MEK2 in the ERK pathway.
+    supporting_text: BRAF is a RAF-family kinase whose primary role in the ERK pathway is to act as a MAP kinase kinase 
+      kinase (MAP3K) that phosphorylates and activates MEK1/MEK2.
 - id: GO_REF:0000002
-  title: Gene Ontology annotation through association of InterPro records with GO
-    terms
+  title: Gene Ontology annotation through association of InterPro records with GO terms
   findings: []
 - id: GO_REF:0000003
   title: Gene Ontology annotation based on Enzyme Commission mapping
@@ -1665,20 +2696,17 @@ references:
   title: Annotation inferences using phylogenetic trees
   findings: []
 - id: GO_REF:0000044
-  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location
-    vocabulary mapping, accompanied by conservative changes to GO terms applied by
-    UniProt
+  title: Gene Ontology annotation based on UniProtKB/Swiss-Prot Subcellular Location vocabulary mapping, accompanied by 
+    conservative changes to GO terms applied by UniProt
   findings: []
 - id: GO_REF:0000052
   title: Gene Ontology annotation based on curation of immunofluorescence data
   findings: []
 - id: GO_REF:0000107
-  title: Automatic transfer of experimentally verified manual GO annotation data to
-    orthologs using Ensembl Compara
+  title: Automatic transfer of experimentally verified manual GO annotation data to orthologs using Ensembl Compara
   findings: []
 - id: GO_REF:0000108
-  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology
-    links
+  title: Automatic assignment of GO terms using logical inference, based on on inter-ontology links
   findings: []
 - id: GO_REF:0000116
   title: Automatic Gene Ontology annotation based on Rhea mapping
@@ -1690,195 +2718,236 @@ references:
   title: Combined Automated Annotation using Multiple IEA Methods
   findings: []
 - id: PMID:12194967
-  title: Di-Ras, a distinct subgroup of ras family GTPases with unique biochemical
-    properties.
+  title: Di-Ras, a distinct subgroup of ras family GTPases with unique biochemical properties.
   findings: []
 - id: PMID:12620389
-  title: Novel raf kinase protein-protein interactions found by an exhaustive yeast
-    two-hybrid analysis.
+  title: Novel raf kinase protein-protein interactions found by an exhaustive yeast two-hybrid analysis.
   findings: []
 - id: PMID:15161933
-  title: Comprehensive proteomic analysis of interphase and mitotic 14-3-3-binding
-    proteins.
+  title: Comprehensive proteomic analysis of interphase and mitotic 14-3-3-binding proteins.
   findings: []
 - id: PMID:15778465
-  title: Targeted proteomic analysis of 14-3-3 sigma, a p53 effector commonly silenced
-    in cancer.
+  title: Targeted proteomic analysis of 14-3-3 sigma, a p53 effector commonly silenced in cancer.
   findings: []
 - id: PMID:16810323
-  title: FGF-2 protects small cell lung cancer cells from apoptosis through a complex
-    involving PKCepsilon, B-Raf and S6K2.
+  title: FGF-2 protects small cell lung cancer cells from apoptosis through a complex involving PKCepsilon, B-Raf and 
+    S6K2.
   findings: []
 - id: PMID:16858395
-  title: The amino-terminal B-Raf-specific region mediates calcium-dependent homo-
-    and hetero-dimerization of Raf.
-  findings: []
+  title: The amino-terminal B-Raf-specific region mediates calcium-dependent homo- and hetero-dimerization of Raf.
+  findings:
+  - statement: The B-Raf-specific amino-terminal region is essential for calcium-dependent homo- and heterodimerization 
+      of BRAF at the plasma membrane; increased intracellular calcium is necessary for dimerization and sufficient for 
+      plasma membrane translocation
+    supporting_text: this amino-terminal B-Raf-specific region is essential for homo-dimerization of B-Raf and 
+      hetero-dimerization of B-Raf and c-Raf at the plasma membrane, followed by phosphorylation of Thr118 in the 
+      amino-terminal B-Raf-specific region
 - id: PMID:16888650
-  title: Glucocorticoids cause rapid dissociation of a T-cell-receptor-associated
-    protein complex containing LCK and FYN.
+  title: Glucocorticoids cause rapid dissociation of a T-cell-receptor-associated protein complex containing LCK and 
+    FYN.
   findings: []
 - id: PMID:17380122
-  title: Selective role for RGS12 as a Ras/Raf/MEK scaffold in nerve growth factor-mediated
-    differentiation.
+  title: Selective role for RGS12 as a Ras/Raf/MEK scaffold in nerve growth factor-mediated differentiation.
   findings: []
 - id: PMID:17563371
   title: IQGAP1 modulates activation of B-Raf.
-  findings: []
+  findings:
+  - statement: IQGAP1 is a scaffold required for B-Raf activation by EGF; IQGAP1-null cells and cells expressing an 
+      IQGAP1 mutant unable to bind B-Raf fail to stimulate B-Raf activity in response to EGF; IQGAP1 binding directly 
+      enhances B-Raf kinase activity in vitro
+    supporting_text: EGF is unable to stimulate B-Raf activity in IQGAP1-null cells and in cells transfected with an 
+      IQGAP1 mutant construct that is unable to bind B-Raf
 - id: PMID:17979178
-  title: A novel tandem affinity purification strategy for the efficient isolation
-    and characterisation of native protein complexes.
+  title: A novel tandem affinity purification strategy for the efficient isolation and characterisation of native 
+    protein complexes.
   findings: []
 - id: PMID:18567582
   title: IQGAP1 integrates Ca2+/calmodulin and B-Raf signaling.
-  findings: []
+  findings:
+  - statement: IQGAP1 mediates crosstalk from Ca2+ and calmodulin signaling to B-Raf; Ca2+ promotes IQGAP1-B-Raf binding
+      while Ca2+/calmodulin abrogates it, and chelating intracellular Ca2+ enhances EGF-stimulated B-Raf activity in an 
+      IQGAP1-dependent manner
+    supporting_text: Ca 2+ promotes the direct binding of IQGAP1 to B-Raf. This interaction is inhibited by calmodulin 
+      in a Ca 2+ -regulated manner
 - id: PMID:19667065
-  title: 'Identification of novel in vivo phosphorylation sites of the human proapoptotic
-    protein BAD: pore-forming activity of BAD is regulated by phosphorylation.'
-  findings: []
+  title: 'Identification of novel in vivo phosphorylation sites of the human proapoptotic protein BAD: pore-forming activity
+    of BAD is regulated by phosphorylation.'
+  findings:
+  - statement: Novel in vivo phosphorylation sites on the proapoptotic protein BAD were identified; BAD phosphorylation 
+      regulates its pore-forming activity, linking kinases upstream of the MAPK cascade (including BRAF) to apoptotic 
+      regulation
+    full_text_unavailable: true
 - id: PMID:19710016
   title: Diacylglycerol kinase eta augments C-Raf activity and B-Raf/C-Raf heterodimerization.
-  findings: []
+  findings:
+  - statement: Diacylglycerol kinase eta (DGKeta) functions as a scaffold/adaptor that promotes B-Raf/C-Raf 
+      heterodimerization in a kinase-activity-independent manner; DGKeta knockdown impairs EGF-stimulated 
+      Ras/B-Raf/C-Raf/MEK/ERK signaling
+    supporting_text: DGKeta1 could activate the Ras/B-Raf/C-Raf/MEK/ERK pathway in a DGK activity-independent manner, 
+      suggesting that DGKeta serves as a scaffold/adaptor protein
 - id: PMID:19727074
   title: A dimerization-dependent mechanism drives RAF catalytic activation.
-  findings: []
+  findings:
+  - statement: RAF catalytic function is regulated by side-to-side kinase domain dimerization; the pseudokinase KSR also
+      forms side-to-side heterodimers with RAF to directly trigger RAF activation; side-to-side dimer interface 
+      mutations abrogate oncogenic BRAF signaling
+    full_text_unavailable: true
 - id: PMID:20130576
-  title: RAF inhibitors prime wild-type RAF to activate the MAPK pathway and enhance
-    growth.
-  findings: []
+  title: RAF inhibitors prime wild-type RAF to activate the MAPK pathway and enhance growth.
+  findings:
+  - statement: ATP-competitive RAF inhibitors paradoxically prime wild-type RAF to activate the MAPK pathway through 
+      drug-induced RAF dimerization in cells with upstream RAS activation
+    full_text_unavailable: true
 - id: PMID:20141835
-  title: Kinase-dead BRAF and oncogenic RAS cooperate to drive tumor progression through
-    CRAF.
-  findings: []
+  title: Kinase-dead BRAF and oncogenic RAS cooperate to drive tumor progression through CRAF.
+  findings:
+  - statement: Kinase-dead BRAF cooperates with oncogenic RAS to drive tumor progression through CRAF; RAF inhibitors 
+      that selectively inhibit BRAF paradoxically activate this kinase-dead BRAF/oncogenic RAS/CRAF signaling axis
+    supporting_text: drugs that selectively inhibit BRAF activate RAS-dependent kinase-dead BRAF signaling through CRAF
 - id: PMID:21441910
-  title: A Raf-induced allosteric transition of KSR stimulates phosphorylation of
-    MEK.
-  findings: []
+  title: A Raf-induced allosteric transition of KSR stimulates phosphorylation of MEK.
+  findings:
+  - statement: BRAF allosterically stimulates KSR2 kinase activity via side-to-side heterodimerization; this promotes 
+      MEK phosphorylation by relaying a signal that releases the MEK activation segment
+    full_text_unavailable: true
 - id: PMID:21478863
   title: ERK and PDE4 cooperate to induce RAF isoform switching in melanoma.
   findings: []
 - id: PMID:21625473
-  title: A novel requirement for Janus kinases as mediators of drug resistance induced
-    by fibroblast growth factor-2 in human cancer cells.
+  title: A novel requirement for Janus kinases as mediators of drug resistance induced by fibroblast growth factor-2 in 
+    human cancer cells.
   findings: []
 - id: PMID:22065586
-  title: Oncogenic Ras and B-Raf proteins positively regulate death receptor 5 expression
-    through co-activation of ERK and JNK signaling.
+  title: Oncogenic Ras and B-Raf proteins positively regulate death receptor 5 expression through co-activation of ERK 
+    and JNK signaling.
   findings: []
 - id: PMID:22169110
-  title: Nilotinib and MEK inhibitors induce synthetic lethality through paradoxical
-    activation of RAF in drug-resistant chronic myeloid leukemia.
+  title: Nilotinib and MEK inhibitors induce synthetic lethality through paradoxical activation of RAF in drug-resistant
+    chronic myeloid leukemia.
   findings: []
 - id: PMID:22510884
-  title: Distinct requirement for an intact dimer interface in wild-type, V600E and
-    kinase-dead B-Raf signalling.
-  findings: []
+  title: Distinct requirement for an intact dimer interface in wild-type, V600E and kinase-dead B-Raf signalling.
+  findings:
+  - statement: The kinase-domain dimer interface is pivotal for wild-type BRAF activity, whereas oncogenic BRAF(V600E) 
+      and BRAF(G469A) are resistant to dimer-interface mutations and display extended protomer contacts and increased 
+      homodimerization
+    supporting_text: the B-Raf(V600E), B-Raf(insT) and B-Raf(G469A) oncoproteins are remarkably resistant to mutations 
+      in the DIF. However, compared with B-Raf(wt), B-Raf(V600E) displays extended protomer contacts, increased 
+      homodimerisation and incorporation into larger protein complexes
 - id: PMID:2284096
-  title: Complete coding sequence of a human B-raf cDNA and detection of B-raf protein
-    kinase with isozyme specific antibodies.
-  findings: []
+  title: Complete coding sequence of a human B-raf cDNA and detection of B-raf protein kinase with isozyme specific 
+    antibodies.
+  findings:
+  - statement: A 2.2 kb cDNA encoding the complete human BRAF coding sequence was isolated and contains all three 
+      conserved regions CR1, CR2, and CR3 characteristic of RAF-family protein kinases
+    full_text_unavailable: true
 - id: PMID:22939624
-  title: Quantitative analysis of HSP90-client interactions reveals principles of
-    substrate recognition.
+  title: Quantitative analysis of HSP90-client interactions reveals principles of substrate recognition.
   findings: []
 - id: PMID:23010278
   title: Stimulation of the Na(+)-coupled glucose transporter SGLT1 by B-RAF.
-  findings: []
+  findings:
+  - statement: Wild-type B-RAF stimulates Na+-coupled glucose transporter SGLT1 by increasing SGLT1 protein abundance at
+      the cell membrane without altering substrate affinity
+    full_text_unavailable: true
 - id: PMID:23153539
-  title: Relief of profound feedback inhibition of mitogenic signaling by RAF inhibitors
-    attenuates their activity in BRAFV600E melanomas.
-  findings: []
+  title: Relief of profound feedback inhibition of mitogenic signaling by RAF inhibitors attenuates their activity in 
+    BRAFV600E melanomas.
+  findings:
+  - statement: RAF inhibitors relieve profound ERK-dependent negative feedback in BRAF(V600E) melanomas, paradoxically 
+      reactivating upstream RAS signaling; this feedback relief attenuates the antiproliferative effect of RAF 
+      inhibitors
+    supporting_text: RAF inhibitors effectively inhibit ERK signaling only in tumors with mutant BRAF
 - id: PMID:23680146
   title: RAF inhibitors activate the MAPK pathway by relieving inhibitory autophosphorylation.
-  findings: []
+  findings:
+  - statement: RAF inhibitors activate wild-type RAF by relieving inhibitory autophosphorylation of the 
+      phosphate-binding loop; activation is ATP-dependent and linked to RAF kinase activity itself
+    full_text_unavailable: true
 - id: PMID:23934108
-  title: Mechanism of MEK inhibition determines efficacy in mutant KRAS- versus BRAF-driven
-    cancers.
+  title: Mechanism of MEK inhibition determines efficacy in mutant KRAS- versus BRAF-driven cancers.
   findings: []
 - id: PMID:24255178
-  title: Protein interaction network of the mammalian Hippo pathway reveals mechanisms
-    of kinase-phosphatase interactions.
+  title: Protein interaction network of the mammalian Hippo pathway reveals mechanisms of kinase-phosphatase 
+    interactions.
   findings: []
 - id: PMID:24441586
-  title: Integrated RAS signaling defined by parallel NMR detection of effectors and
-    regulators.
+  title: Integrated RAS signaling defined by parallel NMR detection of effectors and regulators.
   findings: []
 - id: PMID:24746704
-  title: Disruption of CRAF-mediated MEK activation is required for effective MEK
-    inhibition in KRAS mutant tumors.
+  title: Disruption of CRAF-mediated MEK activation is required for effective MEK inhibition in KRAS mutant tumors.
   findings: []
 - id: PMID:25155755
-  title: Structure of the BRAF-MEK complex reveals a kinase activity independent role
-    for BRAF in MAPK signaling.
-  findings: []
+  title: Structure of the BRAF-MEK complex reveals a kinase activity independent role for BRAF in MAPK signaling.
+  findings:
+  - statement: Crystal structure of the BRAF-MEK complex reveals a kinase activity-independent scaffolding role for BRAF
+      in positioning MEK for phosphorylation within the MAPK signaling complex
+    full_text_unavailable: true
 - id: PMID:25241761
-  title: Using an in situ proximity ligation assay to systematically profile endogenous
-    protein-protein interactions in a pathway network.
+  title: Using an in situ proximity ligation assay to systematically profile endogenous protein-protein interactions in 
+    a pathway network.
   findings: []
 - id: PMID:25437913
-  title: Crystal structure of a BRAF kinase domain monomer explains basis for allosteric
-    regulation.
-  findings: []
+  title: Crystal structure of a BRAF kinase domain monomer explains basis for allosteric regulation.
+  findings:
+  - statement: Crystal structure of a BRAF kinase domain monomer reveals the off-state dimer interface; sulfonamide 
+      inhibitors stabilize the monomer by displacing helix αC via AS-H1, the region targeted by potent BRAF oncogenic 
+      mutations
+    full_text_unavailable: true
 - id: PMID:25600339
-  title: Tunable-combinatorial mechanisms of acquired resistance limit the efficacy
-    of BRAF/MEK cotargeting but result in melanoma drug addiction.
+  title: Tunable-combinatorial mechanisms of acquired resistance limit the efficacy of BRAF/MEK cotargeting but result 
+    in melanoma drug addiction.
   findings: []
 - id: PMID:26165597
-  title: The RAS-Binding Domain of Human BRAF Protein Serine/Threonine Kinase Exhibits
-    Allosteric Conformational Changes upon Binding HRAS.
+  title: The RAS-Binding Domain of Human BRAF Protein Serine/Threonine Kinase Exhibits Allosteric Conformational Changes
+    upon Binding HRAS.
   findings: []
 - id: PMID:26466569
   title: RAF inhibitors that evade paradoxical MAPK pathway activation.
   findings: []
 - id: PMID:26496610
-  title: A human interactome in three quantitative dimensions organized by stoichiometries
-    and abundances.
+  title: A human interactome in three quantitative dimensions organized by stoichiometries and abundances.
   findings: []
 - id: PMID:27353360
-  title: The FNIP co-chaperones decelerate the Hsp90 chaperone cycle and enhance drug
-    binding.
+  title: The FNIP co-chaperones decelerate the Hsp90 chaperone cycle and enhance drug binding.
   findings: []
 - id: PMID:28514442
-  title: Architecture of the human interactome defines protein communities and disease
-    networks.
+  title: Architecture of the human interactome defines protein communities and disease networks.
   findings: []
 - id: PMID:29433126
   title: MEK drives BRAF activation through allosteric control of KSR proteins.
-  findings: []
+  findings:
+  - statement: MEK binding to the KSR1 kinase domain asymmetrically drives BRAF-KSR1 heterodimerization, stimulating 
+      BRAF catalytic activity toward free MEK molecules
+    supporting_text: MEK binding to the kinase domain of KSR1 asymmetrically drives BRAF-KSR1 heterodimerization, 
+      resulting in the concomitant stimulation of BRAF catalytic activity towards free MEK molecules
 - id: PMID:30194290
-  title: Interrogating the protein interactomes of RAS isoforms identifies PIP5K1A
-    as a KRAS-specific vulnerability.
+  title: Interrogating the protein interactomes of RAS isoforms identifies PIP5K1A as a KRAS-specific vulnerability.
   findings: []
 - id: PMID:31024343
-  title: A YWHAZ Variant Associated With Cardiofaciocutaneous Syndrome Activates the
-    RAF-ERK Pathway.
+  title: A YWHAZ Variant Associated With Cardiofaciocutaneous Syndrome Activates the RAF-ERK Pathway.
   findings: []
 - id: PMID:31980649
-  title: Extensive rewiring of the EGFR network in colorectal cancer cells expressing
-    transforming levels of KRAS(G13D).
+  title: Extensive rewiring of the EGFR network in colorectal cancer cells expressing transforming levels of KRAS(G13D).
   findings: []
 - id: PMID:32707033
-  title: Kinase Interaction Network Expands Functional and Disease Roles of Human
-    Kinases.
+  title: Kinase Interaction Network Expands Functional and Disease Roles of Human Kinases.
   findings: []
 - id: PMID:33961781
-  title: Dual proteome-scale networks reveal cell-specific remodeling of the human
-    interactome.
+  title: Dual proteome-scale networks reveal cell-specific remodeling of the human interactome.
   findings: []
 - id: PMID:34591642
-  title: A protein network map of head and neck cancer reveals PIK3CA mutant drug
-    sensitivity.
+  title: A protein network map of head and neck cancer reveals PIK3CA mutant drug sensitivity.
   findings: []
 - id: PMID:35512704
-  title: Systematic discovery of mutation-directed neo-protein-protein interactions
-    in cancer.
+  title: Systematic discovery of mutation-directed neo-protein-protein interactions in cancer.
   findings: []
 - id: PMID:35839996
-  title: A Proteomic Approach Identifies Isoform-Specific and Nucleotide-Dependent
-    RAS Interactions.
+  title: A Proteomic Approach Identifies Isoform-Specific and Nucleotide-Dependent RAS Interactions.
   findings: []
 - id: PMID:36241744
-  title: HERC2 deficiency activates C-RAF/MKK3/p38 signalling pathway altering the
-    cellular response to oxidative stress.
+  title: HERC2 deficiency activates C-RAF/MKK3/p38 signalling pathway altering the cellular response to oxidative 
+    stress.
   findings: []
 - id: PMID:36931259
   title: A central chaperone-like role for 14-3-3 proteins in human cells.
@@ -1891,7 +2960,11 @@ references:
   findings: []
 - id: PMID:9207797
   title: Endothelial apoptosis in Braf-deficient mice.
-  findings: []
+  findings:
+  - statement: Braf-/- mice die of vascular defects during mid-gestation; embryos show increased endothelial precursor 
+      cells, dramatically enlarged blood vessels, and apoptotic death of differentiated endothelial cells, establishing 
+      BRAF as critical for vascular system formation
+    full_text_unavailable: true
 - id: Reactome:R-HSA-1295604
   title: B-RAF dissociates from S110/S120 p-SPRY2
   findings: []
@@ -1953,8 +3026,7 @@ references:
   title: RAS mutants bind inactive RAF
   findings: []
 - id: Reactome:R-HSA-6802910
-  title: Activated MAP2Ks phosphorylate MAPKs downstream of high kinase activity BRAF
-    mutants
+  title: Activated MAP2Ks phosphorylate MAPKs downstream of high kinase activity BRAF mutants
   findings: []
 - id: Reactome:R-HSA-6802911
   title: High kinase activity BRAF complexes phosphorylate MAP2Ks
@@ -1978,8 +3050,7 @@ references:
   title: RAS:GTP:moderate kinase activity p-RAF complexes phosphorylate MAP2Ks
   findings: []
 - id: Reactome:R-HSA-6802921
-  title: Activated MAP2Ks phosphorylate MAPKs downstream of moderate kinase activity
-    BRAF mutants
+  title: Activated MAP2Ks phosphorylate MAPKs downstream of moderate kinase activity BRAF mutants
   findings: []
 - id: Reactome:R-HSA-6802922
   title: Activated MAP2Ks phosphorylate MAPKs downstream of oncogenic RAS
@@ -1994,8 +3065,7 @@ references:
   title: Mutant RAS:p-RAF complexes phosphorylate MAP2Ks
   findings: []
 - id: Reactome:R-HSA-6802930
-  title: Dimerization of BRAF V600E splice variants contributes to BRAF inhibitor
-    resistance
+  title: Dimerization of BRAF V600E splice variants contributes to BRAF inhibitor resistance
   findings: []
 - id: Reactome:R-HSA-6802937
   title: Inactive BRAF mutants bind mutant RAS:GTP
@@ -2093,22 +3163,18 @@ references:
 - id: file:human/BRAF/BRAF-uniprot.txt
   title: UniProt record for human BRAF (P15056)
   findings:
-  - statement: BRAF phosphorylates MAP2K1 (MEK1) and thereby activates the MAP kinase
-      signal transduction pathway.
-    supporting_text: Phosphorylates MAP2K1, and thereby activates the MAP kinase signal
-      transduction pathway
+  - statement: BRAF phosphorylates MAP2K1 (MEK1) and thereby activates the MAP kinase signal transduction pathway.
+    supporting_text: Phosphorylates MAP2K1, and thereby activates the MAP kinase signal transduction pathway
   - statement: BRAF is an ATP-dependent protein serine/threonine kinase (EC 2.7.11.1).
     supporting_text: L-seryl-[protein] + ATP = O-phospho-L-seryl-[protein] + ADP
 core_functions:
-- description: BRAF is the canonical RAF-family MAP kinase kinase kinase (MAP3K) of the
-    RAS-RAF-MEK-ERK cascade. After RAS-GTP-driven membrane recruitment and side-to-side
-    dimerization (BRAF homodimers and the more potent BRAF-RAF1 heterodimers), BRAF
-    phosphorylates and activates MAP2K1/MAP2K2 (MEK1/MEK2) — the committed step that
-    propagates mitogenic signaling to ERK1/ERK2.
+- description: BRAF is the canonical RAF-family MAP kinase kinase kinase (MAP3K) of the RAS-RAF-MEK-ERK cascade. After 
+    RAS-GTP-driven membrane recruitment and side-to-side dimerization (BRAF homodimers and the more potent BRAF-RAF1 
+    heterodimers), BRAF phosphorylates and activates MAP2K1/MAP2K2 (MEK1/MEK2) — the committed step that propagates 
+    mitogenic signaling to ERK1/ERK2.
   supported_by:
   - reference_id: file:human/BRAF/BRAF-uniprot.txt
-    supporting_text: Phosphorylates MAP2K1, and thereby activates the MAP kinase signal
-      transduction pathway
+    supporting_text: Phosphorylates MAP2K1, and thereby activates the MAP kinase signal transduction pathway
   - reference_id: PMID:29433126
     supporting_text: BRAF phosphorylation of MEK1
   molecular_function:
@@ -2124,11 +3190,10 @@ core_functions:
     label: cytosol
   - id: GO:0005886
     label: plasma membrane
-- description: BRAF is an ATP-dependent protein serine/threonine kinase. Its intrinsic
-    catalytic activity, demonstrated by direct in vitro kinase assays, phosphorylates
-    substrate serine/threonine residues (most importantly the activation-loop serines
-    of MEK1/MEK2); this enzymatic activity is the molecular basis for its MAP3K function
-    and for its oncogenic activation by the V600E mutation.
+- description: BRAF is an ATP-dependent protein serine/threonine kinase. Its intrinsic catalytic activity, demonstrated 
+    by direct in vitro kinase assays, phosphorylates substrate serine/threonine residues (most importantly the 
+    activation-loop serines of MEK1/MEK2); this enzymatic activity is the molecular basis for its MAP3K function and for
+    its oncogenic activation by the V600E mutation.
   supported_by:
   - reference_id: file:human/BRAF/BRAF-uniprot.txt
     supporting_text: L-seryl-[protein] + ATP = O-phospho-L-seryl-[protein] + ADP
@@ -2146,3 +3211,34 @@ core_functions:
   - id: GO:0005886
     label: plasma membrane
 proposed_new_terms: []
+suggested_questions:
+- question: Does BRAF homodimerization versus BRAF-RAF1 heterodimerization yield qualitatively or quantitatively 
+    distinct MEK activation outputs, and what cellular signals or post-translational modifications tip the balance in 
+    vivo?
+- question: How is the stoichiometry and dynamics of the autoinhibited cytosolic BRAF-MEK-14-3-3 complex regulated 
+    during growth factor stimulation, and does the complex dissociate as a unit or do components exchange independently 
+    upon RAS activation?
+- question: What is the full complement of direct BRAF substrates beyond MEK1/2 in normal physiological contexts, and do
+    non-MEK targets such as BAD contribute to BRAF function in vascular development?
+- question: Can the BRAF amino-terminal B-Raf-specific region (mediating calcium-dependent dimerization) be targeted 
+    pharmacologically to modulate wild-type BRAF activity without triggering paradoxical RAF inhibitor-type pathway 
+    activation?
+suggested_experiments:
+- description: Cryo-EM reconstitution of the active BRAF-RAF1 heterodimer and the BRAF-KSR1-MEK ternary complex on 
+    nanodisc membranes in the presence of RAS-GTP to determine how membrane context and substrate engagement reshape the
+    active conformation.
+  hypothesis: RAS-GTP at the membrane induces a distinct active-dimer conformation compared to drug-stabilized dimers, 
+    and KSR1-MEK positioning within the ternary complex explains the allosteric stimulation of BRAF catalytic activity.
+  experiment_type: structural
+- description: Phosphoproteomic profiling of isogenic cells with conditional BRAF knockout versus BRAF(V600E) knock-in 
+    under matched growth conditions to identify direct BRAF-dependent phosphorylation events beyond MEK1/2.
+  hypothesis: BRAF has physiological substrates beyond MEK1/2 that contribute to its essential role in endothelial 
+    survival and vascular development, and these are distinct from the MEK-dependent oncogenic signaling in V600E 
+    tumors.
+  experiment_type: biochemical
+- description: Calcium-imaging combined with BRAF FRET-based dimerization reporters in primary endothelial cells to 
+    establish the kinetics and threshold of calcium-dependent BRAF membrane translocation and dimerization.
+  hypothesis: The B-Raf-specific amino-terminal region converts transient calcium signals into sustained BRAF 
+    dimerization at the plasma membrane, providing a calcium-dependent amplification mechanism for MAPK signaling in 
+    endothelial cells.
+  experiment_type: cell_biology


### PR DESCRIPTION
## Summary

Enriches the BRAF review with reference findings and suggested research directions, closing the compliance gap flagged in issue #344.

- Adds `findings` to **20 of 131 references**: the deep-research summary file, 2 core-function-cited papers (PMID:29433126 KSR-MEK allosteric control, PMID:21441910 RAF-KSR allosteric transition), and 17 additional mechanistically important papers covering BRAF dimerization, autoinhibition, the RAF inhibitor paradox, vascular development, IQGAP1 scaffold biology, and calcium-dependent regulation
- Adds **4 `suggested_questions`**: dimer-type selectivity (homodimer vs BRAF-RAF1 heterodimer), BRAF-MEK-14-3-3 complex stoichiometry/dynamics, non-MEK BRAF substrates, and the N-terminal B-Raf-specific region as a therapeutic target
- Adds **3 `suggested_experiments`**: cryo-EM of BRAF-RAF1/KSR1-MEK ternary complex on nanodiscs; BRAF knockout phosphoproteomics for non-MEK substrate discovery; BRAF FRET dimerization reporters in endothelial cells

## Test plan

- [x] `just validate human BRAF` → ✓ Valid, 0 warnings, 0 errors
- [x] Cherry-picked cleanly from `braf-enrich-reference-findings-344` onto current main (no conflicts)
- [x] 131 references unchanged; only `findings` fields added

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)