### PR TITLE
[codex] Add Codex agent compatibility

### DIFF
--- a/.claude/skills/annotation-reviewer/SKILL.md
+++ b/.claude/skills/annotation-reviewer/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: annotation-reviewer
-description: Use this agent when you need to systematically review existing GO annotations for a gene and make curation decisions based on literature evidence and functional analysis. This agent should be called after seeding the SPECIES/GENE/GENE-ai-review.yaml file, which seeds each annotation with `action: PENDING`, these should all be manually reviewed.
+description: >
+  Use this agent when you need to systematically review existing GO annotations for
+  a gene and make curation decisions based on literature evidence and functional
+  analysis. This agent should be called after seeding the
+  SPECIES/GENE/GENE-ai-review.yaml file, which seeds each annotation with
+  `action: PENDING`; these should all be manually reviewed.
 model: inherit
 ---
 

--- a/.claude/skills/boss/SKILL.md
+++ b/.claude/skills/boss/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: boss
 description: Use ONLY when the user explicitly asks to orchestrate parallel external agents (Codex or Claude Code) in tmux sessions via tp (tmux-pilot). Or when a user tells you that you're the boss or orchestrator. You can also use this if you are an operclaw agent. NEVER auto-invoke for a generic "do this in parallel" request. For in-process subagents, use superpowers:dispatching-parallel-agents instead.
-argument-hint: [ "review" | "status" | "kill" ] [INFO]
+argument-hint: '"review" | "status" | "kill" [INFO]'
 ---
 
 # boss: orchestrate multiple agents in the ai-gene-review repo

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -1,6 +1,7 @@
 ---
+name: pm
 description: Manage and drive forward an ongoing project, tracked in projects/ dir
-argument-hint: [PROJECT_NAME]
+argument-hint: "[PROJECT_NAME]"
 ---
 
 You should find either a file or a folder:

--- a/.claude/skills/reference-findings-summarizer/SKILL.md
+++ b/.claude/skills/reference-findings-summarizer/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reference-findings-summarize
+name: reference-findings-summarizer
 description: Use this agent when you need to extract and summarize key findings from scientific references that are relevant to a gene's function. This agent should be used after references have been identified in a gene review to provide detailed supporting evidence from the literature. The agent will look up cached publications and extract only the most relevant findings related to the gene's direct function, excluding irrelevant experimental details unless they directly inform gene function.
 model: inherit
 ---

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,6 +1,7 @@
 ---
+name: review
 description: Review, either de-novo, or augment the review of an existing one. A list of deep research providers may be specified.
-argument-hint: [ORGANISM] [GENE_SYMBOL] ( using [DEEP_RESEARCH_PROVIDER] )
+argument-hint: "[ORGANISM] [GENE_SYMBOL] (using [DEEP_RESEARCH_PROVIDER])"
 ---
 
 Review the gene specified in $ARGUMENTS.

--- a/.codex/skills/annotation-reviewer
+++ b/.codex/skills/annotation-reviewer
@@ -1,0 +1,1 @@
+../../.claude/skills/annotation-reviewer

--- a/.codex/skills/bioinformatics-analyzer
+++ b/.codex/skills/bioinformatics-analyzer
@@ -1,0 +1,1 @@
+../../.claude/skills/bioinformatics-analyzer

--- a/.codex/skills/bioreason-predictions
+++ b/.codex/skills/bioreason-predictions
@@ -1,0 +1,1 @@
+../../.claude/skills/bioreason-predictions

--- a/.codex/skills/boss
+++ b/.codex/skills/boss
@@ -1,0 +1,1 @@
+../../.claude/skills/boss

--- a/.codex/skills/core-function-synthesizer
+++ b/.codex/skills/core-function-synthesizer
@@ -1,0 +1,1 @@
+../../.claude/skills/core-function-synthesizer

--- a/.codex/skills/pathway-inference-agent
+++ b/.codex/skills/pathway-inference-agent
@@ -1,0 +1,1 @@
+../../.claude/skills/pathway-inference-agent

--- a/.codex/skills/pm
+++ b/.codex/skills/pm
@@ -1,0 +1,1 @@
+../../.claude/skills/pm

--- a/.codex/skills/reference-findings-summarizer
+++ b/.codex/skills/reference-findings-summarizer
@@ -1,0 +1,1 @@
+../../.claude/skills/reference-findings-summarizer

--- a/.codex/skills/review
+++ b/.codex/skills/review
@@ -1,0 +1,1 @@
+../../.claude/skills/review

--- a/.codex/skills/rule-reviewer
+++ b/.codex/skills/rule-reviewer
@@ -1,0 +1,1 @@
+../../.claude/skills/rule-reviewer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## Summary

Adds Codex compatibility wiring for the existing Claude-oriented agent setup.

- Adds `AGENTS.md` as a symlink to `CLAUDE.md` so Codex and Claude share one repo instruction source.
- Adds `.codex/skills/*` symlinks for the remaining `.claude/skills/*` entries.
- Fixes YAML frontmatter in several `SKILL.md` files so Codex can parse required skill metadata.

## Root Cause

The repository already had Claude skills and one Codex skill symlink, but most skills were not exposed through `.codex/skills`. A few Claude skill frontmatter blocks also used Claude-tolerated syntax that was invalid YAML or missing the required `name` field for Codex skill discovery.

## Validation

- Parsed all `.claude/skills/*/SKILL.md` and `.codex/skills/*/SKILL.md` frontmatter with PyYAML.
- Confirmed each skill has required `name` and `description` fields.
- Confirmed `.codex/skills` resolves to 11 `SKILL.md` files.
- Confirmed `AGENTS.md` is a symlink to `CLAUDE.md`.