### PR TITLE
BACSU/aprE: fix inconsistent GO:0008236 parent-MF handling (issue #816)

### DIFF
--- a/genes/BACSU/aprE/aprE-ai-review.yaml
+++ b/genes/BACSU/aprE/aprE-ai-review.yaml
@@ -154,13 +154,16 @@ existing_annotations:
   evidence_type: IEA
   original_reference_id: GO_REF:0000120
   review:
-    summary: IEA annotation for serine-type peptidase activity is a parent term of
-      serine-type endopeptidase activity (GO:0004252). While correct, it is less specific.
-    action: ACCEPT
-    reason: This term is a parent of GO:0004252 (serine-type endopeptidase activity)
-      but is still appropriate as it captures the serine protease mechanism. IEA mappings
-      often include multiple levels of the ontology hierarchy. This annotation is
-      acceptable though less informative than GO:0004252.
+    summary: IEA annotation for serine-type peptidase activity is a direct parent
+      of serine-type endopeptidase activity (GO:0004252), which is already annotated
+      at the most specific level. Analogous to peptidase activity (GO:0008233), which
+      is MARK_AS_OVER_ANNOTATED for the same reason.
+    action: MARK_AS_OVER_ANNOTATED
+    reason: GO:0008236 (serine-type peptidase activity) is a strict parent of GO:0004252
+      (serine-type endopeptidase activity), which is already annotated. There is no
+      principled basis to accept GO:0008236 while marking the sibling parent GO:0008233
+      (peptidase activity) as over-annotated; both are fully subsumed by GO:0004252.
+      Consistent treatment with GO:0008233 requires MARK_AS_OVER_ANNOTATED.
     supported_by:
     - reference_id: UniProt:P04189
       supporting_text: Inhibited by PMSF (phenylmethylsulphonyl fluoride) and 3,4-dichloroisocoumarin
@@ -231,25 +234,25 @@ existing_annotations:
     - reference_id: UniProt:P04189
       supporting_text: Name=Ca(2+); Xref=ChEBI:CHEBI:29108; Evidence={ECO:0000269|PubMed:9811547};
         Note=Binds 2 calcium ions per subunit
-    - reference_id: file:BACSU/aprE/aprE-deep-research-falcon.md
-      supporting_text: 'Catalytic mechanism and specificity: Like other "true" subtilisins,
-        catalysis proceeds through a Ser-alkoxide nucleophile assisted by His and
-        Asp, forming and resolving an acyl-enzyme intermediate'
 - term:
     id: GO:0008236
     label: serine-type peptidase activity
   evidence_type: IDA
   original_reference_id: PMID:17666034
   review:
-    summary: IDA annotation for serine-type peptidase activity based on PMID:17666034
-      which demonstrated that subtilisin processes proCSF to CSF. The study identified
-      subtilisin as one of three sigma-H-regulated secreted serine proteases involved
-      in CSF production.
-    action: ACCEPT
-    reason: The study (PMID:17666034) provides direct experimental evidence that subtilisin
-      cleaves proCSF to produce the active CSF signaling peptide. Purified subtilisin
-      was shown to process proCSF and PhrA peptides. This demonstrates serine-type
-      peptidase activity in a specific biological context (signaling peptide maturation).
+    summary: IDA annotation for serine-type peptidase activity based on PMID:17666034,
+      which demonstrated endoproteolytic cleavage of proCSF to the active CSF pentapeptide.
+      The same evidence supports the more specific GO:0004252 (serine-type endopeptidase
+      activity), as proCSF-to-CSF processing is an internal-bond cleavage event.
+    action: MODIFY
+    reason: The proCSF-to-CSF processing in PMID:17666034 is endoproteolytic (internal
+      peptide bond cleavage to generate the mature pentapeptide). This directly supports
+      GO:0004252 (serine-type endopeptidase activity) rather than the less specific
+      parent GO:0008236. Upgrading retains the IDA experimental evidence on the most
+      informative term.
+    proposed_replacement_terms:
+    - id: GO:0004252
+      label: serine-type endopeptidase activity
     supported_by:
     - reference_id: PMID:17666034
       supporting_text: Using both a cellular and a mass spectrometric approach, we


### PR DESCRIPTION
Closes #816

## Summary

Addresses three findings from the independent re-review of BACSU/aprE (subtilisin E).

- **[Major] IEA GO:0008236 (GO_REF:0000120): ACCEPT → MARK_AS_OVER_ANNOTATED.** `serine-type peptidase activity` (GO:0008236) is a strict parent of the specifically annotated `serine-type endopeptidase activity` (GO:0004252). The sibling parent `peptidase activity` (GO:0008233, IEA) was already MARK_AS_OVER_ANNOTATED for the same reason; no principled basis to treat GO:0008236 differently. Consistent treatment requires MARK_AS_OVER_ANNOTATED.

- **[Minor] IDA GO:0008236 (PMID:17666034): ACCEPT → MODIFY → GO:0004252.** The proCSF→CSF cleavage demonstrated in PMID:17666034 is endoproteolytic (internal-bond cleavage producing the active pentapeptide), so the same IDA evidence directly supports the more specific `serine-type endopeptidase activity` (GO:0004252). Upgrading retains experimental backing on the most informative term.

- **[Minor] GO:0046872 MODIFY supported_by cleanup.** Removed a `file:BACSU/aprE/aprE-deep-research-falcon.md` entry whose `supporting_text` quoted catalytic-mechanism text (Ser-alkoxide nucleophile) irrelevant to calcium ion binding. The UniProt entry (`ECO:0000269|PubMed:9811547`, 2 Ca²⁺/subunit) is sufficient and authoritative.

## Test plan

- [x] `just validate BACSU aprE` passes ✅
- [ ] Human review of GO:0008236 IDA→MODIFY (optional upgrade, biologically sound)

🤖 Generated with [Claude Code](https://claude.com/claude-code)