### PR TITLE
[codex] Pin Claude review workflow to Opus

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -72,6 +72,7 @@ jobs:
           track_progress: ${{ github.event_name == 'pull_request' }}
           allowed_bots: 'claude,github-actions'
           claude_args: |
+            --model claude-opus-4-6
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(find:*),Bash(ls:*),Bash(just:*),Bash(uv run:*)"
 
           prompt: |


### PR DESCRIPTION
## Summary

- Pin the Claude Code review workflow to `claude-opus-4-6` via `claude_args`.
- Avoid inheriting the v1 action default, which currently runs review jobs on Sonnet.

## Validation

- Parsed `.github/workflows/claude-code-review.yml` with PyYAML.