### PR TITLE
chrR (PSEPK): enrich review with falcon deep research evidence

### DIFF
--- a/genes/PSEPK/chrR/chrR-ai-review.yaml
+++ b/genes/PSEPK/chrR/chrR-ai-review.yaml
@@ -36,6 +36,10 @@ existing_annotations:
     supported_by:
     - reference_id: file:PSEPK/chrR/chrR-uniprot.txt
       supporting_text: ChrR, a soluble quinone reductase
+    - reference_id: file:PSEPK/chrR/chrR-deep-research-falcon.md
+      reference_section_type: OTHER
+      supporting_text: |-
+        It is described and purified as a **soluble** flavoprotein, indicating a **cytosolic** functional locale rather than membrane association
 - term:
     id: GO:0008753
     label: NADPH dehydrogenase (quinone) activity
@@ -45,7 +49,7 @@ existing_annotations:
     summary: NADPH-dependent quinone reductase activity is experimentally supported for ChrR.
     action: ACCEPT
     reason: Retain this specific molecular-function annotation.
-    supported_by: &id001
+    supported_by:
     - reference_id: file:PSEPK/chrR/chrR-uniprot.txt
       supporting_text: Reaction=a quinone + NADPH + H(+) = a quinol + NADP(+);
 - term:
@@ -60,6 +64,10 @@ existing_annotations:
     supported_by:
     - reference_id: file:PSEPK/chrR/chrR-uniprot.txt
       supporting_text: Name=FMN; Xref=ChEBI:CHEBI:58210;
+    - reference_id: file:PSEPK/chrR/chrR-deep-research-falcon.md
+      reference_section_type: OTHER
+      supporting_text: |-
+        ChrR is an FMN-dependent enzyme: the flavin cofactor can be released (e.g., by boiling) and identified by TLC as **FMN**
 - term:
     id: GO:0016491
     label: oxidoreductase activity
@@ -95,7 +103,7 @@ existing_annotations:
     summary: NADH-dependent non-electrogenic quinone reduction is a core ChrR activity.
     action: ACCEPT
     reason: Retain this specific molecular-function annotation.
-    supported_by: &id002
+    supported_by:
     - reference_id: file:PSEPK/chrR/chrR-uniprot.txt
       supporting_text: Reaction=a quinone + NADH + H(+) = a quinol + NAD(+);
 - term:
@@ -107,7 +115,13 @@ existing_annotations:
     summary: NADPH-dependent quinone reductase activity is experimentally supported for ChrR.
     action: ACCEPT
     reason: Retain this specific molecular-function annotation.
-    supported_by: *id001
+    supported_by:
+    - reference_id: file:PSEPK/chrR/chrR-uniprot.txt
+      supporting_text: Reaction=a quinone + NADPH + H(+) = a quinol + NADP(+);
+    - reference_id: file:PSEPK/chrR/chrR-deep-research-falcon.md
+      reference_section_type: OTHER
+      supporting_text: |-
+        ChrR also reduces **quinones**, potassium ferrocyanide, and 2,6-dichloroindophenol
 - term:
     id: GO:0050136
     label: NADH dehydrogenase (quinone) (non-electrogenic) activity
@@ -117,7 +131,13 @@ existing_annotations:
     summary: NADH-dependent non-electrogenic quinone reduction is a core ChrR activity.
     action: ACCEPT
     reason: Retain this specific molecular-function annotation.
-    supported_by: *id002
+    supported_by:
+    - reference_id: file:PSEPK/chrR/chrR-uniprot.txt
+      supporting_text: Reaction=a quinone + NADH + H(+) = a quinol + NAD(+);
+    - reference_id: file:PSEPK/chrR/chrR-deep-research-falcon.md
+      reference_section_type: OTHER
+      supporting_text: |-
+        ChrR preferentially uses **NADH over NADPH**, with an approximately **8-fold** preference under limiting cofactor conditions
 - term:
     id: GO:0006979
     label: response to oxidative stress
@@ -133,6 +153,10 @@ existing_annotations:
     - reference_id: PMID:15840577
       supporting_text: Expression of chrR was induced by H(2)O(2)
       reference_section_type: ABSTRACT
+    - reference_id: file:PSEPK/chrR/chrR-deep-research-falcon.md
+      reference_section_type: OTHER
+      supporting_text: |-
+        Electron partitioning measurements indicate that during chromate reduction, roughly **1 out of every 4 electrons** from NADH can go to **O2**, yielding **H2O2** (ROS) rather than chromate reduction
 references:
 - id: GO_REF:0000003
   title: Gene Ontology annotation based on Enzyme Commission mapping.
@@ -173,6 +197,33 @@ references:
   findings:
   - statement: Initial biochemical work characterized chromate reductase activity and FMN
       binding.
+- id: file:PSEPK/chrR/chrR-deep-research-falcon.md
+  title: Falcon (Edison Scientific) deep research report on chrR (Q88FF8), P. putida KT2440
+  findings:
+  - reference_section_type: OTHER
+    supporting_text: |-
+      In vitro, it uses reducing equivalents from **NAD(P)H** (with strong preference for NADH) to reduce chromate and quinones
+  - reference_section_type: OTHER
+    supporting_text: |-
+      ChrR is an FMN-dependent enzyme: the flavin cofactor can be released (e.g., by boiling) and identified by TLC as **FMN**
+  - reference_section_type: OTHER
+    supporting_text: |-
+      It is described and purified as a **soluble** flavoprotein, indicating a **cytosolic** functional locale rather than membrane association
+  - reference_section_type: OTHER
+    supporting_text: |-
+      ChrR preferentially uses **NADH over NADPH**, with an approximately **8-fold** preference under limiting cofactor conditions
+  - reference_section_type: OTHER
+    supporting_text: |-
+      ChrR also reduces **quinones**, potassium ferrocyanide, and 2,6-dichloroindophenol
+  - reference_section_type: OTHER
+    supporting_text: |-
+      Electron partitioning measurements indicate that during chromate reduction, roughly **1 out of every 4 electrons** from NADH can go to **O2**, yielding **H2O2** (ROS) rather than chromate reduction
+  - reference_section_type: OTHER
+    supporting_text: |-
+      ChrR protein levels are reported to be induced by both **chromate exposure** and **entry into stationary phase**
+  - reference_section_type: OTHER
+    supporting_text: |-
+      A KT2440 **chrR disruption mutant** shows impaired chromate-related phenotypes compared to wild type, consistent with ChrR contributing to both chromate reduction and tolerance in vivo
 core_functions:
 - description: ChrR catalyzes two-electron reduction of quinones using NADH, producing
     quinols while avoiding reactive semiquinone intermediates; chromate reduction is a secondary
@@ -191,6 +242,10 @@ core_functions:
   - reference_id: PMID:15840577
     supporting_text: ChrR reduces quinones by
     reference_section_type: ABSTRACT
+  - reference_id: file:PSEPK/chrR/chrR-deep-research-falcon.md
+    reference_section_type: OTHER
+    supporting_text: |-
+      In vitro, it uses reducing equivalents from **NAD(P)H** (with strong preference for NADH) to reduce chromate and quinones
 - description: ChrR also catalyzes NADPH-dependent quinone reduction, supporting the same
     quinone-detoxifying oxidative-stress role.
   molecular_function:
@@ -205,6 +260,10 @@ core_functions:
   - reference_id: PMID:15840577
     supporting_text: producing quinols that promote tolerance of
     reference_section_type: ABSTRACT
+  - reference_id: file:PSEPK/chrR/chrR-deep-research-falcon.md
+    reference_section_type: OTHER
+    supporting_text: |-
+      ChrR also reduces **quinones**, potassium ferrocyanide, and 2,6-dichloroindophenol
 proposed_new_terms: []
 suggested_questions:
 - question: Which physiological quinone substrates dominate the ChrR-dependent H2O2 tolerance

--- a/genes/PSEPK/chrR/chrR-ai-review.yaml
+++ b/genes/PSEPK/chrR/chrR-ai-review.yaml
@@ -9,6 +9,8 @@ description: chrR encodes a soluble FMN-dependent quinone reductase. Although hi
   described as a chromate reductase, UniProt and experimental work indicate that the primary
   biological role is two-electron reduction of quinones to quinols, avoiding semiquinone intermediates
   and promoting hydrogen-peroxide tolerance; chromate reduction is likely a secondary activity.
+  ChrR can use either NADH or NADPH as the electron donor but preferentially uses NADH (approximately
+  8-fold preference under limiting cofactor conditions).
 existing_annotations:
 - term:
     id: GO:0003955
@@ -141,22 +143,24 @@ existing_annotations:
 - term:
     id: GO:0006979
     label: response to oxidative stress
-  evidence_type: IC
+  evidence_type: IMP
   original_reference_id: PMID:15840577
   review:
     summary: ChrR quinone reduction promotes H2O2 tolerance and chrR expression is induced
-      by H2O2.
+      by H2O2; a knock-out mutant shows reduced H2O2 tolerance and scavenging.
     action: NEW
     reason: Existing GOA lacks a biological-process annotation for the experimentally supported
-      oxidative-stress role of ChrR.
+      oxidative-stress role of ChrR. Evidence is IMP - a chrR knock-out mutant has reduced
+      H2O2 tolerance, and chrR expression is induced by H2O2 (PMID:15840577).
     supported_by:
     - reference_id: PMID:15840577
       supporting_text: Expression of chrR was induced by H(2)O(2)
       reference_section_type: ABSTRACT
-    - reference_id: file:PSEPK/chrR/chrR-deep-research-falcon.md
-      reference_section_type: OTHER
-      supporting_text: |-
-        Electron partitioning measurements indicate that during chromate reduction, roughly **1 out of every 4 electrons** from NADH can go to **O2**, yielding **H2O2** (ROS) rather than chromate reduction
+    - reference_id: PMID:15840577
+      reference_section_type: ABSTRACT
+      supporting_text: levels of chrR expression in overexpressing, wild type, and knock-out
+        mutant strains correlated with the H(2)O(2) tolerance and scavenging ability of each
+        strain
 references:
 - id: GO_REF:0000003
   title: Gene Ontology annotation based on Enzyme Commission mapping.

--- a/genes/PSEPK/chrR/chrR-deep-research-falcon.md
+++ b/genes/PSEPK/chrR/chrR-deep-research-falcon.md
@@ -1,0 +1,315 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-06-01T07:29:21.514877'
+end_time: '2026-06-01T07:41:23.762529'
+duration_seconds: 722.25
+template_file: templates/gene_research_go_focused.md
+template_variables:
+  organism: PSEPK
+  gene_id: chrR
+  gene_symbol: chrR
+  uniprot_accession: Q88FF8
+  protein_description: 'RecName: Full=Quinone reductase {ECO:0000305}; EC=1.6.5.2
+    {ECO:0000269|PubMed:15840577}; AltName: Full=Chromate reductase {ECO:0000305};
+    Short=CHRR; EC=1.6.-.- {ECO:0000269|PubMed:14766567}; AltName: Full=NAD(P)H dehydrogenase
+    (quinone) {ECO:0000305};'
+  gene_info: Name=chrR {ECO:0000303|PubMed:14766567}; OrderedLocusNames=PP_4138;
+  organism_full: Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB
+    11950 / KT2440).
+  protein_family: Belongs to the SsuE family. .
+  protein_domains: Flavoprotein-like_sf. (IPR029039); FMN_Rdtase-like_dom. (IPR005025);
+    NAD(P)H-dep_reductase. (IPR050712); FMN_red (PF03358)
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+    max_embedded_images: 8
+citation_count: 21
+artifact_count: 1
+artifact_sources:
+  edison_answer_artifacts: 1
+artifacts:
+- filename: artifact-00.md
+  path: chrR-deep-research-falcon_artifacts/artifact-00.md
+  media_type: text/markdown
+  source: edison_answer_artifacts
+  data_storage_id: null
+  description: Edison artifact artifact-00
+---
+
+## Question
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q88FF8
+- **Protein Description:** RecName: Full=Quinone reductase {ECO:0000305}; EC=1.6.5.2 {ECO:0000269|PubMed:15840577}; AltName: Full=Chromate reductase {ECO:0000305}; Short=CHRR; EC=1.6.-.- {ECO:0000269|PubMed:14766567}; AltName: Full=NAD(P)H dehydrogenase (quinone) {ECO:0000305};
+- **Gene Information:** Name=chrR {ECO:0000303|PubMed:14766567}; OrderedLocusNames=PP_4138;
+- **Organism (full):** Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950 / KT2440).
+- **Protein Family:** Belongs to the SsuE family. .
+- **Key Domains:** Flavoprotein-like_sf. (IPR029039); FMN_Rdtase-like_dom. (IPR005025); NAD(P)H-dep_reductase. (IPR050712); FMN_red (PF03358)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "chrR" matches the protein description above**
+2. **Verify the organism is correct:** Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950 / KT2440).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'chrR' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **chrR** (gene ID: chrR, UniProt: Q88FF8) in PSEPK.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Gene Research for Functional Annotation
+
+## ⚠️ CRITICAL: Gene/Protein Identification Context
+
+**BEFORE YOU BEGIN RESEARCH:** You MUST verify you are researching the CORRECT gene/protein. Gene symbols can be ambiguous, especially for less well-characterized genes from non-model organisms.
+
+### Target Gene/Protein Identity (from UniProt):
+- **UniProt Accession:** Q88FF8
+- **Protein Description:** RecName: Full=Quinone reductase {ECO:0000305}; EC=1.6.5.2 {ECO:0000269|PubMed:15840577}; AltName: Full=Chromate reductase {ECO:0000305}; Short=CHRR; EC=1.6.-.- {ECO:0000269|PubMed:14766567}; AltName: Full=NAD(P)H dehydrogenase (quinone) {ECO:0000305};
+- **Gene Information:** Name=chrR {ECO:0000303|PubMed:14766567}; OrderedLocusNames=PP_4138;
+- **Organism (full):** Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950 / KT2440).
+- **Protein Family:** Belongs to the SsuE family. .
+- **Key Domains:** Flavoprotein-like_sf. (IPR029039); FMN_Rdtase-like_dom. (IPR005025); NAD(P)H-dep_reductase. (IPR050712); FMN_red (PF03358)
+
+### MANDATORY VERIFICATION STEPS:
+
+1. **Check if the gene symbol "chrR" matches the protein description above**
+2. **Verify the organism is correct:** Pseudomonas putida (strain ATCC 47054 / DSM 6125 / CFBP 8728 / NCIMB 11950 / KT2440).
+3. **Check if protein family/domains align with what you find in literature**
+4. **If you find literature for a DIFFERENT gene with the same or similar symbol, STOP**
+
+### If Gene Symbol is Ambiguous or You Cannot Find Relevant Literature:
+
+**DO NOT PROCEED WITH RESEARCH ON A DIFFERENT GENE.** Instead:
+- State clearly: "The gene symbol 'chrR' is ambiguous or literature is limited for this specific protein"
+- Explain what you found (e.g., "Found extensive literature on a different gene with the same symbol in a different organism")
+- Describe the protein based ONLY on the UniProt information provided above
+- Suggest that the protein function can be inferred from domain/family information
+
+### Research Target:
+
+Please provide a comprehensive research report on the gene **chrR** (gene ID: chrR, UniProt: Q88FF8) in PSEPK.
+
+The research report should be a detailed narrative explaining the function, biological processes, and localization of the gene product. Citations should be given for all claims.
+
+You should prioritize authoritative reviews and primary scientific literature when conducting research. You can supplement
+this with annotations you find in gene/protein databases, but these can be outdated or inaccurate.
+
+We are specifically interested in the primary function of the gene - for enzymes, what reaction is catalyzed, and what is the substrate specificity? For transporters, what is the substrate? For structural proteins or adapters, what is the broader structural role? For signaling molecules, what is the role in the pathway.
+
+We are interested in where in or outside the cell the gene product carries out its function.
+
+We are also interested in the signaling or biochemical pathways in which the gene functions. We are less interested in broad pleiotropic effects, except where these elucidate the precise role.
+
+Include evidence where possible. We are interested in both experimental evidence as well as inference from structure, evolution, or bioinformatic analysis. Precise studies should be prioritized over high-throughput, where available.
+
+## Research report: **chrR (UniProt Q88FF8)**—quinone/chromate reductase (ChrR) in *Pseudomonas putida* KT2440
+
+### 0) Target verification (critical disambiguation)
+The **chrR** gene discussed here is the **soluble flavoprotein ChrR from *Pseudomonas putida* KT2440**, experimentally characterized as a chromate-reducing flavoprotein and used in gene-disruption studies in KT2440. (gonzalez2003asolubleflavoprotein pages 1-3, ackerley2004chromatereducingpropertiesof pages 2-3). In this KT2440 system, ChrR is a **soluble, dimeric, FMN-containing** oxidoreductase that reduces Cr(VI) to Cr(III) (ackerley2004chromatereducingpropertiesof pages 4-5). These properties align with the UniProt description provided (Q88FF8: quinone reductase / chromate reductase; FMN reductase-like domains), though the retrieved primary articles do **not** explicitly mention the KT2440 locus tag **PP_4138** on the pages available here (gonzalez2003asolubleflavoprotein pages 3-7, ackerley2004chromatereducingpropertiesof pages 3-4).
+
+### 1) Key concepts and definitions (current understanding)
+
+#### 1.1 Chromate reduction and detoxification
+Hexavalent chromium **Cr(VI)** (chromate) is a soluble, toxic environmental contaminant. Enzymatic reduction of Cr(VI) to **Cr(III)** is a detoxification route because Cr(III) is less soluble and less bioavailable than chromate (ackerley2004chromatereducingpropertiesof pages 1-2).
+
+A key conceptual nuance is that many cellular chromate-reduction processes can proceed through **one-electron steps**, forming **Cr(V)** intermediates and driving **redox cycling** that produces reactive oxygen species (ROS). ChrR is studied partly because it can reduce chromate efficiently but still generates measurable ROS through electron leakage to oxygen (ackerley2004chromatereducingpropertiesof pages 8-9, ackerley2004chromatereducingpropertiesof pages 1-2).
+
+#### 1.2 What ChrR is (enzyme class)
+ChrR from *P. putida* KT2440 is a **soluble flavoprotein oxidoreductase** with a **noncovalently bound FMN** cofactor (gonzalez2003asolubleflavoprotein pages 3-7, ackerley2004chromatereducingpropertiesof pages 4-5). In vitro, it uses reducing equivalents from **NAD(P)H** (with strong preference for NADH) to reduce chromate and quinones (ackerley2004chromatereducingpropertiesof pages 5-6, gonzalez2003asolubleflavoprotein pages 3-7).
+
+### 2) Experimentally supported function of ChrR in *P. putida* KT2440
+
+#### 2.1 Reaction catalyzed and substrates (primary function)
+**Primary reaction:** reduction of **Cr(VI) → Cr(III)** by a soluble flavoprotein enzyme (ackerley2004chromatereducingpropertiesof pages 5-6, ackerley2004chromatereducingpropertiesof pages 1-2). ChrR shows no activity using **Cr(III)** as substrate, consistent with a reductive detoxification directionality (ackerley2004chromatereducingpropertiesof pages 5-6).
+
+**Additional substrates (substrate scope relevant to quinone reductase annotation):** ChrR also reduces **quinones** and several artificial electron acceptors (e.g., potassium ferrocyanide and 2,6-dichloroindophenol) (ackerley2004chromatereducingpropertiesof pages 5-6). Conversely, under the tested conditions it lacked activity toward certain other high-valence metals such as U(VI), V(V), Mn(IV), and Mo(VI) (ackerley2004chromatereducingpropertiesof pages 5-6).
+
+#### 2.2 Electron donor specificity
+ChrR preferentially uses **NADH over NADPH**, with an approximately **8-fold** preference under limiting cofactor conditions (ackerley2004chromatereducingpropertiesof pages 5-6, ackerley2004chromatereducingpropertiesof pages 4-5). This matters for pathway placement, because it indicates ChrR likely draws reducing equivalents directly from NADH-dependent cellular redox metabolism during chromate stress.
+
+#### 2.3 Cofactor, oligomeric state, and localization
+ChrR is an FMN-dependent enzyme: the flavin cofactor can be released (e.g., by boiling) and identified by TLC as **FMN** (gonzalez2003asolubleflavoprotein pages 3-7, ackerley2004chromatereducingpropertiesof pages 4-5). ChrR behaves as a **dimeric** enzyme with ~22 kDa subunits and ~50 kDa native size (ackerley2004chromatereducingpropertiesof pages 4-5). It is described and purified as a **soluble** flavoprotein, indicating a **cytosolic** functional locale rather than membrane association (gonzalez2003asolubleflavoprotein pages 3-7, ackerley2004chromatereducingpropertiesof pages 1-2).
+
+#### 2.4 Kinetics and quantitative enzymology (recently cited core statistics)
+Quantitative parameters reported for KT2440 ChrR include:
+- **Km (chromate)** reported around **190 µM** (Gonzalez et al., 2003-07; https://doi.org/10.1002/abio.200390030) (gonzalez2003asolubleflavoprotein pages 3-7).
+- **Vmax** reported as **1.71 µmol·min⁻¹·mg⁻¹** for chromate reduction (same study) (gonzalez2003asolubleflavoprotein pages 3-7).
+- A separate kinetic analysis reports **kcat/Km ≈ 2.2 × 10^4 M⁻¹·s⁻¹** for chromate reduction, and reports additional kinetic values including **Km ~260 µM** and **kcat ~5.8 s⁻¹** (Ackerley et al., 2004-02; https://doi.org/10.1128/AEM.70.2.873-882.2004) (ackerley2004chromatereducingpropertiesof pages 5-6, ackerley2004chromatereducingpropertiesof pages 4-5).
+
+These values establish ChrR as an efficient soluble chromate reductase in vitro, supporting its classification as a detoxification enzyme.
+
+#### 2.5 Mechanism and ROS production (critical for understanding “chromate reductase” vs “safe detoxification”)
+A kinetic model consistent with a **ping-pong (bi-bi) mechanism** was inferred from double-reciprocal plots: electrons transfer from **NAD(P)H → enzyme-bound FMN → chromate** (gonzalez2003asolubleflavoprotein pages 3-7).
+
+Stopped-flow studies observed a **flavin semiquinone intermediate** during turnover for ChrR, indicating that at least part of the catalytic cycle involves one-electron flavin chemistry (ackerley2004chromatereducingpropertiesof pages 6-6, ackerley2004chromatereducingpropertiesof pages 6-8). This is important because one-electron chemistry can correlate with **Cr(V)** transient formation and ROS.
+
+Electron partitioning measurements indicate that during chromate reduction, roughly **1 out of every 4 electrons** from NADH can go to **O2**, yielding **H2O2** (ROS) rather than chromate reduction—i.e., ~25% diversion to oxygen (ackerley2004chromatereducingpropertiesof pages 6-6, ackerley2004chromatereducingpropertiesof pages 1-2). This mechanistic detail underpins expert concern that some chromate reductases can detoxify Cr(VI) yet still impose oxidative stress via ROS.
+
+### 3) Biological role and pathway context in *P. putida* KT2440
+
+#### 3.1 Evidence from mutants and physiological assays
+A KT2440 **chrR disruption mutant** shows impaired chromate-related phenotypes compared to wild type, consistent with ChrR contributing to both chromate reduction and tolerance in vivo (gonzalez2003asolubleflavoprotein pages 3-7, ackerley2004chromatereducingpropertiesof pages 6-8). For example, in cell-based assays in the Ackerley et al. dataset, the mutant is described as showing a **70% decrease in initial chromate conversion rate** relative to wild type under the tested conditions, alongside lower overall transformation after 24 h (ackerley2004chromatereducingpropertiesof pages 6-8).
+
+#### 3.2 Regulation / induction under stress
+ChrR protein levels are reported to be induced by both **chromate exposure** and **entry into stationary phase**, with a “fourfold induction at the onset of stationary phase” and increased levels upon addition of chromate in the tested conditions (ackerley2004chromatereducingpropertiesof pages 8-9). This supports a role in general stress physiology and detoxification, not merely a constitutive housekeeping reductase.
+
+#### 3.3 Where in the cell ChrR acts
+ChrR is consistently treated as a **soluble** enzyme in biochemical purification and analysis, implying a **cytosolic** site of action (gonzalez2003asolubleflavoprotein pages 3-7, ackerley2004chromatereducingpropertiesof pages 1-2). In whole-cell assays, chromate reduction required an **energy source**, and minimal chromate removal occurred in buffer-only suspensions compared to rich medium, arguing against mere adsorption and for active, metabolism-coupled reduction processes (ackerley2004chromatereducingpropertiesof pages 8-9).
+
+### 4) Current applications and real-world implementations
+
+#### 4.1 Bioremediation rationale and constraints
+ChrR converts soluble Cr(VI) to insoluble Cr(III) (ackerley2004chromatereducingpropertiesof pages 1-2, ackerley2004chromatereducingpropertiesof pages 5-6), which is a core bioremediation goal. However, expert mechanistic analysis emphasizes that bioremediation design should consider **ROS production**: enzymes that reduce Cr(VI) but strongly generate ROS (via one-electron pathways or flavin redox cycling) may damage host cells and reduce remediation robustness (ackerley2004chromatereducingpropertiesof pages 8-9, ackerley2004chromatereducingpropertiesof pages 9-10).
+
+In early KT2440-focused work, authors explicitly framed the enzyme as a candidate for improvement and deployment and discussed strategies like reducing ROS via protein engineering and controlling expression timing (e.g., stress/starvation promoters) to decouple growth from detoxification burdens (gonzalez2003asolubleflavoprotein pages 3-7).
+
+#### 4.2 Recent (2024) real-world bioremediation performance context (not ChrR-specific)
+While no 2023–2024 primary papers specifically on *P. putida* KT2440 ChrR were retrieved in this tool session, recent chromium-remediation studies illustrate the broader applied landscape in which ChrR-like FMN-dependent reductases are discussed.
+
+- A 2024 *BMC Genomics* study reports *Shewanella putrefaciens* 4H reduced **300 mg/L Cr(VI) in 72 h** under the tested anaerobic conditions, with an optimum pH of ~9.0 and optimum temperature ~30 °C (publication date: 2024-02; https://doi.org/10.1186/s12864-024-10031-9) (cai2024genomeanalysisof pages 1-2). This provides a modern benchmark for strain-level performance in chromium bioremediation systems.
+- A 2024 transcriptomics preprint on *Cellulomonas fimi* under Cr(VI) stress reports upregulation of an **FMN reductase gene ssuE** and quinone oxidoreductases, implicating flavin/quinone redox enzymes in chromium reduction networks; under **0.5 mM Cr(VI)** stress, **654 genes were upregulated** (publication date: 2024-04; https://doi.org/10.21203/rs.3.rs-4290350/v1) (li2024transcriptomicsextractthe pages 1-5). This supports current interest in FMN-reductase family members (SsuE-like) as parts of chromium-reduction pathways.
+
+### 5) Expert opinions and authoritative analysis (from the cited primary literature)
+Two themes recur in authoritative mechanistic discussion of ChrR:
+
+1) **Reducing Cr(VI) is not automatically “safe detoxification”** because side reactions with oxygen can produce ROS. ChrR forms a semiquinone and diverts a substantial fraction of electrons to oxygen, producing H2O2; this can contribute to oxidative stress even as Cr(VI) decreases (ackerley2004chromatereducingpropertiesof pages 6-6, ackerley2004chromatereducingpropertiesof pages 1-2).
+
+2) **Cell physiology matters for remediation:** chromate reduction requires an energy source and depends on cellular redox metabolism, so practical deployment must consider medium/electron-donor availability and growth phase (stationary-phase induction) (ackerley2004chromatereducingpropertiesof pages 8-9).
+
+### 6) Summary of key experimentally supported properties (evidence map)
+| Feature | Key finding | Evidence/source (author year) | Notes/conditions |
+|---|---|---|---|
+| Enzyme type | ChrR from *Pseudomonas putida* KT2440 is a soluble flavoprotein chromate/quinone reductase; primary literature uses the gene/protein name **chrR/ChrR** | Gonzalez et al. 2003; Ackerley et al. 2004 (gonzalez2003asolubleflavoprotein pages 1-3, ackerley2004chromatereducingpropertiesof pages 1-2) | Studied as purified recombinant KTChrR and in KT2440 mutant backgrounds |
+| Cellular localization / physical state | The enzyme is **soluble**, consistent with a cytosolic flavoprotein rather than a membrane protein | Gonzalez et al. 2003; Ackerley et al. 2004 (gonzalez2003asolubleflavoprotein pages 3-7, ackerley2004chromatereducingpropertiesof pages 1-2) | Purified from soluble fractions; described in the title/analysis as a soluble flavoprotein |
+| Cofactor | ChrR contains a **tightly/noncovalently bound FMN** cofactor identified by TLC | Gonzalez et al. 2003; Ackerley et al. 2004 (gonzalez2003asolubleflavoprotein pages 3-7, ackerley2004chromatereducingpropertiesof pages 4-5) | Yellow purified protein; cofactor released by boiling and matched FMN standard |
+| Oligomeric state | ChrR is **dimeric** | Ackerley et al. 2004 (ackerley2004chromatereducingpropertiesof pages 4-5) | Approx. 22 kDa subunit and ~50 kDa native enzyme |
+| Electron donor preference | ChrR uses **NADH preferentially** over NADPH, with an approximately **8-fold preference** for NADH | Ackerley et al. 2004 (ackerley2004chromatereducingpropertiesof pages 5-6, ackerley2004chromatereducingpropertiesof pages 4-5) | Preference reported at limiting cofactor concentrations |
+| Primary reaction | ChrR reduces **Cr(VI) to Cr(III)** efficiently and shows no activity with Cr(III) as substrate | Ackerley et al. 2004 (ackerley2004chromatereducingpropertiesof pages 5-6, ackerley2004chromatereducingpropertiesof pages 1-2) | End product supported by XANES in the 2004 study |
+| Additional substrates | ChrR also reduces **quinones**, potassium ferrocyanide, and 2,6-dichloroindophenol | Ackerley et al. 2004 (ackerley2004chromatereducingpropertiesof pages 5-6) | No activity reported for several tested high-valence metals including U(VI), V(V), Mn(IV), and Mo(VI) |
+| Chromate Km | Reported **Km for chromate ~190 µM** | Gonzalez et al. 2003 (gonzalez2003asolubleflavoprotein pages 3-7) | Purified KTChrR enzyme assays |
+| Chromate Vmax | Reported **Vmax ~1.71 µmol min⁻¹ mg⁻¹** | Gonzalez et al. 2003 (gonzalez2003asolubleflavoprotein pages 3-7) | Measured for purified KTChrR chromate reduction |
+| Catalytic efficiency | Reported **kcat/Km ~2.2 × 10^4 M⁻¹ s⁻¹** for chromate reduction | Ackerley et al. 2004 (ackerley2004chromatereducingpropertiesof pages 5-6, ackerley2004chromatereducingpropertiesof pages 4-5) | Table 2 / steady-state kinetic analysis |
+| Other kinetic values | Ackerley et al. report **Km ~260 µM** and **kcat ~5.8 s⁻¹** for chromate reduction | Ackerley et al. 2004 (ackerley2004chromatereducingpropertiesof pages 5-6) | Values reflect a separate assay framework from the 2003 report |
+| Mechanism: overall | Kinetic analysis supports a **bi-substrate ping-pong (double-displacement)** mechanism | Gonzalez et al. 2003 (gonzalez2003asolubleflavoprotein pages 3-7) | Electrons are transferred from NAD(P)H to enzyme-bound FMN and then to chromate |
+| Mechanism: redox intermediate | Stopped-flow experiments detected a **flavin semiquinone intermediate** during ChrR turnover | Ackerley et al. 2004 (ackerley2004chromatereducingpropertiesof pages 6-6, ackerley2004chromatereducingpropertiesof pages 6-8) | Supports partial one-electron chemistry within the catalytic cycle |
+| ROS stoichiometry | Roughly **25% of NADH electrons are diverted to O2**, generating **H2O2/ROS** during chromate reduction | Ackerley et al. 2004 (ackerley2004chromatereducingpropertiesof pages 6-6, ackerley2004chromatereducingpropertiesof pages 8-9, ackerley2004chromatereducingpropertiesof pages 1-2) | Reported as about 1 of every 4 electrons going to O2 rather than chromate |
+| Physiological role in vivo | **chrR disruption reduces chromate transformation and increases chromate sensitivity/tolerance defects** | Gonzalez et al. 2003; Ackerley et al. 2004 (gonzalez2003asolubleflavoprotein pages 3-7, ackerley2004chromatereducingpropertiesof pages 6-8) | Mutant strains showed slower growth and/or lower initial chromate conversion rates than wild type |
+| Regulation / induction | ChrR is induced by **chromate exposure** and by **entry into stationary phase** | Ackerley et al. 2004 (ackerley2004chromatereducingpropertiesof pages 8-9) | Protein levels were reported to rise under both conditions |
+| Temperature profile | ChrR shows an unusually high apparent temperature optimum of about **70 °C**, while retaining activity over a broad range | Gonzalez et al. 2003; Ackerley et al. 2004 (gonzalez2003asolubleflavoprotein pages 3-7, ackerley2004chromatereducingpropertiesof pages 4-5) | Broad activity reported from ~30–80 °C in one study; physiological relevance in vivo remains uncertain |
+
+
+*Table: This table compiles the main experimentally supported biochemical and physiological properties of *Pseudomonas putida* KT2440 ChrR from the primary literature. It is useful as a concise evidence map for enzyme function, mechanism, and in vivo role.*
+
+### 7) Evidence gaps and limitations (important for functional annotation quality)
+- **Locus tag linkage (PP_4138)** and explicit **“SsuE family”** wording were not present in the retrieved primary-text pages; thus, within this tool session, those specific identifiers come from the user-provided UniProt context rather than directly quoted from the captured papers (gonzalez2003asolubleflavoprotein pages 3-7, ackerley2004chromatereducingpropertiesof pages 3-4).
+- Despite targeted searching, **2023–2024 ChrR/KТ2440-specific** peer-reviewed updates were not retrieved here. Therefore, ChrR’s core functional annotation remains anchored to the **2003–2004** biochemical/genetic characterization, with 2024 sources used for contextualizing the broader chromate-reduction field and FMN-reductase involvement (gonzalez2003asolubleflavoprotein pages 3-7, ackerley2004chromatereducingpropertiesof pages 5-6, li2024transcriptomicsextractthe pages 1-5, cai2024genomeanalysisof pages 1-2).
+
+### 8) Primary sources (URLs and publication dates)
+- Gonzalez CF, Ackerley DF, Park CH, Matin A. **A soluble flavoprotein contributes to chromate reduction and tolerance by *Pseudomonas putida*.** *Acta Biotechnologica* (published **2003-07**). https://doi.org/10.1002/abio.200390030 (gonzalez2003asolubleflavoprotein pages 3-7)
+- Ackerley D, Gonzalez CF, Park C, Blake RC, Keyhan M, Matin A. **Chromate-reducing properties of soluble flavoproteins from *Pseudomonas putida* and *Escherichia coli*.** *Applied and Environmental Microbiology* (published **2004-02**). https://doi.org/10.1128/AEM.70.2.873-882.2004 (ackerley2004chromatereducingpropertiesof pages 5-6)
+- Cai Y, et al. **Genome analysis of *Shewanella putrefaciens* 4H revealing the potential mechanisms for chromium remediation.** *BMC Genomics* (published **2024-02**). https://doi.org/10.1186/s12864-024-10031-9 (cai2024genomeanalysisof pages 1-2)
+- Li Y, et al. **Transcriptomics extract the key chromium resistance genes of *Cellulomonas*.** Research Square preprint (posted **2024-04**). https://doi.org/10.21203/rs.3.rs-4290350/v1 (li2024transcriptomicsextractthe pages 1-5)
+
+
+References
+
+1. (gonzalez2003asolubleflavoprotein pages 1-3): C. F. Gonzalez, D. F. Ackerley, C. H. Park, and A. Matin. A soluble flavoprotein contributes to chromate reduction and tolerance by pseudomonas putida. Acta Biotechnologica, 23:233-239, Jul 2003. URL: https://doi.org/10.1002/abio.200390030, doi:10.1002/abio.200390030. This article has 75 citations.
+
+2. (ackerley2004chromatereducingpropertiesof pages 2-3): D. Ackerley, Claudio F. Gonzalez, C. Park, Robert C. Blake, M. Keyhan, and Abdul Matin. Chromate-reducing properties of soluble flavoproteins from pseudomonas putida and escherichia coli. Applied and Environmental Microbiology, 70:873-882, Feb 2004. URL: https://doi.org/10.1128/aem.70.2.873-882.2004, doi:10.1128/aem.70.2.873-882.2004. This article has 420 citations and is from a peer-reviewed journal.
+
+3. (ackerley2004chromatereducingpropertiesof pages 4-5): D. Ackerley, Claudio F. Gonzalez, C. Park, Robert C. Blake, M. Keyhan, and Abdul Matin. Chromate-reducing properties of soluble flavoproteins from pseudomonas putida and escherichia coli. Applied and Environmental Microbiology, 70:873-882, Feb 2004. URL: https://doi.org/10.1128/aem.70.2.873-882.2004, doi:10.1128/aem.70.2.873-882.2004. This article has 420 citations and is from a peer-reviewed journal.
+
+4. (gonzalez2003asolubleflavoprotein pages 3-7): C. F. Gonzalez, D. F. Ackerley, C. H. Park, and A. Matin. A soluble flavoprotein contributes to chromate reduction and tolerance by pseudomonas putida. Acta Biotechnologica, 23:233-239, Jul 2003. URL: https://doi.org/10.1002/abio.200390030, doi:10.1002/abio.200390030. This article has 75 citations.
+
+5. (ackerley2004chromatereducingpropertiesof pages 3-4): D. Ackerley, Claudio F. Gonzalez, C. Park, Robert C. Blake, M. Keyhan, and Abdul Matin. Chromate-reducing properties of soluble flavoproteins from pseudomonas putida and escherichia coli. Applied and Environmental Microbiology, 70:873-882, Feb 2004. URL: https://doi.org/10.1128/aem.70.2.873-882.2004, doi:10.1128/aem.70.2.873-882.2004. This article has 420 citations and is from a peer-reviewed journal.
+
+6. (ackerley2004chromatereducingpropertiesof pages 1-2): D. Ackerley, Claudio F. Gonzalez, C. Park, Robert C. Blake, M. Keyhan, and Abdul Matin. Chromate-reducing properties of soluble flavoproteins from pseudomonas putida and escherichia coli. Applied and Environmental Microbiology, 70:873-882, Feb 2004. URL: https://doi.org/10.1128/aem.70.2.873-882.2004, doi:10.1128/aem.70.2.873-882.2004. This article has 420 citations and is from a peer-reviewed journal.
+
+7. (ackerley2004chromatereducingpropertiesof pages 8-9): D. Ackerley, Claudio F. Gonzalez, C. Park, Robert C. Blake, M. Keyhan, and Abdul Matin. Chromate-reducing properties of soluble flavoproteins from pseudomonas putida and escherichia coli. Applied and Environmental Microbiology, 70:873-882, Feb 2004. URL: https://doi.org/10.1128/aem.70.2.873-882.2004, doi:10.1128/aem.70.2.873-882.2004. This article has 420 citations and is from a peer-reviewed journal.
+
+8. (ackerley2004chromatereducingpropertiesof pages 5-6): D. Ackerley, Claudio F. Gonzalez, C. Park, Robert C. Blake, M. Keyhan, and Abdul Matin. Chromate-reducing properties of soluble flavoproteins from pseudomonas putida and escherichia coli. Applied and Environmental Microbiology, 70:873-882, Feb 2004. URL: https://doi.org/10.1128/aem.70.2.873-882.2004, doi:10.1128/aem.70.2.873-882.2004. This article has 420 citations and is from a peer-reviewed journal.
+
+9. (ackerley2004chromatereducingpropertiesof pages 6-6): D. Ackerley, Claudio F. Gonzalez, C. Park, Robert C. Blake, M. Keyhan, and Abdul Matin. Chromate-reducing properties of soluble flavoproteins from pseudomonas putida and escherichia coli. Applied and Environmental Microbiology, 70:873-882, Feb 2004. URL: https://doi.org/10.1128/aem.70.2.873-882.2004, doi:10.1128/aem.70.2.873-882.2004. This article has 420 citations and is from a peer-reviewed journal.
+
+10. (ackerley2004chromatereducingpropertiesof pages 6-8): D. Ackerley, Claudio F. Gonzalez, C. Park, Robert C. Blake, M. Keyhan, and Abdul Matin. Chromate-reducing properties of soluble flavoproteins from pseudomonas putida and escherichia coli. Applied and Environmental Microbiology, 70:873-882, Feb 2004. URL: https://doi.org/10.1128/aem.70.2.873-882.2004, doi:10.1128/aem.70.2.873-882.2004. This article has 420 citations and is from a peer-reviewed journal.
+
+11. (ackerley2004chromatereducingpropertiesof pages 9-10): D. Ackerley, Claudio F. Gonzalez, C. Park, Robert C. Blake, M. Keyhan, and Abdul Matin. Chromate-reducing properties of soluble flavoproteins from pseudomonas putida and escherichia coli. Applied and Environmental Microbiology, 70:873-882, Feb 2004. URL: https://doi.org/10.1128/aem.70.2.873-882.2004, doi:10.1128/aem.70.2.873-882.2004. This article has 420 citations and is from a peer-reviewed journal.
+
+12. (cai2024genomeanalysisof pages 1-2): Yajun Cai, Xu Chen, Hanghang Qi, Fantong Bu, Muhammad Shaaban, and Qi-An Peng. Genome analysis of shewanella putrefaciens 4h revealing the potential mechanisms for the chromium remediation. BMC Genomics, Feb 2024. URL: https://doi.org/10.1186/s12864-024-10031-9, doi:10.1186/s12864-024-10031-9. This article has 13 citations and is from a peer-reviewed journal.
+
+13. (li2024transcriptomicsextractthe pages 1-5): Yongdong Li, Shengchao Gao, Hongmei Sun, Lianbin Cao, Tong Li, Wentong Li, Tongbiao Li, Mingchneg Wang, Enzhong Li, Hongxia Ni, Yi Chen, and Ying Liu. Transcriptomics extract the key chromium resistance genes of cellulomonas. Unknown journal, Apr 2024. URL: https://doi.org/10.21203/rs.3.rs-4290350/v1, doi:10.21203/rs.3.rs-4290350/v1.
+
+## Artifacts
+
+- [Edison artifact artifact-00](chrR-deep-research-falcon_artifacts/artifact-00.md)
+
+## Citations
+
+1. ackerley2004chromatereducingpropertiesof pages 4-5
+2. ackerley2004chromatereducingpropertiesof pages 1-2
+3. ackerley2004chromatereducingpropertiesof pages 5-6
+4. gonzalez2003asolubleflavoprotein pages 3-7
+5. ackerley2004chromatereducingpropertiesof pages 6-8
+6. ackerley2004chromatereducingpropertiesof pages 8-9
+7. cai2024genomeanalysisof pages 1-2
+8. li2024transcriptomicsextractthe pages 1-5
+9. gonzalez2003asolubleflavoprotein pages 1-3
+10. ackerley2004chromatereducingpropertiesof pages 2-3
+11. ackerley2004chromatereducingpropertiesof pages 3-4
+12. ackerley2004chromatereducingpropertiesof pages 6-6
+13. ackerley2004chromatereducingpropertiesof pages 9-10
+14. https://doi.org/10.1002/abio.200390030
+15. https://doi.org/10.1128/AEM.70.2.873-882.2004
+16. https://doi.org/10.1186/s12864-024-10031-9
+17. https://doi.org/10.21203/rs.3.rs-4290350/v1
+18. https://doi.org/10.1002/abio.200390030,
+19. https://doi.org/10.1128/aem.70.2.873-882.2004,
+20. https://doi.org/10.1186/s12864-024-10031-9,
+21. https://doi.org/10.21203/rs.3.rs-4290350/v1,

--- a/genes/PSEPK/chrR/chrR-deep-research-falcon_artifacts/artifact-00.md
+++ b/genes/PSEPK/chrR/chrR-deep-research-falcon_artifacts/artifact-00.md
@@ -1,0 +1,22 @@
+| Feature | Key finding | Evidence/source (author year) | Notes/conditions |
+|---|---|---|---|
+| Enzyme type | ChrR from *Pseudomonas putida* KT2440 is a soluble flavoprotein chromate/quinone reductase; primary literature uses the gene/protein name **chrR/ChrR** | Gonzalez et al. 2003; Ackerley et al. 2004 (pqac-00000003, pqac-00000005) | Studied as purified recombinant KTChrR and in KT2440 mutant backgrounds |
+| Cellular localization / physical state | The enzyme is **soluble**, consistent with a cytosolic flavoprotein rather than a membrane protein | Gonzalez et al. 2003; Ackerley et al. 2004 (pqac-00000016, pqac-00000018) | Purified from soluble fractions; described in the title/analysis as a soluble flavoprotein |
+| Cofactor | ChrR contains a **tightly/noncovalently bound FMN** cofactor identified by TLC | Gonzalez et al. 2003; Ackerley et al. 2004 (pqac-00000001, pqac-00000009) | Yellow purified protein; cofactor released by boiling and matched FMN standard |
+| Oligomeric state | ChrR is **dimeric** | Ackerley et al. 2004 (pqac-00000000, pqac-00000009) | Approx. 22 kDa subunit and ~50 kDa native enzyme |
+| Electron donor preference | ChrR uses **NADH preferentially** over NADPH, with an approximately **8-fold preference** for NADH | Ackerley et al. 2004 (pqac-00000008, pqac-00000009) | Preference reported at limiting cofactor concentrations |
+| Primary reaction | ChrR reduces **Cr(VI) to Cr(III)** efficiently and shows no activity with Cr(III) as substrate | Ackerley et al. 2004 (pqac-00000008, pqac-00000014) | End product supported by XANES in the 2004 study |
+| Additional substrates | ChrR also reduces **quinones**, potassium ferrocyanide, and 2,6-dichloroindophenol | Ackerley et al. 2004 (pqac-00000008) | No activity reported for several tested high-valence metals including U(VI), V(V), Mn(IV), and Mo(VI) |
+| Chromate Km | Reported **Km for chromate ~190 µM** | Gonzalez et al. 2003 (pqac-00000011, pqac-00000016) | Purified KTChrR enzyme assays |
+| Chromate Vmax | Reported **Vmax ~1.71 µmol min⁻¹ mg⁻¹** | Gonzalez et al. 2003 (pqac-00000011, pqac-00000016) | Measured for purified KTChrR chromate reduction |
+| Catalytic efficiency | Reported **kcat/Km ~2.2 × 10^4 M⁻¹ s⁻¹** for chromate reduction | Ackerley et al. 2004 (pqac-00000008, pqac-00000009) | Table 2 / steady-state kinetic analysis |
+| Other kinetic values | Ackerley et al. report **Km ~260 µM** and **kcat ~5.8 s⁻¹** for chromate reduction | Ackerley et al. 2004 (pqac-00000008) | Values reflect a separate assay framework from the 2003 report |
+| Mechanism: overall | Kinetic analysis supports a **bi-substrate ping-pong (double-displacement)** mechanism | Gonzalez et al. 2003 (pqac-00000011, pqac-00000016) | Electrons are transferred from NAD(P)H to enzyme-bound FMN and then to chromate |
+| Mechanism: redox intermediate | Stopped-flow experiments detected a **flavin semiquinone intermediate** during ChrR turnover | Ackerley et al. 2004 (pqac-00000010, pqac-00000013) | Supports partial one-electron chemistry within the catalytic cycle |
+| ROS stoichiometry | Roughly **25% of NADH electrons are diverted to O2**, generating **H2O2/ROS** during chromate reduction | Ackerley et al. 2004 (pqac-00000010, pqac-00000012, pqac-00000014) | Reported as about 1 of every 4 electrons going to O2 rather than chromate |
+| Physiological role in vivo | **chrR disruption reduces chromate transformation and increases chromate sensitivity/tolerance defects** | Gonzalez et al. 2003; Ackerley et al. 2004 (pqac-00000001, pqac-00000020) | Mutant strains showed slower growth and/or lower initial chromate conversion rates than wild type |
+| Regulation / induction | ChrR is induced by **chromate exposure** and by **entry into stationary phase** | Ackerley et al. 2004 (pqac-00000012, pqac-00000017) | Protein levels were reported to rise under both conditions |
+| Temperature profile | ChrR shows an unusually high apparent temperature optimum of about **70 °C**, while retaining activity over a broad range | Gonzalez et al. 2003; Ackerley et al. 2004 (pqac-00000011, pqac-00000009) | Broad activity reported from ~30–80 °C in one study; physiological relevance in vivo remains uncertain |
+
+
+*Table: This table compiles the main experimentally supported biochemical and physiological properties of *Pseudomonas putida* KT2440 ChrR from the primary literature. It is useful as a concise evidence map for enzyme function, mechanism, and in vivo role.*


### PR DESCRIPTION
Integrates falcon (Edison Scientific) deep research into the P. putida chrR review: adds a file: reference with verbatim findings and supported_by evidence; revisits action calls. Validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)