### PR TITLE
fix(human/SSR2): correct STING1 IPI mis-remapping and tighten annotation actions

### DIFF
--- a/genes/human/SSR2/SSR2-ai-review.yaml
+++ b/genes/human/SSR2/SSR2-ai-review.yaml
@@ -15,8 +15,10 @@ description: >-
   single-pass membrane glycoprotein with its N-terminus facing the ER lumen, where it
   contributes to the lumenal crescent structure that contacts nascent chains exiting
   the Sec61 pore. The TRAP complex also coordinates with the oligosaccharyltransferase
-  (OST) complex to facilitate N-glycosylation of nascent proteins. SSR2 has been shown
-  to interact with STING1, suggesting potential roles in innate immune signaling pathways.
+  (OST) complex to facilitate N-glycosylation of nascent proteins. SSR2 was identified
+  as a STING1 interactor in a yeast-two-hybrid screen (PMID:18724357), but the
+  biological significance of this interaction is uncertain; it likely reflects
+  proximity at the ER membrane rather than a dedicated immune-signaling function.
 existing_annotations:
 - term:
     id: GO:0005783
@@ -68,12 +70,12 @@ existing_annotations:
       This IEA annotation is derived from InterPro domain mapping. While correct that
       SSR2 is a membrane protein, this term is too general compared to the more specific
       GO:0005789 (endoplasmic reticulum membrane) annotation that is also present.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      This is a valid but general annotation. Given that the more specific term
-      GO:0005789 (ER membrane) is already annotated, this broader term provides
-      redundant but not incorrect information. Accept as it doesn't violate any rules
-      and is consistent with the protein's membrane localization.
+      GO:0005789 (endoplasmic reticulum membrane) is already annotated and is strictly
+      more specific. GO:0016020 is redundant given that more precise localization
+      information is captured by the ER-membrane term; best-practice curation flags
+      such general terms as over-annotations when a specific child is present.
     supported_by:
       - reference_id: PMID:7789174
         supporting_text: "which codes for an endoplasmic reticulum (ER) membrane protein"
@@ -88,22 +90,45 @@ existing_annotations:
       demonstrated by yeast two-hybrid screening and co-immunoprecipitation in PMID:18724357.
       The study identified SSR2 as a STING1 interactor and showed that TRAP-beta ablation
       reduced STING's ability to induce interferon-beta.
-    action: MODIFY
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      The generic term "protein binding" is uninformative for GO annotation purposes.
-      While the STING1 interaction is experimentally validated (yeast two-hybrid and
-      co-IP), the biological significance and mechanism of this interaction are not
-      fully characterized. However, a more informative annotation would be to the
-      specific complex (TRAP complex) or to Sec61 translocon complex binding, which
-      represents the core function of SSR2.
-    proposed_replacement_terms:
-      - id: GO:0106138
-        label: Sec61 translocon complex binding
+      The evidence for this IPI record is the STING1 interaction (WITH Q86WV6,
+      PMID:18724357, yeast-two-hybrid plus co-IP). The interaction is experimentally
+      real but its biological significance is uncertain; the paper frames it as
+      the translocon potentially influencing STING-mediated innate signalling, not
+      as a core SSR2 function. Substituting GO:0106138 (Sec61 translocon complex
+      binding) as the replacement term would swap in a different molecular partner
+      unsupported by this IPI evidence record. MARK_AS_OVER_ANNOTATED is the
+      appropriate disposition: protein binding is non-informative and this specific
+      STING1 interaction is peripheral to SSR2's core role. GO:0106138 is retained in
+      core_functions, supported by structural co-complex evidence (PMID:36697828).
     supported_by:
       - reference_id: PMID:18724357
         supporting_text: "we screened an IFN-induced, human fibroblast yeast two-hybrid cDNA library using STING (amino acids 173-379) as a bait and repeatedly isolated Ssr2/TRAPbeta, a member of the TRAP complex comprising four subunits (alpha-delta) that facilitates translocation of proteins into the ER following translation"
       - reference_id: PMID:18724357
         supporting_text: "we confirmed that TRAPbeta can indeed associate with endogenous STING in HEK 293 cells following co-immunoprecipitation experiments"
+- term:
+    id: GO:0106138
+    label: Sec61 translocon complex binding
+  evidence_type: IDA
+  original_reference_id: PMID:36697828
+  review:
+    summary: >-
+      NEW annotation proposed to capture the direct physical association of SSR2/TRAP-beta
+      with the Sec61 translocon, as demonstrated by cryo-electron tomography showing
+      the near-complete atomic model of the SEC61-TRAP-OSTA complex. TRAP stably
+      associates with Sec61 at the ER membrane.
+    action: NEW
+    reason: >-
+      The cryo-ET study (PMID:36697828) directly visualizes the TRAP complex in stable
+      association with Sec61 in native ER membranes, providing structural IDA-level
+      evidence for Sec61 translocon complex binding. This is the core MF of SSR2 and
+      should be annotated directly rather than inferred by remapping the STING1 IPI
+      record. The co-IP data in PMID:18724357 (Sec61beta co-IP) provides additional
+      biochemical support.
+    supported_by:
+      - reference_id: PMID:36697828
+        supporting_text: "The near-complete atomic model of the most abundant ER translocon variant comprising the protein-conducting channel SEC61, TRAP and the oligosaccharyltransferase complex A (OSTA) reveals specific interactions of TRAP with other translocon components."
 - term:
     id: GO:0005789
     label: endoplasmic reticulum membrane
@@ -134,18 +159,14 @@ existing_annotations:
       protein translocation. However, the TRAP complex is primarily associated with
       co-translational translocation, assisting the Sec61 translocon during ribosome-
       associated protein synthesis and membrane insertion.
-    action: MODIFY
+    action: REMOVE
     reason: >-
-      The TRAP complex is predominantly associated with co-translational (SRP-dependent)
-      protein translocation, not post-translational translocation. While the Sec61
-      translocon can function in both pathways, TRAP specifically associates with
-      ribosome-bound translocons and facilitates translocation of nascent chains with
-      weak signal peptides during active translation [file:human/SSR2/SSR2-deep-research-falcon.md].
-      GO:0006613 (cotranslational protein targeting to membrane) is the more appropriate
-      term and is already annotated.
-    proposed_replacement_terms:
-      - id: GO:0006613
-        label: cotranslational protein targeting to membrane
+      GO:0031204 captures post-translational protein targeting, but the TRAP complex
+      acts co-translationally (ribosome-bound Sec61 complexes). The correct sub-pathway
+      term, GO:0006613 (cotranslational protein targeting to membrane), is already
+      independently annotated from PMID:7789174. MODIFY to a term already present
+      would produce a duplicate; REMOVE is the cleaner disposition for the incorrectly
+      assigned sub-pathway term.
     supported_by:
       - reference_id: PMID:36697828
         supporting_text: "distinct polysomes bind to different ER translocons specialized in the synthesis of proteins with signal peptides or multipass transmembrane proteins with the translocon-associated protein complex (TRAP) present in both"
@@ -202,11 +223,11 @@ existing_annotations:
       This TAS annotation based on PMID:7789174 indicates SSR2 is a membrane protein.
       This is accurate but less specific than GO:0005789 (ER membrane) which is also
       annotated from the same reference.
-    action: ACCEPT
+    action: MARK_AS_OVER_ANNOTATED
     reason: >-
-      Accurate but general annotation. The more specific term GO:0005789 (ER membrane)
-      better captures the localization. However, this annotation is not incorrect and
-      is supported by the cited literature.
+      GO:0005789 (endoplasmic reticulum membrane) is annotated from the same reference
+      and is more informative. GO:0016020 is a redundant parent term; retaining only
+      the specific child term is consistent with curation best practice.
     supported_by:
       - reference_id: PMID:7789174
         supporting_text: "which codes for an endoplasmic reticulum (ER) membrane protein"
@@ -285,7 +306,10 @@ proposed_new_terms:
       (TRAP) complex. This heterotetrameric complex (SSR1-4/TRAP-alpha,beta,gamma,delta)
       is distinct from the Sec61 translocon core and functions as a co-factor for
       protein translocation. A dedicated cellular component term would improve
-      annotation precision for all TRAP subunit genes.
+      annotation precision for all TRAP subunit genes. Note that ComplexPortal
+      CPX-8024 ("Translocon-associated protein complex") already captures this
+      complex and is cited in the UniProt record; the GO request should reference
+      CPX-8024 as supporting evidence for the complex's existence and composition.
 suggested_questions:
   - question: >-
       What is the precise mechanism by which the TRAP complex modulates Sec61 lateral


### PR DESCRIPTION
## Summary

Fixes curation issues identified in #811 (independent re-review of human/SSR2 TRAP-beta):

- **[Major]** STING1 IPI (GO:0005515, PMID:18724357): corrects `MODIFY → GO:0106138` to `MARK_AS_OVER_ANNOTATED`. The IPI evidence is specifically the STING1 interaction (WITH Q86WV6); substituting "Sec61 translocon complex binding" as the replacement term swaps in a different molecular partner unsupported by this record. GO:0106138 is instead added as a proper `NEW` annotation with IDA evidence from the cryo-ET co-complex structure (PMID:36697828).
- **[Minor]** GO:0031204 (post-translational protein targeting): corrects `MODIFY → GO:0006613` to `REMOVE`. GO:0006613 (cotranslational protein targeting) is already independently annotated, making the MODIFY a duplicate. GO:0031204 is the wrong sub-pathway — TRAP acts co-translationally.
- **[Minor]** Two GO:0016020 (membrane) records: `ACCEPT → MARK_AS_OVER_ANNOTATED`. Both are redundant parent terms given GO:0005789 (ER membrane) is already annotated.
- **[Minor]** Description: demotes STING1/innate-immune-signaling angle from "suggesting potential roles" to clearly peripheral/uncertain, consistent with the review body.
- **[Minor]** `proposed_new_terms`: adds reference to ComplexPortal CPX-8024 as supporting evidence for the TRAP complex GO term request.

## Test plan

- [x] `just validate human SSR2` — passes cleanly (0 warnings after adding the NEW annotation)
- [ ] Human curator review of the STING1 IPI disposition and the new GO:0106138 IDA entry

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)